### PR TITLE
Remove Yasson from test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,16 +204,6 @@
             <version>${openapi-parser.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse</groupId>
-            <artifactId>yasson</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
While investigating a deserialization issue with the Hibernate Reactive migration branch, I noticed Yasson in the POM. Since Jackson is already available and the app is relying on it, I think we can get rid of Yasson.