### PR TITLE
Change NotificationHistory.id type from Integer to UUID

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
@@ -36,7 +36,7 @@ public class NotificationResources {
                 .onItem().transformToMulti(Multi.createFrom()::iterable);
     }
 
-    public Uni<JsonObject> getNotificationDetails(String tenant, Query limiter, UUID endpoint, Integer historyId) {
+    public Uni<JsonObject> getNotificationDetails(String tenant, Query limiter, UUID endpoint, UUID historyId) {
         String query = "SELECT details FROM NotificationHistory WHERE accountId = :accountId AND endpoint.id = :endpointId AND id = :historyId";
         if (limiter != null) {
             query = limiter.getModifiedQuery(query);

--- a/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -8,7 +8,6 @@ import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -28,9 +27,9 @@ import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
 public class NotificationHistory extends CreationTimestamped {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "notification_history_id_seq")
+    @GeneratedValue
     @JsonProperty(access = READ_ONLY)
-    private Integer id;
+    private UUID id;
 
     @NotNull
     @Size(max = 50)
@@ -60,7 +59,7 @@ public class NotificationHistory extends CreationTimestamped {
     public NotificationHistory() {
     }
 
-    public NotificationHistory(Integer id, String accountId, Long invocationTime, Boolean invocationResult, String eventId, Endpoint endpoint, LocalDateTime created) {
+    public NotificationHistory(UUID id, String accountId, Long invocationTime, Boolean invocationResult, String eventId, Endpoint endpoint, LocalDateTime created) {
         this.id = id;
         this.accountId = accountId;
         this.invocationTime = invocationTime;
@@ -70,11 +69,11 @@ public class NotificationHistory extends CreationTimestamped {
         setCreated(created);
     }
 
-    public Integer getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -202,7 +202,7 @@ public class EndpointService {
             )
     })
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    public Uni<Response> getDetailedEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID id, @PathParam("history_id") Integer historyId, @BeanParam Query query) {
+    public Uni<Response> getDetailedEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID id, @PathParam("history_id") UUID historyId, @BeanParam Query query) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return notifResources.getNotificationDetails(principal.getAccount(), query, id, historyId)
                 // Maybe 404 should only be returned if history_id matches nothing? Otherwise 204

--- a/src/main/resources/db/migration/V1.12.0__notification_history_id.sql
+++ b/src/main/resources/db/migration/V1.12.0__notification_history_id.sql
@@ -1,0 +1,11 @@
+--
+-- This script changes the notification_history.id type from integer to uuid.
+-- We need that for the delivery-via-camel PoC, but it will also be better if we decide to expose the history through an
+-- API in the future (exposing an auto-incremented integer id would be a security flaw).
+--
+
+ALTER TABLE notification_history DROP CONSTRAINT notification_history_pkey;
+ALTER TABLE notification_history DROP COLUMN id;
+ALTER TABLE notification_history ADD COLUMN id uuid DEFAULT public.gen_random_uuid() NOT NULL;
+ALTER TABLE notification_history ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE notification_history ADD CONSTRAINT notification_history_pkey PRIMARY KEY(id);

--- a/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -330,7 +330,7 @@ public class LifecycleITest {
                             .header(identityHeader)
                             .when()
                             .contentType(ContentType.JSON)
-                            .get(String.format("/endpoints/%s/history/%s/details", ep.getString("id"), history.getInteger("id")))
+                            .get(String.format("/endpoints/%s/history/%s/details", ep.getString("id"), history.getString("id")))
                             .then()
                             .statusCode(200)
                             .extract().response();


### PR DESCRIPTION
This PR changes the notification_history.id type from integer to uuid.

We need that for the delivery-via-camel PoC, but it will also be better if we decide to expose the history through an API in the future (exposing an auto-incremented integer id would be a security flaw).

It's a draft for now because I need to figure out how to update the frontend.