### PR TITLE
NOTIF-116 Introduce Bundles

### DIFF
--- a/helpers/create_application.py
+++ b/helpers/create_application.py
@@ -1,0 +1,29 @@
+import requests
+import helpers
+
+base_url = "http://localhost:8085"
+tp_part = ""  # set to /api/notifications if going via TurnPike
+
+helpers.set_path_prefix(base_url + tp_part)
+
+# Parameters to set
+bundle_name = "ABundle"
+bundle_description = "My Bundle"
+app_name = "my-app"
+app_display_name = "My application"
+event_type = "ET1"
+event_type_display_name = "First Event Type"
+
+
+
+# ---
+# Add the application
+
+print(">>> create bundle")
+bundle_id = helpers.add_bundle("my-bundle", "My Bundle")
+
+print(">>> create application")
+app_id = helpers.add_application(app_name, app_display_name, bundle_id)
+
+print(">>> add eventType to application")
+helpers.add_event_type(app_id, event_type, event_type_display_name)

--- a/helpers/create_application.py
+++ b/helpers/create_application.py
@@ -7,7 +7,7 @@ tp_part = ""  # set to /api/notifications if going via TurnPike
 helpers.set_path_prefix(base_url + tp_part)
 
 # Parameters to set
-bundle_name = "ABundle"
+bundle_name = "a-bundle"
 bundle_description = "My Bundle"
 app_name = "my-app"
 app_display_name = "My application"
@@ -20,10 +20,10 @@ event_type_display_name = "First Event Type"
 # Add the application
 
 print(">>> create bundle")
-bundle_id = helpers.add_bundle("my-bundle", "My Bundle")
+bundle_id = helpers.add_bundle(bundle_name, bundle_description)
 
 print(">>> create application")
-app_id = helpers.add_application(app_name, app_display_name, bundle_id)
+app_id = helpers.add_application(app_name, app_display_name, bundle_name)
 
 print(">>> add eventType to application")
 helpers.add_event_type(app_id, event_type, event_type_display_name)

--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -8,34 +8,37 @@ def set_path_prefix(base_path):
     bundles_prefix = base_path + "/internal/bundles"
 
 
-def find_application(name):
+def find_application(app_name, bundle_name):
     """Find an application by name and return its UUID or return None
     :param name: Name of the application
     """
-    r = requests.get(applications_prefix)
+    r = requests.get(applications_prefix + "?bundleName=" + bundle_name)
     if r.status_code != 200:
         return None
 
     j = r.json()
     for app in j:
-        if app["name"] == name:
+        if app["name"] == app_name:
             return app["id"]
 
     return None
 
-def add_application(name, display_name, bundle_id):
+
+def add_application(name, display_name, bundle_name):
     """Adds an application if it does not yet exist
-    :param bundle_id:
+    :param bundle_name: name of the bundle we add the application to
     :param name: Name of the application, [a-z0-9-]+
     :param display_name: Display name of the application
     """
 
     # First try to find it.
-    ret = find_application(name)
+    ret = find_application(name,bundle_name)
     if ret is not None:
         return ret
 
-    # It does not yet exist, so try to create
+    bundle_id = find_bundle(bundle_name)
+
+    # The app does not yet exist, so try to create
     app_json = {"name": name,
                 "display_name": display_name,
                 "bundle_id": bundle_id}

--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -1,0 +1,130 @@
+import requests
+
+
+def set_path_prefix(base_path):
+    global applications_prefix
+    global bundles_prefix
+    applications_prefix = base_path + "/internal/applications"
+    bundles_prefix = base_path + "/internal/bundles"
+
+
+def find_application(name):
+    """Find an application by name and return its UUID or return None
+    :param name: Name of the application
+    """
+    r = requests.get(applications_prefix)
+    if r.status_code != 200:
+        return None
+
+    j = r.json()
+    for app in j:
+        if app["name"] == name:
+            return app["id"]
+
+    return None
+
+def add_application(name, display_name, bundle_id):
+    """Adds an application if it does not yet exist
+    :param bundle_id:
+    :param name: Name of the application, [a-z0-9-]+
+    :param display_name: Display name of the application
+    """
+
+    # First try to find it.
+    ret = find_application(name)
+    if ret is not None:
+        return ret
+
+    # It does not yet exist, so try to create
+    app_json = {"name": name,
+                "display_name": display_name,
+                "bundle_id": bundle_id}
+
+    r = requests.post(applications_prefix, json=app_json)
+    print(r.status_code)
+    response_json = r.json()
+    print(response_json)
+    if r.status_code / 10 != 20:
+        exit(1)
+    aid = response_json['id']
+    return aid
+
+
+def add_event_type(application_id, name, display_name):
+    """Add an EventType by name
+    :param application_id: UUID of the application
+    :param name: Name of the type
+    :param display_name: Display name of the type
+    """
+
+    # First try to find it
+    ret = find_event_type(application_id, name)
+    if ret is not None:
+        return ret
+
+    # It does not exist, so create it
+
+    et_json = {"name": name, "display_name": display_name}
+    r = requests.post(applications_prefix + "/" + application_id + "/eventTypes",
+                      json=et_json)
+    if r.status_code / 10 != 20:
+        exit(2)
+    response_json = r.json()
+    print(response_json)
+
+
+def add_bundle(name, display_name):
+    """Adds a bundle if it does not yet exist
+    :param name: Name of the bundle, [a-z0-9-]+
+    :param display_name: Display name of the application
+    """
+
+    # First try to find it.
+    ret = find_bundle(name)
+    if ret is not None:
+        return ret
+
+    # It does not yet exist, so try to create
+    bundle_json = {"name": name,
+                "display_name": display_name}
+
+    r = requests.post(bundles_prefix, json=bundle_json)
+    print(r.status_code)
+    response_json = r.json()
+    print(response_json)
+    if r.status_code / 10 != 20:
+        exit(1)
+    aid = response_json['id']
+    return aid
+
+
+def find_bundle(name):
+    """Find an application by name and return its UUID or return None
+    :param name: Name of the application
+    """
+    r = requests.get(bundles_prefix)
+    if r.status_code != 200:
+        return None
+
+    j = r.json()
+    for bundle in j:
+        if bundle["name"] == name:
+            return bundle["id"]
+
+    return None
+
+
+def find_event_type(application_id, name):
+    """Find an event type by name for an application"""
+    r = requests.get(applications_prefix + "/" + application_id + "/eventTypes/")
+
+    if r.status_code != 200:
+        return None
+
+    j = r.json()
+    for et in j:
+        if et["name"] == name:
+            return et["id"]
+
+    return None
+

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <checkstyle-plugin.version>3.1.1</checkstyle-plugin.version>
         <checkstyle.version>8.36.2</checkstyle.version>
         <mutiny-reactor.version>0.10.0</mutiny-reactor.version>
-        <testcontainers.version>1.14.3</testcontainers.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <mockserver-client-java.version>5.5.4</mockserver-client-java.version> <!-- not the newest, but matches what is in org.testcontainers:mockserver -->
         <version.cloud-commons>0.1.1</version.cloud-commons>
         <openapi-parser.version>4.0.4</openapi-parser.version>

--- a/src/main/java/com/redhat/cloud/notifications/db/AbstractGenericResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/AbstractGenericResource.java
@@ -1,0 +1,37 @@
+package com.redhat.cloud.notifications.db;
+
+import io.r2dbc.postgresql.api.PostgresqlConnection;
+import io.r2dbc.postgresql.api.PostgresqlResult;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import reactor.core.publisher.Flux;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.UUID;
+
+/**
+ * A base class for some of the resources stuff
+ */
+public abstract class AbstractGenericResource {
+
+    @Inject
+    Provider<Uni<PostgresqlConnection>> connectionPublisher;
+
+    protected Uni<Boolean> runDeleteQuery(UUID eventTypeId, String query) {
+        return connectionPublisher.get().onItem()
+                .transformToMulti(c -> Multi.createFrom().resource(() -> c,
+                    c2 -> {
+                        Flux<PostgresqlResult> execute = c2.createStatement(query)
+                                .bind("$1", eventTypeId)
+                                .execute();
+                        return execute.flatMap(PostgresqlResult::getRowsUpdated)
+                                .map(i -> true).next();
+
+                    })
+                    .withFinalizer(postgresqlConnection -> {
+                        postgresqlConnection.close().subscribe();
+                    })
+                ).toUni();
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
@@ -13,6 +13,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.validation.constraints.NotNull;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
@@ -21,6 +22,7 @@ import java.util.UUID;
 public class ApplicationResources extends AbstractGenericResource {
 
     private static final String APPLICATION_QUERY = "SELECT a.id, a.name, a.display_name, a.created, a.updated, a.bundle_id FROM public.applications a";
+    private static final String APPLICATION_QUERY_BY_BUNDLE_NAME = APPLICATION_QUERY + " JOIN bundles AS b ON a.bundle_id = b.id WHERE b.name = $1";
     @Inject
     Provider<Uni<PostgresqlConnection>> connectionPublisher;
 
@@ -77,7 +79,8 @@ public class ApplicationResources extends AbstractGenericResource {
         return connectionPublisher.get().onItem()
                 .transformToMulti(c -> Multi.createFrom().resource(() -> c,
                         c2 -> {
-                            Flux<PostgresqlResult> execute = c2.createStatement(APPLICATION_QUERY)
+                            Flux<PostgresqlResult> execute = c2.createStatement(APPLICATION_QUERY_BY_BUNDLE_NAME)
+                                    .bind("$1", bundleName)
                                     .execute();
 
                             return mapResultSetToApplication(execute);

--- a/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
@@ -13,7 +13,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.validation.constraints.NotNull;
-import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 import java.util.UUID;

--- a/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
@@ -73,7 +73,7 @@ public class ApplicationResources extends AbstractGenericResource {
                 .toUni();
     }
 
-    public Multi<Application> getApplications() {
+    public Multi<Application> getApplications(String bundleName) {
         return connectionPublisher.get().onItem()
                 .transformToMulti(c -> Multi.createFrom().resource(() -> c,
                         c2 -> {

--- a/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
@@ -1,0 +1,143 @@
+package com.redhat.cloud.notifications.db;
+
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import io.r2dbc.postgresql.api.PostgresqlResult;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import reactor.core.publisher.Flux;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * Deal with Bundles.
+ * More or less stupid copy & paste & search & replace of
+ * code in BundleResources
+ */
+@ApplicationScoped
+public class BundleResources extends  AbstractGenericResource {
+
+    public Uni<Bundle> createBundle(Bundle bundle) {
+        String query = "INSERT INTO public.bundles (name, display_name) VALUES ($1, $2)";
+        // Return filled with id
+        return connectionPublisher.get().onItem()
+                .transformToMulti(c -> Multi.createFrom().resource(() -> c,
+                    c2 -> c2.createStatement(query)
+                    .bind("$1", bundle.getName())
+                    .bind("$2", bundle.getDisplay_name())
+                    .returnGeneratedValues("id", "created")
+                    .execute()
+                    .flatMap(res -> res.map((row, rowMetadata) -> {
+                        bundle.setId(row.get("id", UUID.class));
+                        bundle.setCreated(row.get("created", Date.class));
+                        return bundle;
+                    })))
+            .withFinalizer(postgresqlConnection -> {
+                postgresqlConnection.close().subscribe();
+            }))
+                .toUni();
+    }
+
+    private static final String BUNDLE_QUERY = "SELECT b.id, b.name, b.display_name, b.created, b.updated FROM public.bundles b";
+
+    public Multi<Bundle> getBundles() {
+        return connectionPublisher.get().onItem()
+            .transformToMulti(c -> Multi.createFrom().resource(() -> c,
+                c2 -> {
+                    Flux<PostgresqlResult> execute = c2.createStatement(BUNDLE_QUERY)
+                        .execute();
+
+                    return mapResultSetToBundle(execute);
+                })
+                .withFinalizer(postgresqlConnection -> {
+                    postgresqlConnection.close().subscribe();
+                }));
+    }
+
+    private Flux<Bundle> mapResultSetToBundle(Flux<PostgresqlResult> resultFlux) {
+        return resultFlux.flatMap(postgresqlResult -> postgresqlResult.map((row, rowMetadata) -> {
+            Bundle bundle = new Bundle();
+            bundle.setId(row.get("id", UUID.class));
+            bundle.setName(row.get("name", String.class));
+            bundle.setDisplay_name(row.get("display_name", String.class));
+            bundle.setCreated(row.get("created", Date.class));
+            bundle.setUpdated(row.get("updated", Date.class));
+            return bundle;
+        }));
+    }
+
+    public Uni<Bundle> getBundle(UUID bundleId) {
+        String query = BUNDLE_QUERY + " WHERE id = $1";
+        return connectionPublisher.get().onItem()
+            .transformToMulti(c -> Multi.createFrom().resource(() -> c,
+                c2 -> {
+                    Flux<PostgresqlResult> execute = c2.createStatement(query)
+                            .bind("$1", bundleId)
+                            .execute();
+
+                    return mapResultSetToBundle(execute);
+                })
+                .withFinalizer(postgresqlConnection -> {
+                    postgresqlConnection.close().subscribe();
+                })).toUni();
+    }
+
+    public Uni<Boolean> deleteBundle(UUID bundleId) {
+        String query = "DELETE FROM public.bundles WHERE id = $1";
+
+        return runDeleteQuery(bundleId, query);
+    }
+
+
+    public Multi<Application> getApplications(UUID bundleId) {
+        String query = "SELECT et.id, et.name, et.display_name FROM public.applications et " +
+                "WHERE et.bundle_id = $1";
+
+        return connectionPublisher.get().onItem()
+            .transformToMulti(c -> Multi.createFrom().resource(() -> c,
+                c2 -> {
+                    Flux<PostgresqlResult> execute = c2.createStatement(query)
+                            .bind("$1", bundleId)
+                            .execute();
+
+                    return execute.flatMap(res -> res.map((row, rowMetadata) -> {
+                        Application application = new Application();
+                        application.setId(row.get("id", UUID.class));
+                        application.setName(row.get("name", String.class));
+                        application.setDisplay_name(row.get("display_name", String.class));
+                        application.setBundleId(bundleId);
+                        return application;
+                    }));
+                })
+                .withFinalizer(postgresqlConnection -> {
+                    postgresqlConnection.close().subscribe();
+                }));
+    }
+
+    public Uni<Application> addApplicationToBundle(UUID bundleId, Application app) {
+        String insertQuery = "INSERT INTO public.application (name, display_name, bundleId) VALUES ($1, $2, $3)";
+
+        return connectionPublisher.get().onItem()
+                .transformToMulti(c -> Multi.createFrom().resource(() -> c,
+                    c2 ->  c2.createStatement(insertQuery)
+                            .bind("$1", app.getName())
+                            .bind("$2", app.getDisplay_name())
+                            .bind("$3", bundleId)
+                            .returnGeneratedValues("id")
+                            .execute()
+                            .flatMap(res -> res.map((row, rowMetadata) -> {
+                                app.setId(row.get("id", UUID.class));
+                                return app;
+                            }))
+
+                )
+                        .withFinalizer(postgresqlConnection -> {
+                            postgresqlConnection.close().subscribe();
+                        }))
+                .toUni();
+    }
+
+
+}

--- a/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
@@ -19,8 +19,11 @@ import java.util.UUID;
 @ApplicationScoped
 public class BundleResources extends  AbstractGenericResource {
 
+    public static final String PUBLIC_APPLICATIONS = "public.applications";
+    public static final String PUBLIC_BUNDLES = "public.bundles";
+
     public Uni<Bundle> createBundle(Bundle bundle) {
-        String query = "INSERT INTO public.bundles (name, display_name) VALUES ($1, $2)";
+        String query = "INSERT INTO " + PUBLIC_BUNDLES + " (name, display_name) VALUES ($1, $2)";
         // Return filled with id
         return connectionPublisher.get().onItem()
                 .transformToMulti(c -> Multi.createFrom().resource(() -> c,
@@ -40,7 +43,7 @@ public class BundleResources extends  AbstractGenericResource {
                 .toUni();
     }
 
-    private static final String BUNDLE_QUERY = "SELECT b.id, b.name, b.display_name, b.created, b.updated FROM public.bundles b";
+    private static final String BUNDLE_QUERY = "SELECT b.id, b.name, b.display_name, b.created, b.updated FROM " + PUBLIC_BUNDLES + " b";
 
     public Multi<Bundle> getBundles() {
         return connectionPublisher.get().onItem()
@@ -85,14 +88,14 @@ public class BundleResources extends  AbstractGenericResource {
     }
 
     public Uni<Boolean> deleteBundle(UUID bundleId) {
-        String query = "DELETE FROM public.bundles WHERE id = $1";
+        String query = "DELETE FROM " + PUBLIC_BUNDLES + " WHERE id = $1";
 
         return runDeleteQuery(bundleId, query);
     }
 
 
     public Multi<Application> getApplications(UUID bundleId) {
-        String query = "SELECT et.id, et.name, et.display_name FROM public.applications et " +
+        String query = "SELECT et.id, et.name, et.display_name FROM " + PUBLIC_APPLICATIONS + " et " +
                 "WHERE et.bundle_id = $1";
 
         return connectionPublisher.get().onItem()
@@ -117,7 +120,7 @@ public class BundleResources extends  AbstractGenericResource {
     }
 
     public Uni<Application> addApplicationToBundle(UUID bundleId, Application app) {
-        String insertQuery = "INSERT INTO public.application (name, display_name, bundleId) VALUES ($1, $2, $3)";
+        String insertQuery = "INSERT INTO " + PUBLIC_APPLICATIONS + " (name, display_name, bundle_Id) VALUES ($1, $2, $3)";
 
         return connectionPublisher.get().onItem()
                 .transformToMulti(c -> Multi.createFrom().resource(() -> c,

--- a/src/main/java/com/redhat/cloud/notifications/models/Application.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Application.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
@@ -14,6 +15,7 @@ public class Application {
     private UUID id;
 
     @NotNull
+    @Pattern(regexp = "[a-z][a-z_0-9-]*")
     private String name;
 
     @NotNull

--- a/src/main/java/com/redhat/cloud/notifications/models/Bundle.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Bundle.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
@@ -16,6 +17,7 @@ public class Bundle {
     UUID id;
 
     @NotNull
+    @Pattern(regexp = "[a-z][a-z_0-9-]*")
     String name;
 
     @NotNull

--- a/src/main/java/com/redhat/cloud/notifications/models/Bundle.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Bundle.java
@@ -1,24 +1,26 @@
 package com.redhat.cloud.notifications.models;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
 import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
 
-public class Application {
-    private UUID id;
+/**
+ * A bundle is an aggregation of applications.
+ */
+public class Bundle {
+
+    UUID id;
 
     @NotNull
-    private String name;
+    String name;
 
     @NotNull
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private String display_name;
+    String display_name;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -29,15 +31,14 @@ public class Application {
     private Date updated;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private Set<EventType> eventTypes; // optional
+    private Set<Application> applications;
 
-    @NotNull
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("bundle_id")
-    private UUID bundleId;
+    public Bundle() {
+    }
 
-    public Application() {
-
+    public Bundle(String bundleName, String display_name) {
+        this.name = bundleName;
+        this.display_name = display_name;
     }
 
     public UUID getId() {
@@ -64,31 +65,27 @@ public class Application {
         this.display_name = display_name;
     }
 
-    @JsonProperty
     public Date getCreated() {
         return created;
     }
 
-    @JsonIgnore
     public void setCreated(Date created) {
         this.created = created;
     }
 
-    @JsonProperty
     public Date getUpdated() {
         return updated;
     }
 
-    @JsonIgnore
     public void setUpdated(Date updated) {
         this.updated = updated;
     }
 
-    public UUID getBundleId() {
-        return bundleId;
+    public Set<Application> getApplications() {
+        return applications;
     }
 
-    public void setBundleId(UUID bundleId) {
-        this.bundleId = bundleId;
+    public void setApplications(Set<Application> applications) {
+        this.applications = applications;
     }
 }

--- a/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -3,11 +3,13 @@ package com.redhat.cloud.notifications.models;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import java.util.Set;
 
 public class EventType {
     private Integer id;
 
+    @Pattern(regexp = "[a-z][a-z_0-9-]*")
     @NotNull
     private String name;
 

--- a/src/main/java/com/redhat/cloud/notifications/routers/ApplicationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/ApplicationService.java
@@ -15,7 +15,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 @Path("/internal/applications")
@@ -27,9 +29,14 @@ public class ApplicationService {
     ApplicationResources appResources;
 
     @GET
-    public Multi<Application> getApplications() {
+    public Multi<Response> getApplications(@QueryParam("bundleName") String bundleName) {
         // Return configured with types?
-        return appResources.getApplications();
+        if (bundleName == null || bundleName.isBlank()) {
+            return Multi.createFrom().failure(new IllegalArgumentException());
+        }
+        // TODO how can we find out there is nothing to send and return a 404 ?
+        return appResources.getApplications(bundleName).onItem()
+                .transform(app -> { return Response.ok(app).build(); });
     }
 
     @POST

--- a/src/main/java/com/redhat/cloud/notifications/routers/ApplicationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/ApplicationService.java
@@ -9,6 +9,7 @@ import io.smallrye.mutiny.Uni;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -37,6 +38,12 @@ public class ApplicationService {
         return appResources.createApplication(application);
     }
 
+    @DELETE
+    @Path("/{id}")
+    public Uni<Boolean> deleteApplication(@PathParam("id") UUID id) {
+        return appResources.deleteApplication(id);
+    }
+
     @GET
     @Path("/{id}")
     public Uni<Application> getApplication(@PathParam("id") UUID id) {
@@ -53,5 +60,11 @@ public class ApplicationService {
     @Path("/{id}/eventTypes")
     public Multi<EventType> getEventTypes(@PathParam("id") UUID applicationId) {
         return appResources.getEventTypes(applicationId);
+    }
+
+    @DELETE
+    @Path("/eventType")
+    public Uni<Boolean> deleteEventTypeById(@PathParam("eid") UUID endTypeId) {
+        return appResources.deleteEventTypeById(endTypeId);
     }
 }

--- a/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
@@ -11,11 +11,13 @@ import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 /**
@@ -50,7 +52,9 @@ public class BundlesService {
     @GET
     @Path("/{id}")
     public Uni<Bundle> getBundle(@PathParam("id") UUID id) {
-        return bundleResources.getBundle(id);
+        Uni<Bundle> bundleUni = bundleResources.getBundle(id);
+
+        return bundleUni.onItem().ifNull().failWith(new NotFoundException(id.toString()));
     }
 
     @POST

--- a/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
@@ -1,0 +1,68 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.db.BundleResources;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.UUID;
+
+/**
+ * Deal with bundles
+ */
+@Path("/internal/bundles")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class BundlesService {
+
+    @Inject
+    BundleResources bundleResources;
+
+    @GET
+    public Multi<Bundle> getBundles() {
+        // Return configured with types?
+        return bundleResources.getBundles();
+    }
+
+    @POST
+    public Uni<Bundle> addBundle(@Valid Bundle bundle) {
+        // We need to ensure that the x-rh-identity isn't present here
+        return bundleResources.createBundle(bundle);
+    }
+
+    @DELETE
+    @Path("/{id}")
+    public Uni<Boolean> deleteBundle(@PathParam("id") UUID id) {
+        return bundleResources.deleteBundle(id);
+    }
+
+    @GET
+    @Path("/{id}")
+    public Uni<Bundle> getBundle(@PathParam("id") UUID id) {
+        return bundleResources.getBundle(id);
+    }
+
+    @POST
+    @Path("/{id}/applications")
+    public Uni<Application> addApplication(@PathParam("id") UUID bundleId, @Valid Application application) {
+        return bundleResources.addApplicationToBundle(bundleId, application);
+    }
+
+    @GET
+    @Path("/{id}/applications")
+    public Multi<Application> getApplications(@PathParam("id") UUID bundleId) {
+        return bundleResources.getApplications(bundleId);
+    }
+
+}

--- a/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
@@ -17,7 +17,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 /**

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -178,7 +178,7 @@ public class NotificationService {
     @GET
     @Path("/facets/applications")
     @Operation(summary = "Return a thin list of configured applications. This can be used to configure a filter in the UI")
-    public Multi<ApplicationFacet> getApplicationsFacets(@Context SecurityContext sec) {
-        return apps.getApplications().onItem().transform(a -> new ApplicationFacet(a.getName(), a.getId().toString()));
+    public Multi<ApplicationFacet> getApplicationsFacets(@Context SecurityContext sec, @QueryParam("bundleName") String bundleName) {
+        return apps.getApplications(bundleName).onItem().transform(a -> new ApplicationFacet(a.getName(), a.getId().toString()));
     }
 }

--- a/src/main/resources/db/migration/V1.5.0__NOTIF-116_add_bundles.sql
+++ b/src/main/resources/db/migration/V1.5.0__NOTIF-116_add_bundles.sql
@@ -1,0 +1,15 @@
+create table bundles (id uuid primary key DEFAULT public.gen_random_uuid() NOT NULL,
+    name character varying(255),
+    display_name character varying,
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    updated timestamp with time zone
+);
+
+alter table applications add column bundle_id uuid NOT NULL;
+
+alter table applications add constraint app_bundle_fk
+  foreign key (bundle_id) references bundles(id)
+  on delete cascade;
+
+create unique index app_bundle_idx ON public.applications(name, bundle_id);
+

--- a/src/main/resources/db/migration/V1.5.0__NOTIF-116_add_bundles.sql
+++ b/src/main/resources/db/migration/V1.5.0__NOTIF-116_add_bundles.sql
@@ -5,11 +5,22 @@ create table bundles (id uuid primary key DEFAULT public.gen_random_uuid() NOT N
     updated timestamp with time zone
 );
 
-alter table applications add column bundle_id uuid NOT NULL;
+insert into bundles (name, display_name) VALUES ('insights', 'Insights');
+
+-- we can not set this to NOT NULL here, as we first need to link the bundle
+-- to the existing 'Policies' app (see v1.1.1)
+ALTER TABLE applications add column bundle_id uuid;
+
+update applications set bundle_id = (
+select id from bundles where name = 'insights'
+);
+
 
 alter table applications add constraint app_bundle_fk
   foreign key (bundle_id) references bundles(id)
   on delete cascade;
+
+
 
 create unique index app_bundle_idx ON public.applications(name, bundle_id);
 

--- a/src/main/resources/db/migration/V1.5.0__NOTIF-116_add_bundles.sql
+++ b/src/main/resources/db/migration/V1.5.0__NOTIF-116_add_bundles.sql
@@ -1,5 +1,5 @@
 create table bundles (id uuid primary key DEFAULT public.gen_random_uuid() NOT NULL,
-    name character varying(255),
+    name character varying(255) UNIQUE,
     display_name character varying,
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone
@@ -20,7 +20,7 @@ alter table applications add constraint app_bundle_fk
   foreign key (bundle_id) references bundles(id)
   on delete cascade;
 
-
-
 create unique index app_bundle_idx ON public.applications(name, bundle_id);
+
+DROP INDEX "IX_application_name"
 

--- a/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -74,6 +74,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
         String jdbcUrl = postgreSQLContainer.getJdbcUrl();
         String dbUrl = jdbcUrl.substring(jdbcUrl.indexOf(':') + 1);
         String classicJdbcUrl = "jdbc:" /* + "tracing:" */ + dbUrl;
+        classicJdbcUrl = classicJdbcUrl.replace("localhost", "127.0.0.1");
         props.put("quarkus.datasource.jdbc.url", classicJdbcUrl);
         String vertxJdbcUrl = "vertx-reactive:" + dbUrl;
         props.put("quarkus.datasource.reactive.url", "vertx-reactive:" + vertxJdbcUrl);

--- a/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db;
 
 import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.models.EmailSubscription;
 import com.redhat.cloud.notifications.models.EmailSubscription.EmailSubscriptionType;
@@ -22,12 +23,16 @@ public class ResourceHelpers {
     public static final String TEST_APP_NAME = "Tester";
     public static final String TEST_APP_NAME_2 = "MyOtherTester";
     public static final String TEST_EVENT_TYPE_FORMAT = "EventType%d";
+    private static final String TEST_BUNDLE_NAME = "TestBundle";
 
     @Inject
     EndpointResources resources;
 
     @Inject
     ApplicationResources appResources;
+
+    @Inject
+    BundleResources bundleResources;
 
     @Inject
     EndpointEmailSubscriptionResources subscriptionResources;
@@ -44,9 +49,13 @@ public class ResourceHelpers {
     }
 
     public void createTestAppAndEventTypes() {
+        Bundle bundle = new Bundle(TEST_BUNDLE_NAME, "...");
+        Bundle b = bundleResources.createBundle(bundle).await().indefinitely();
+
         Application app = new Application();
         app.setName(TEST_APP_NAME);
         app.setDisplay_name("...");
+        app.setBundleId(b.getId());
         Application added = appResources.createApplication(app).await().indefinitely();
 
         for (int i = 0; i < 100; i++) {
@@ -59,6 +68,7 @@ public class ResourceHelpers {
         Application app2 = new Application();
         app2.setName(TEST_APP_NAME_2);
         app2.setDisplay_name("...");
+        app2.setBundleId(b.getId());
         Application added2 = appResources.createApplication(app2).await().indefinitely();
 
         for (int i = 0; i < 100; i++) {

--- a/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -23,7 +23,7 @@ public class ResourceHelpers {
     public static final String TEST_APP_NAME = "Tester";
     public static final String TEST_APP_NAME_2 = "MyOtherTester";
     public static final String TEST_EVENT_TYPE_FORMAT = "EventType%d";
-    private static final String TEST_BUNDLE_NAME = "TestBundle";
+    public static final String TEST_BUNDLE_NAME = "TestBundle";
 
     @Inject
     EndpointResources resources;
@@ -40,8 +40,8 @@ public class ResourceHelpers {
     @Inject
     EmailAggregationResources emailAggregationResources;
 
-    public List<Application> getApplications() {
-        return appResources.getApplications().collectItems().asList().await().indefinitely();
+    public List<Application> getApplications(String bundleName) {
+        return appResources.getApplications(bundleName).collectItems().asList().await().indefinitely();
     }
 
     public EmailSubscription getSubscription(String accountNumber, String username, EmailSubscription.EmailSubscriptionType type) {

--- a/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -57,8 +57,8 @@ import static org.mockserver.model.HttpResponse.response;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class LifecycleITest {
 
-    private static final String APP_NAME = "PoliciesLifecycleTest";
-    private static final String EVENT_TYPE_NAME = "All";
+    private static final String APP_NAME = "policies-lifecycle-test";
+    private static final String EVENT_TYPE_NAME = "all";
 
     @BeforeEach
     void beforeEach() {

--- a/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
@@ -13,6 +13,9 @@ import io.restassured.response.Response;
 import io.vertx.core.json.Json;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
+
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,12 +51,8 @@ public class ApplicationServiceTest {
         app.setBundleId(returnedBundle.getId());
 
         // All of these are without identityHeader
-        given()
-                // Set header to x-rh-identity
-                .when().get("/internal/applications")
-                .then()
-                .statusCode(500);
 
+        // Now create an application
         Response response = given()
                 .when()
                 .contentType(ContentType.JSON)
@@ -67,13 +66,22 @@ public class ApplicationServiceTest {
         assertNotNull(appResponse.getId());
         assertEquals(returnedBundle.getId(), appResponse.getBundleId());
 
-        given()
-                // Set header to x-rh-identity
-                .when().get("/internal/applications?bundleName=" + BUNDLE_NAME)
-                .then()
-                .statusCode(200);
-
         // Fetch the applications to check they were really added
+        Response resp =
+            given()
+                    // Set header to x-rh-identity
+                    .when()
+                    .get("/internal/applications?bundleName=" + BUNDLE_NAME)
+                    .then()
+                    .statusCode(200)
+                    .extract().response();
+        assertNotNull(resp);
+        List apps = Json.decodeValue(resp.getBody().asString(), List.class);
+        assertEquals(1, apps.size());
+        Map<String, Object> map = (Map<String, Object>) apps.get(0);
+        Map<String, Object> appMap = (Map<String, Object>) map.get("entity");
+        assertEquals(returnedBundle.getId().toString(), appMap.get("bundle_id"));
+        assertEquals(appResponse.getId().toString(), appMap.get("id"));
 
         // Create eventType
         EventType eventType = new EventType();
@@ -91,5 +99,17 @@ public class ApplicationServiceTest {
 
         EventType typeResponse = Json.decodeValue(response.getBody().asString(), EventType.class);
         assertNotNull(typeResponse.getId());
+    }
+
+    @Test
+    void testGetApplicationsRequiresBundleName() {
+        // Check that the get applications won't work without bundleName
+        given()
+                // Set header to x-rh-identity
+                .when()
+                .get("/internal/applications")
+                .then()
+                .statusCode(500);
+
     }
 }

--- a/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
@@ -23,6 +23,7 @@ public class ApplicationServiceTest {
 
     static final String APP_NAME = "policies-application-service-test";
     static final String EVENT_TYPE_NAME = "policy-triggered";
+    public static final String BUNDLE_NAME = "insights-test";
 
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
@@ -30,7 +31,7 @@ public class ApplicationServiceTest {
     @Test
     void testPoliciesApplicationAdding() {
         Bundle bundle = new Bundle();
-        bundle.setName("insights-test");
+        bundle.setName(BUNDLE_NAME);
         bundle.setDisplay_name("Insights");
         Bundle returnedBundle =
             given()
@@ -51,7 +52,7 @@ public class ApplicationServiceTest {
                 // Set header to x-rh-identity
                 .when().get("/internal/applications")
                 .then()
-                .statusCode(200);
+                .statusCode(500);
 
         Response response = given()
                 .when()
@@ -65,6 +66,12 @@ public class ApplicationServiceTest {
         Application appResponse = Json.decodeValue(response.getBody().asString(), Application.class);
         assertNotNull(appResponse.getId());
         assertEquals(returnedBundle.getId(), appResponse.getBundleId());
+
+        given()
+                // Set header to x-rh-identity
+                .when().get("/internal/applications?bundleName=" + BUNDLE_NAME)
+                .then()
+                .statusCode(200);
 
         // Fetch the applications to check they were really added
 

--- a/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
@@ -30,7 +30,7 @@ public class ApplicationServiceTest {
     @Test
     void testPoliciesApplicationAdding() {
         Bundle bundle = new Bundle();
-        bundle.setName("insights");
+        bundle.setName("insights-test");
         bundle.setDisplay_name("Insights");
         Bundle returnedBundle =
             given()

--- a/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -13,6 +14,7 @@ import io.vertx.core.json.Json;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
@@ -27,9 +29,22 @@ public class ApplicationServiceTest {
 
     @Test
     void testPoliciesApplicationAdding() {
+        Bundle bundle = new Bundle();
+        bundle.setName("insights");
+        bundle.setDisplay_name("Insights");
+        Bundle returnedBundle =
+            given()
+                    .body(bundle)
+                    .contentType(ContentType.JSON)
+                .when().post("/internal/bundles")
+                .then()
+                    .statusCode(200)
+                .extract().body().as(Bundle.class);
+
         Application app = new Application();
         app.setName(APP_NAME);
         app.setDisplay_name("The best app");
+        app.setBundleId(returnedBundle.getId());
 
         // All of these are without identityHeader
         given()
@@ -49,6 +64,7 @@ public class ApplicationServiceTest {
 
         Application appResponse = Json.decodeValue(response.getBody().asString(), Application.class);
         assertNotNull(appResponse.getId());
+        assertEquals(returnedBundle.getId(), appResponse.getBundleId());
 
         // Fetch the applications to check they were really added
 

--- a/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @QuarkusTestResource(TestLifecycleManager.class)
 public class ApplicationServiceTest {
 
-    static final String APP_NAME = "PoliciesApplicationServiceTest";
+    static final String APP_NAME = "policies-application-service-test";
     static final String EVENT_TYPE_NAME = "policy-triggered";
 
     @MockServerConfig

--- a/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
@@ -1,0 +1,61 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.models.Bundle;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test working with Bundles
+ */
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class BundleServiceTest {
+
+    @Test
+    void testAdd() {
+        Bundle bundle = new Bundle();
+        bundle.setName("insights1");
+        bundle.setDisplay_name("Insights1");
+        Bundle returnedBundle =
+            given()
+                    .body(bundle)
+                    .contentType(ContentType.JSON)
+                .when().post("/internal/bundles")
+                .then()
+                    .statusCode(200)
+                .extract().body().as(Bundle.class);
+
+        UUID bundleId = returnedBundle.getId();
+        assertNotNull(bundleId);
+        assertEquals("insights1", returnedBundle.getName());
+        assertEquals("Insights1", returnedBundle.getDisplay_name());
+
+        given()
+            .accept(ContentType.JSON)
+        .when()
+            .get("/internal/bundles/" + bundleId)
+        .then()
+            .statusCode(200);
+
+        when()
+                .delete("/internal/bundles/" + bundleId)
+        .then()
+                .statusCode(200);
+
+        when()
+            .get("/internal/bundles/" + bundleId)
+        .then()
+            .statusCode(204);
+
+    }
+}

--- a/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
@@ -51,16 +51,16 @@ public class BundleServiceTest {
 
     @Test
     void testAddTwoBundles() {
-        Bundle b1 = null, b2 = null;
+        Bundle b1 = null;
+        Bundle b2 = null;
         try {
             b1 = createBundle("b1", 200);
             b2 = createBundle("b2", 200);
-        }
-        finally {
-            if (b1!=null) {
+        } finally {
+            if (b1 != null) {
                 deleteBundleById(b1.getId());
             }
-            if (b2!=null) {
+            if (b2 != null) {
                 deleteBundleById(b2.getId());
             }
         }
@@ -68,13 +68,12 @@ public class BundleServiceTest {
 
     @Test
     void testNoAddSameBundleTwice() {
-        Bundle b1 = null, b2 = null;
+        Bundle b1 = null;
         try {
             b1 = createBundle("b1", 200);
-            b2 = createBundle("b1", 500);
-        }
-        finally {
-            if (b1!=null) {
+            createBundle("b1", 500);
+        } finally {
+            if (b1 != null) {
                 deleteBundleById(b1.getId());
             }
         }
@@ -92,7 +91,7 @@ public class BundleServiceTest {
 
         try {
             Application created =
-            given()
+                given()
                     .body(app)
                     .contentType(ContentType.JSON)
                 .when()
@@ -101,8 +100,7 @@ public class BundleServiceTest {
                     .statusCode(200)
                     .extract().body().as(Application.class);
             app.setBundleId(created.getBundleId());
-        }
-        finally {
+        } finally {
             deleteBundleById(returnedBundle.getId());
 
             when()
@@ -136,8 +134,7 @@ public class BundleServiceTest {
                     .when().post("/internal/bundles/" + returnedBundle.getId() + "/applications")
                     .then()
                     .statusCode(500);
-        }
-        finally {
+        } finally {
             deleteBundleById(returnedBundle.getId());
         }
     }
@@ -172,8 +169,7 @@ public class BundleServiceTest {
                     .when().post("/internal/bundles/" + returnedBundle2.getId() + "/applications")
                     .then()
                     .statusCode(200);
-        }
-        finally {
+        } finally {
             deleteBundleById(returnedBundle1.getId());
             deleteBundleById(returnedBundle2.getId());
         }
@@ -192,7 +188,7 @@ public class BundleServiceTest {
                 .statusCode(expectedReturnCode)
                 .extract();
 
-        if (expectedReturnCode==200) {
+        if (expectedReturnCode == 200) {
             Bundle returned = response
                     .body().as(Bundle.class);
             return returned;

--- a/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
@@ -1,10 +1,12 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -21,24 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @QuarkusTestResource(TestLifecycleManager.class)
 public class BundleServiceTest {
 
+    public static final String INSIGHTS_1 = "insights1";
+
     @Test
     void testAdd() {
-        Bundle bundle = new Bundle();
-        bundle.setName("insights1");
-        bundle.setDisplay_name("Insights1");
-        Bundle returnedBundle =
-            given()
-                    .body(bundle)
-                    .contentType(ContentType.JSON)
-                .when().post("/internal/bundles")
-                .then()
-                    .statusCode(200)
-                .extract().body().as(Bundle.class);
+        Bundle returnedBundle = createBundle(INSIGHTS_1, 200);
 
         UUID bundleId = returnedBundle.getId();
         assertNotNull(bundleId);
-        assertEquals("insights1", returnedBundle.getName());
-        assertEquals("Insights1", returnedBundle.getDisplay_name());
+        assertEquals(INSIGHTS_1, returnedBundle.getName());
+        assertEquals(INSIGHTS_1.toUpperCase(), returnedBundle.getDisplay_name());
 
         given()
             .accept(ContentType.JSON)
@@ -47,15 +41,170 @@ public class BundleServiceTest {
         .then()
             .statusCode(200);
 
-        when()
-                .delete("/internal/bundles/" + bundleId)
-        .then()
-                .statusCode(200);
+        deleteBundleById(bundleId);
 
         when()
             .get("/internal/bundles/" + bundleId)
         .then()
-            .statusCode(204);
+            .statusCode(404);
+    }
 
+    @Test
+    void testAddTwoBundles() {
+        Bundle b1 = null, b2 = null;
+        try {
+            b1 = createBundle("b1", 200);
+            b2 = createBundle("b2", 200);
+        }
+        finally {
+            if (b1!=null) {
+                deleteBundleById(b1.getId());
+            }
+            if (b2!=null) {
+                deleteBundleById(b2.getId());
+            }
+        }
+    }
+
+    @Test
+    void testNoAddSameBundleTwice() {
+        Bundle b1 = null, b2 = null;
+        try {
+            b1 = createBundle("b1", 200);
+            b2 = createBundle("b1", 500);
+        }
+        finally {
+            if (b1!=null) {
+                deleteBundleById(b1.getId());
+            }
+        }
+    }
+
+    @Test
+    void testAddApplicationOnce() {
+
+        Bundle returnedBundle = createBundle(INSIGHTS_1, 200);
+
+        Application app = new Application();
+        app.setBundleId(returnedBundle.getId());
+        app.setName("test");
+        app.setDisplay_name("..");
+
+        try {
+            Application created =
+            given()
+                    .body(app)
+                    .contentType(ContentType.JSON)
+                .when()
+                    .post("/internal/bundles/" + returnedBundle.getId() + "/applications")
+                .then()
+                    .statusCode(200)
+                    .extract().body().as(Application.class);
+            app.setBundleId(created.getBundleId());
+        }
+        finally {
+            deleteBundleById(returnedBundle.getId());
+
+            when()
+                    .get("/internal/applications/" + app.getId())
+                .then()
+                    .statusCode(404);
+        }
+    }
+
+    @Test
+    void testNoAddApplicationTwice() {
+
+        Bundle returnedBundle = createBundle(INSIGHTS_1, 200);
+
+        Application app = new Application();
+        app.setBundleId(returnedBundle.getId());
+        app.setName("test");
+        app.setDisplay_name("..");
+
+        try {
+            given()
+                    .body(app)
+                    .contentType(ContentType.JSON)
+                    .when().post("/internal/bundles/" + returnedBundle.getId() + "/applications")
+                    .then()
+                    .statusCode(200);
+
+            given()
+                    .body(app)
+                    .contentType(ContentType.JSON)
+                    .when().post("/internal/bundles/" + returnedBundle.getId() + "/applications")
+                    .then()
+                    .statusCode(500);
+        }
+        finally {
+            deleteBundleById(returnedBundle.getId());
+        }
+    }
+
+    @Test
+    void testAddTwoApplicationTwoBundles() {
+
+        Bundle returnedBundle1 = createBundle(INSIGHTS_1, 200);
+        Bundle returnedBundle2 = createBundle("other_one", 200);
+
+        Application app1 = new Application();
+        app1.setBundleId(returnedBundle1.getId());
+        app1.setName("test");
+        app1.setDisplay_name("..");
+
+        Application app2 = new Application();
+        app2.setBundleId(returnedBundle2.getId());
+        app2.setName("test");
+        app2.setDisplay_name("..");
+
+        try {
+            given()
+                    .body(app1)
+                    .contentType(ContentType.JSON)
+                    .when().post("/internal/bundles/" + returnedBundle1.getId() + "/applications")
+                    .then()
+                    .statusCode(200);
+
+            given()
+                    .body(app2)
+                    .contentType(ContentType.JSON)
+                    .when().post("/internal/bundles/" + returnedBundle2.getId() + "/applications")
+                    .then()
+                    .statusCode(200);
+        }
+        finally {
+            deleteBundleById(returnedBundle1.getId());
+            deleteBundleById(returnedBundle2.getId());
+        }
+    }
+
+    private Bundle createBundle(String bundleName, int expectedReturnCode) {
+        Bundle bundle = new Bundle();
+        bundle.setName(bundleName);
+        bundle.setDisplay_name(bundleName.toUpperCase());
+        ExtractableResponse response = given()
+                .body(bundle)
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/internal/bundles")
+                .then()
+                .statusCode(expectedReturnCode)
+                .extract();
+
+        if (expectedReturnCode==200) {
+            Bundle returned = response
+                    .body().as(Bundle.class);
+            return returned;
+        } else {
+            return null;
+        }
+    }
+
+    private void deleteBundleById(UUID id) {
+        when()
+                .delete("/internal/bundles/" + id)
+            .then()
+                .statusCode(200);
     }
 }

--- a/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -82,7 +82,7 @@ public class NotificationServiceTest {
     @Test
     void testEventTypeFetchingByApplication() {
 
-        List<Application> applications = this.helpers.getApplications();
+        List<Application> applications = this.helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
         UUID myOtherTesterApplicationId = applications.stream().filter(a -> a.getName().equals(this.helpers.TEST_APP_NAME_2)).findFirst().get().getId();
 
         Response response = given()
@@ -155,7 +155,7 @@ public class NotificationServiceTest {
         Header localIdentityHeader = TestHelpers.createIdentityHeader(localIdentityHeaderValue);
         mockServerConfig.addMockRbacAccess(localIdentityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
 
-        UUID applicationId = this.helpers.getApplications().stream().filter(a -> a.getName().equals(this.helpers.TEST_APP_NAME_2)).findFirst().get().getId();
+        UUID applicationId = this.helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME).stream().filter(a -> a.getName().equals(this.helpers.TEST_APP_NAME_2)).findFirst().get().getId();
         UUID ep1 = this.helpers.createWebhookEndpoint(tenant);
         UUID ep2 = this.helpers.createWebhookEndpoint(tenant);
         UUID defaultEp = this.helpers.getDefaultEndpointId(tenant);


### PR DESCRIPTION
Introduce Bundles as group of applications. 

Bundle->Applications is 1:n
The application now has a field bundle_id.
Application names are now only unique within a bundle.

The PR also adds some python code in helpers that one can use to quickly generate a Bundle+Application+EventType

