### PR TITLE
Match the subtype case with the EndpointType values

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -40,8 +40,8 @@ public class Endpoint {
             property = "type",
             include = JsonTypeInfo.As.EXTERNAL_PROPERTY)
     @JsonSubTypes({
-            @JsonSubTypes.Type(value = WebhookAttributes.class, name = "webhook"),
-            @JsonSubTypes.Type(value = EmailAttributes.class, name = "email"),
+            @JsonSubTypes.Type(value = WebhookAttributes.class, name = "WEBHOOK"),
+            @JsonSubTypes.Type(value = EmailAttributes.class, name = "EMAIL"),
     })
     private Attributes properties;
 


### PR DESCRIPTION
I was getting:

```
com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'WEBHOOK' as a subtype of `com.redhat.cloud.notifications.models.Attributes`: known type ids = [email, webhook] (for POJO property 'properties') at [Source: (io.quarkus.vertx.http.runtime.VertxInputStream); line: 1, column: 186]
```

Server was expecting `webhook`, but the actual type is on upper case `WEBHOOK`