### PR TITLE
Introduces timeAgo() function on templates.

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/templates/LocalDateTimeExtension.java
+++ b/src/main/java/com/redhat/cloud/notifications/templates/LocalDateTimeExtension.java
@@ -1,8 +1,10 @@
 package com.redhat.cloud.notifications.templates;
 
+import com.redhat.cloud.notifications.utils.TimeAgoFormatter;
 import io.quarkus.qute.TemplateExtension;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
@@ -11,6 +13,7 @@ public class LocalDateTimeExtension {
 
     private static final DateTimeFormatter utcDateTimeFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm 'UTC'").withLocale(Locale.US);
     private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy").withLocale(Locale.US);
+    private static final TimeAgoFormatter timeAgoFormatter = new TimeAgoFormatter();
 
     public static String toUtcFormat(LocalDateTime date) {
         return date.format(utcDateTimeFormatter);
@@ -26,6 +29,14 @@ public class LocalDateTimeExtension {
 
     public static String toStringFormat(String date) {
         return toStringFormat(fromIsoLocalDateTime(date));
+    }
+
+    public static String toTimeAgo(LocalDateTime date) {
+        return timeAgoFormatter.format(LocalDateTime.now(ZoneOffset.UTC), date);
+    }
+
+    public static String toTimeAgo(String date) {
+        return toTimeAgo(fromIsoLocalDateTime(date));
     }
 
     public static LocalDateTime fromIsoLocalDateTime(String date) {

--- a/src/main/java/com/redhat/cloud/notifications/utils/TimeAgoFormatter.java
+++ b/src/main/java/com/redhat/cloud/notifications/utils/TimeAgoFormatter.java
@@ -1,0 +1,73 @@
+package com.redhat.cloud.notifications.utils;
+
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalField;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TimeAgoFormatter {
+
+    private static class Configuration {
+        private final TemporalField temporalField;
+        private final String singular;
+        private final String pluralFormat;
+
+        Configuration(TemporalField temporalField, String singular, String pluralFormat) {
+            this.temporalField = temporalField;
+            this.singular = singular;
+            this.pluralFormat = pluralFormat;
+        }
+
+    }
+
+    private static final List<Configuration> config = List.of(
+            new Configuration(ChronoField.YEAR, "1 year ago", "%d years ago"),
+            new Configuration(ChronoField.MONTH_OF_YEAR, "1 month ago", "%d months ago"),
+            new Configuration(ChronoField.DAY_OF_MONTH, "1 day ago", "%d days ago"),
+            new Configuration(null, "Today", null)
+    );
+
+    static {
+        List<Configuration> fallbackConfiguration = TimeAgoFormatter.config
+                .stream()
+                .filter(configuration -> configuration.temporalField == null && configuration.singular != null)
+                .collect(Collectors.toList());
+
+        if (fallbackConfiguration.size() == 0) {
+            throw new RuntimeException("Configuration does not have a fallback label");
+        }
+
+        if (fallbackConfiguration.size() > 1) {
+            throw new RuntimeException("Configuration has more than one fallback label");
+        }
+
+        if (TimeAgoFormatter.config.indexOf(fallbackConfiguration.get(0)) != TimeAgoFormatter.config.size() - 1) {
+            throw new RuntimeException("Configuration fallback must be the last element in the list");
+        }
+    }
+
+    public String format(LocalDateTime base, LocalDateTime dateTime) {
+        Period period = Period.between(dateTime.toLocalDate(), base.toLocalDate());
+
+        for (Configuration configuration : TimeAgoFormatter.config) {
+            if (configuration.temporalField == null) {
+                return configuration.singular;
+            }
+
+            long units = period.get(configuration.temporalField.getBaseUnit());
+            if (units >= 1) {
+                // Calculate natural units so that 2018-Jun-16 is 3 years ago from 2021-Apr-15 and not 2
+                long naturalUnit = base.toLocalDate().get(configuration.temporalField) - dateTime.get(configuration.temporalField);
+                if (naturalUnit == 1) {
+                    return configuration.singular;
+                } else if (naturalUnit > 1) {
+                    return String.format(configuration.pluralFormat, naturalUnit);
+                }
+            }
+        }
+
+        throw new RuntimeException("Configuration does not have a fallback label");
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/utils/TimeAgoFormatter.java
+++ b/src/main/java/com/redhat/cloud/notifications/utils/TimeAgoFormatter.java
@@ -1,38 +1,52 @@
 package com.redhat.cloud.notifications.utils;
 
 import java.time.LocalDateTime;
-import java.time.Period;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalField;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+// Based on: https://github.com/RedHatInsights/frontend-components/blob/86b02e3c206663d640d30b32087061c04db1595d/packages/components/src/DateFormat/helper.js#L4-L19
 public class TimeAgoFormatter {
 
+    private static final long SECOND = 1;
+    private static final long MINUTE = SECOND * 60;
+    private static final long HOUR = MINUTE * 60;
+    private static final long DAY = HOUR * 24;
+    private static final long MONTH = DAY * 30;
+    private static final long YEAR = DAY * 365;
+
     private static class Configuration {
-        private final TemporalField temporalField;
-        private final String singular;
-        private final String pluralFormat;
+        private final Long boundary;
+        private final Function<Long, String> description;
 
-        Configuration(TemporalField temporalField, String singular, String pluralFormat) {
-            this.temporalField = temporalField;
-            this.singular = singular;
-            this.pluralFormat = pluralFormat;
+        Configuration(Long boundary, Function<Long, String> description) {
+            this.boundary = boundary;
+            this.description = description;
         }
+    }
 
+    private static String formatTime(long count, String unit) {
+        return String.format("%d %s%s ago", count, unit, count > 1 ? "s" : "");
+    }
+
+    private static long roundDiv(double numerator, double denominator) {
+        return Math.round(numerator / denominator);
     }
 
     private static final List<Configuration> config = List.of(
-            new Configuration(ChronoField.YEAR, "1 year ago", "%d years ago"),
-            new Configuration(ChronoField.MONTH_OF_YEAR, "1 month ago", "%d months ago"),
-            new Configuration(ChronoField.DAY_OF_MONTH, "1 day ago", "%d days ago"),
-            new Configuration(null, "Today", null)
+            new Configuration(MINUTE, count -> "Just now"),
+            new Configuration(HOUR, count -> formatTime(roundDiv(count, MINUTE), "minute")),
+            new Configuration(DAY, count -> formatTime(roundDiv(count, HOUR), "hour")),
+            new Configuration(MONTH, count -> formatTime(roundDiv(count, DAY), "day")),
+            new Configuration(YEAR, count -> formatTime(roundDiv(count, MONTH), "month")),
+            new Configuration(Long.MAX_VALUE, count -> formatTime(roundDiv(count, YEAR), "year"))
     );
 
     static {
         List<Configuration> fallbackConfiguration = TimeAgoFormatter.config
                 .stream()
-                .filter(configuration -> configuration.temporalField == null && configuration.singular != null)
+                .filter(configuration -> configuration.boundary == Long.MAX_VALUE)
                 .collect(Collectors.toList());
 
         if (fallbackConfiguration.size() == 0) {
@@ -49,22 +63,17 @@ public class TimeAgoFormatter {
     }
 
     public String format(LocalDateTime base, LocalDateTime dateTime) {
-        Period period = Period.between(dateTime.toLocalDate(), base.toLocalDate());
+        long baseEpoch = base.toEpochSecond(ZoneOffset.UTC);
+        long epoch = dateTime.toEpochSecond(ZoneOffset.UTC);
+        long diff = baseEpoch - epoch;
+
+        if (diff < 0) {
+            throw new IllegalArgumentException("Base must be greater than the date to compare");
+        }
 
         for (Configuration configuration : TimeAgoFormatter.config) {
-            if (configuration.temporalField == null) {
-                return configuration.singular;
-            }
-
-            long units = period.get(configuration.temporalField.getBaseUnit());
-            if (units >= 1) {
-                // Calculate natural units so that 2018-Jun-16 is 3 years ago from 2021-Apr-15 and not 2
-                long naturalUnit = base.toLocalDate().get(configuration.temporalField) - dateTime.get(configuration.temporalField);
-                if (naturalUnit == 1) {
-                    return configuration.singular;
-                } else if (naturalUnit > 1) {
-                    return String.format(configuration.pluralFormat, naturalUnit);
-                }
+            if (diff < configuration.boundary) {
+                return configuration.description.apply(diff);
             }
         }
 

--- a/src/main/resources/templates/Advisor/newRecommendationInstantEmailBody.html
+++ b/src/main/resources/templates/Advisor/newRecommendationInstantEmailBody.html
@@ -78,7 +78,7 @@
                         <!-- Hi {{user.first_name}},
                         <br>
                         <br> -->
-                        Your system <a href="#" target="_blank">system name</a> has {action.events.size()} new recommendations.
+                        Your system <a href="#" target="_blank">{action.context.display_name}</a> has {action.events.size()} new recommendations.
                     </p>
                 </td>
             </tr>
@@ -161,7 +161,7 @@
                                     <img src="https://eoa-editor.s3.amazonaws.com/f9388bed35977299312ddd671606ecd0fa89a82c%2FInsights%2Fimg_critical.png" alt="Critical severity" width="70" border="0">
                                     {/switch}
                                 </td>
-                                <td>{it.payload.publish_date.toStringFormat()}</td>
+                                <td>{it.payload.publish_date.toTimeAgo()}</td>
                             </tr>
                         {/each}
                         </tbody>

--- a/src/test/java/com/redhat/cloud/notifications/utils/TestTimeAgoFormatter.java
+++ b/src/test/java/com/redhat/cloud/notifications/utils/TestTimeAgoFormatter.java
@@ -8,27 +8,62 @@ import java.time.LocalDateTime;
 public class TestTimeAgoFormatter {
 
     @Test
-    public void testToday() {
+    public void testSecondsAgo() {
         TimeAgoFormatter formatter = new TimeAgoFormatter();
 
-        Assertions.assertEquals("Today", formatter.format(
+        Assertions.assertEquals("Just now", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 31, 23, 59, 30)
+        ));
+    }
+
+    @Test
+    public void test1MinuteAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("1 minute ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 31, 23, 58, 55)
+        ));
+    }
+
+    @Test
+    public void testMinutesAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("29 minutes ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 31, 23, 30, 55)
+        ));
+    }
+
+    @Test
+    public void test1HourAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("1 hour ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 31, 22, 56, 55)
+        ));
+    }
+
+    @Test
+    public void testManyHoursAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("23 hours ago", formatter.format(
                 LocalDateTime.of(2020, 12, 31, 23, 59, 59),
                 LocalDateTime.of(2020, 12, 31, 1, 12, 10)
         ));
-        Assertions.assertEquals("Today", formatter.format(
+        Assertions.assertEquals("2 hours ago", formatter.format(
                 LocalDateTime.of(2020, 12, 31, 23, 59, 59),
-                LocalDateTime.of(2020, 12, 31, 1, 1, 55)
+                LocalDateTime.of(2020, 12, 31, 22, 1, 55)
         ));
     }
 
     @Test
     public void test1DayAgo() {
         TimeAgoFormatter formatter = new TimeAgoFormatter();
-
-        Assertions.assertEquals("1 day ago", formatter.format(
-                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
-                LocalDateTime.of(2020, 12, 30, 1, 1, 55)
-        ));
 
         Assertions.assertEquals("1 day ago", formatter.format(
                 LocalDateTime.of(2020, 12, 31, 23, 59, 59),
@@ -40,7 +75,13 @@ public class TestTimeAgoFormatter {
     public void testManyDaysAgo() {
         TimeAgoFormatter formatter = new TimeAgoFormatter();
 
-        Assertions.assertEquals("11 days ago", formatter.format(
+        // Close to 2 days ago
+        Assertions.assertEquals("2 days ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 30, 1, 1, 55)
+        ));
+
+        Assertions.assertEquals("12 days ago", formatter.format(
                 LocalDateTime.of(2020, 12, 31, 23, 59, 59),
                 LocalDateTime.of(2020, 12, 20, 1, 1, 55)
         ));

--- a/src/test/java/com/redhat/cloud/notifications/utils/TestTimeAgoFormatter.java
+++ b/src/test/java/com/redhat/cloud/notifications/utils/TestTimeAgoFormatter.java
@@ -1,0 +1,119 @@
+package com.redhat.cloud.notifications.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+public class TestTimeAgoFormatter {
+
+    @Test
+    public void testToday() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("Today", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 31, 1, 12, 10)
+        ));
+        Assertions.assertEquals("Today", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 31, 1, 1, 55)
+        ));
+    }
+
+    @Test
+    public void test1DayAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("1 day ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 30, 1, 1, 55)
+        ));
+
+        Assertions.assertEquals("1 day ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 30, 23, 59, 59)
+        ));
+    }
+
+    @Test
+    public void testManyDaysAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("11 days ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 20, 1, 1, 55)
+        ));
+
+        Assertions.assertEquals("13 days ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 12, 18, 23, 59, 59)
+        ));
+    }
+
+    @Test
+    public void test1MonthAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("1 month ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 11, 30, 1, 1, 55)
+        ));
+
+        Assertions.assertEquals("1 month ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 11, 30, 23, 59, 59)
+        ));
+    }
+
+    @Test
+    public void testManyMonthsAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("5 months ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 7, 30, 1, 1, 55)
+        ));
+
+        Assertions.assertEquals("9 months ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2020, 3, 30, 23, 59, 59)
+        ));
+    }
+
+    @Test
+    public void test1YearAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("1 year ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2019, 11, 30, 1, 1, 55)
+        ));
+
+        Assertions.assertEquals("1 year ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2019, 11, 30, 23, 59, 59)
+        ));
+    }
+
+    @Test
+    public void testManyYearsAgo() {
+        TimeAgoFormatter formatter = new TimeAgoFormatter();
+
+        Assertions.assertEquals("5 years ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2015, 11, 30, 1, 1, 55)
+        ));
+
+        Assertions.assertEquals("20 years ago", formatter.format(
+                LocalDateTime.of(2020, 12, 31, 23, 59, 59),
+                LocalDateTime.of(2000, 11, 30, 23, 59, 59)
+        ));
+
+        Assertions.assertEquals("3 years ago", formatter.format(
+                LocalDateTime.of(2021, 4, 15, 12, 0, 0),
+                LocalDateTime.of(2018, 6, 16, 12, 0, 0)
+        ));
+    }
+
+}


### PR DESCRIPTION
 - Transforms dates(or date-strings) to a "1 year ago" format
 - Fixes on Advisor templates

I ended up using an implementation based on `Period` to mimic what Advisor has in their [UI](https://cloud.redhat.com/insights/advisor/recommendations?rule_status=enabled&sort=-total_risk&limit=10&offset=0&text=%2Fvar%2Fww). 

