### PR TITLE
Test EndpointType order is not changed

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -15,6 +15,9 @@ import java.util.UUID;
 
 public class Endpoint {
 
+    // Add new values to the bottom of the enum
+    // The ordinal order must remain the same as is used internally
+    // Update test com.redhat.cloud.notifications.models.TestEndpointType to reflect any new enum value
     @Schema(enumeration = { "webhook", "email_subscription", "default" })
     public enum EndpointType {
         @JsonProperty("webhook")

--- a/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -18,11 +18,11 @@ public class Endpoint {
     @Schema(enumeration = { "webhook", "email_subscription", "default" })
     public enum EndpointType {
         @JsonProperty("webhook")
-        WEBHOOK,
+        WEBHOOK, // 0
         @JsonProperty("email_subscription")
-        EMAIL_SUBSCRIPTION,
+        EMAIL_SUBSCRIPTION, // 1
         @JsonProperty("default")
-        DEFAULT
+        DEFAULT // 2
     }
 
     private UUID id; // Should be UUID

--- a/src/test/java/com/redhat/cloud/notifications/models/TestEndpointType.java
+++ b/src/test/java/com/redhat/cloud/notifications/models/TestEndpointType.java
@@ -1,0 +1,26 @@
+package com.redhat.cloud.notifications.models;
+
+import com.redhat.cloud.notifications.models.Endpoint.EndpointType;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class TestEndpointType {
+
+    @Test
+    void endpointTypeWebhookIs0() {
+        assertEquals(0, EndpointType.WEBHOOK.ordinal());
+    }
+
+    @Test
+    void endpointTypeEmailSubscriptionIs1() {
+        assertEquals(1, EndpointType.EMAIL_SUBSCRIPTION.ordinal());
+    }
+
+    @Test
+    void endpointTypeDefaultIs2() {
+        assertEquals(2, EndpointType.DEFAULT.ordinal());
+    }
+}


### PR DESCRIPTION
Something I noticed, we need to be careful with the EndpointType enum, and always add new entries at the end of it. The ordinal number is the one stored in the db as "endpoint_type".