### PR TITLE
NOTIF-138 Fix database concurrency issues

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -62,15 +62,12 @@ public class EndpointProcessor {
                 action.getBundle(),
                 action.getApplication(),
                 action.getEventType())
-                .onItem()
-                .transformToUni(endpoint -> {
+                .onItem().transformToUniAndConcatenate(endpoint -> {
                     endpointTargeted.increment();
                     Notification endpointNotif = new Notification(action, endpoint);
                     return endpointTypeToProcessor(endpoint.getType()).process(endpointNotif);
                 })
-                .concatenate()
-                .onItem().transformToUni(history -> notifResources.createNotificationHistory(history))
-                .concatenate();
+                .onItem().transformToUniAndConcatenate(history -> notifResources.createNotificationHistory(history));
 
         // Should this be a separate endpoint type as well (since it is configurable) ?
         Notification notification = new Notification(action, null);

--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -68,15 +68,18 @@ public class EndpointProcessor {
                     Notification endpointNotif = new Notification(action, endpoint);
                     return endpointTypeToProcessor(endpoint.getType()).process(endpointNotif);
                 })
-                .merge()
+                .concatenate()
                 .onItem().transformToUni(history -> notifResources.createNotificationHistory(history))
-                .merge();
+                .concatenate();
 
         // Should this be a separate endpoint type as well (since it is configurable) ?
         Notification notification = new Notification(action, null);
         Uni<NotificationHistory> notificationResult = notificationProcessor.process(notification);
 
-        return Uni.combine().all().unis(endpointsCallResult.onItem().ignoreAsUni(), notificationResult).discardItems();
+        return endpointsCallResult
+                .onItem().ignoreAsUni()
+                .replaceWith(notificationResult)
+                .replaceWith(Uni.createFrom().voidItem());
     }
 
     public EndpointTypeProcessor endpointTypeToProcessor(EndpointType endpointType) {

--- a/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -293,7 +293,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
                     Notification item = new Notification(action, null);
 
                     return sendEmail(item, emailSubscriptionType).onItem().transformToMulti(notificationHistory -> Multi.createFrom().item(Tuple2.of(notificationHistory, aggregationKey)));
-                }).merge()
+                }).concatenate()
                 .onItem().transformToMulti(result -> {
                     if (delete) {
                         return emailAggregationResources.purgeOldAggregation(aggregationKey, endTime)
@@ -302,7 +302,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
                     }
 
                     return Multi.createFrom().item(result);
-                }).merge();
+                }).concatenate();
                 // Todo: If we want to save the NotificationHistory, this could be a good place to do so. We would probably require a special EndpointType
                 // .onItem().invoke(result -> { })
     }
@@ -318,7 +318,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
 
         return emailAggregationResources.getApplicationsWithPendingAggregation(startTime, endTime)
                 .onItem().transformToMulti(aggregationKey -> processAggregateEmailsByAggregationKey(aggregationKey, startTime, endTime, emailSubscriptionType, delete))
-                .merge().collectItems().asList()
+                .concatenate().collectItems().asList()
                 .onItem().invoke(result -> {
                     final LocalDateTime aggregateFinished = LocalDateTime.now();
                     log.info(

--- a/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -98,10 +98,9 @@ public class EndpointService {
             count = resources.getEndpointsCount(principal.getAccount());
         }
 
-        return Uni.combine().all().unis(
-                endpoints.collectItems().asList(),
-                count
-        ).asTuple().onItem().transform(t -> new EndpointPage(t.getItem1(), new HashMap<>(), new Meta(t.getItem2())));
+        return endpoints.collectItems().asList()
+                .onItem().transformToUni(endpointsList -> count
+                        .onItem().transform(endpointsCount -> new EndpointPage(endpointsList, new HashMap<>(), new Meta(endpointsCount))));
     }
 
     @POST

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -120,7 +120,7 @@ public class NotificationService {
                     })
         );
 
-        return Multi.createBy().merging().streams(directlyAffected, indirectlyAffected);
+        return Multi.createBy().concatenating().streams(directlyAffected, indirectlyAffected);
     }
 
     @PUT


### PR DESCRIPTION
This PR contains some preparation work for the Hibernate Reactive migration.

It prevents exisiting (and yet mostly invisible) concurrent accesses to the database which will become a blocking problem with Hibernate Reactive since the `Session` (and the underlying `EntityManager`) should not be used concurrently.

@cescoffier Could you please review these changes? I know there are many other things we need to fix regarding the way Mutiny is used in this project. We will take care of them soon, but not in this PR :)