### PR TITLE
Set Json type of Date's as string

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -39,9 +40,11 @@ public class Endpoint {
     private EndpointType type;
 
     // TODO JSON should be formatted based on the insights type, so ISO8601
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private Date created;
 
     // TODO JSON should be formatted based on the insights type, so ISO8601
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private Date updated;
 
     @Schema(oneOf = { WebhookAttributes.class, EmailAttributes.class })

--- a/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.vertx.core.json.JsonObject;
 
@@ -15,6 +16,7 @@ public class NotificationHistory {
 
     private long invocationTime;
     private boolean invocationResult;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private Date created;
     private JsonObject details;
 


### PR DESCRIPTION
The openapi.json specified the created/updated date were strings, but it was returning numbers.
I noticed the comment about the ISO8601 and changed the dates to be string.