### PR TITLE
NOTIF-138 Prepare tests for the Hibernate Reactive migration

### DIFF
--- a/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
@@ -11,9 +11,12 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -23,6 +26,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
 public class ApplicationServiceTest {
+
+    /*
+     * In the tests below, most JSON responses are verified using JsonObject/JsonArray instead of deserializing these
+     * responses into model instances and checking their attributes values. That's because the model classes contain
+     * attributes annotated with @JsonProperty(access = READ_ONLY) which can't be deserialized and therefore verified
+     * here. The deserialization is still performed only to verify that the JSON responses data structure is correct.
+     */
 
     static final String APP_NAME = "policies-application-service-test";
     static final String EVENT_TYPE_NAME = "policy-triggered";
@@ -36,24 +46,26 @@ public class ApplicationServiceTest {
         Bundle bundle = new Bundle();
         bundle.setName(BUNDLE_NAME);
         bundle.setDisplay_name("Insights");
-        Bundle returnedBundle =
-            given()
-                    .body(bundle)
-                    .contentType(ContentType.JSON)
-                .when().post("/internal/bundles")
-                .then()
-                    .statusCode(200)
-                .extract().body().as(Bundle.class);
+        Response response =
+                given()
+                        .body(bundle)
+                        .contentType(ContentType.JSON)
+                        .when().post("/internal/bundles")
+                        .then()
+                        .statusCode(200)
+                        .extract().response();
+        JsonObject returnedBundle = new JsonObject(response.body().asString());
+        returnedBundle.mapTo(Bundle.class);
 
         Application app = new Application();
         app.setName(APP_NAME);
         app.setDisplay_name("The best app");
-        app.setBundleId(returnedBundle.getId());
+        app.setBundleId(UUID.fromString(returnedBundle.getString("id")));
 
         // All of these are without identityHeader
 
         // Now create an application
-        Response response = given()
+        response = given()
                 .when()
                 .contentType(ContentType.JSON)
                 .body(Json.encode(app))
@@ -62,29 +74,31 @@ public class ApplicationServiceTest {
                 .statusCode(200)
                 .extract().response();
 
-        Application appResponse = Json.decodeValue(response.getBody().asString(), Application.class);
-        assertNotNull(appResponse.getId());
-        assertEquals(returnedBundle.getId(), appResponse.getBundleId());
+        JsonObject appResponse = new JsonObject(response.getBody().asString());
+        appResponse.mapTo(Application.class);
+        assertNotNull(appResponse.getString("id"));
+        assertEquals(returnedBundle.getString("id"), appResponse.getString("bundle_id"));
 
         // Fetch the applications to check they were really added
         response =
-            given()
-                    // Set header to x-rh-identity
-                    .when()
-                    .get("/internal/applications?bundleName=" + BUNDLE_NAME)
-                    .then()
-                    .statusCode(200)
-                    .extract().response();
+                given()
+                        // Set header to x-rh-identity
+                        .when()
+                        .get("/internal/applications?bundleName=" + BUNDLE_NAME)
+                        .then()
+                        .statusCode(200)
+                        .extract().response();
         assertNotNull(response);
-        List<Application> apps = response.jsonPath().getList(".", Application.class);
+        JsonArray apps = new JsonArray(response.body().asString());
+        apps.getJsonObject(0).mapTo(Application.class);
         assertEquals(1, apps.size());
-        assertEquals(returnedBundle.getId().toString(), apps.get(0).getBundleId().toString());
-        assertEquals(appResponse.getId().toString(), apps.get(0).getId().toString());
+        assertEquals(returnedBundle.getString("id"), apps.getJsonObject(0).getString("bundle_id"));
+        assertEquals(appResponse.getString("id"), apps.getJsonObject(0).getString("id"));
 
         // Check, we can get it by its id.
         given()
                 .when()
-                .get("/internal/applications/" + appResponse.getId())
+                .get("/internal/applications/" + appResponse.getString("id"))
                 .then()
                 .statusCode(200);
 
@@ -98,37 +112,39 @@ public class ApplicationServiceTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(Json.encode(eventType))
-                .post(String.format("/internal/applications/%s/eventTypes", appResponse.getId()))
+                .post(String.format("/internal/applications/%s/eventTypes", appResponse.getString("id")))
                 .then()
                 .statusCode(200)
                 .extract().response();
 
-        EventType typeResponse = Json.decodeValue(response.getBody().asString(), EventType.class);
-        assertNotNull(typeResponse.getId());
-        assertEquals(eventType.getDescription(), typeResponse.getDescription());
+        JsonObject typeResponse = new JsonObject(response.getBody().asString());
+        typeResponse.mapTo(EventType.class);
+        assertNotNull(typeResponse.getString("id"));
+        assertEquals(eventType.getDescription(), typeResponse.getString("description"));
 
         // Now delete the app and verify that it is gone along with the eventType
         given()
                 .when()
-                .delete("/internal/applications/" + appResponse.getId())
+                .delete("/internal/applications/" + appResponse.getString("id"))
                 .then()
                 .statusCode(200);
 
         // Check that get by Id does not return a 200, as it is gone.
         given()
                 .when()
-                .get("/internal/applications/" + appResponse.getId())
+                .get("/internal/applications/" + appResponse.getString("id"))
                 .then()
                 .statusCode(204); // TODO api reports a 204 "empty response", but should return a 404
 
         // Now check that the eventTypes for that id is also empty
-        List list =
-            given()
-                    .when()
-                    .get("/internal/applications/" + appResponse.getId() + "/eventTypes")
-                    .then()
-                    .statusCode(200)
-                    .extract().as(List.class);
+        response =
+                given()
+                        .when()
+                        .get("/internal/applications/" + appResponse.getString("id") + "/eventTypes")
+                        .then()
+                        .statusCode(200)
+                        .extract().response();
+        JsonArray list = new JsonArray(response.body().asString());
 
         assertEquals(0, list.size());
 
@@ -152,21 +168,23 @@ public class ApplicationServiceTest {
         Bundle bundle = new Bundle();
         bundle.setName(LOCAL_BUNDLE_NAME);
         bundle.setDisplay_name("Insights");
-        Bundle returnedBundle =
+        Response bundleResponse =
                 given()
                         .body(bundle)
                         .contentType(ContentType.JSON)
                         .when().post("/internal/bundles")
                         .then()
                         .statusCode(200)
-                        .extract().body().as(Bundle.class);
+                        .extract().response();
+        JsonObject returnedBundle = new JsonObject(bundleResponse.body().asString());
+        returnedBundle.mapTo(Bundle.class);
 
         for (int i = 0; i < 10; ++i) {
             String LOCAL_APP_NAME = "my-app-" + i;
             Application app = new Application();
             app.setName(LOCAL_APP_NAME);
             app.setDisplay_name("The best app");
-            app.setBundleId(returnedBundle.getId());
+            app.setBundleId(UUID.fromString(returnedBundle.getString("id")));
 
             given()
                     .when()
@@ -179,12 +197,12 @@ public class ApplicationServiceTest {
 
         assertDoesNotThrow(() -> {
             Response response = given()
-                            // Set header to x-rh-identity
-                            .when()
-                            .get("/internal/applications?bundleName=" + LOCAL_BUNDLE_NAME)
-                            .then()
-                            .statusCode(200)
-                            .extract().response();
+                    // Set header to x-rh-identity
+                    .when()
+                    .get("/internal/applications?bundleName=" + LOCAL_BUNDLE_NAME)
+                    .then()
+                    .statusCode(200)
+                    .extract().response();
 
             List<Application> applications = response.jsonPath().getList(".", Application.class);
 


### PR DESCRIPTION
This PR contains some preparation work for the Hibernate Reactive migration.

Unlike R2DBC or Hibernate ORM, Hibernate Reactive does not allow us to retrieve values (UUID or timestamp) generated by PostgreSQL during an `INSERT` or an `UPDATE`. Because of that, if we want to keep sending generated values in the REST responses without performing an additional `SELECT` each time we change something in the database, the generation has to happen in the Java code (which is fairly easy with Hibernate). But the Hibernate UUID generator is only run if the `id` attribute is `null` when the data is about to be persisted, so we have to make sure that an `id` will never come from an API request. Therefore, in the Hibernate Reactive migration PR, all API classes identifiers will be annotated with `@JsonProperty(access = READ_ONLY)` to make sure the UUID generation is working fine. Same goes for timestamps which should not come from the API requests. The problem with read-only attributes is that we can't deserialize REST responses into API classes anymore in our tests because Jackson now knows that the attributes are read-only. This is why I had to refactor the tests a bit.

▶️ The review is easier than it looks and the tests coverage is exactly the same as before.