### PR TITLE
Fix rake db:seed 

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,43 +1,16 @@
 # frozen_string_literal: true
 
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
-app_count = ENV['APP_COUNT'] || 100
-type_count = ENV['TYPE_COUNT'] || 10
-
-account = Account.new(:account_number => '1234')
-account.save!
+app_count = ENV['APP_COUNT'] || 10
+type_count = ENV['TYPE_COUNT'] || 5
 
 ActiveRecord::Base.transaction do
   app_count.times do |app_id|
-    app = Builder::App.build! do |app|
+    Builder::App.build! do |app|
       app.name "seed-app-#{app_id}"
-
-      Random.rand(type_count).times do |type_id|
+      event_type_count = Random.rand(type_count)
+      event_type_count.times do |type_id|
         app.event_type "seed-type-#{type_id}"
       end
     end
-
-    Builder::Filter.build!(account) do |filter|
-      filter.application(app.name)
-            .event_types(app.event_types.pluck(:name))
-      filter.severity.any!
-    end
   end
-
-  test_acc = Account.find_or_create_by(id: '00000000-0000-0000-0000-000000000000', account_number: '0000')
-  test_acc.save!
-  test_endpoint = Endpoints::HttpEndpoint.new(
-    name: 'test_endpoint',
-    url: 'http://rails:3000/logger',
-    account: test_acc
-  )
-  test_filter = Filter.new(account_id: test_acc.id, endpoints: [test_endpoint]) # filter all
-  test_filter.save!
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,14 +2,19 @@
 
 app_count = ENV['APP_COUNT'] || 10
 type_count = ENV['TYPE_COUNT'] || 5
+level_count = ENV['LEVEL_COUNT'] || 5
 
 ActiveRecord::Base.transaction do
   app_count.times do |app_id|
     Builder::App.build! do |app|
       app.name "seed-app-#{app_id}"
-      event_type_count = Random.rand(type_count)
-      event_type_count.times do |type_id|
-        app.event_type "seed-type-#{type_id}"
+      random_event_type_count = Random.rand(type_count)
+      random_level_count = Random.rand(level_count)
+      random_event_type_count.times do |type_id|
+        event_type = app.event_type "seed-type-#{type_id}"
+        event_type.levels [0..random_level_count].map do |level_id|
+          "level-#{level_id}"
+        end
       end
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,4 +16,14 @@ ActiveRecord::Base.transaction do
       end
     end
   end
+
+  test_acc = Account.find_or_create_by(id: '00000000-0000-0000-0000-000000000000', account_number: '0000')
+  test_acc.save!
+  test_endpoint = Endpoints::HttpEndpoint.new(
+    name: 'test_endpoint',
+    url: 'http://rails:3000/logger',
+    account: test_acc
+  )
+  test_filter = Filter.new(account_id: test_acc.id, endpoints: [test_endpoint]) # filter all
+  test_filter.save!
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,9 +12,7 @@ ActiveRecord::Base.transaction do
       random_level_count = Random.rand(level_count)
       random_event_type_count.times do |type_id|
         event_type = app.event_type "seed-type-#{type_id}"
-        event_type.levels [0...random_level_count].map do |level_id|
-          "level-#{level_id}"
-        end
+        event_type.levels((0...random_level_count).map { |level_id| "level-#{level_id}" })
       end
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ ActiveRecord::Base.transaction do
       random_level_count = Random.rand(level_count)
       random_event_type_count.times do |type_id|
         event_type = app.event_type "seed-type-#{type_id}"
-        event_type.levels [0..random_level_count].map do |level_id|
+        event_type.levels [0...random_level_count].map do |level_id|
           "level-#{level_id}"
         end
       end


### PR DESCRIPTION
This is a quick fix for db seeding by removing the code that is failing and outdated.
The amount of data is also decreased. By default 10 example applications and max. 5 event types, that can have none or up to 5 levels each should be enough for testing.