### PR TITLE
Discard messages with missing keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,4 @@ gem 'resque'
 
 # Kafka connector
 gem 'racecar'
+gem 'resque-scheduler', :git => 'https://github.com/resque/resque-scheduler.git', :ref => 'bbf4930'

--- a/app/consumers/job_creator_consumer.rb
+++ b/app/consumers/job_creator_consumer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'notifications'
-require 'dispatcher'
 
 class JobCreatorConsumer < Racecar::Consumer
   subscribes_to Notifications::INCOMING_TOPIC
@@ -10,14 +9,6 @@ class JobCreatorConsumer < Racecar::Consumer
     message_value = kafka_message.value
     Rails.logger.debug("Received message: #{message_value}")
 
-    begin
-      message = Message.from_json(message_value)
-    rescue ArgumentError => e
-      Rails.logger.warn("Encountered #{e.inspect} when processing message #{message_value}, discarding.")
-      return
-    end
-
-    dispatcher = Dispatcher.new(message)
-    dispatcher.dispatch!
+    DispatchMessageJob.perform_later(message_value)
   end
 end

--- a/app/consumers/job_creator_consumer.rb
+++ b/app/consumers/job_creator_consumer.rb
@@ -10,7 +10,12 @@ class JobCreatorConsumer < Racecar::Consumer
     message_value = kafka_message.value
     Rails.logger.debug("Received message: #{message_value}")
 
-    message = Message.from_json(message_value)
+    begin
+      message = Message.from_json(message_value)
+    rescue ArgumentError => e
+      Rails.logger.warn("Encountered #{e.inspect} when processing message #{message_value}, discarding.")
+      return
+    end
 
     dispatcher = Dispatcher.new(message)
     dispatcher.dispatch!

--- a/app/jobs/dispatch_message_job.rb
+++ b/app/jobs/dispatch_message_job.rb
@@ -5,7 +5,7 @@ require 'dispatcher'
 
 class DispatchMessageJob < ApplicationJob
   retry_on(::Notifications::RecoverableError, wait: :exponentially_longer, attempts: 3) do |job, error|
-    Rails.logger.warn("Discarding message #{message} after too many retries for #{error.message}")
+    Rails.logger.warn("Discarding message #{job.message} after too many retries for #{error.message}")
   end
 
   def perform(message_hash)

--- a/app/jobs/dispatch_message_job.rb
+++ b/app/jobs/dispatch_message_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'notifications'
+require 'dispatcher'
+
+class DispatchMessageJob < ApplicationJob
+  retry_on(::Notifications::RecoverableError, wait: :exponentially_longer, attempts: 3) do |job, error|
+    Rails.logger.warn("Discarding message #{message} after too many retries for #{error.message}")
+  end
+
+  def perform(message_hash)
+    Rails.logger.debug("Received a message to dispatch: #{message_hash}")
+
+    begin
+      message = Message.from_json(message_hash)
+    rescue ArgumentError => e
+      raise ::Notifications::RecoverableError, e.inspect
+    end
+
+    dispatcher = ::Dispatcher.new(message)
+    dispatcher.dispatch!
+
+    Rails.logger.debug("Successfully dispatched message #{message}")
+  end
+
+  def message
+    arguments.first
+  end
+end

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -74,6 +74,22 @@ services:
     depends_on:
       - postgres
       - mcom-redis
+  resque-scheduler:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.rails
+    volumes:
+      - ..:/app
+    command: bin/rake environment resque:scheduler
+    environment:
+      REDIS_SERVICE_NAME: mcom-redis
+      REDIS_PASSWORD: redispass
+      MCOM_REDIS_SERVICE_HOST: mcom-redis
+    env_file:
+      - postgres.env
+    depends_on:
+      - postgres
+      - mcom-redis
   racecar:
     build:
       context: ..

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Resque tasks
 require 'resque/tasks'
 require 'resque/scheduler/tasks'

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,3 @@
+# Resque tasks
+require 'resque/tasks'
+require 'resque/scheduler/tasks'


### PR DESCRIPTION
Processing message with missing keys would raise an exception in the
consumer, which would cause the message to remain on the bus and be
processed over and over without actually being taken off the bus.

Fixes RHINOTIF-48