### PR TITLE
Close DB-connections after health-checking

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/routers/LivenessService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/LivenessService.java
@@ -2,11 +2,14 @@ package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.StuffHolder;
 import io.r2dbc.postgresql.api.PostgresqlConnection;
+import io.r2dbc.postgresql.api.PostgresqlResult;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
+import reactor.core.publisher.Flux;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -39,10 +42,16 @@ public class LivenessService implements HealthCheck {
 
     Uni<Boolean> postgresConnectionHealth() {
         return connectionPublisherUni.toMulti()
-                .onItem().transform(conn -> conn.createStatement("SELECT COUNT(1)").execute())
-                .flatMap(flux -> flux
-                        .flatMap(postgresqlResult -> postgresqlResult.map((row, rowMetadata) -> true)))
-                .toUni()
+                .onItem().transformToMulti(c -> Multi.createFrom().resource(() -> c,
+                        c2 -> {
+                            Flux<PostgresqlResult> execute = c2.createStatement("SELECT COUNT(1)").execute();
+
+                            return execute.flatMap(postgresqlResult -> postgresqlResult.map((row, rowMetadata) -> true));
+                        })
+                        .withFinalizer(postgresqlConnection -> {
+                            postgresqlConnection.close().subscribe();
+                        }))
+                .merge().toUni()
                 .onFailure().recoverWithItem(false);
     }
 
@@ -51,11 +60,12 @@ public class LivenessService implements HealthCheck {
 
         boolean adminDown = StuffHolder.getInstance().isAdminDown();
 
-        HealthCheckResponseBuilder response = HealthCheckResponse.named("Notifications Engine readiness check");
+        HealthCheckResponseBuilder response = HealthCheckResponse.named("Notifications readiness check");
         if (adminDown) {
             response.down().withData("status", "admin-down");
         } else {
-            response.state(postgresConnectionHealth().await().indefinitely());
+            boolean dbState = postgresConnectionHealth().await().indefinitely();
+            response.state(dbState).withData("reactive-db-check", dbState);
         }
 
         return response.build();

--- a/src/main/java/com/redhat/cloud/notifications/routers/LivenessService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/LivenessService.java
@@ -8,14 +8,14 @@ import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
-import org.eclipse.microprofile.health.Readiness;
+import org.eclipse.microprofile.health.Liveness;
 import reactor.core.publisher.Flux;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 @ApplicationScoped
-@Readiness
+@Liveness
 public class LivenessService implements HealthCheck {
 
 //    @Inject

--- a/src/test/java/com/redhat/cloud/notifications/routers/HealthCheckTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/HealthCheckTest.java
@@ -1,12 +1,13 @@
 package com.redhat.cloud.notifications.routers;
 
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.when;
 import static io.restassured.RestAssured.with;
 import static org.hamcrest.Matchers.in;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Health checks and admin-down from admin-interface
@@ -16,13 +17,18 @@ public class HealthCheckTest {
 
     @Test
     void testNormalHealth() {
+        normalHealthCheck();
+    }
+
+    private String normalHealthCheck() {
         String body =
                 when()
                         .get("/health")
                         .then()
                         .statusCode(in(new Integer[]{200, 503})) // may be 503 as there is no Kafka we can talk to
                         .extract().asString();
-        Assertions.assertFalse(body.contains("admin-down"));
+        assertFalse(body.contains("admin-down"));
+        return body;
     }
 
     @Test
@@ -44,7 +50,7 @@ public class HealthCheckTest {
                             .then()
                             .statusCode(503)
                             .extract().asString();
-            Assertions.assertTrue(body.contains("admin-down"));
+            assertTrue(body.contains("admin-down"));
         } finally {
             with()
                     .queryParam("status", "ok")
@@ -54,6 +60,15 @@ public class HealthCheckTest {
                     .post("/admin/status")
                     .then()
                     .statusCode(200);
+        }
+    }
+
+    // Make sure we don't leak connections here
+    @Test
+    void testRepeatedHealth() {
+        for (int i = 0; i < 150; i++) {
+            String body = normalHealthCheck();
+            assertTrue(body.contains("\"reactive-db-check\": true"));
         }
     }
 }

--- a/src/test/java/com/redhat/cloud/notifications/routers/HealthCheckTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/HealthCheckTest.java
@@ -44,8 +44,6 @@ public class HealthCheckTest {
                             .then()
                             .statusCode(503)
                             .extract().asString();
-            System.out.println(body);
-            System.out.flush();
             Assertions.assertTrue(body.contains("admin-down"));
         } finally {
             with()


### PR DESCRIPTION
If we don't close them, we leak connections and deplete the pool.