### PR TITLE
Update Quarkus JAR path for Docker

### DIFF
--- a/src/main/docker/Dockerfile-build.jvm
+++ b/src/main/docker/Dockerfile-build.jvm
@@ -38,7 +38,7 @@ RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
 COPY --from=build /home/jboss/target/lib/* /deployments/lib/
-COPY --from=build /home/jboss/target/*-runner.jar /deployments/app.jar
+COPY --from=build /home/jboss/target/quarkus-app/quarkus-run.jar /deployments/app.jar
 
 EXPOSE 8080
 USER 1001


### PR DESCRIPTION
https://github.com/quarkusio/quarkus/wiki/Migration-Guide-1.12

> Starting the application
The biggest change here is that to start your Quarkus application, you should now use:
java -jar target/quarkus-app/quarkus-run.jar
(instead of using the versioned -runner jar)