### PR TITLE
Fix instant email body

### DIFF
--- a/src/main/resources/templates/Policies/instantEmailBody.html
+++ b/src/main/resources/templates/Policies/instantEmailBody.html
@@ -61,7 +61,7 @@
                                                 {#with params.triggers}
                                                     {#for key in keySet}
                                                     <tr style="font-size: 14px;">
-                                                        <td style="padding:10px 10px;border: 1px solid #f5f5f5;"><a href="https://cloud.redhat.com/insights/policies/policy/{key}" target="_blank">{get(key)}</a></td>
+                                                        <td style="padding:10px 10px;border: 1px solid #f5f5f5;"><a href="https://cloud.redhat.com/insights/policies/policy/{key}" target="_blank">{params.triggers.get(key)}</a></td>
                                                     </tr>
                                                     {/for}
                                                 {/with}

--- a/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
@@ -192,7 +192,7 @@ public class EmailTest {
         for (String key : triggers.keySet()) {
             String value = triggers.get(key);
             assertTrue(bodyRequest.contains(key), "Body should contain trigger key" + key);
-            assertTrue(bodyRequest.contains(key), "Body should contain trigger value" + value);
+            assertTrue(bodyRequest.contains(value), "Body should contain trigger value" + value);
         }
 
         // Display name

--- a/src/test/java/com/redhat/cloud/notifications/templates/TestPoliciesTemplate.java
+++ b/src/test/java/com/redhat/cloud/notifications/templates/TestPoliciesTemplate.java
@@ -1,0 +1,68 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.ingress.Tag;
+import io.quarkus.test.junit.QuarkusTest;
+import org.joda.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestPoliciesTemplate {
+
+    @Test
+    public void testInstantEmailTitle() {
+        List<Tag> tags = new ArrayList<Tag>();
+        tags.add(Tag.newBuilder().setName("display_name").setValue("FooMachine").build());
+
+        Map<String, String> triggers = new HashMap<>();
+        triggers.put("abcd-efghi-jkl-lmn", "Foobar");
+        triggers.put("0123-456-789-5721f", "Latest foo is installed");
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("triggers", triggers);
+
+        String result = Policies.Templates.instantEmailTitle()
+                .data("params", params)
+                .data("tags", tags)
+                .data("timestamp", new LocalDateTime())
+                .render();
+
+        assertTrue(result.contains("2"), "Title contains the number of policies triggered");
+        assertTrue(result.contains("FooMachine"), "Body should contain the display_name");
+    }
+
+    @Test
+    public void testInstantEmailBody() {
+
+        List<Tag> tags = new ArrayList<Tag>();
+        tags.add(Tag.newBuilder().setName("display_name").setValue("FooMachine").build());
+
+        Map<String, String> triggers = new HashMap<>();
+        triggers.put("abcd-efghi-jkl-lmn", "Foobar");
+        triggers.put("0123-456-789-5721f", "Latest foo is installed");
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("triggers", triggers);
+
+        String result = Policies.Templates.instantEmailBody()
+                .data("params", params)
+                .data("tags", tags)
+                .data("timestamp", new LocalDateTime())
+                .render();
+
+        for (String key : triggers.keySet()) {
+            String value = triggers.get(key);
+            assertTrue(result.contains(key), "Body should contain trigger key '" + key + "'");
+            assertTrue(result.contains(value), "Body should contain trigger value '" + value + "'");
+        }
+
+        // Display name
+        assertTrue(result.contains("FooMachine"), "Body should contain the display_name");
+    }
+}


### PR DESCRIPTION
 - Adds the triggered policy name

Before:

![Screenshot_2020-11-26_13-37-02](https://user-images.githubusercontent.com/3845764/100389252-88e17480-2ff2-11eb-8852-25767c38e981.png)

After:

![Screenshot_2020-11-26_14-16-37](https://user-images.githubusercontent.com/3845764/100389263-8da62880-2ff2-11eb-90a8-c8d266601c84.png)
