### PR TITLE
Another try to log Rbac-failures. 

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/auth/RbacClientResponseFilter.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/RbacClientResponseFilter.java
@@ -1,0 +1,26 @@
+package com.redhat.cloud.notifications.auth;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+/**
+ * Filter to look at the response (code) from the Rbac server.
+ * Log a warning if we have trouble reaching the server.
+ */
+public class RbacClientResponseFilter implements ClientResponseFilter {
+
+    private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
+        Response.StatusType statusInfo = responseContext.getStatusInfo();
+        int status = statusInfo.getStatusCode();
+        if (status != 200) {
+            log.warning("Call to the Rbac server failed with code " + status + ", " + statusInfo.getReasonPhrase());
+        }
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/auth/RbacRestClientRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/RbacRestClientRequestFilter.java
@@ -1,0 +1,34 @@
+package com.redhat.cloud.notifications.auth;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Base64;
+
+/**
+ * Filter to optionally add data on outgoing requests to the RBAC service.
+ * This is meant for local development and not production.
+ */
+public class RbacRestClientRequestFilter implements ClientRequestFilter {
+
+    private String authInfo;
+
+    public RbacRestClientRequestFilter() {
+        String tmp = System.getProperty("develop.exceptional.user.auth.info");
+        if (tmp != null && !tmp.isEmpty()) {
+            authInfo = Base64.getEncoder().encodeToString(tmp.getBytes());
+        }
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+
+        if (authInfo != null) {
+            URI uri = requestContext.getUri();
+            if (uri.toString().startsWith("https://ci.cloud.redhat.com")) {
+                requestContext.getHeaders().putSingle("Authorization", "Basic " + authInfo);
+            }
+        }
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/auth/RbacServer.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/RbacServer.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.auth;
 
 import io.quarkus.cache.CacheResult;
 import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import javax.ws.rs.Consumes;
@@ -13,6 +14,8 @@ import javax.ws.rs.QueryParam;
 
 @Path("/api/rbac/v1")
 @RegisterRestClient(configKey = "rbac")
+@RegisterProvider(RbacRestClientRequestFilter.class)
+@RegisterProvider(RbacClientResponseFilter.class)
 public interface RbacServer {
 
     @GET

--- a/src/test/java/com/redhat/cloud/notifications/openapi/OpenApiTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/openapi/OpenApiTest.java
@@ -63,7 +63,7 @@ public class OpenApiTest {
                 .when()
                 .get(badUrl)
                 .then()
-                .statusCode(404);
+                .statusCode(401); // We do credential checks before path check.
     }
 
     @Test

--- a/src/test/java/com/redhat/cloud/notifications/routers/AuthenticationTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/AuthenticationTest.java
@@ -33,12 +33,12 @@ public class AuthenticationTest {
         String identityHeaderValue = TestHelpers.encodeIdentityInfo(tenant, userName);
         Header identityHeader = TestHelpers.createIdentityHeader(identityHeaderValue);
 
-        // Fetch endpoint without any Rbac details - errors cause 403
+        // Fetch endpoint without any Rbac details - errors cause 401 -- unauthorized
         given()
                 // Don't set the header at all
                 .when().get("/endpoints")
                 .then()
-                .statusCode(403);
+                .statusCode(401);
 
         // Fetch endpoint without any Rbac details - errors cause 401
         given()


### PR DESCRIPTION
Also be more explicit about dealing with missing x-rh-id header.

This also adds the `-Ddevelop.exceptional.user.auth.info` property like for policies-ui-backend.