### PR TITLE
Introduce CounterAssertionHelper and fix test instability

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -13,6 +13,7 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment.Strategy;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.io.IOException;
@@ -22,8 +23,12 @@ import java.util.logging.Logger;
 @ApplicationScoped
 public class EventConsumer {
 
+    public static final String REJECTED_COUNTER_NAME = "input.rejected";
+    public static final String PROCESSING_ERROR_COUNTER_NAME = "input.processing.error";
+
     private static final Logger log = Logger.getLogger(EventConsumer.class.getName());
 
+    @Inject
     MeterRegistry registry;
 
     @Inject
@@ -32,10 +37,10 @@ public class EventConsumer {
     private Counter rejectedCount;
     private Counter processingErrorCount;
 
-    public EventConsumer(MeterRegistry registry) {
-        this.registry = registry;
-        rejectedCount = registry.counter("input.rejected");
-        processingErrorCount = registry.counter("input.processing.error");
+    @PostConstruct
+    public void init() {
+        rejectedCount = registry.counter(REJECTED_COUNTER_NAME);
+        processingErrorCount = registry.counter(PROCESSING_ERROR_COUNTER_NAME);
     }
 
     @Incoming("ingress")

--- a/src/test/java/com/redhat/cloud/notifications/CounterAssertionHelper.java
+++ b/src/test/java/com/redhat/cloud/notifications/CounterAssertionHelper.java
@@ -1,0 +1,39 @@
+package com.redhat.cloud.notifications;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link MeterRegistry#clear()} cannot be called between tests to reset counters because it would remove the counters
+ * instances from the registry while we use many {@link ApplicationScoped} beans which hold references pointing at the
+ * aforementioned counters instances. That's why we need this helper to assert increments in a reliable way.
+ */
+@ApplicationScoped
+public class CounterAssertionHelper {
+
+    @Inject
+    MeterRegistry registry;
+
+    private final Map<String, Double> counterValuesBeforeTest = new HashMap<>();
+
+    public void saveCounterValuesBeforeTest(String... counterNames) {
+        for (String counterName : counterNames) {
+            counterValuesBeforeTest.put(counterName, registry.counter(counterName).count());
+        }
+    }
+
+    public void assertIncrement(String counterName, double expectedIncrement) {
+        double actualIncrement = registry.counter(counterName).count() - counterValuesBeforeTest.getOrDefault(counterName, 0d);
+        assertEquals(expectedIncrement, actualIncrement);
+    }
+
+    public void clear() {
+        counterValuesBeforeTest.clear();
+    }
+}

--- a/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -1,15 +1,16 @@
 package com.redhat.cloud.notifications.events;
 
+import com.redhat.cloud.notifications.CounterAssertionHelper;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.ingress.Action;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Metrics;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
@@ -19,7 +20,8 @@ import java.time.LocalDateTime;
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.TestHelpers.serializeAction;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.redhat.cloud.notifications.events.EventConsumer.PROCESSING_ERROR_COUNTER_NAME;
+import static com.redhat.cloud.notifications.events.EventConsumer.REJECTED_COUNTER_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -38,22 +40,34 @@ public class EventConsumerTest {
     @InjectMock
     EndpointProcessor destinations;
 
-    private Counter rejectedCounter = Metrics.counter("input.rejected");
-    private Counter processingErrorCounter = Metrics.counter("input.processing.error");
+    @Inject
+    CounterAssertionHelper counterAssertionHelper;
+
+    @BeforeEach
+    void init() {
+        counterAssertionHelper.saveCounterValuesBeforeTest(REJECTED_COUNTER_NAME, PROCESSING_ERROR_COUNTER_NAME);
+    }
+
+    @AfterEach
+    void clear() {
+        counterAssertionHelper.clear();
+    }
 
     @Test
     void testValidMessagePayload() throws IOException {
         Action action = buildValidAction();
         String serializedAction = serializeAction(action);
-        assertCountersIncrement(0, 0,
-                () -> inMemoryConnector.source("ingress").send(serializedAction));
+        inMemoryConnector.source("ingress").send(serializedAction);
+        counterAssertionHelper.assertIncrement(REJECTED_COUNTER_NAME, 0);
+        counterAssertionHelper.assertIncrement(PROCESSING_ERROR_COUNTER_NAME, 0);
         verify(destinations, times(1)).process(eq(action));
     }
 
     @Test
     void testInvalidMessagePayload() {
-        assertCountersIncrement(1, 0,
-                () -> inMemoryConnector.source("ingress").send("I am not a valid serialized action!"));
+        inMemoryConnector.source("ingress").send("I am not a valid serialized action!");
+        counterAssertionHelper.assertIncrement(REJECTED_COUNTER_NAME, 1);
+        counterAssertionHelper.assertIncrement(PROCESSING_ERROR_COUNTER_NAME, 0);
         verify(destinations, never()).process(any(Action.class));
     }
 
@@ -64,8 +78,9 @@ public class EventConsumerTest {
         when(destinations.process(eq(action))).thenReturn(
                 Uni.createFrom().failure(() -> new RuntimeException("I am a forced exception!"))
         );
-        assertCountersIncrement(0, 1,
-                () -> inMemoryConnector.source("ingress").send(serializedAction));
+        inMemoryConnector.source("ingress").send(serializedAction);
+        counterAssertionHelper.assertIncrement(REJECTED_COUNTER_NAME, 0);
+        counterAssertionHelper.assertIncrement(PROCESSING_ERROR_COUNTER_NAME, 1);
         verify(destinations, times(1)).process(eq(action));
     }
 
@@ -78,13 +93,5 @@ public class EventConsumerTest {
         action.setAccountId("testTenant");
         action.setPayload(Map.of("k", "v", "k2", "v2", "k3", "v"));
         return action;
-    }
-
-    private void assertCountersIncrement(int expectedRejectedIncrement, int expectedProcessingErrorIncrement, Runnable runnable) {
-        double initialRejectedCount = rejectedCounter.count();
-        double initialProcessingErrorCount = processingErrorCounter.count();
-        runnable.run();
-        assertEquals(expectedRejectedIncrement, rejectedCounter.count() - initialRejectedCount);
-        assertEquals(expectedProcessingErrorIncrement, processingErrorCounter.count() - initialProcessingErrorCount);
     }
 }


### PR DESCRIPTION
`LifecycleITest.t02_pushMessage()` started failing on my machine (because of the counter check at the end) after #151 was merged.

This PR introduces a reliable way to assert counters increments during tests.