### PR TITLE
NOTIF-138 Replace jsonb with text in database

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/EmailAggregationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EmailAggregationResources.java
@@ -4,7 +4,6 @@ import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.models.EmailAggregationKey;
 import io.r2dbc.postgresql.api.PostgresqlConnection;
 import io.r2dbc.postgresql.api.PostgresqlResult;
-import io.r2dbc.postgresql.codec.Json;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
@@ -33,7 +32,7 @@ public class EmailAggregationResources extends DatasourceProvider {
                                 .bind("$1", aggregation.getAccountId())
                                 .bind("$2", aggregation.getBundle())
                                 .bind("$3", aggregation.getApplication())
-                                .bind("$4", Json.of(aggregation.getPayload().encode()))
+                                .bind("$4", aggregation.getPayload().encode())
                                 .execute();
                             return execute.flatMap(PostgresqlResult::getRowsUpdated).map(i -> i > 0);
                         })

--- a/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -88,9 +88,9 @@ public class EndpointResources extends DatasourceProvider {
 
         if (attr.getBasicAuthentication() != null) {
             String encodedJson = Json.encode(attr.getBasicAuthentication());
-            bind.bind("$6", io.r2dbc.postgresql.codec.Json.of(encodedJson));
+            bind.bind("$6", encodedJson);
         } else {
-            bind.bindNull("$6", io.r2dbc.postgresql.codec.Json.class);
+            bind.bindNull("$6", String.class);
         }
 
         Flux<PostgresqlResult> execute = bind

--- a/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
@@ -4,7 +4,6 @@ import com.redhat.cloud.notifications.models.NotificationHistory;
 import io.r2dbc.postgresql.api.PostgresqlConnection;
 import io.r2dbc.postgresql.api.PostgresqlResult;
 import io.r2dbc.postgresql.api.PostgresqlStatement;
-import io.r2dbc.postgresql.codec.Json;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.converters.multi.MultiReactorConverters;
@@ -41,9 +40,9 @@ public class NotificationResources {
                             .bind("$5", history.getEventId());
 
                     if (history.getDetails() != null) {
-                        st.bind("$6", Json.of(new JsonObject(history.getDetails()).encode()));
+                        st.bind("$6", new JsonObject(history.getDetails()).encode());
                     } else {
-                        st.bindNull("$6", Json.class);
+                        st.bindNull("$6", String.class);
                     }
                     Flux<PostgresqlResult> execute = st.returnGeneratedValues("id", "created").execute();
                     return execute.flatMap(res -> res.map((row, rowMetadata) -> {

--- a/src/main/resources/db/migration/V1.9.0__NOTIF-138_hibernate_reactive_remove_jsonb.sql
+++ b/src/main/resources/db/migration/V1.9.0__NOTIF-138_hibernate_reactive_remove_jsonb.sql
@@ -1,0 +1,13 @@
+--
+-- NOTIF-138
+-- Hibernate Reactive does not support the jsonb type from PostgreSQL.
+--
+
+ALTER TABLE public.endpoint_webhooks
+  ALTER COLUMN basic_authentication TYPE text;
+
+ALTER TABLE public.email_aggregation
+  ALTER COLUMN payload TYPE text;
+
+ALTER TABLE public.notification_history
+  ALTER COLUMN details TYPE text;


### PR DESCRIPTION
The `jsonb` native type from PostgreSQL isn't natively supported by Hibernate (Reactive or ORM). Someone from the Quarkus community created a [Quarkiverse extension](https://github.com/quarkiverse/quarkus-hibernate-types) (based on Vlad Mihalcea's [hibernate-types](https://github.com/vladmihalcea/hibernate-types)) to add `jsonb` support to Hibernate ORM with Quarkus, but it does not work with Hibernate Reactive.

@josejulio I tested this locally, everything seemed OK from a backend point of view. My tests included manipulating data saved from `master` with the `jsonb` type and then reused from this branch with the migrated `text` type.

As we discussed earlier, could you please test this with the full notifications app?

cc @pilhuhn 