### PR TITLE
 Change db name to notifications_backend to be more consistent with p…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,8 +12,8 @@ mp.messaging.incoming.ingress.value.deserializer=org.apache.kafka.common.seriali
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=hook
 quarkus.datasource.password=9FLK6cMm5px8vZ52
-quarkus.datasource.jdbc.url=jdbc:postgresql://192.168.1.139:5432/notifications
-quarkus.datasource.reactive.url=vertx-reactive:postgresql://192.168.1.139:5432/notifications
+quarkus.datasource.jdbc.url=jdbc:postgresql://192.168.1.139:5432/notifications_backend
+quarkus.datasource.reactive.url=vertx-reactive:postgresql://192.168.1.139:5432/notifications_backend
 
 # Flyway minimal config properties
 quarkus.flyway.migrate-at-start=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -5,8 +5,8 @@ quarkus.http.test-port=8084
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=hook
 quarkus.datasource.password=9FLK6cMm5px8vZ52
-quarkus.datasource.jdbc.url=jdbc:postgresql://192.168.1.139:5432/notifications
-quarkus.datasource.reactive.url=vertx-reactive:postgresql://192.168.1.139:5432/notifications
+quarkus.datasource.jdbc.url=jdbc:postgresql://192.168.1.139:5432/notifications_backend
+quarkus.datasource.reactive.url=vertx-reactive:postgresql://192.168.1.139:5432/notifications_backend
 
 # Flyway minimal config properties
 quarkus.flyway.migrate-at-start=true


### PR DESCRIPTION
…olicies.
 Hey Micke. Is this all the places to change to rename the database name to 'notifications-backend' ? 
For why see:  
   - https://github.com/RedHatInsights/e2e-deploy/pull/2248#issuecomment-691883466