### PR TITLE
Improve tests isolation and maintainability

### DIFF
--- a/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
@@ -1,0 +1,51 @@
+package com.redhat.cloud.notifications.db;
+
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.models.EmailSubscription;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointDefault;
+import com.redhat.cloud.notifications.models.EndpointTarget;
+import com.redhat.cloud.notifications.models.EndpointWebhook;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.NotificationHistory;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class DbCleaner {
+
+    @Inject
+    Mutiny.Session session;
+
+    /**
+     * Deletes all records from all database tables (except for flyway_schema_history). This method should be called
+     * from a method annotated with <b>both</b> {@link BeforeEach} and {@link AfterEach} in all test classes that
+     * involve SQL queries to guarantee the tests isolation in terms of stored data. Ideally, we should do that with
+     * {@link io.quarkus.test.TestTransaction} but it doesn't work with Hibernate Reactive, so this is a temporary
+     * workaround to make our tests more reliable and easy to maintain.
+     */
+    public void clean() {
+        session.withTransaction(transaction -> deleteAllFrom(EmailAggregation.class)
+                .chain(() -> deleteAllFrom(EmailSubscription.class))
+                .chain(() -> deleteAllFrom(NotificationHistory.class))
+                .chain(() -> deleteAllFrom(EndpointDefault.class))
+                .chain(() -> deleteAllFrom(EndpointTarget.class))
+                .chain(() -> deleteAllFrom(EndpointWebhook.class))
+                .chain(() -> deleteAllFrom(Endpoint.class))
+                .chain(() -> deleteAllFrom(EventType.class))
+                .chain(() -> deleteAllFrom(Application.class))
+                .chain(() -> deleteAllFrom(Bundle.class))
+        ).await().indefinitely();
+    }
+
+    private Uni<Integer> deleteAllFrom(Class<?> classname) {
+        return session.createQuery("DELETE FROM " + classname.getSimpleName()).executeUpdate();
+    }
+}

--- a/src/test/java/com/redhat/cloud/notifications/db/DbIsolatedTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/DbIsolatedTest.java
@@ -1,0 +1,22 @@
+package com.redhat.cloud.notifications.db;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import javax.inject.Inject;
+
+/**
+ * When a test class extends {@link DbIsolatedTest}, all of its tests are individually preceded and followed by a
+ * complete database records reset. The tests are therefore isolated in terms of stored data.
+ */
+public abstract class DbIsolatedTest {
+
+    @Inject
+    DbCleaner dbCleaner;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        dbCleaner.clean();
+    }
+}

--- a/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -81,23 +81,6 @@ public class ResourceHelpers {
         }
     }
 
-    public void createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType() {
-        Bundle bundle = new Bundle("rhel", "Red Hat Enterprise Linux");
-        Bundle b = bundleResources.createBundle(bundle).await().indefinitely();
-
-        Application app = new Application();
-        app.setName("policies");
-        app.setDisplayName("Policies");
-        app.setBundleId(b.getId());
-        Application a = appResources.createApplication(app).await().indefinitely();
-
-        EventType eventType = new EventType();
-        eventType.setName("policy-triggered");
-        eventType.setDisplayName("");
-        eventType.setDescription("");
-        appResources.addEventTypeToApplication(a.getId(), eventType).await().indefinitely();
-    }
-
     public int[] createTestEndpoints(String tenant, int count) {
         int[] statsValues = new int[3];
         statsValues[0] = count;

--- a/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -16,7 +16,6 @@ import io.vertx.core.json.JsonObject;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @ApplicationScoped
@@ -51,15 +50,6 @@ public class ResourceHelpers {
     }
 
     public void createTestAppAndEventTypes() {
-        // Delete TEST_BUNDLE if it exists
-        Optional<Bundle> existingBundle = bundleResources
-                .getBundles().collect().asList().await().indefinitely()
-                .stream().filter(bundle -> bundle.getName().equals(TEST_BUNDLE_NAME)).findFirst();
-
-        if (existingBundle.isPresent()) {
-            bundleResources.deleteBundle(existingBundle.get().getId()).await().indefinitely();
-        }
-
         Bundle bundle = new Bundle(TEST_BUNDLE_NAME, "...");
         Bundle b = bundleResources.createBundle(bundle).await().indefinitely();
 
@@ -89,6 +79,23 @@ public class ResourceHelpers {
             eventType.setDisplayName("... -> " + i);
             appResources.addEventTypeToApplication(added2.getId(), eventType).await().indefinitely();
         }
+    }
+
+    public void createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType() {
+        Bundle bundle = new Bundle("rhel", "Red Hat Enterprise Linux");
+        Bundle b = bundleResources.createBundle(bundle).await().indefinitely();
+
+        Application app = new Application();
+        app.setName("policies");
+        app.setDisplayName("Policies");
+        app.setBundleId(b.getId());
+        Application a = appResources.createApplication(app).await().indefinitely();
+
+        EventType eventType = new EventType();
+        eventType.setName("policy-triggered");
+        eventType.setDisplayName("");
+        eventType.setDescription("");
+        appResources.addEventTypeToApplication(a.getId(), eventType).await().indefinitely();
     }
 
     public int[] createTestEndpoints(String tenant, int count) {

--- a/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -8,11 +8,11 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
-import org.eclipse.microprofile.reactive.messaging.spi.Connector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 public class EventConsumerTest {
 
     @Inject
-    @Connector("smallrye-in-memory")
+    @Any
     InMemoryConnector inMemoryConnector;
 
     @InjectMock

--- a/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -6,7 +6,7 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
@@ -26,7 +26,6 @@ import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +55,7 @@ import static org.mockserver.model.HttpResponse.response;
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class LifecycleITest {
+public class LifecycleITest extends DbIsolatedTest {
 
     /*
      * In the tests below, most JSON responses are verified using JsonObject/JsonArray instead of deserializing these
@@ -98,15 +97,6 @@ public class LifecycleITest {
 
         mockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
 
-    }
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
     }
 
     @Test

--- a/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
@@ -6,7 +6,6 @@ import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.EndpointResources;
 import com.redhat.cloud.notifications.db.Query;
-import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.migration.policynotification.PoliciesMigrationService.MigrateResponse;
 import com.redhat.cloud.notifications.models.EmailSubscription;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
@@ -46,12 +45,8 @@ public class PoliciesMigrationServiceTest extends DbIsolatedTest {
     @Inject
     EndpointResources endpointResources;
 
-    @Inject
-    ResourceHelpers resourceHelpers;
-
     @Test
     void testSingleUserMigration() {
-        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         String accountId1 = "single-user-migration-1";
         String userId1 = "user1";
 
@@ -78,7 +73,6 @@ public class PoliciesMigrationServiceTest extends DbIsolatedTest {
 
     @Test
     void testMultipleUsersMigration() {
-        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         String accountId1 = "multi-user-migration-1";
         String[] users = {"user1", "user2", "user3", "user4"};
 
@@ -111,7 +105,6 @@ public class PoliciesMigrationServiceTest extends DbIsolatedTest {
 
     @Test
     void testMultipleUsersAndAccountsMigration() {
-        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
 
         List<PoliciesEmailSubscription> policies = new ArrayList<>();
 

--- a/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
@@ -2,9 +2,11 @@ package com.redhat.cloud.notifications.migration.policynotification;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.ApplicationResources;
+import com.redhat.cloud.notifications.db.DbCleaner;
 import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.EndpointResources;
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.migration.policynotification.PoliciesMigrationService.MigrateResponse;
 import com.redhat.cloud.notifications.models.EmailSubscription;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
@@ -17,6 +19,8 @@ import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.http.ContentType;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -44,8 +48,21 @@ public class PoliciesMigrationServiceTest {
     @Inject
     EndpointResources endpointResources;
 
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @Inject
+    DbCleaner dbCleaner;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        dbCleaner.clean();
+    }
+
     @Test
     void testSingleUserMigration() {
+        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         String accountId1 = "single-user-migration-1";
         String userId1 = "user1";
 
@@ -72,6 +89,7 @@ public class PoliciesMigrationServiceTest {
 
     @Test
     void testMultipleUsersMigration() {
+        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         String accountId1 = "multi-user-migration-1";
         String[] users = {"user1", "user2", "user3", "user4"};
 
@@ -104,6 +122,7 @@ public class PoliciesMigrationServiceTest {
 
     @Test
     void testMultipleUsersAndAccountsMigration() {
+        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
 
         List<PoliciesEmailSubscription> policies = new ArrayList<>();
 

--- a/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/migration/policynotification/PoliciesMigrationServiceTest.java
@@ -2,7 +2,7 @@ package com.redhat.cloud.notifications.migration.policynotification;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.ApplicationResources;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.EndpointResources;
 import com.redhat.cloud.notifications.db.Query;
@@ -19,8 +19,6 @@ import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.http.ContentType;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -33,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class PoliciesMigrationServiceTest {
+public class PoliciesMigrationServiceTest extends DbIsolatedTest {
 
     @InjectMock
     @RestClient
@@ -50,15 +48,6 @@ public class PoliciesMigrationServiceTest {
 
     @Inject
     ResourceHelpers resourceHelpers;
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
-    }
 
     @Test
     void testSingleUserMigration() {

--- a/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.processors.email;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbCleaner;
 import com.redhat.cloud.notifications.db.EmailAggregationResources;
 import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
@@ -23,7 +24,9 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.core.Vertx;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockserver.mock.action.ExpectationResponseCallback;
@@ -72,6 +75,15 @@ public class EmailTest {
 
     @Inject
     EndpointEmailSubscriptionResources subscriptionResources;
+
+    @Inject
+    DbCleaner dbCleaner;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        dbCleaner.clean();
+    }
 
     @BeforeAll
     void init() {

--- a/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.processors.email;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.EmailAggregationResources;
 import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
@@ -24,9 +24,7 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.core.Vertx;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockserver.mock.action.ExpectationResponseCallback;
@@ -55,7 +53,7 @@ import static org.mockserver.model.HttpResponse.response;
 @QuarkusTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @QuarkusTestResource(TestLifecycleManager.class)
-public class EmailTest {
+public class EmailTest extends DbIsolatedTest {
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
 
@@ -75,15 +73,6 @@ public class EmailTest {
 
     @Inject
     EndpointEmailSubscriptionResources subscriptionResources;
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
-    }
 
     @BeforeAll
     void init() {

--- a/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.processors.webhook;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
@@ -16,8 +16,6 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockserver.mock.action.ExpectationResponseCallback;
 import org.mockserver.model.HttpRequest;
@@ -36,22 +34,13 @@ import static org.mockserver.model.HttpResponse.response;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class WebhookTest {
+public class WebhookTest extends DbIsolatedTest {
 
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
 
     @Inject
     WebhookTypeProcessor webhookTypeProcessor;
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
-    }
 
     private HttpRequest getMockHttpRequest(ExpectationResponseCallback verifyEmptyRequest) {
         HttpRequest postReq = new HttpRequest()

--- a/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.processors.webhook;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.DbCleaner;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
@@ -16,8 +16,9 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.mockserver.mock.action.ExpectationResponseCallback;
 import org.mockserver.model.HttpRequest;
 
@@ -34,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockserver.model.HttpResponse.response;
 
 @QuarkusTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @QuarkusTestResource(TestLifecycleManager.class)
 public class WebhookTest {
 
@@ -45,7 +45,13 @@ public class WebhookTest {
     WebhookTypeProcessor webhookTypeProcessor;
 
     @Inject
-    ResourceHelpers helpers;
+    DbCleaner dbCleaner;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        dbCleaner.clean();
+    }
 
     private HttpRequest getMockHttpRequest(ExpectationResponseCallback verifyEmptyRequest) {
         HttpRequest postReq = new HttpRequest()

--- a/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
@@ -1,8 +1,7 @@
 package com.redhat.cloud.notifications.routers;
 
-import com.redhat.cloud.notifications.MockServerClientConfig;
-import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbCleaner;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
@@ -13,8 +12,11 @@ import io.restassured.response.Response;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.util.List;
 import java.util.UUID;
 
@@ -38,8 +40,14 @@ public class ApplicationServiceTest {
     static final String EVENT_TYPE_NAME = "policy-triggered";
     public static final String BUNDLE_NAME = "insights-test";
 
-    @MockServerConfig
-    MockServerClientConfig mockServerConfig;
+    @Inject
+    DbCleaner dbCleaner;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        dbCleaner.clean();
+    }
 
     @Test
     void testPoliciesApplicationAddingAndDeletion() {

--- a/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
@@ -1,7 +1,7 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
@@ -12,11 +12,8 @@ import io.restassured.response.Response;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.util.List;
 import java.util.UUID;
 
@@ -27,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class ApplicationServiceTest {
+public class ApplicationServiceTest extends DbIsolatedTest {
 
     /*
      * In the tests below, most JSON responses are verified using JsonObject/JsonArray instead of deserializing these
@@ -39,15 +36,6 @@ public class ApplicationServiceTest {
     static final String APP_NAME = "policies-application-service-test";
     static final String EVENT_TYPE_NAME = "policy-triggered";
     public static final String BUNDLE_NAME = "insights-test";
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
-    }
 
     @Test
     void testPoliciesApplicationAddingAndDeletion() {

--- a/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbCleaner;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -8,8 +9,11 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
@@ -32,6 +36,15 @@ public class BundleServiceTest {
      */
 
     public static final String INSIGHTS_1 = "insights1";
+
+    @Inject
+    DbCleaner dbCleaner;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        dbCleaner.clean();
+    }
 
     @Test
     void testAdd() {

--- a/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/BundleServiceTest.java
@@ -1,7 +1,7 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -9,11 +9,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
@@ -26,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class BundleServiceTest {
+public class BundleServiceTest extends DbIsolatedTest {
 
     /*
      * In the tests below, most JSON responses are verified using JsonObject/JsonArray instead of deserializing these
@@ -36,15 +33,6 @@ public class BundleServiceTest {
      */
 
     public static final String INSIGHTS_1 = "insights1";
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
-    }
 
     @Test
     void testAdd() {

--- a/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -758,8 +758,6 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/idontexist/meneither/instant")
                 .then().statusCode(404);
 
-        helpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
-
         // Disable everything as preparation
         // rhel/policies instant and daily
         // TEST_BUNDLE_NAME/TEST_APP_NAME instant and daily

--- a/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbCleaner;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.BasicAuthentication;
 import com.redhat.cloud.notifications.models.EmailSubscriptionAttributes;
@@ -22,6 +23,7 @@ import io.restassured.http.Header;
 import io.restassured.response.Response;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +60,15 @@ public class EndpointServiceTest {
 
     @Inject
     ResourceHelpers helpers;
+
+    @Inject
+    DbCleaner dbCleaner;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        dbCleaner.clean();
+    }
 
     @Test
     void testEndpointAdding() {
@@ -756,6 +767,8 @@ public class EndpointServiceTest {
                 .contentType(ContentType.JSON)
                 .put("/endpoints/email/subscription/idontexist/meneither/instant")
                 .then().statusCode(404);
+
+        helpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
 
         // Disable everything as preparation
         // rhel/policies instant and daily

--- a/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -5,7 +5,7 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.BasicAuthentication;
 import com.redhat.cloud.notifications.models.EmailSubscriptionAttributes;
@@ -23,7 +23,6 @@ import io.restassured.http.Header;
 import io.restassured.response.Response;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class EndpointServiceTest {
+public class EndpointServiceTest extends DbIsolatedTest {
 
     /*
      * In the tests below, most JSON responses are verified using JsonObject/JsonArray instead of deserializing these
@@ -60,15 +59,6 @@ public class EndpointServiceTest {
 
     @Inject
     ResourceHelpers helpers;
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
-    }
 
     @Test
     void testEndpointAdding() {

--- a/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -83,7 +83,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .extract().response();
 
         JsonArray eventTypes = new JsonArray(response.getBody().asString());
-        assertEquals(200, eventTypes.size());
+        assertEquals(201, eventTypes.size()); // One of the event types is part of the default DB records.
 
         JsonObject policiesAll = eventTypes.getJsonObject(0);
         policiesAll.mapTo(EventType.class);
@@ -471,7 +471,6 @@ public class NotificationServiceTest extends DbIsolatedTest {
 
     @Test
     void testGetApplicationFacets() {
-        helpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         Header identityHeader = initRbacMock("test", "user", RbacAccess.READ_ACCESS);
         List<Facet> applications = given()
                 .header(identityHeader)
@@ -489,7 +488,6 @@ public class NotificationServiceTest extends DbIsolatedTest {
 
     @Test
     void testGetBundlesFacets() {
-        helpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         Header identityHeader = initRbacMock("test", "user", RbacAccess.READ_ACCESS);
         List<Facet> bundles = given()
                 .header(identityHeader)

--- a/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -6,7 +6,7 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Endpoint;
@@ -22,7 +22,6 @@ import io.restassured.response.Response;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class NotificationServiceTest {
+public class NotificationServiceTest extends DbIsolatedTest {
 
     /*
      * In the tests below, most JSON responses are verified using JsonObject/JsonArray instead of deserializing these
@@ -56,15 +55,6 @@ public class NotificationServiceTest {
 
     @Inject
     ResourceHelpers helpers;
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
-    }
 
     @BeforeEach
     void beforeEach() {

--- a/src/test/java/com/redhat/cloud/notifications/routers/OldUserConfigServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/OldUserConfigServiceTest.java
@@ -5,7 +5,7 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.routers.models.OldSettingsValueJsonForm;
@@ -19,7 +19,6 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.vertx.core.json.Json;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class OldUserConfigServiceTest {
+public class OldUserConfigServiceTest extends DbIsolatedTest {
 
     @BeforeEach
     void beforeEach() {
@@ -46,15 +45,6 @@ public class OldUserConfigServiceTest {
 
     @Inject
     ResourceHelpers resourceHelpers;
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
-    }
 
     private OldSettingsValueJsonForm rhelPolicyForm(List<OldSettingsValueJsonForm> jsonForms) {
         for (OldSettingsValueJsonForm settingsValueJsonForm : jsonForms) {

--- a/src/test/java/com/redhat/cloud/notifications/routers/OldUserConfigServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/OldUserConfigServiceTest.java
@@ -6,7 +6,6 @@ import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
-import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.routers.models.OldSettingsValueJsonForm;
 import com.redhat.cloud.notifications.routers.models.OldSettingsValueJsonForm.Field;
@@ -22,7 +21,6 @@ import io.vertx.core.json.Json;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,9 +40,6 @@ public class OldUserConfigServiceTest extends DbIsolatedTest {
 
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
-
-    @Inject
-    ResourceHelpers resourceHelpers;
 
     private OldSettingsValueJsonForm rhelPolicyForm(List<OldSettingsValueJsonForm> jsonForms) {
         for (OldSettingsValueJsonForm settingsValueJsonForm : jsonForms) {
@@ -87,7 +82,6 @@ public class OldUserConfigServiceTest extends DbIsolatedTest {
 
     @Test
     void testSettings() {
-        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         String tenant = "empty";
         String username = "user";
         String identityHeaderValue = TestHelpers.encodeIdentityInfo(tenant, username);

--- a/src/test/java/com/redhat/cloud/notifications/routers/OldUserConfigServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/OldUserConfigServiceTest.java
@@ -5,6 +5,8 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.routers.models.OldSettingsValueJsonForm;
 import com.redhat.cloud.notifications.routers.models.OldSettingsValueJsonForm.Field;
@@ -17,9 +19,11 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.vertx.core.json.Json;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +44,17 @@ public class OldUserConfigServiceTest {
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
 
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @Inject
+    DbCleaner dbCleaner;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        dbCleaner.clean();
+    }
 
     private OldSettingsValueJsonForm rhelPolicyForm(List<OldSettingsValueJsonForm> jsonForms) {
         for (OldSettingsValueJsonForm settingsValueJsonForm : jsonForms) {
@@ -82,6 +97,7 @@ public class OldUserConfigServiceTest {
 
     @Test
     void testSettings() {
+        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         String tenant = "empty";
         String username = "user";
         String identityHeaderValue = TestHelpers.encodeIdentityInfo(tenant, username);

--- a/src/test/java/com/redhat/cloud/notifications/routers/UserConfigServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/UserConfigServiceTest.java
@@ -5,6 +5,8 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.routers.models.SettingsValueJsonForm;
 import com.redhat.cloud.notifications.routers.models.SettingsValueJsonForm.Field;
@@ -18,9 +20,11 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.vertx.core.json.Json;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,6 +44,17 @@ public class UserConfigServiceTest {
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
 
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @Inject
+    DbCleaner dbCleaner;
+
+    @BeforeEach
+    @AfterEach
+    void cleanDatabase() {
+        dbCleaner.clean();
+    }
 
     private Field rhelPolicyForm(SettingsValueJsonForm jsonForm) {
         for (Field section : jsonForm.fields.get(0).sections) {
@@ -80,6 +95,7 @@ public class UserConfigServiceTest {
 
     @Test
     void testSettings() {
+        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         String tenant = "empty";
         String username = "user";
         String identityHeaderValue = TestHelpers.encodeIdentityInfo(tenant, username);

--- a/src/test/java/com/redhat/cloud/notifications/routers/UserConfigServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/UserConfigServiceTest.java
@@ -6,7 +6,6 @@ import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
-import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.routers.models.SettingsValueJsonForm;
 import com.redhat.cloud.notifications.routers.models.SettingsValueJsonForm.Field;
@@ -23,7 +22,6 @@ import io.vertx.core.json.Json;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,9 +40,6 @@ public class UserConfigServiceTest extends DbIsolatedTest {
 
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
-
-    @Inject
-    ResourceHelpers resourceHelpers;
 
     private Field rhelPolicyForm(SettingsValueJsonForm jsonForm) {
         for (Field section : jsonForm.fields.get(0).sections) {
@@ -85,7 +80,6 @@ public class UserConfigServiceTest extends DbIsolatedTest {
 
     @Test
     void testSettings() {
-        resourceHelpers.createRhelBundleAndPoliciesAppAndPolicyTriggeredEventType();
         String tenant = "empty";
         String username = "user";
         String identityHeaderValue = TestHelpers.encodeIdentityInfo(tenant, username);

--- a/src/test/java/com/redhat/cloud/notifications/routers/UserConfigServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/UserConfigServiceTest.java
@@ -5,7 +5,7 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.DbCleaner;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.routers.models.SettingsValueJsonForm;
@@ -20,7 +20,6 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.vertx.core.json.Json;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class UserConfigServiceTest {
+public class UserConfigServiceTest extends DbIsolatedTest {
 
     @BeforeEach
     void beforeEach() {
@@ -46,15 +45,6 @@ public class UserConfigServiceTest {
 
     @Inject
     ResourceHelpers resourceHelpers;
-
-    @Inject
-    DbCleaner dbCleaner;
-
-    @BeforeEach
-    @AfterEach
-    void cleanDatabase() {
-        dbCleaner.clean();
-    }
 
     private Field rhelPolicyForm(SettingsValueJsonForm jsonForm) {
         for (Field section : jsonForm.fields.get(0).sections) {


### PR DESCRIPTION
Our tests are full of side-effects: many of them depend on / suffer from data persisted by other tests. This makes the tests unreliable and sometimes very hard to maintain.

This PR fixes that issue by resetting the database before and after each test. I wanted to do that using [io.quarkus.test.TestTransaction](https://github.com/gwenneg/quarkus/blob/main/test-framework/common/src/main/java/io/quarkus/test/TestTransaction.java) but unfortunately it does not work with Hibernate Reactive. I'll create a Quarkus issue about this later.

I need this PR to be merged before I can finish the behavior groups PR.

⚠️ Check `Hide whitespace changes` for an easier review.