### PR TITLE
Remove `.inspect` from error responses

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -12,7 +12,7 @@ module ErrorHandling
       render :json => exception_hash(
         exception,
         status: :internal_server_error,
-        detail: "Server encountered an unexpected error: #{exception.inspect}"
+        detail: 'Server encountered an unexpected error'
       ), status: :internal_server_error
     end
 
@@ -35,7 +35,7 @@ module ErrorHandling
       render :json => exception_hash(
         exception,
         status: :bad_request,
-        detail: "Server cannot accept given parameters, reason: #{exception.inspect}"
+        detail: 'Server cannot accept given parameters'
       ), status: :bad_request
     end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ApplicationController do
     it 'responds with json error' do
       request.headers['X-RH-IDENTITY'] = encoded_header
       get :index
-      expect(response.body).to match(/Test exception/)
+      expect(response.body).to match(/Server encountered an unexpected error/)
     end
   end
 


### PR DESCRIPTION
The output of `.inspect` isn't properly rendered, since these traces are only useful for developers, who'll likely look for more information in logs, I think it's safe to remove it.