### PR TITLE
Set locale to EN for checkstyle messages.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -22,6 +22,7 @@
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
+    <property name="localeLanguage" value="en"/>
     <module name="FileTabCharacter">
         <property name="eachLine" value="true" />
     </module>


### PR DESCRIPTION
Makes filtering by message work globally.

This is after the discussion from #6 and closes #6.