### PR TITLE
Remove production.log created when building image

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -3,3 +3,4 @@
 /usr/libexec/s2i/assemble
 
 RAILS_ENV=production bundle exec rake documentation:generate
+rm log/production.log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     env_file:
       - postgres.env
       - app.env
+    environment:
+      RAILS_LOG_TO_STDOUT: "true"
     ports:
       - 3000:3000
     depends_on:
@@ -73,6 +75,7 @@ services:
       REDIS_PASSWORD: redispass
       MCOM_REDIS_SERVICE_HOST: mcom-redis
       JOBS_PER_FORK: 50
+      RAILS_LOG_TO_STDOUT: "true"
     env_file:
       - postgres.env
     depends_on:
@@ -89,6 +92,7 @@ services:
       REDIS_SERVICE_NAME: mcom-redis
       REDIS_PASSWORD: redispass
       MCOM_REDIS_SERVICE_HOST: mcom-redis
+      RAILS_LOG_TO_STDOUT: "true"
     env_file:
       - postgres.env
     depends_on:
@@ -107,6 +111,7 @@ services:
       REDIS_SERVICE_NAME: mcom-redis
       REDIS_PASSWORD: redispass
       MCOM_REDIS_SERVICE_HOST: mcom-redis
+      RAILS_LOG_TO_STDOUT: "true"
     env_file:
       - postgres.env
     depends_on:


### PR DESCRIPTION
If we don't do this, the log file has incorrect permissions set
and the application can't log into it.

The error is:
```
Rails Error: Unable to access log file. Please ensure that /opt/app-root/src/log/production.log exists and is writable (ie, make it writable for user and group: chmod 0664 /opt/app-root/src/log/production.log). The log level has been raised to WARN and the output directed to STDERR until the problem is fixed.
```