### PR TITLE
 Add command to include pgcrypto in migrated configuration.

### DIFF
--- a/src/main/resources/db/migration/V1.0.0__notifications.sql
+++ b/src/main/resources/db/migration/V1.0.0__notifications.sql
@@ -20,7 +20,7 @@ SET row_security = off;
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
 --
 
--- CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 
 
 --


### PR DESCRIPTION
Current proposal is to attempt to include the 'pgcrypto' install as part of the migration definition. As this change should be idempotent, if we merge this change we will then need to confirm that it addresses the container instantiation issue without requiring elevated permissions for OSDv4.