### PR TITLE
Fix hidden database concurrency issue

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -92,7 +92,7 @@ public class EndpointProcessor {
 
     public Multi<Endpoint> getEndpoints(String tenant, String bundleName, String applicationName, String eventTypeName) {
         return resources.getTargetEndpoints(tenant, bundleName, applicationName, eventTypeName)
-                .flatMap((Function<Endpoint, Publisher<Endpoint>>) endpoint -> {
+                .onItem().transformToMultiAndConcatenate((Function<Endpoint, Publisher<Endpoint>>) endpoint -> {
                     // If the tenant has a default endpoint for the eventType, then add the target endpoints here
                     if (endpoint.getType() == EndpointType.DEFAULT) {
                         return defaultProcessor.getDefaultEndpoints(endpoint);


### PR DESCRIPTION
`flatMap()` is a shortcut for `onItem().transformToMulti(mapper).merge()`.

We shouldn't `merge()` here because it will cause DB queries to be executed concurrently, which is not allowed by Hibernate Reactive within a single unit of work.