### PR TITLE
Make the non-application-root-path consistent with policies

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/auth/RHIdentityAuthMechanism.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/RHIdentityAuthMechanism.java
@@ -49,7 +49,7 @@ public class RHIdentityAuthMechanism implements HttpAuthenticationMechanism {
                     good = true;
                 }
             } else if (path.startsWith("/openapi.json") || path.startsWith("/internal")
-                    || path.startsWith("/admin") || path.startsWith("/health") || path.startsWith("/q/health")) {
+                    || path.startsWith("/admin") || path.startsWith("/health")) {
                 good = true;
             }
 

--- a/src/main/java/com/redhat/cloud/notifications/auth/RHIdentityAuthMechanism.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/RHIdentityAuthMechanism.java
@@ -49,7 +49,7 @@ public class RHIdentityAuthMechanism implements HttpAuthenticationMechanism {
                     good = true;
                 }
             } else if (path.startsWith("/openapi.json") || path.startsWith("/internal")
-                    || path.startsWith("/admin") || path.startsWith("/health")) {
+                    || path.startsWith("/admin") || path.startsWith("/health") || path.startsWith("/metrics")) {
                 good = true;
             }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,6 +50,9 @@ rbac/mp-rest/readTimeout=2000
 # Duration rbac entries are kept in cache
 quarkus.cache.caffeine.rbac-cache.expire-after-write=PT120s
 
+# Quarkus since 1.11 redirects non-apps to /q/. We need to prevent this
+quarkus.http.redirect-to-non-application-root-path=false
+quarkus.http.non-application-root-path=/
 
 # Sentry logging. Off by default, enabled on OpenShift
 # See https://quarkus.io/guides/logging-sentry#in-app-packages


### PR DESCRIPTION
Let's align with https://github.com/RedHatInsights/policies-ui-backend/pull/179, it will make things easier to maintain if all projects have the same behavior.