### PR TITLE
Clear Hibernate session L1 cache after message processing

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -15,6 +15,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
 import org.reactivestreams.Publisher;
 
 import javax.annotation.PostConstruct;
@@ -24,6 +25,9 @@ import java.util.function.Function;
 
 @ApplicationScoped
 public class EndpointProcessor {
+
+    @Inject
+    Mutiny.Session session;
 
     @Inject
     EndpointResources resources;
@@ -76,7 +80,8 @@ public class EndpointProcessor {
         return endpointsCallResult
                 .onItem().ignoreAsUni()
                 .replaceWith(notificationResult)
-                .replaceWith(Uni.createFrom().voidItem());
+                .replaceWith(Uni.createFrom().voidItem())
+                .onItem().invoke(ignored -> session.clear());
     }
 
     public EndpointTypeProcessor endpointTypeToProcessor(EndpointType endpointType) {


### PR DESCRIPTION
@josejulio found an issue on CI: after he successfully changed a webhook URL (the change was persisted), `EndpointProcessor` was still using the old URL while processing a new payload.

I will confirm that tomorrow, but I'm pretty sure this happened because the Hibernate `session` is a `@RequestScoped` bean and it seems there are no request boundaries for a Smallrye RM inbound connector. The request context seems to be created when the first incoming message is received and is never destroyed after that.

This PR contains a simple fix for that issue: the `session` L1 cache is cleared after each processed message. I'll talk with the SM RM and/or Hibernate Reactive teams to determine if that's the best approach. In the meantime, this can be merged to fix the bug.