### PR TITLE
Fix openapi path

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,7 @@ quarkus.datasource.reactive.url=vertx-reactive:postgresql://192.168.1.139:5432/n
 quarkus.flyway.migrate-at-start=true
 
 # OpenAPI path
-quarkus.smallrye-openapi.path=/api/notifications/v1.0/openapi.json
+quarkus.smallrye-openapi.path=/openapi.json
 
 quarkus.http.root-path=/api/notifications/v1.0
 


### PR DESCRIPTION
`quarkus.smallrye-openapi.path` uses `quarkus.http.root-path`, updating
it to have the openapi.json in:
`/api/notifications/v1.0/openapi.json`