### PR TITLE
Remove "Response" object from openapi

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -69,6 +69,7 @@ public class NotificationService {
 
     @DELETE
     @Path("/{id}")
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> markRead(@Context SecurityContext sec, Integer id) {
         // Mark the notification id for <tenantId><userId> 's subscription as read
         return Uni.createFrom().nullItem();
@@ -106,6 +107,7 @@ public class NotificationService {
     @DELETE
     @Path("/eventTypes/{eventTypeId}/{endpointId}")
     @RolesAllowed("write")
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> unlinkEndpointFromEventType(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId, @PathParam("eventTypeId") Integer eventTypeId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.unlinkEndpoint(principal.getAccount(), endpointId, eventTypeId)
@@ -130,6 +132,7 @@ public class NotificationService {
 
     @PUT
     @Path("/defaults/{endpointId}")
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> addEndpointToDefaults(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.addEndpointToDefaults(principal.getAccount(), endpointId)
@@ -138,6 +141,7 @@ public class NotificationService {
 
     @DELETE
     @Path("/defaults/{endpointId}")
+    @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> deleteEndpointFromDefaults(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.deleteEndpointFromDefaults(principal.getAccount(), endpointId)


### PR DESCRIPTION
By specifying the schema as string for empty responses.