### PR TITLE
NOTIF-138 Work around Quarkus flyway/hibernate-reactive incompatibility

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
@@ -1,0 +1,34 @@
+package com.redhat.cloud.notifications.db;
+
+import io.quarkus.runtime.StartupEvent;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.flywaydb.core.Flyway;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+/**
+ * This is a temporary workaround for a quarkus-flyway / quarkus-hibernate-reactive incompatibility.
+ * See https://github.com/quarkusio/quarkus/issues/10716 for more details.
+ */
+@ApplicationScoped
+public class FlywayWorkaround {
+
+    private static final Logger LOGGER = Logger.getLogger(FlywayWorkaround.class);
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.url")
+    String datasourceUrl;
+
+    @ConfigProperty(name = "quarkus.datasource.username")
+    String datasourceUsername;
+
+    @ConfigProperty(name = "quarkus.datasource.password")
+    String datasourcePassword;
+
+    public void runFlywayMigration(@Observes StartupEvent event) {
+        LOGGER.warn("Starting Flyway workaround... remove it ASAP!");
+        Flyway flyway = Flyway.configure().dataSource(datasourceUrl, datasourceUsername, datasourcePassword).load();
+        flyway.migrate();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,8 @@ quarkus.datasource.jdbc.url=jdbc:postgresql://127.0.0.1:5432/notifications
 quarkus.datasource.jdbc.max-size=4
 
 # Flyway minimal config properties
-quarkus.flyway.migrate-at-start=true
+# Temporarily disabled, see com.redhat.cloud.notifications.db.FlywayWorkaround for more details.
+#quarkus.flyway.migrate-at-start=true
 
 # OpenAPI path
 quarkus.smallrye-openapi.path=/openapi.json

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,7 +9,8 @@ quarkus.datasource.password=9FLK6cMm5px8vZ52
 quarkus.datasource.jdbc.url=jdbc:postgresql://192.168.1.139:5432/notifications-test
 
 # Flyway minimal config properties
-quarkus.flyway.migrate-at-start=true
+# Temporarily disabled, see com.redhat.cloud.notifications.db.FlywayWorkaround for more details.
+#quarkus.flyway.migrate-at-start=true
 
 #quarkus.http.access-log.enabled=true
 quarkus.http.access-log.category=info


### PR DESCRIPTION
This PR contains some preparation work for the Hibernate Reactive migration.

`quarkus-hibernate-reactive` is not currently compatible with `quarkus-flyway` because:

- Flyway requires a JDBC connection
- `quarkus-flyway` creates a JDBC datasource to satisfy Flyway's requirement
- `quarkus-hibernate-reactive` cannot start if there is a JDBC datasource in the application

This incompatibility is in the process of being fixed. More infos in the following Quarkus ticket: https://github.com/quarkusio/quarkus/issues/10716

In the meantime, we can work around this issue with this PR which can be merged into `master` as soon as it has been reviewed.

FYI, the same issue happens with `quarkus-liquibase`.