### PR TITLE
NOTIF-69 Separate RBAC for Notifications and Integrations.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,16 @@
             <version>${openapi-parser.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/redhat/cloud/notifications/auth/RbacIdentityProvider.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/RbacIdentityProvider.java
@@ -21,8 +21,8 @@ public class RbacIdentityProvider implements IdentityProvider<RhIdentityAuthenti
 
     public static final String RBAC_READ_NOTIFICATIONS = "read:notifications";
     public static final String RBAC_WRITE_NOTIFICATIONS = "write:notifications";
-    public static final String RBAC_READ_INTEGRATIONS = "read:integrations";
-    public static final String RBAC_WRITE_INTEGRATIONS = "write:integrations";
+    public static final String RBAC_READ_INTEGRATIONS_ENDPOINTS = "read:integrations_ep";
+    public static final String RBAC_WRITE_INTEGRATIONS_ENDPOINTS = "write:integrations_ep";
     private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
 
     @Inject
@@ -55,11 +55,11 @@ public class RbacIdentityProvider implements IdentityProvider<RhIdentityAuthenti
                     if (raw.canWrite("notifications")) {
                         builder.addRole(RBAC_WRITE_NOTIFICATIONS);
                     }
-                    if (raw.canRead("integrations")) {
-                        builder.addRole(RBAC_READ_INTEGRATIONS);
+                    if (raw.canRead("integrations", "endpoints")) {
+                        builder.addRole(RBAC_READ_INTEGRATIONS_ENDPOINTS);
                     }
-                    if (raw.canWrite("integrations")) {
-                        builder.addRole(RBAC_WRITE_INTEGRATIONS);
+                    if (raw.canWrite("integrations", "endpoints")) {
+                        builder.addRole(RBAC_WRITE_INTEGRATIONS_ENDPOINTS);
                     }
 
                     return (SecurityIdentity) builder.build();

--- a/src/main/java/com/redhat/cloud/notifications/auth/RbacRaw.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/RbacRaw.java
@@ -8,27 +8,35 @@ public class RbacRaw {
     public Map<String, Integer> meta;
     public List<Map<String, Object>> data;
 
-    public boolean canRead(String path) {
-        return findPermission(path, "read");
+    public boolean canRead(String application) {
+        return findPermission(application, "read");
     }
 
-    public boolean canWrite(String path) {
-        return findPermission(path, "write");
+    public boolean canRead(String application, String item) {
+        return findPermission(application, item, "read");
     }
 
-    public boolean canReadAll() {
-        return canRead("*");
+    public boolean canWrite(String application) {
+        return findPermission(application, "write");
     }
 
-    public boolean canWriteAll() {
-        return canWrite("*");
+    public boolean canWrite(String application, String item) {
+        return findPermission(application, item, "write");
     }
 
-    public boolean canDo(String path, String permission) {
-        return findPermission(path, permission);
+    public boolean canDo(String application, String permission) {
+        return findPermission(application, permission);
     }
 
-    private boolean findPermission(String path, String what) {
+    public boolean canDo(String application, String item, String permission) {
+        return findPermission(application, item, permission);
+    }
+
+    private boolean findPermission(String application, String what) {
+        return findPermission(application, "*", what);
+    }
+
+    private boolean findPermission(String application, String item, String what) {
         if (data == null || data.size() == 0) {
             return false;
         }
@@ -38,9 +46,11 @@ public class RbacRaw {
             if (fields.length < 3) {
                 return false;
             }
-            if (fields[1].equals(path)) {
-                if (fields[2].equals(what) || fields[2].equals("*")) {
-                    return true;
+            if (fields[0].equals(application)) {
+                if (fields[1].equals(item) || fields[1].equals("*")) {
+                    if (fields[2].equals(what) || fields[2].equals("*")) {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -63,7 +63,7 @@ public class EndpointService {
     EndpointEmailSubscriptionResources emailSubscriptionResources;
 
     @GET
-    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
     @Parameters({
             @Parameter(
                     name = "limit",
@@ -101,7 +101,7 @@ public class EndpointService {
     }
 
     @POST
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public Uni<Endpoint> createEndpoint(@Context SecurityContext sec, @NotNull @Valid Endpoint endpoint) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         endpoint.setTenant(principal.getAccount());
@@ -122,7 +122,7 @@ public class EndpointService {
 
     @GET
     @Path("/{id}")
-    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
     public Uni<Endpoint> getEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.getEndpoint(principal.getAccount(), id)
@@ -131,7 +131,7 @@ public class EndpointService {
 
     @DELETE
     @Path("/{id}")
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -142,7 +142,7 @@ public class EndpointService {
 
     @PUT
     @Path("/{id}/enable")
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -152,7 +152,7 @@ public class EndpointService {
 
     @DELETE
     @Path("/{id}/enable")
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -162,7 +162,7 @@ public class EndpointService {
 
     @PUT
     @Path("/{id}")
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> updateEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id, @NotNull @Valid Endpoint endpoint) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -174,7 +174,7 @@ public class EndpointService {
 
     @GET
     @Path("/{id}/history")
-    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
     public Multi<NotificationHistory> getEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID id) {
         // TODO We need globally limitations (Paging support and limits etc)
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -183,7 +183,7 @@ public class EndpointService {
 
     @GET
     @Path("/{id}/history/{history_id}/details")
-    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
     @Parameters({
             @Parameter(
                     name = "pageSize",
@@ -214,7 +214,7 @@ public class EndpointService {
 
     @PUT
     @Path("/email/subscription/instant")
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public Uni<Boolean> subscribeInstantEmail(@Context SecurityContext sec) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return emailSubscriptionResources.subscribe(
@@ -226,7 +226,7 @@ public class EndpointService {
 
     @DELETE
     @Path("/email/subscription/instant")
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public Uni<Boolean> unsubscribeInstantEmail(@Context SecurityContext sec) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return emailSubscriptionResources.unsubscribe(
@@ -238,7 +238,7 @@ public class EndpointService {
 
     @PUT
     @Path("/email/subscription/daily")
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public Uni<Boolean> subscribeDailyEmail(@Context SecurityContext sec) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return emailSubscriptionResources.subscribe(
@@ -250,7 +250,7 @@ public class EndpointService {
 
     @DELETE
     @Path("/email/subscription/daily")
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public Uni<Boolean> unsubscribeDailyEmail(@Context SecurityContext sec) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return emailSubscriptionResources.unsubscribe(

--- a/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.Constants;
+import com.redhat.cloud.notifications.auth.RbacIdentityProvider;
 import com.redhat.cloud.notifications.auth.RhIdPrincipal;
 import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.EndpointResources;
@@ -62,7 +63,7 @@ public class EndpointService {
     EndpointEmailSubscriptionResources emailSubscriptionResources;
 
     @GET
-    @RolesAllowed("read")
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS)
     @Parameters({
             @Parameter(
                     name = "limit",
@@ -100,7 +101,7 @@ public class EndpointService {
     }
 
     @POST
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
     public Uni<Endpoint> createEndpoint(@Context SecurityContext sec, @NotNull @Valid Endpoint endpoint) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         endpoint.setTenant(principal.getAccount());
@@ -121,7 +122,7 @@ public class EndpointService {
 
     @GET
     @Path("/{id}")
-    @RolesAllowed("read")
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS)
     public Uni<Endpoint> getEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.getEndpoint(principal.getAccount(), id)
@@ -130,7 +131,7 @@ public class EndpointService {
 
     @DELETE
     @Path("/{id}")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -141,7 +142,7 @@ public class EndpointService {
 
     @PUT
     @Path("/{id}/enable")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -151,7 +152,7 @@ public class EndpointService {
 
     @DELETE
     @Path("/{id}/enable")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -161,7 +162,7 @@ public class EndpointService {
 
     @PUT
     @Path("/{id}")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> updateEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id, @NotNull @Valid Endpoint endpoint) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -173,7 +174,7 @@ public class EndpointService {
 
     @GET
     @Path("/{id}/history")
-    @RolesAllowed("read")
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS)
     public Multi<NotificationHistory> getEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID id) {
         // TODO We need globally limitations (Paging support and limits etc)
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -182,7 +183,7 @@ public class EndpointService {
 
     @GET
     @Path("/{id}/history/{history_id}/details")
-    @RolesAllowed("read")
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS)
     @Parameters({
             @Parameter(
                     name = "pageSize",
@@ -213,7 +214,7 @@ public class EndpointService {
 
     @PUT
     @Path("/email/subscription/instant")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
     public Uni<Boolean> subscribeInstantEmail(@Context SecurityContext sec) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return emailSubscriptionResources.subscribe(
@@ -225,7 +226,7 @@ public class EndpointService {
 
     @DELETE
     @Path("/email/subscription/instant")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
     public Uni<Boolean> unsubscribeInstantEmail(@Context SecurityContext sec) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return emailSubscriptionResources.unsubscribe(
@@ -237,7 +238,7 @@ public class EndpointService {
 
     @PUT
     @Path("/email/subscription/daily")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
     public Uni<Boolean> subscribeDailyEmail(@Context SecurityContext sec) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return emailSubscriptionResources.subscribe(
@@ -249,7 +250,7 @@ public class EndpointService {
 
     @DELETE
     @Path("/email/subscription/daily")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS)
     public Uni<Boolean> unsubscribeDailyEmail(@Context SecurityContext sec) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return emailSubscriptionResources.unsubscribe(

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.Constants;
+import com.redhat.cloud.notifications.auth.RbacIdentityProvider;
 import com.redhat.cloud.notifications.auth.RhIdPrincipal;
 import com.redhat.cloud.notifications.db.ApplicationResources;
 import com.redhat.cloud.notifications.db.EndpointResources;
@@ -12,6 +13,7 @@ import com.redhat.cloud.notifications.models.Notification;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.Vertx;
+import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -89,14 +91,14 @@ public class NotificationService {
 
     @GET
     @Path("/eventTypes")
-    @RolesAllowed("read")
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public Multi<EventType> getEventTypes(@BeanParam Query query, @QueryParam("applicationIds") Set<UUID> applicationIds) {
         return apps.getEventTypes(query, applicationIds);
     }
 
     @PUT
     @Path("/eventTypes/{eventTypeId}/{endpointId}")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> linkEndpointToEventType(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId, @PathParam("eventTypeId") Integer eventTypeId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -106,7 +108,7 @@ public class NotificationService {
 
     @DELETE
     @Path("/eventTypes/{eventTypeId}/{endpointId}")
-    @RolesAllowed("write")
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> unlinkEndpointFromEventType(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId, @PathParam("eventTypeId") Integer eventTypeId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -116,7 +118,7 @@ public class NotificationService {
 
     @GET
     @Path("/eventTypes/{eventTypeId}")
-    @RolesAllowed("read")
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public Multi<Endpoint> getLinkedEndpoints(@Context SecurityContext sec, @PathParam("eventTypeId") Integer eventTypeId, @BeanParam Query query) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.getLinkedEndpoints(principal.getAccount(), eventTypeId, query);
@@ -124,7 +126,8 @@ public class NotificationService {
 
     @GET
     @Path("/defaults")
-    @RolesAllowed("read")
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_NOTIFICATIONS)
+    @Operation(summary = "Retrieve all integrations of the configured default actions.")
     public Multi<Endpoint> getEndpointsForDefaults(@Context SecurityContext sec) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.getDefaultEndpoints(principal.getAccount());
@@ -132,6 +135,7 @@ public class NotificationService {
 
     @PUT
     @Path("/defaults/{endpointId}")
+    @Operation(summary = "Add an integration to the list of configured default actions.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> addEndpointToDefaults(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -141,6 +145,7 @@ public class NotificationService {
 
     @DELETE
     @Path("/defaults/{endpointId}")
+    @Operation(summary = "Remove an integration from the list of configured default actions.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> deleteEndpointFromDefaults(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
@@ -150,6 +155,7 @@ public class NotificationService {
 
     @GET
     @Path("/facets/applications")
+    @Operation(summary = "Return a thin list of configured applications. This can be used to configure a filter in the UI")
     public Multi<ApplicationFacet> getApplicationsFacets(@Context SecurityContext sec) {
         return apps.getApplications().onItem().transform(a -> new ApplicationFacet(a.getName(), a.getId().toString()));
     }

--- a/src/test/java/com/redhat/cloud/notifications/MockServerClientConfig.java
+++ b/src/test/java/com/redhat/cloud/notifications/MockServerClientConfig.java
@@ -34,7 +34,7 @@ public class MockServerClientConfig {
         this.mockServerClient
                 .when(request()
                         .withPath("/api/rbac/v1/access/")
-                        .withQueryStringParameter("application", "notifications")
+                        .withQueryStringParameter("application", "notifications,integrations")
                         .withHeader(RHIdentityAuthMechanism.IDENTITY_HEADER, xRhIdentity)
                 )
                 .respond(response()

--- a/src/test/java/com/redhat/cloud/notifications/RbacParsingTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/RbacParsingTest.java
@@ -50,7 +50,8 @@ public class RbacParsingTest {
         assert rbac.canRead("notifications");
         assert !rbac.canRead("dummy");
         assert rbac.canWrite("notifications");
-        assert rbac.canWrite("integrations");
+        assert rbac.canWrite("integrations", "endpoints");
+        assert rbac.canWrite("integrations", "does-not-exist");
         assert !rbac.canWrite("dummy");
     }
 
@@ -76,11 +77,16 @@ public class RbacParsingTest {
         RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
 
         assert !rbac.canRead("notifications");
-        assert rbac.canRead("integrations", "dummy");
-        assert rbac.canRead("integrations");
         assert !rbac.canWrite("notifications");
         assert rbac.canDo("notifications", "execute");
-        assert rbac.canDo("integrations", "read");
+
+        assert rbac.canRead("integrations", "endpoints");
+        assert !rbac.canWrite("integrations", "endpoints");
+        // We have no * item
+        assert !rbac.canRead("integrations");
+        assert !rbac.canWrite("integrations");
+
+        assert !rbac.canDo("integrations", "read");
         assert !rbac.canDo("integrations", "execute");
         assert rbac.canDo("integrations", "admin", "execute");
     }

--- a/src/test/java/com/redhat/cloud/notifications/RbacParsingTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/RbacParsingTest.java
@@ -1,0 +1,87 @@
+package com.redhat.cloud.notifications;
+
+import com.redhat.cloud.notifications.auth.RbacRaw;
+import org.junit.jupiter.api.Test;
+
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
+/**
+ * Test RBAC parsing.
+ * Brought over from policies-ui-backend and extended
+ */
+public class RbacParsingTest {
+
+    private static final String BASE = "src/test/resources/rbac-examples/";
+
+    @Test
+    void testParseExample() throws Exception {
+        File file = new File(BASE + "rbac_example.json");
+        Jsonb jb = JsonbBuilder.create();
+        RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
+        assert rbac.data.size() == 2;
+
+        assert rbac.canWrite("bar", "resname");
+        assert !rbac.canRead("resname");
+        assert !rbac.canWrite("*");
+        assert !rbac.canWrite("no-perm");
+
+    }
+
+    @Test
+    void testNoAccess() throws Exception {
+        File file = new File(BASE + "rbac_example_no_access.json");
+        Jsonb jb = JsonbBuilder.create();
+        RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
+
+        assert !rbac.canRead("*");
+        assert !rbac.canWrite("*");
+    }
+
+    @Test
+    void testFullAccess() throws Exception {
+        File file = new File(BASE + "rbac_example_full_access.json");
+        Jsonb jb = JsonbBuilder.create();
+        RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
+
+        assert rbac.canRead("notifications");
+        assert !rbac.canRead("dummy");
+        assert rbac.canWrite("notifications");
+        assert rbac.canWrite("integrations");
+        assert !rbac.canWrite("dummy");
+    }
+
+    @Test
+    void testPartialAccess() throws FileNotFoundException {
+        File file = new File(BASE + "rbac_example_partial_access.json");
+        Jsonb jb = JsonbBuilder.create();
+        RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
+
+        assert rbac.canRead("policies");
+        assert !rbac.canRead("dummy");
+        assert !rbac.canWrite("policies");
+        assert !rbac.canWrite("dummy");
+        assert rbac.canDo("policies", "execute");
+        assert rbac.canDo("policies", "*", "execute");
+        assert !rbac.canDo("policies", "*", "list");
+    }
+
+    @Test
+    void testTwoApps() throws FileNotFoundException {
+        File file = new File(BASE + "rbac_example_two_apps1.json");
+        Jsonb jb = JsonbBuilder.create();
+        RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
+
+        assert !rbac.canRead("notifications");
+        assert rbac.canRead("integrations", "dummy");
+        assert rbac.canRead("integrations");
+        assert !rbac.canWrite("notifications");
+        assert rbac.canDo("notifications", "execute");
+        assert rbac.canDo("integrations", "read");
+        assert !rbac.canDo("integrations", "execute");
+        assert rbac.canDo("integrations", "admin", "execute");
+    }
+}

--- a/src/test/resources/rbac-examples/rbac_example_two_apps1.json
+++ b/src/test/resources/rbac-examples/rbac_example_two_apps1.json
@@ -16,7 +16,7 @@
       "resourceDefinitions": []
     },
     {
-      "permission": "integrations:*:read",
+      "permission": "integrations:endpoints:read",
       "resourceDefinitions": []
     },
     {

--- a/src/test/resources/rbac-examples/rbac_example_two_apps1.json
+++ b/src/test/resources/rbac-examples/rbac_example_two_apps1.json
@@ -12,11 +12,15 @@
   },
   "data": [
     {
-      "permission": "notifications:*:*",
+      "permission": "notifications:*:execute",
       "resourceDefinitions": []
     },
     {
-      "permission": "integrations:*:*",
+      "permission": "integrations:*:read",
+      "resourceDefinitions": []
+    },
+    {
+      "permission": "integrations:admin:execute",
       "resourceDefinitions": []
     }
   ]


### PR DESCRIPTION
This queries the RBAC server for both notifications and integrations data and then sets the roles accordingly.

The RBAC-server needs a configuration for integrations before this can be deployed.