### PR TITLE
NOTIF-22 Update policies templates

### DIFF
--- a/src/main/resources/templates/Policies/dailyEmailBody.html
+++ b/src/main/resources/templates/Policies/dailyEmailBody.html
@@ -1,105 +1,45 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Policy Notification</title>
-</head>
-<body>
-<div width="100%" style="margin:0;padding:0!important;font-family:overpass,arial;font-size:20px;box-sizing:border-box">
-    <table border="0" cellpadding="0" cellspacing="0" width="100%">
-        <tbody>
-        <tr>
-            <td>
-                <table align="center" border="0" cellpadding="0" cellspacing="0" width="600"
-                       style="border-collapse:collapse">
-                    <tbody>
-                    <tr>
-                        <td align="center" bgcolor="#000000" style="padding:20px 0 20px 0">
-                            <a href="https://cloud.redhat.com/insights/" style="display:block">
-                                <img src="https://cloud.redhat.com/apps/insights/images/email/rh-insights-logo.png"
-                                     alt="Red Hat Insights logo" width="152" height="60" style="display:block">
-                            </a>
-                        </td>
-                    </tr>
-
-                    <tr>
-                        <td bgcolor="#2c2c2" width="600" valign="top">
-                            <div width="100%" align="center"
-                                 style="padding:20px 20px 20px 20px;color:#ffffff;font-size:18px;font-weight:bold">
-                                Daily Policy Summary - {payload.start_time.toStringFormat()}
-                            </div>
-                        </td>
-                    </tr>
-
-                    <tr>
-                        <td bgcolor="#f5f5f5" style="padding:20px 20px 0 20px">
-                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                <tbody>
-                                <tr>
-                                    <td bgcolor="ffffff" style="padding:24px 20px 20px 20px;font-size:16px">
-                                        Daily policy summary for <strong>{payload.start_time.toStringFormat()}</strong> from Red Hat Insights.<br>
-                                        <strong>{payload.policies.size()} {#if payload.policies.size() == 1}policy{#else}policies{/if}</strong> triggered on <strong>{payload.unique_system_count} {#if payload.unique_system_count == 1}system{#else}unique systems{/if}</strong>.
-                                    </td>
-                                </tr>
-
-                                <tr style="background-color:#fff">
-                                    <td align="center"
-                                        style="padding:20px 20px 24px 20px;font-size:18px;text-decoration:none;font-family:interstatecondensed,arial,sans-serif">
-                                        <table text-align="left" width="100%" style="border-collapse: collapse;">
-                                            <thead style="text-align: left">
-                                            <tr style="background-color: #ddf3ff;text-transform: uppercase;font-size: 14px;">
-                                                <th style="padding:10px 10px;border: 1px solid #f5f5f5;">POLICY</th>
-                                                <th style="padding:10px 10px;border: 1px solid #f5f5f5;">SYSTEMS AFFECTED</th>
-                                            </tr>
-                                            </thead>
-                                            <tbody>
-                                                {#for key in payload.policies.keySet()}
-                                                    <tr style="font-size: 14px;">
-                                                        <td style="padding:10px 10px;border: 1px solid #f5f5f5;"><a href="https://cloud.redhat.com/insights/policies/policy/{key}" target="_blank">{payload.policies.get(key).policy_name}</a></td>
-                                                        <td style="padding:10px 10px;border: 1px solid #f5f5f5;">{payload.policies.get(key).unique_system_count}</td>
-                                                    </tr>
-                                                {/for}
-                                            </tbody>
-                                        </table>
-                                    </td>
-                                </tr>
-
-                                <tr style="background-color:#fff">
-                                    <td align="center"
-                                        style="padding:20px 20px 24px 20px;color:#ffffff;font-size:18px;text-decoration:none;font-family:interstatecondensed,arial,sans-serif;font-weight:bold">
-                                        <table align="center">
-                                            <tbody>
-                                            <tr>
-                                                <td bgcolor="#0066cc"
-                                                    style="padding:8px 8px;background-color:#0066cc"
-                                                    align="center">
-                                                    <a href="https://cloud.redhat.com/insights/policies"
-                                                       style="color:#ffffff;text-decoration:none;display:block;display:inline-block;background:#0066cc;border-radius:4px;font-size:18px;text-decoration:none;font-family:'interstatecondensed',arial,sans-serif;font-weight:bold;width:100%;height:100%"
-                                                       target="_blank">
-                                                        Open Policies in Insights
-                                                    </a>
-                                                </td>
-                                            </tr>
-                                            </tbody>
-                                        </table>
-                                    </td>
-                                </tr>
-
-                                <tr>
-                                    <td bgcolor="#f5f5f5" style="padding:20px 0px;font-size:12px">
-                                        This alert was sent by Red Hat Insights | <a href="https://cloud.redhat.com/user-preferences/email" style="color:#551a8b"
-                                                                                     target="_blank">Manage email preferences</a>.
-                                    </td>
-                                </tr>
-                                </tbody>
-                            </table>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </td>
-        </tr>
-        </tbody>
-    </table>
-</div>
-</body>
-</html>
+{#include insightsEmailBody}
+{#content-title}Daily Policy Summary - {payload.start_time.toStringFormat()}{/content-title}
+{#content-body}
+<tr>
+    <td class="rh-content__block">
+        <p>Daily policy summary for <b>{payload.start_time.toStringFormat()}</b> from Red Hat Insights. <b>{payload.policies.size()} {#if payload.policies.size() == 1}policy{#else}policies{/if}</b> triggered on <b>{payload.unique_system_count} {#if payload.unique_system_count == 1}system{#else}unique systems{/if}</b>.</p>
+    </td>
+</tr>
+<tr>
+    <td class="rh-content__block">
+        <table class="rh-data-table rh-m-bordered">
+            <thead>
+            <tr>
+                <th>Policy</th>
+                <th>Systems</th>
+            </tr>
+            </thead>
+            <tbody>
+            {#for key in payload.policies.keySet()}
+            <tr>
+                <td><a href="https://cloud.redhat.com/insights/policies/policy/{payload.policies.get(key).policy_id}" target="_blank">{payload.policies.get(key).policy_name}</a></td>
+                <td>{payload.policies.get(key).unique_system_count}</td>
+            </tr>
+            {/for}
+            </tbody>
+        </table>
+    </td>
+</tr>
+<tr>
+    <td class="rh-content__block">
+        <table align="center">
+            <tr>
+                <td class="rh-cta-link" align="center">
+                    <a target="_blank" href="https://cloud.redhat.com/insights/policies">
+                                <span>
+                                  Open Policies in Insights
+                                </span>
+                    </a>
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+{/content-body}
+{/include}

--- a/src/main/resources/templates/Policies/instantEmailBody.html
+++ b/src/main/resources/templates/Policies/instantEmailBody.html
@@ -1,114 +1,57 @@
 {@java.lang.String payload.system_check_in}
 {@java.lang.String payload.display_name}
 {@java.util.Map<java.lang.String, java.lang.String> payload.triggers}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>Policy Notification</title>
-</head>
-<body>
-<div width="100%" style="margin:0;padding:0!important;font-family:overpass,arial;font-size:20px;box-sizing:border-box">
-    <table border="0" cellpadding="0" cellspacing="0" width="100%">
-        <tbody>
-        <tr>
-            <td>
-                <table align="center" border="0" cellpadding="0" cellspacing="0" width="600"
-                       style="border-collapse:collapse">
-                    <tbody>
-                    <tr>
-                        <td align="center" bgcolor="#000000" style="padding:20px 0 20px 0">
-                            <a href="https://cloud.redhat.com/insights/" style="display:block">
-                                <img src="https://cloud.redhat.com/apps/insights/images/email/rh-insights-logo.png"
-                                     alt="Red Hat Insights logo" width="152" height="60" style="display:block">
-                            </a>
-                        </td>
-                    </tr>
-
-                    <tr>
-                        <td bgcolor="#2c2c2" width="600" valign="top">
-                            <div width="100%" align="center"
-                                 style="padding:20px 20px 20px 20px;color:#ffffff;font-size:18px;font-weight:bold">
-                                Policies triggered - {payload.system_check_in.toUtcFormat()}
-                            </div>
-                        </td>
-                    </tr>
-
-                    <tr>
-                        <td bgcolor="#f5f5f5" style="padding:20px 20px 0 20px">
-                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                                <tbody>
-                                <tr>
-                                    <td bgcolor="ffffff" style="padding:20px 20px 20px 20px;font-size:16px">
-                                        Policy trigger notification for <strong>{payload.display_name}</strong>.<br>
-                                        System checked in at {payload.system_check_in.toUtcFormat()} and triggered {payload.triggers.size()} {#if payload.triggers.size() is 1}policy{#else}policies{/if}.
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td bgcolor="ffffff" style="padding:0px 20px 20px 20px;font-size:16px;font-weight:bold">
-                                        {payload.display_name}
-                                    </td>
-                                </tr>
-                                <tr style="background-color:#fff">
-                                    <td align="center"
-                                        style="padding:0px 20px 24px 20px;font-size:18px;text-decoration:none;font-family:interstatecondensed,arial,sans-serif">
-                                        <table text-align="left" width="100%" style="border-collapse: collapse;">
-                                            <thead style="text-align: left">
-                                            <tr style="background-color: #ddf3ff;text-transform: uppercase;font-size: 14px;">
-                                                <th style="padding:10px 10px;border: 1px solid #f5f5f5;">Policy</th>
-                                            </tr>
-                                            </thead>
-                                            <tbody>
-                                            {#if payload.triggers.size() > 0}
-                                                {#with payload.triggers}
-                                                    {#for key in keySet}
-                                                    <tr style="font-size: 14px;">
-                                                        <td style="padding:10px 10px;border: 1px solid #f5f5f5;"><a href="https://cloud.redhat.com/insights/policies/policy/{key}" target="_blank">{payload.triggers.get(key)}</a></td>
-                                                    </tr>
-                                                    {/for}
-                                                {/with}
-                                            {/if}
-                                            </tbody>
-                                        </table>
-                                    </td>
-                                </tr>
-
-                                <tr style="background-color:#fff">
-                                    <td align="center"
-                                        style="padding:20px 20px 24px 20px;color:#ffffff;font-size:18px;text-decoration:none;font-family:interstatecondensed,arial,sans-serif;font-weight:bold">
-                                        <table align="center">
-                                            <tbody>
-                                            <tr>
-                                                <td bgcolor="#0066cc"
-                                                    style="padding:8px 8px;background-color:#0066cc"
-                                                    align="center">
-                                                    <a href="https://cloud.redhat.com/insights/policies"
-                                                       style="color:#ffffff;text-decoration:none;display:block;display:inline-block;background:#0066cc;border-radius:4px;font-size:18px;text-decoration:none;font-family:'interstatecondensed',arial,sans-serif;font-weight:bold;width:100%;height:100%"
-                                                       target="_blank">
-                                                        Open Policies in Insights
-                                                    </a>
-                                                </td>
-                                            </tr>
-                                            </tbody>
-                                        </table>
-                                    </td>
-                                </tr>
-
-                                <tr>
-                                    <td bgcolor="#f5f5f5" style="padding:20px 0px;font-size:12px">
-                                        This alert was sent by Red Hat Insights | <a href="https://cloud.redhat.com/user-preferences/email" style="color:#551a8b"
-                                                                                     target="_blank">Manage email preferences</a>.
-                                    </td>
-                                </tr>
-                                </tbody>
-                            </table>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            </td>
-        </tr>
-        </tbody>
-    </table>
-</div>
-</body>
-</html>
+{#include insightsEmailBody}
+{#content-title}Policies triggered - {payload.system_check_in.toUtcFormat()}{/content-title}
+{#content-body}
+<tr>
+    <td class="rh-content__block">
+        <p>Policy trigger notification for <b>{payload.display_name}</b>. System checked in at {payload.system_check_in.toUtcFormat()} and triggered {payload.triggers.size()} {#if payload.triggers.size() is 1}policy{#else}policies{/if}.</p>
+    </td>
+</tr>
+<tr>
+    <td class="rh-content__block">
+        <div class="rh-stack">
+            <a class="rh-url" href="https://cloud.redhat.com/insights/inventory/{payload.insights_id}"><b>{payload.display_name}</b></a>
+        </div>
+    </td>
+</tr>
+<tr>
+    <td class="rh-content__block">
+        <table class="rh-data-table rh-m-bordered">
+            <thead>
+            <tr>
+                <th>Policy</th>
+            </tr>
+            </thead>
+            <tbody>
+                {#if payload.triggers.size() > 0}
+                    {#with payload.triggers}
+                        {#for key in keySet}
+                <tr style="font-size: 14px;">
+                    <a href="https://cloud.redhat.com/insights/policies/policy/{key}" target="_blank">{payload.triggers.get(key)}</a>
+                </tr>
+                        {/for}
+                    {/with}
+                {/if}
+            </tbody>
+        </table>
+    </td>
+</tr>
+<tr>
+    <td class="rh-content__block">
+        <table align="center">
+            <tr>
+                <td class="rh-cta-link" align="center">
+                    <a target="_blank" href="https://cloud.redhat.com/insights/policies">
+                                <span>
+                                  Open Policies in Insights
+                                </span>
+                    </a>
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+{/content-body}
+{/include}

--- a/src/main/resources/templates/insightsEmailBody.html
+++ b/src/main/resources/templates/insightsEmailBody.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Red Hat Insights</title>
+{|
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Text&display=swap');
+
+        .rh-masthead__content-title,
+        .rh-masthead__metric-block-count,
+        .rh-masthead__metric-block-text,
+        .rh-masthead__subhead {
+            font-family: 'Red Hat Display', Helvetica, sans-serif;
+        }
+
+        body,
+        .rh-content__block,
+        .rh-data-table,
+        .rh-masthead__subhead {
+            font-family: 'Red Hat Text', Helvetica, sans-serif;
+        }
+
+        #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" message */
+        body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:100%; -ms-text-size-adjust:100%;} /* Prevent WebKit and Windows mobile changing default text sizes */
+        table, td{mso-table-lspace:0pt; mso-table-rspace:0pt;} /* Remove spacing between tables in Outlook 2007 and up */
+        img{-ms-interpolation-mode:bicubic;} /* Allow smoother rendering of resized image in Internet Explorer */
+
+        /* reset styles */
+        img{border:0; height:auto; line-height:100%; outline:none; text-decoration:none;}
+        table{border-collapse:collapse !important;}
+        a{text-decoration: none !important;}
+
+        /* Remove space around email design */
+        html,
+        body {
+            margin: 0 auto !important;
+            padding: 0 !important;
+            height: 100% !important;
+            width: 100% !important;
+            background-color: #fff;
+        }
+
+        /* Stop Outlook resizing small text */
+        * {
+            -ms-text-size-adjust: 100%;
+        }
+        /* Stop Outlook from adding extra spacing to tables */
+        table, td {
+            mso-table-lspace: 0pt !important;
+            mso-table-rspace: 0pt !important;
+        }
+        /* Better rendering method when resizing impages in Outlook IE */
+        img {
+            -ms-interpolation-mode:bicubic;
+        }
+
+        a {
+            text-decoration: none;
+            color: #fff;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            font-family: 'Red Hat Display', sans-serif;
+            font-size: 16px;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        p {
+            margin-top: 0;
+        }
+
+        h1:last-child,
+        h2:last-child,
+        h3:last-child,
+        h4:last-child,
+        h5:last-child,
+        h6:last-child,
+        p:last-child {
+            margin-bottom: 0;
+        }
+
+
+        .rh-masthead__content-title h1,
+        .rh-masthead__content-title h2,
+        .rh-masthead__content-title h3,
+        .rh-masthead__content-title h4,
+        .rh-masthead__subhead h1,
+        .rh-masthead__subhead h2,
+        .rh-masthead__subhead h3,
+        .rh-masthead__subhead h4 {
+            font-weight: 400;
+            line-height: 1;
+        }
+
+        .rh-body-table,
+        .rh-body-cell {
+            height:100% !important;
+            margin:0;
+            padding:0;
+            width:100% !important;
+        }
+
+        .rh-body-table {
+            background-color: #f5f5f5;
+            background-color: #fff;
+        }
+
+        .rh-page {
+            padding: 0 0 30px 0;
+            background: #efefef;
+        }
+
+        .rh-template-container {
+            padding: 0 0 30px 0;
+            width: 600px;
+        }
+
+        .rh-template-container,
+        .rh-template-container > tbody {
+            background: #ededed;
+        }
+
+        .rh-head,
+        .rh-body,
+        .rh-footer {
+            margin: 0;
+            mso-line-height-rule: exactly;
+            font-family: arial;
+            font-size: 16px;
+            box-sizing: border-box;
+        }
+
+        .rh-body {
+            padding: 0 20px 20px 20px;
+        }
+
+        .rh-body,
+        .rh-masthead,
+        .rh-content,
+        .rh-data-table,
+        .rh-head {
+            width: 100% !important;
+        }
+
+        .rh-head {
+            padding: 0 0 20px 0;
+        }
+
+        .rh-footer {
+            padding: 10px 20px 30px 20px;
+        }
+
+        .rh-masthead__content {
+            background-color: #090a0a !important;
+            background-color: #030303 !important;
+            background-image: url(https://cloud.redhat.com/apps/frontend-assets/email-assets/bg_masthead-hat.png);
+            background-size: cover;
+        }
+
+        .rh-masthead__subhead {
+            background-color: #282828 !important;
+            padding: 20px;
+            color: #ffffff !important;
+            font-size: 18px;
+            text-align: center;
+        }
+
+        .rh-masthead__block {
+            width: 200px;
+        }
+
+        .rh-masthead__brand {
+            padding: 5px 20px 5px 20px;
+            background-color: #151515 !important;
+            background-repeat: repeat;
+            background-image: url(https://cloud.redhat.com/apps/frontend-assets/email-assets/bg_151515.jpg);
+            text-align: center;
+        }
+
+        .rh-masthead__brand-link {
+            display: block;
+            text-align: center;
+        }
+
+        .rh-masthead__content {
+            background-color: #151515;
+            background-size: cover;
+            background-repeat: no-repeat;
+        }
+
+        .rh-masthead__content-title {
+            padding: 20px 20px 20px 20px;
+            margin: 0 0 10px 0;
+            color: #ffffff;
+            font-size: 18px;
+            position: relative;
+            font-weight: 400;
+        }
+
+        .rh-masthead__metric-block-count {
+            display: block;
+            padding-bottom: 10px;
+            text-align: center;
+            font-size: 28px;
+            word-break:break-all;
+            color: #ffffff !important;
+            line-height: 1;
+        }
+
+        .rh-masthead__metric-block-text {
+            display: block;
+            padding: 0 20px 40px 20px;
+            word-break: break-all;
+            color: #ffffff !important;
+            line-height: 1;
+            font-size: 14px;
+        }
+
+        .rh-masthead__metric-block-icon {
+            padding: 0 0 20px;
+            display: block;
+        }
+
+        .rh-content + .rh-content {
+            padding: 0 0 20px 0;
+        }
+
+        .rh-content a {
+            color: #0066cc;
+        }
+
+        .rh-content {
+            background: #efefef;
+        }
+
+        .rh-content table {
+            background: #fff;
+        }
+
+        /* Content block */
+        .rh-content__block {
+            max-width: 100%;
+            padding: 20px 20px 20px 20px;
+            overflow: hidden;
+        }
+
+        .rh-content tr + tr .rh-content__block {
+            padding-top: 0;
+        }
+
+        .rh-content .rh-content__block {
+            background-color: #fff;
+        }
+
+        .rh-content__block-title {
+            font-weight: bold;
+        }
+
+        .rh-footer__text {
+            font-size: 14px;
+        }
+
+        .rh-footer__text a {
+            color: #0066cc;
+        }
+
+        .rh-content__spacer {
+            font-size: 0;
+            line-height: 0;
+            height: 20px;
+            background-color: #ffffff;
+        }
+
+        .rh-cta-link {
+            display:block;
+            padding: 10px 20px;
+            background-color: #0066cc;
+            border-radius: 3px;
+            text-decoration:none;
+            font-weight:bold;
+        }
+
+        .rh-cta-link a {
+            color:#ffffff;
+            text-decoration: none;
+        }
+
+        .rh-data-table thead th {
+            font-weight: 700;
+            text-align: left;
+        }
+
+        .rh-data-table tbody th {
+            font-weight: 500;
+            text-align: left;
+            width: 200px;
+        }
+
+        .rh-data-table.rh-m-bordered th {
+            padding: 10px;
+            text-align: left;
+            font-size: 14px;
+            font-weight: 500;
+            text-transform: uppercase;
+            background-color: #ededed;
+        }
+
+        .rh-data-table.rh-m-bordered td {
+            padding: 10px;
+            text-align: left;
+        }
+
+        .rh-data-table.rh-m-bordered {
+            border-collapse: collapse;
+        }
+
+        .rh-table-header {
+            text-align: left;
+            padding-bottom: 0;
+        }
+
+        .rh-m-bordered th,
+        .rh-m-bordered td {
+            border-width: 1px;
+            border-color: #b8bbbe;
+            border-style: solid;
+        }
+
+        .rh-m-bordered tr:nth-child(even) {
+            background-color: #fafafa;
+        }
+
+        .rh-color__red {
+            color: #a30000;
+        }
+
+        .rh-color__orange {
+            color: #ec7a08;
+        }
+
+        .rh-color__green {
+            color: #486b00;
+        }
+
+        .rh-m-block {
+            display: block;
+        }
+
+        .rh-url {
+            word-break: break-word;
+        }
+
+        .rh-stack > * + * {
+            margin-top: 10px;
+        }
+
+        .rh-inline {
+            display: flex;
+            align-items: center;
+        }
+
+        .rh-icon {
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            line-height: 1;
+        }
+
+        .rh-inline > * + * {
+            display: inline-block;
+            margin-left: 5px;
+        }
+
+        /* dark mode hacks */
+        [data-ogsc] .rh-masthead__brand,
+        [data-ogsb] .rh-masthead__brand {
+            background-color: #151515 !important;
+        }
+
+        @media only screen and (max-width: 320px) {
+            .rh-masthead__block {
+                width: 100% !important;
+                display: block !important;
+            }
+        }
+
+        @media only screen and (max-width: 480px) {
+            .rh-template-container {
+                max-width: 480px !important;
+                /*@editable*/ width:100% !important;
+            }
+
+            .rh-data-table tbody th {
+                width: auto !important;
+            }
+
+            .rh-data-table th,
+            .rh-data-table td {
+                font-size: 14px;
+            }
+
+            .rh-data-table.rh-m-bordered th,
+            .rh-data-table.rh-m-bordered td {
+                padding: 5px;
+                text-align: left;
+            }
+        }
+
+        @media only screen and (max-width: 600px) {
+            body{
+                width: 100% !important;
+                min-width: 100% !important;
+            }
+
+            .rh-template-container {
+                max-width: 600px !important;
+                /*@editable*/ width:100% !important;
+            }
+
+            .rh-masthead__block {
+                width: 33%;
+                max-width: 200px;
+            }
+        }
+    </style>
+|}
+</head>
+
+<body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" class="rh-body">
+<center>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" class="rh-body-table">
+        <tr>
+            <td align="center" valign="top" class="rh-body-cell">
+                <table border="0" cellpadding="0" cellspacing="0" class="rh-template-container">
+
+                    <!-- Head -->
+                    <tr>
+                        <td class="rh-head">
+                            <table class="rh-masthead" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <!--Red Hat logo-->
+                                    <td align="center" class="rh-masthead__brand" bgcolor="#151515">
+                                        <a href="https://cloud.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                            <img src="https://cloud.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
+                                        </a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="rh-masthead__subhead">
+                                        <h1>{#insert content-title}{/}</h1>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <!-- end head -->
+
+                    <!-- Body section -->
+                    <tr>
+                        <td class="rh-body">
+                            <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                {#insert content-body}{/}
+                            </table>
+                        </td>
+                    </tr>
+                    <!-- end body section -->
+
+                    <!-- Footer -->
+                    <tr>
+                        <td class="rh-footer">
+                            <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td class="rh-footer__text">
+                                        This email was sent by Red Hat Insights |<a href="https://cloud.redhat.com/user-preferences/email" target="_blank">&nbsp;Manage email preferences</a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <!-- end footer -->
+
+                    <!-- Ensure padding bottom - don't remove empty row -->
+                    <tr>
+                        <td>
+                        </td>
+                    </tr>
+                    <!-- leave - empty row -->
+
+                </table>
+            </td>
+        </tr>
+    </table>
+</center>
+</body>
+</html>

--- a/src/test/java/com/redhat/cloud/notifications/templates/TestPoliciesTemplate.java
+++ b/src/test/java/com/redhat/cloud/notifications/templates/TestPoliciesTemplate.java
@@ -44,6 +44,7 @@ public class TestPoliciesTemplate {
         payload.put("triggers", triggers);
         payload.put("display_name", "FooMachine");
         payload.put("system_check_in", "2020-04-16T16:10:42.199046");
+        payload.put("insights_id", "this-is-my-id");
 
         String result = Policies.Templates.instantEmailBody()
                 .data("payload", payload)
@@ -104,6 +105,7 @@ public class TestPoliciesTemplate {
 
         Map<String, Object> policy01 = new HashMap<>();
         policy01.put("policy_id", "policy-01");
+        policy01.put("policy_name", "My policy 01");
         policy01.put("unique_system_count", 1);
 
         Map<String, Object> policies = new HashMap<>();
@@ -130,15 +132,18 @@ public class TestPoliciesTemplate {
 
         Map<String, Object> policy01 = new HashMap<>();
         policy01.put("policy_id", "policy-01");
+        policy01.put("policy_name", "My policy 01");
         policy01.put("unique_system_count", 2);
 
         Map<String, Object> policy02 = new HashMap<>();
-        policy01.put("policy_id", "policy-02");
-        policy01.put("unique_system_count", 1);
+        policy02.put("policy_id", "policy-02");
+        policy02.put("policy_name", "My policy 02");
+        policy02.put("unique_system_count", 1);
 
         Map<String, Object> policy03 = new HashMap<>();
-        policy01.put("policy_id", "policy-03");
-        policy01.put("unique_system_count", 1);
+        policy03.put("policy_id", "policy-03");
+        policy03.put("policy_name", "My policy 03");
+        policy03.put("unique_system_count", 1);
 
         Map<String, Object> policies = new HashMap<>();
         policies.put("policy-01", policy01);
@@ -155,7 +160,8 @@ public class TestPoliciesTemplate {
                 .data("payload", payload)
                 .render();
 
-        assertTrue(result.contains("<strong>3 policies</strong> triggered on <strong>3 unique systems</strong>"));
+        assertTrue(result.contains("<b>3 policies</b> triggered on <b>3 unique systems</b>"));
+        assertFalse(result.contains("NOT_FOUND"), "A replacement was not correctly done");
     }
 
     @Test
@@ -166,6 +172,7 @@ public class TestPoliciesTemplate {
 
         Map<String, Object> policy01 = new HashMap<>();
         policy01.put("policy_id", "policy-01");
+        policy01.put("policy_name", "My policy 01");
         policy01.put("unique_system_count", 1);
 
         Map<String, Object> policies = new HashMap<>();
@@ -181,7 +188,8 @@ public class TestPoliciesTemplate {
                 .data("payload", payload)
                 .render();
 
-        assertTrue(result.contains("<strong>1 policy</strong> triggered on <strong>1 system</strong>"));
+        assertTrue(result.contains("<b>1 policy</b> triggered on <b>1 system</b>"));
+        assertFalse(result.contains("NOT_FOUND"), "A replacement was not correctly done");
     }
 
 }


### PR DESCRIPTION
  - Split into insightsEmailTemplate base and policies

The content should be same but more compatible with browsers and email clients.

Took them from https://github.com/RedHatInsights/frontend-assets/tree/master/src/email-assets/email-templates
- Had to manually update image urls from github to cloud.redhat.com
- Use qute to prevent evaluation of some parts. {padding:0} was picked by qute and throw errors when running the tests
- Remove some content to match the "simple" templates.