### PR TITLE
NOTIF-161 Adding internal endpoint to pull data from policies-notifications

### DIFF
--- a/helpers/policies-notification-to-sql.py
+++ b/helpers/policies-notification-to-sql.py
@@ -1,0 +1,41 @@
+'''
+Helper script to load a csv file (with headers) from stdin with the contents of the email-subscriptions table from
+policies-notification.
+This script will output sql queries to insert the subscriptions to notification-backend, create email endpoints for
+each account, delete endpoints from the endpoint_targets of the accounts and insert the newly created endpoint to
+endpoint_target under the event_type provided as the first argument.
+
+Usage:
+cat subs.cvs | python policies-notification-to-sql.py id-of-policy-triggered-event-type
+'''
+import sys
+import uuid
+import csv
+
+app = 'policies'
+bundle = 'insights'
+
+if len(sys.argv) < 2:
+    raise Exception('Specify the event_type_id of policy-triggered')
+
+event_type_id = sys.argv[1]
+
+reader = csv.DictReader(sys.stdin)
+account_ids = set()
+for row in reader:
+    policies_event_type = row['event_type']
+    if policies_event_type == 'policies-instant-mail':
+        event_type = 'INSTANT'
+    elif policies_event_type == 'policies-daily-mail':
+        event_type = 'DAILY'
+    else:
+        raise Exception(f"Invalid policies_event_type {policies_event_type}")
+
+    account_ids.add(row['account_id'])
+    print(f"INSERT INTO endpoint_email_subscriptions(account_id, user_id, subscription_type, application, bundle) VALUES ('{row['account_id']}', '{row['user_id']}', '{event_type}', '{app}', '{bundle}');")
+
+for account_id in account_ids:
+    print(f"DELETE FROM endpoint_targets WHERE account_id='{account_id}';")
+    endpoint_id = uuid.uuid4()
+    print(f"INSERT INTO endpoints(id, account_id, endpoint_type, enabled, name, description) VALUES('{endpoint_id}', '{account_id}', 1, true, 'email-endpoint', '');")
+    print(f"INSERT INTO endpoint_targets(account_id, endpoint_id, event_type_id) VALUES('{account_id}', '{endpoint_id}', '{event_type_id}');")

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -165,11 +165,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-mockito</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
@@ -71,6 +71,15 @@ public class ApplicationResources {
                 .getSingleResultOrNull();
     }
 
+    public Uni<EventType> getEventType(String bundleName, String applicationName, String eventTypeName) {
+        final String query = "FROM EventType WHERE name = :eventTypeName AND application.name = :applicationName AND application.bundle.name = :bundleName";
+        return session.createQuery(query, EventType.class)
+                .setParameter("bundleName", bundleName)
+                .setParameter("applicationName", applicationName)
+                .setParameter("eventTypeName", eventTypeName)
+                .getSingleResultOrNull();
+    }
+
     public Multi<EventType> getEventTypes(UUID appId) {
         String query = "FROM EventType WHERE application.id = :appId";
         return session.createQuery(query, EventType.class)

--- a/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesEmailSubscription.java
+++ b/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesEmailSubscription.java
@@ -1,0 +1,11 @@
+package com.redhat.cloud.notifications.migration.policynotification;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public class PoliciesEmailSubscription {
+    public String accountId;
+    public String eventType;
+    public String userId;
+}

--- a/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesEmailSubscription.java
+++ b/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesEmailSubscription.java
@@ -8,4 +8,14 @@ public class PoliciesEmailSubscription {
     public String accountId;
     public String eventType;
     public String userId;
+
+    PoliciesEmailSubscription() {
+
+    }
+
+    PoliciesEmailSubscription(String accountId, String userId, String eventType) {
+        this.accountId = accountId;
+        this.eventType = eventType;
+        this.userId = userId;
+    }
 }

--- a/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationService.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Produces(MediaType.APPLICATION_JSON)
 public class PoliciesMigrationService {
 
-    static final String BUNDLE = "insights";
+    static final String BUNDLE = "rhel";
     static final String APPLICATION = "policies";
     static final String EVENT_TYPE = "policy-triggered";
     static final String DAILY_EMAIL_TYPE = "policies-daily-mail";

--- a/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationService.java
@@ -67,7 +67,7 @@ public class PoliciesMigrationService {
             )
                     .invoke(() -> response.eventTypesMigrated.incrementAndGet())
                     .onItem().transform(subscribed -> pes.accountId).toMulti())
-                    .concatenate().collectItems().in(HashSet::new, HashSet::add)
+                    .concatenate().collect().in(HashSet::new, HashSet::add)
                     .onItem().transformToMulti(accountIds -> Multi.createFrom().iterable(accountIds))
                     .onItem().castTo(String.class)
                     .onItem().transformToMultiAndConcatenate(accountId -> {
@@ -76,7 +76,7 @@ public class PoliciesMigrationService {
                         return endpointResources.getLinkedEndpoints(accountId, eventType.getId(), new Query())
                         .onItem().transformToMultiAndConcatenate(endpoint -> endpointResources.unlinkEndpoint(accountId, endpoint.getId(), eventType.getId()).toMulti())
                         // Create EmailAction (Endpoint) and add it to the eventType
-                        .collectItems().asList()
+                        .collect().asList()
                         .onItem().transformToUni(_removed -> {
                             Endpoint endpoint = new Endpoint();
                             endpoint.setAccountId(accountId);
@@ -89,7 +89,7 @@ public class PoliciesMigrationService {
                         })
                         .onItem().transformToUni(endpoint -> endpointResources.linkEndpoint(accountId, endpoint.getId(), eventType.getId())).toMulti();
                     });
-        }).collectItems().asList().onItem().transform(objects -> response);
+        }).collect().asList().onItem().transform(objects -> response);
     }
 
     private EmailSubscriptionType fromPoliciesEventType(String eventType) {

--- a/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationService.java
@@ -1,0 +1,101 @@
+package com.redhat.cloud.notifications.migration.policynotification;
+
+import com.redhat.cloud.notifications.db.ApplicationResources;
+import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
+import com.redhat.cloud.notifications.db.EndpointResources;
+import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.models.EmailSubscriptionAttributes;
+import com.redhat.cloud.notifications.models.EmailSubscriptionType;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Path("/internal/policies-notifications")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class PoliciesMigrationService {
+
+    private final String BUNDLE = "insights";
+    private final String APPLICATION = "policies";
+    private final String EVENT_TYPE = "policy-triggered";
+
+    @Inject
+    @RestClient
+    PolicyNotifications policyNotifications;
+
+    @Inject
+    EndpointEmailSubscriptionResources emailSubscriptionResources;
+
+    @Inject
+    EndpointResources endpointResources;
+
+    @Inject
+    ApplicationResources applicationResources;
+
+    class MigrateResponse {
+        public AtomicInteger eventTypesMigrated = new AtomicInteger();
+        public AtomicInteger accountsMigrated = new AtomicInteger();
+    }
+
+    @Path("/migrate")
+    @GET
+    public Uni<MigrateResponse> migrate() {
+        final MigrateResponse response = new MigrateResponse();
+        return applicationResources.getEventType(BUNDLE, APPLICATION, EVENT_TYPE)
+        .onItem().transformToMulti(eventType -> {
+            return policyNotifications.getSubscriptions()
+                    .onItem().transformToMulti(policiesEmailSubscriptions -> Multi.createFrom().iterable(policiesEmailSubscriptions))
+                    .onItem().transformToMulti(pes -> emailSubscriptionResources.subscribe(
+                    pes.accountId,
+                    pes.userId,
+                    BUNDLE,
+                    APPLICATION,
+                    fromPoliciesEventType(pes.eventType.toLowerCase())
+            )
+                    .invoke(() -> response.eventTypesMigrated.incrementAndGet())
+                    .onItem().transform(subscribed -> pes.accountId).toMulti())
+                    .merge().collectItems().in(HashSet::new, HashSet::add)
+                    .onItem().transformToMulti(accountIds -> Multi.createFrom().iterable(accountIds))
+                    .onItem().castTo(String.class)
+                    .onItem().transformToMulti(accountId -> {
+                        response.accountsMigrated.incrementAndGet();
+                        // Remove existing endpoints
+                        return endpointResources.getLinkedEndpoints(accountId, eventType.getId(), new Query())
+                        .onItem().transform(endpoint -> endpointResources.unlinkEndpoint(accountId, endpoint.getId(), eventType.getId()))
+                        .collectItems().asList()
+                        // Create EmailAction (Endpoint) and add it to the eventType
+                        .onItem().transformToMulti(_removed -> {
+                            Endpoint endpoint = new Endpoint();
+                            endpoint.setAccountId(accountId);
+                            endpoint.setEnabled(true);
+                            endpoint.setDescription("");
+                            endpoint.setName("email-endpoint");
+                            endpoint.setType(EndpointType.EMAIL_SUBSCRIPTION);
+                            endpoint.setProperties(new EmailSubscriptionAttributes());
+                            return endpointResources.createEndpoint(endpoint).toMulti();
+                        })
+                        .onItem().transform(endpoint -> endpointResources.linkEndpoint(accountId, endpoint.getId(), eventType.getId()));
+                    }).merge();
+        }).collectItems().asList().onItem().transform(objects -> response);
+    }
+
+    private EmailSubscriptionType fromPoliciesEventType(String eventType) {
+        if (eventType.equals("policies-daily-mail")) {
+            return EmailSubscriptionType.DAILY;
+        } else if (eventType.equals("policies-instant-mail")) {
+            return EmailSubscriptionType.INSTANT;
+        }
+        throw new IllegalArgumentException("Unknown policies event type: " + eventType);
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PolicyNotifications.java
+++ b/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PolicyNotifications.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.migration.policynotification;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Path("/")
 @RegisterRestClient(configKey = "policynotifications")
+@ApplicationScoped
 public interface PolicyNotifications {
 
     @GET

--- a/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PolicyNotifications.java
+++ b/src/main/java/com/redhat/cloud/notifications/migration/policynotification/PolicyNotifications.java
@@ -1,0 +1,21 @@
+package com.redhat.cloud.notifications.migration.policynotification;
+
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.util.List;
+
+@Path("/")
+@RegisterRestClient(configKey = "policynotifications")
+public interface PolicyNotifications {
+
+    @GET
+    @Path("/endpoints/email/subscriptions")
+    @Consumes("application/json")
+    @Produces("application/json")
+    Uni<List<PoliciesEmailSubscription>> getSubscriptions();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,3 +68,8 @@ processor.email.no_reply=no-reply@redhat.com
 email.subscription.daily.cron=0 0 2 * * ?
 
 %test.quarkus.scheduler.enabled=false
+
+# Policies-notification migration
+policynotifications/mp-rest/url=http://localhost:8090
+policynotifications/mp-rest/connectTimeout=2000
+policynotifications/mp-rest/readTimeout=2000

--- a/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
@@ -1,0 +1,4 @@
+package com.redhat.cloud.notifications.migration.policynotification;
+
+public class PoliciesMigrationServiceTest {
+}

--- a/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
@@ -1,4 +1,176 @@
 package com.redhat.cloud.notifications.migration.policynotification;
 
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.ApplicationResources;
+import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
+import com.redhat.cloud.notifications.db.EndpointResources;
+import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.migration.policynotification.PoliciesMigrationService.MigrateResponse;
+import com.redhat.cloud.notifications.models.EmailSubscription;
+import com.redhat.cloud.notifications.models.EmailSubscriptionType;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.EventType;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.restassured.http.ContentType;
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
 public class PoliciesMigrationServiceTest {
+
+    @InjectMock
+    @RestClient
+    PolicyNotifications policyNotifications;
+
+    @Inject
+    EndpointEmailSubscriptionResources emailSubscriptionResources;
+
+    @Inject
+    ApplicationResources applicationResources;
+
+    @Inject
+    EndpointResources endpointResources;
+
+    @Test
+    void testSingleUserMigration() {
+        String accountId1 = "single-user-migration-1";
+        String userId1 = "user1";
+
+        List<PoliciesEmailSubscription> policies = new ArrayList<>();
+        policies.add(new PoliciesEmailSubscription(accountId1, userId1, PoliciesMigrationService.DAILY_EMAIL_TYPE));
+
+        Mockito
+        .when(policyNotifications.getSubscriptions())
+            .thenReturn(Uni.createFrom().item(policies));
+
+        MigrateResponse response = given()
+                .contentType(ContentType.JSON)
+                .when().get("/internal/policies-notifications/migrate")
+                .then()
+                .statusCode(200)
+                .extract().response().as(MigrateResponse.class);
+
+        assertEquals(1, response.eventTypesMigrated.get());
+        assertEquals(1, response.accountsMigrated.get());
+
+        assertUserEventType(accountId1, userId1, EmailSubscriptionType.DAILY);
+        assertAccountHasEmailAction(accountId1);
+    }
+
+    @Test
+    void testMultipleUsersMigration() {
+        String accountId1 = "multi-user-migration-1";
+        String[] users = {"user1", "user2", "user3", "user4"};
+
+        List<PoliciesEmailSubscription> policies = new ArrayList<>();
+        for (String user: users) {
+            policies.add(new PoliciesEmailSubscription(accountId1, user, PoliciesMigrationService.DAILY_EMAIL_TYPE));
+            policies.add(new PoliciesEmailSubscription(accountId1, user, PoliciesMigrationService.INSTANT_EMAIL_TYPE));
+        }
+
+        Mockito
+                .when(policyNotifications.getSubscriptions())
+                .thenReturn(Uni.createFrom().item(policies));
+
+        MigrateResponse response = given()
+                .contentType(ContentType.JSON)
+                .when().get("/internal/policies-notifications/migrate")
+                .then()
+                .statusCode(200)
+                .extract().response().as(MigrateResponse.class);
+
+        assertEquals(8, response.eventTypesMigrated.get()); // 4 users with 2 eventTypes each
+        assertEquals(1, response.accountsMigrated.get());
+
+        for (String user: users) {
+            assertUserEventType(accountId1, user, EmailSubscriptionType.DAILY);
+        }
+
+        assertAccountHasEmailAction(accountId1);
+    }
+
+    @Test
+    void testMultipleUsersAndAccountsMigration() {
+
+        List<PoliciesEmailSubscription> policies = new ArrayList<>();
+
+        String accountIdFormat = "multi-users-and-account-migration-%d";
+        String userFormat = "user-%d-%d";
+
+        int accountCount = 20;
+        int userCountPerAccount = 11;
+
+        for (int i = 0; i < accountCount; ++i) {
+            for (int j = 0; j < userCountPerAccount; ++j) {
+                String eventType = j % 2 == 0 ? PoliciesMigrationService.INSTANT_EMAIL_TYPE : PoliciesMigrationService.DAILY_EMAIL_TYPE;
+                policies.add(new PoliciesEmailSubscription(
+                        String.format(accountIdFormat, i),
+                        String.format(userFormat, i, j),
+                        eventType
+                ));
+            }
+        }
+
+        Mockito
+                .when(policyNotifications.getSubscriptions())
+                .thenReturn(Uni.createFrom().item(policies));
+
+        MigrateResponse response = given()
+                .contentType(ContentType.JSON)
+                .when().get("/internal/policies-notifications/migrate")
+                .then()
+                .statusCode(200)
+                .extract().response().as(MigrateResponse.class);
+
+        assertEquals(accountCount * userCountPerAccount, response.eventTypesMigrated.get());
+        assertEquals(accountCount, response.accountsMigrated.get());
+
+        for (int i = 0; i < accountCount; ++i) {
+            String accountId = String.format(accountIdFormat, i);
+            assertAccountHasEmailAction(accountId);
+            for (int j = 0; j < userCountPerAccount; ++j) {
+                EmailSubscriptionType type = j % 2 == 0 ? EmailSubscriptionType.INSTANT : EmailSubscriptionType.DAILY;
+                assertUserEventType(accountId, String.format(userFormat, i, j), type);
+            }
+        }
+    }
+
+    private void assertUserEventType(String accountId, String userId, EmailSubscriptionType emailSubscriptionType) {
+        EmailSubscription emailSubscription = emailSubscriptionResources
+                .getEmailSubscription(accountId, userId, PoliciesMigrationService.BUNDLE, PoliciesMigrationService.APPLICATION, emailSubscriptionType)
+                .await().indefinitely();
+
+        assertEquals(accountId, emailSubscription.getAccountId());
+        assertEquals(userId, emailSubscription.getUsername());
+        assertEquals(PoliciesMigrationService.BUNDLE, emailSubscription.getBundle());
+        assertEquals(PoliciesMigrationService.APPLICATION, emailSubscription.getApplication());
+        assertEquals(emailSubscriptionType, emailSubscription.getType());
+    }
+
+    private void assertAccountHasEmailAction(String accountId) {
+        // assert that the account has the email action for insights/policies/policy-triggered
+        EventType eventType = applicationResources.getEventType(
+                PoliciesMigrationService.BUNDLE,
+                PoliciesMigrationService.APPLICATION,
+                PoliciesMigrationService.EVENT_TYPE
+        ).await().indefinitely();
+
+        List<Endpoint> endpoints = endpointResources.getLinkedEndpoints(accountId, eventType.getId(), new Query()).collectItems().asList().await().indefinitely();
+
+        assertEquals(1, endpoints.size());
+        assertEquals(EndpointType.EMAIL_SUBSCRIPTION, endpoints.get(0).getType());
+    }
 }

--- a/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
@@ -154,9 +154,9 @@ public class PoliciesMigrationServiceTest {
                 .await().indefinitely();
 
         assertEquals(accountId, emailSubscription.getAccountId());
-        assertEquals(userId, emailSubscription.getUsername());
-        assertEquals(PoliciesMigrationService.BUNDLE, emailSubscription.getBundle());
-        assertEquals(PoliciesMigrationService.APPLICATION, emailSubscription.getApplication());
+        assertEquals(userId, emailSubscription.getUserId());
+        assertEquals(PoliciesMigrationService.BUNDLE, emailSubscription.getBundleName());
+        assertEquals(PoliciesMigrationService.APPLICATION, emailSubscription.getApplicationName());
         assertEquals(emailSubscriptionType, emailSubscription.getType());
     }
 


### PR DESCRIPTION
This PR adds an internal endpoint to migrate the data from `policies-notification`. 
It subscribes each user to the email type (instant/daily) found and updates the actions of the `policies-triggered` eventType of every account to use "Email" (deletes others if found).