### PR TITLE
NOTIF-150 Introduce behavior groups - Phase 1

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
@@ -133,6 +133,7 @@ public class ApplicationResources {
                 .onItem().transformToMulti(Multi.createFrom()::iterable);
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Multi<EventType> getEventTypesByEndpointId(@NotNull String accountId, @NotNull UUID endpointId) {
         String query = "SELECT e FROM EventType e LEFT JOIN FETCH e.application JOIN e.targets t " +
                 "WHERE t.id.accountId = :accountId AND t.endpoint.id = :endpointId";
@@ -141,6 +142,16 @@ public class ApplicationResources {
                 .setParameter("endpointId", endpointId)
                 .getResultList()
                 .onItem().transformToMulti(Multi.createFrom()::iterable);
+    }
+
+    // TODO [BG Phase 2] Remove '_BG' suffix
+    public Uni<List<EventType>> getEventTypesByEndpointId_BG(String accountId, UUID endpointId) {
+        String query = "SELECT e FROM EventType e LEFT JOIN FETCH e.application JOIN e.behaviors b JOIN b.behaviorGroup.actions a " +
+                "WHERE b.behaviorGroup.accountId = :accountId AND a.endpoint.id = :endpointId";
+        return session.createQuery(query, EventType.class)
+                .setParameter("accountId", accountId)
+                .setParameter("endpointId", endpointId)
+                .getResultList();
     }
 
     /**

--- a/src/main/java/com/redhat/cloud/notifications/db/BehaviorGroupResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/BehaviorGroupResources.java
@@ -1,0 +1,198 @@
+package com.redhat.cloud.notifications.db;
+
+import com.redhat.cloud.notifications.models.BehaviorGroup;
+import com.redhat.cloud.notifications.models.BehaviorGroupAction;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.EventTypeBehavior;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class BehaviorGroupResources {
+
+    private static final Logger LOGGER = Logger.getLogger(BehaviorGroupResources.class.getName());
+
+    @Inject
+    Mutiny.Session session;
+
+    public Uni<BehaviorGroup> create(String accountId, BehaviorGroup behaviorGroup) {
+        return Uni.createFrom().item(behaviorGroup)
+                .onItem().transform(bg -> {
+                    bg.setAccountId(accountId);
+                    Bundle bundle = session.getReference(Bundle.class, bg.getBundleId());
+                    bg.setBundle(bundle);
+                    return bg;
+                })
+                .onItem().transformToUni(session::persist)
+                .call(session::flush)
+                .replaceWith(behaviorGroup);
+    }
+
+    public Uni<List<BehaviorGroup>> findByBundleId(String accountId, UUID bundleId) {
+        // When PostgreSQL sorts a BOOLEAN column in DESC order, true comes first. That's not true for all DBMS.
+        String query = "FROM BehaviorGroup b LEFT JOIN FETCH b.actions WHERE b.accountId = :accountId AND b.bundle.id = :bundleId " +
+                "ORDER BY b.defaultBehavior DESC, b.created DESC";
+        return session.createQuery(query, BehaviorGroup.class)
+                .setParameter("accountId", accountId)
+                .setParameter("bundleId", bundleId)
+                .getResultList();
+    }
+
+    // TODO Should this be forbidden for default behavior groups?
+    public Uni<Boolean> update(String accountId, BehaviorGroup behaviorGroup) {
+        String query = "UPDATE BehaviorGroup SET name = :name, displayName = :displayName WHERE accountId = :accountId AND id = :id";
+        return session.createQuery(query)
+                .setParameter("name", behaviorGroup.getName())
+                .setParameter("displayName", behaviorGroup.getDisplayName())
+                .setParameter("accountId", accountId)
+                .setParameter("id", behaviorGroup.getId())
+                .executeUpdate()
+                .call(session::flush)
+                .onItem().transform(rowCount -> rowCount > 0);
+    }
+
+    // TODO Should this be forbidden for default behavior groups?
+    public Uni<Boolean> delete(String accountId, UUID behaviorGroupId) {
+        String query = "DELETE FROM BehaviorGroup WHERE accountId = :accountId AND id = :id";
+        return session.createQuery(query)
+                .setParameter("accountId", accountId)
+                .setParameter("id", behaviorGroupId)
+                .executeUpdate()
+                .call(session::flush)
+                .onItem().transform(rowCount -> rowCount > 0);
+    }
+
+    public Uni<Boolean> addEventTypeBehavior(String accountId, UUID eventTypeId, UUID behaviorGroupId) {
+        String query = "SELECT COUNT(*) FROM BehaviorGroup WHERE accountId = :accountId AND id = :id";
+        return session.createQuery(query, Long.class)
+                .setParameter("accountId", accountId)
+                .setParameter("id", behaviorGroupId)
+                .getSingleResult()
+                .onItem().transform(count -> {
+                    if (count == 0L) {
+                        throw new NotFoundException("Behavior group not found: " + behaviorGroupId);
+                    } else {
+                        EventType eventType = session.getReference(EventType.class, eventTypeId);
+                        BehaviorGroup behaviorGroup = session.getReference(BehaviorGroup.class, behaviorGroupId);
+                        return new EventTypeBehavior(eventType, behaviorGroup);
+                    }
+                })
+                .onItem().transformToUni(session::persist)
+                .onItem().call(session::flush)
+                .replaceWith(Boolean.TRUE)
+                .onFailure().recoverWithItem(failure -> {
+                    LOGGER.log(Level.WARNING, "Event type behavior addition failed", failure);
+                    return Boolean.FALSE;
+                });
+    }
+
+    public Uni<Boolean> deleteEventTypeBehavior(String accountId, UUID eventTypeId, UUID behaviorGroupId) {
+        String query = "DELETE FROM EventTypeBehavior WHERE eventType.id = :eventTypeId AND behaviorGroup.id = :behaviorGroupId " +
+                "AND behaviorGroup.id IN (SELECT id FROM BehaviorGroup WHERE accountId = :accountId)";
+        return session.createQuery(query)
+                .setParameter("eventTypeId", eventTypeId)
+                .setParameter("behaviorGroupId", behaviorGroupId)
+                .setParameter("accountId", accountId)
+                .executeUpdate()
+                .call(session::flush)
+                .onItem().transform(rowCount -> rowCount > 0);
+    }
+
+    public Uni<List<EventType>> findEventTypesByBehaviorGroupId(String accountId, UUID behaviorGroupId) {
+        String query = "SELECT e FROM EventType e LEFT JOIN FETCH e.application JOIN e.behaviors b " +
+                "WHERE b.behaviorGroup.accountId = :accountId AND b.behaviorGroup.id = :behaviorGroupId";
+        return session.createQuery(query, EventType.class)
+                .setParameter("accountId", accountId)
+                .setParameter("behaviorGroupId", behaviorGroupId)
+                .getResultList();
+    }
+
+    public Uni<List<BehaviorGroup>> findBehaviorGroupsByEventTypeId(String accountId, UUID eventTypeId, Query limiter) {
+        String query = "SELECT bg FROM BehaviorGroup bg JOIN bg.behaviors b WHERE bg.accountId = :accountId AND b.eventType.id = :eventTypeId";
+
+        if (limiter != null) {
+            query = limiter.getModifiedQuery(query);
+        }
+
+        Mutiny.Query<BehaviorGroup> mutinyQuery = session.createQuery(query, BehaviorGroup.class)
+                .setParameter("accountId", accountId)
+                .setParameter("eventTypeId", eventTypeId);
+
+        if (limiter != null && limiter.getLimit() != null && limiter.getLimit().getLimit() > 0) {
+            mutinyQuery = mutinyQuery.setMaxResults(limiter.getLimit().getLimit())
+                    .setFirstResult(limiter.getLimit().getOffset());
+        }
+
+        return mutinyQuery.getResultList()
+                .onItem().invoke(behaviorGroups -> behaviorGroups.forEach(BehaviorGroup::filterOutActions));
+    }
+
+    public Uni<Boolean> addBehaviorGroupAction(String accountId, UUID behaviorGroupId, UUID endpointId) {
+        String query = "SELECT COUNT(*) FROM BehaviorGroup WHERE accountId = :accountId AND id = :id";
+        return session.createQuery(query, Long.class)
+                .setParameter("accountId", accountId)
+                .setParameter("id", behaviorGroupId)
+                .getSingleResult()
+                .onItem().transform(count -> {
+                    if (count == 0L) {
+                        throw new NotFoundException("Behavior group not found: " + behaviorGroupId);
+                    } else {
+                        BehaviorGroup behaviorGroup = session.getReference(BehaviorGroup.class, behaviorGroupId);
+                        Endpoint endpoint = session.getReference(Endpoint.class, endpointId);
+                        return new BehaviorGroupAction(behaviorGroup, endpoint);
+                    }
+                })
+                .onItem().transformToUni(session::persist)
+                .onItem().call(session::flush)
+                .replaceWith(Boolean.TRUE)
+                .onFailure().recoverWithItem(failure -> {
+                    LOGGER.log(Level.WARNING, "Behavior group action addition failed", failure);
+                    return Boolean.FALSE;
+                });
+    }
+
+    public Uni<Boolean> deleteBehaviorGroupAction(String accountId, UUID behaviorGroupId, UUID endpointId) {
+        String query = "DELETE FROM BehaviorGroupAction WHERE behaviorGroup.id = :behaviorGroupId AND endpoint.id = :endpointId " +
+                "AND behaviorGroup.id IN (SELECT id FROM BehaviorGroup WHERE accountId = :accountId)";
+        return session.createQuery(query)
+                .setParameter("behaviorGroupId", behaviorGroupId)
+                .setParameter("endpointId", endpointId)
+                .setParameter("accountId", accountId)
+                .executeUpdate()
+                .call(session::flush)
+                .onItem().transform(rowCount -> rowCount > 0);
+    }
+
+    // This should only be called from an internal API. That's why we don't have to validate the accountId.
+    public Uni<Boolean> setDefaultBehaviorGroup(UUID bundleId, UUID behaviorGroupId) {
+        String query = "UPDATE BehaviorGroup SET defaultBehavior = (CASE WHEN id = :behaviorGroupId THEN TRUE ELSE FALSE END) " +
+                "WHERE bundle.id = :bundleId";
+        return session.createQuery(query)
+                .setParameter("behaviorGroupId", behaviorGroupId)
+                .setParameter("bundleId", bundleId)
+                .executeUpdate()
+                .call(session::flush)
+                .onItem().transform(rowCount -> rowCount > 0);
+    }
+
+    public Uni<Boolean> muteEventType(String accountId, UUID eventTypeId) {
+        String query = "DELETE FROM EventTypeBehavior b " +
+                "WHERE b.behaviorGroup.id IN (SELECT id FROM BehaviorGroup WHERE accountId = :accountId) AND b.eventType.id = :eventTypeId";
+        return session.createQuery(query)
+                .setParameter("accountId", accountId)
+                .setParameter("eventTypeId", eventTypeId)
+                .executeUpdate()
+                .call(session::flush)
+                .onItem().transform(rowCount -> rowCount > 0);
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -78,11 +78,28 @@ public class EndpointResources {
         return mutinyQuery.getSingleResult();
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Multi<Endpoint> getTargetEndpoints(String tenant, String bundleName, String applicationName, String eventTypeName) {
         // TODO Add UNION JOIN for different endpoint types here
         String query = "SELECT e FROM Endpoint e LEFT JOIN FETCH e.webhook JOIN e.targets t " +
                 "WHERE e.enabled = TRUE AND t.eventType.name = :eventTypeName AND t.id.accountId = :accountId " +
                 "AND t.eventType.application.name = :applicationName AND t.eventType.application.bundle.name = :bundleName";
+
+        return session.createQuery(query, Endpoint.class)
+                .setParameter("applicationName", applicationName)
+                .setParameter("eventTypeName", eventTypeName)
+                .setParameter("accountId", tenant)
+                .setParameter("bundleName", bundleName)
+                .getResultList()
+                .onItem().transformToMulti(Multi.createFrom()::iterable);
+    }
+
+    // TODO [BG Phase 2] Remove '_BG' suffix
+    public Multi<Endpoint> getTargetEndpoints_BG(String tenant, String bundleName, String applicationName, String eventTypeName) {
+        // TODO Add UNION JOIN for different endpoint types here
+        String query = "SELECT e FROM Endpoint e LEFT JOIN FETCH e.webhook JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
+                "WHERE e.enabled = TRUE AND b.eventType.name = :eventTypeName AND bga.behaviorGroup.accountId = :accountId " +
+                "AND b.eventType.application.name = :applicationName AND b.eventType.application.bundle.name = :bundleName";
 
         return session.createQuery(query, Endpoint.class)
                 .setParameter("applicationName", applicationName)
@@ -161,6 +178,7 @@ public class EndpointResources {
                 .onItem().transform(rowCount -> rowCount > 0);
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Uni<Boolean> linkEndpoint(String tenant, UUID endpointId, UUID eventTypeId) {
         return Uni.createFrom().item(() -> {
             Endpoint endpoint = session.getReference(Endpoint.class, endpointId);
@@ -173,6 +191,7 @@ public class EndpointResources {
                 .onFailure().recoverWithItem(Boolean.FALSE);
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Uni<Boolean> unlinkEndpoint(String tenant, UUID endpointId, UUID eventTypeId) {
         String query = "DELETE FROM EndpointTarget WHERE id.accountId = :accountId AND eventType.id = :eventTypeId AND endpoint.id = :endpointId";
 
@@ -185,6 +204,7 @@ public class EndpointResources {
                 .onItem().transform(rowCount -> rowCount > 0);
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Multi<Endpoint> getLinkedEndpoints(String tenant, UUID eventTypeId, Query limiter) {
         String query = "SELECT e FROM Endpoint e LEFT JOIN FETCH e.webhook JOIN e.targets t WHERE t.id.accountId = :accountId AND t.eventType.id = :eventTypeId";
 
@@ -205,6 +225,7 @@ public class EndpointResources {
                 .onItem().transformToMulti(Multi.createFrom()::iterable);
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Multi<Endpoint> getDefaultEndpoints(String tenant) {
         String query = "SELECT e FROM Endpoint e LEFT JOIN FETCH e.webhook JOIN e.defaults d WHERE d.id.accountId = :accountId";
 
@@ -214,6 +235,7 @@ public class EndpointResources {
                 .onItem().transformToMulti(Multi.createFrom()::iterable);
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Uni<Boolean> endpointInDefaults(String tenant, UUID endpointId) {
         String query = "SELECT COUNT(*) FROM EndpointDefault WHERE id.accountId = :accountId AND endpoint.id = :endpointId";
 
@@ -224,6 +246,7 @@ public class EndpointResources {
                 .onItem().transform(count -> count > 0);
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Uni<Boolean> addEndpointToDefaults(String tenant, UUID endpointId) {
         return Uni.createFrom().item(() -> {
             Endpoint endpoint = session.getReference(Endpoint.class, endpointId);
@@ -235,6 +258,7 @@ public class EndpointResources {
                 .replaceWith(Boolean.TRUE);
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Uni<Boolean> deleteEndpointFromDefaults(String tenant, UUID endpointId) {
         String query = "DELETE FROM EndpointDefault WHERE id.accountId = :accountId AND id.endpointId = :endpointId";
 

--- a/src/main/java/com/redhat/cloud/notifications/events/DefaultProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/DefaultProcessor.java
@@ -10,6 +10,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+// TODO [BG Phase 2] Delete this class
 @ApplicationScoped
 public class DefaultProcessor {
     @Inject

--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -26,6 +26,9 @@ import java.util.function.Function;
 @ApplicationScoped
 public class EndpointProcessor {
 
+    public static final String PROCESSED_MESSAGES_COUNTER_NAME = "processor.input.processed";
+    public static final String PROCESSED_ENDPOINTS_COUNTER_NAME = "processor.input.endpoint.processed";
+
     @Inject
     Mutiny.Session session;
 
@@ -35,6 +38,7 @@ public class EndpointProcessor {
     @Inject
     EventBusTypeProcessor notificationProcessor;
 
+    // TODO [BG Phase 2] Delete this attribute
     @Inject
     DefaultProcessor defaultProcessor;
 
@@ -55,12 +59,13 @@ public class EndpointProcessor {
 
     @PostConstruct
     void init() {
-        processedItems = registry.counter("processor.input.processed");
-        endpointTargeted = registry.counter("processor.input.endpoint.processed");
+        processedItems = registry.counter(PROCESSED_MESSAGES_COUNTER_NAME);
+        endpointTargeted = registry.counter(PROCESSED_ENDPOINTS_COUNTER_NAME);
     }
 
     public Uni<Void> process(Action action) {
         processedItems.increment();
+        // TODO [BG Phase 2] Use EndpointResources.getEndpoints here
         Multi<NotificationHistory> endpointsCallResult = getEndpoints(
                 action.getAccountId(),
                 action.getBundle(),
@@ -95,6 +100,7 @@ public class EndpointProcessor {
         }
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Multi<Endpoint> getEndpoints(String tenant, String bundleName, String applicationName, String eventTypeName) {
         return resources.getTargetEndpoints(tenant, bundleName, applicationName, eventTypeName)
                 .onItem().transformToMultiAndConcatenate((Function<Endpoint, Publisher<Endpoint>>) endpoint -> {

--- a/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroupAction.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroupAction.java
@@ -1,0 +1,83 @@
+package com.redhat.cloud.notifications.models;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.Table;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@Entity
+@Table(name = "behavior_group_action")
+@JsonNaming(SnakeCaseStrategy.class)
+public class BehaviorGroupAction extends CreationTimestamped {
+
+    @EmbeddedId
+    private BehaviorGroupActionId id;
+
+    @ManyToOne
+    @MapsId("behaviorGroupId")
+    @JoinColumn(name = "behavior_group_id")
+    private BehaviorGroup behaviorGroup;
+
+    @ManyToOne
+    @MapsId("endpointId")
+    @JoinColumn(name = "endpoint_id")
+    private Endpoint endpoint;
+
+    public BehaviorGroupAction() {
+    }
+
+    public BehaviorGroupAction(BehaviorGroup behaviorGroup, Endpoint endpoint) {
+        id = new BehaviorGroupActionId(); // Required to prevent a Hibernate NPE at persistence time.
+        this.behaviorGroup = behaviorGroup;
+        this.endpoint = endpoint;
+    }
+
+    public BehaviorGroupActionId getId() {
+        return id;
+    }
+
+    public void setId(BehaviorGroupActionId id) {
+        this.id = id;
+    }
+
+    public BehaviorGroup getBehaviorGroup() {
+        return behaviorGroup;
+    }
+
+    public void setBehaviorGroup(BehaviorGroup behaviorGroup) {
+        this.behaviorGroup = behaviorGroup;
+    }
+
+    public Endpoint getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(Endpoint endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof BehaviorGroupAction) {
+            BehaviorGroupAction other = (BehaviorGroupAction) o;
+            return Objects.equals(id, other.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroupActionId.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroupActionId.java
@@ -6,12 +6,11 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
 
-// TODO [BG Phase 2] Delete this class
 @Embeddable
-public class EndpointDefaultId implements Serializable {
+public class BehaviorGroupActionId implements Serializable {
 
     @NotNull
-    public String accountId;
+    public UUID behaviorGroupId;
 
     @NotNull
     public UUID endpointId;
@@ -21,9 +20,9 @@ public class EndpointDefaultId implements Serializable {
         if (this == o) {
             return true;
         }
-        if (o instanceof EndpointDefaultId) {
-            EndpointDefaultId other = (EndpointDefaultId) o;
-            return Objects.equals(accountId, other.accountId) &&
+        if (o instanceof BehaviorGroupActionId) {
+            BehaviorGroupActionId other = (BehaviorGroupActionId) o;
+            return Objects.equals(behaviorGroupId, other.behaviorGroupId) &&
                     Objects.equals(endpointId, other.endpointId);
         }
         return false;
@@ -31,6 +30,6 @@ public class EndpointDefaultId implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountId, endpointId);
+        return Objects.hash(behaviorGroupId, endpointId);
     }
 }

--- a/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -76,13 +76,19 @@ public class Endpoint extends CreationUpdateTimestamped {
     @JsonIgnore
     private EndpointWebhook webhook;
 
+    // TODO [BG Phase 2] Delete this attribute
     @OneToMany(mappedBy = "endpoint", cascade = CascadeType.ALL)
     @JsonIgnore
     private Set<EndpointTarget> targets;
 
+    // TODO [BG Phase 2] Delete this attribute
     @OneToMany(mappedBy = "endpoint", cascade = CascadeType.ALL)
     @JsonIgnore
     private Set<EndpointDefault> defaults;
+
+    @OneToMany(mappedBy = "endpoint", cascade = CascadeType.REMOVE)
+    @JsonIgnore
+    private Set<BehaviorGroupAction> behaviorGroupActions;
 
     @OneToMany(mappedBy = "endpoint", cascade = CascadeType.ALL)
     @JsonIgnore
@@ -145,7 +151,7 @@ public class Endpoint extends CreationUpdateTimestamped {
                     }
                     break;
                 case EMAIL_SUBSCRIPTION:
-                case DEFAULT:
+                case DEFAULT: // TODO [BG Phase 2] Delete this case
                 default:
                     // Do nothing for now
                     break;
@@ -166,18 +172,30 @@ public class Endpoint extends CreationUpdateTimestamped {
         this.webhook = webhook;
     }
 
+    public Set<BehaviorGroupAction> getBehaviorGroupActions() {
+        return behaviorGroupActions;
+    }
+
+    public void setBehaviorGroupActions(Set<BehaviorGroupAction> behaviorGroupActions) {
+        this.behaviorGroupActions = behaviorGroupActions;
+    }
+
+    // TODO [BG Phase 2] Delete this method
     public Set<EndpointTarget> getTargets() {
         return targets;
     }
 
+    // TODO [BG Phase 2] Delete this method
     public void setTargets(Set<EndpointTarget> targets) {
         this.targets = targets;
     }
 
+    // TODO [BG Phase 2] Delete this method
     public Set<EndpointDefault> getDefaults() {
         return defaults;
     }
 
+    // TODO [BG Phase 2] Delete this method
     public void setDefaults(Set<EndpointDefault> defaults) {
         this.defaults = defaults;
     }

--- a/src/main/java/com/redhat/cloud/notifications/models/EndpointDefault.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/EndpointDefault.java
@@ -8,6 +8,7 @@ import javax.persistence.MapsId;
 import javax.persistence.Table;
 import java.util.Objects;
 
+// TODO [BG Phase 2] Delete this class
 @Entity
 @Table(name = "endpoint_defaults")
 public class EndpointDefault {

--- a/src/main/java/com/redhat/cloud/notifications/models/EndpointTarget.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/EndpointTarget.java
@@ -8,6 +8,7 @@ import javax.persistence.MapsId;
 import javax.persistence.Table;
 import java.util.Objects;
 
+// TODO [BG Phase 2] Delete this class
 @Entity
 @Table(name = "endpoint_targets")
 public class EndpointTarget {

--- a/src/main/java/com/redhat/cloud/notifications/models/EndpointTargetId.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/EndpointTargetId.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
 
+// TODO [BG Phase 2] Delete this class
 @Embeddable
 public class EndpointTargetId implements Serializable {
 

--- a/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
@@ -12,6 +12,6 @@ public enum EndpointType {
     WEBHOOK, // 0
     @JsonProperty("email_subscription")
     EMAIL_SUBSCRIPTION, // 1
-    @JsonProperty("default")
+    @JsonProperty("default") // TODO [BG Phase 2] Delete the DEFAULT enum member
     DEFAULT // 2
 }

--- a/src/main/java/com/redhat/cloud/notifications/models/EventTypeBehavior.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/EventTypeBehavior.java
@@ -1,0 +1,82 @@
+package com.redhat.cloud.notifications.models;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.Table;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@Entity
+@Table(name = "event_type_behavior")
+@JsonNaming(SnakeCaseStrategy.class)
+public class EventTypeBehavior extends CreationTimestamped {
+
+    @EmbeddedId
+    private EventTypeBehaviorId id;
+
+    @ManyToOne
+    @MapsId("eventTypeId")
+    @JoinColumn(name = "event_type_id")
+    private EventType eventType;
+
+    @ManyToOne
+    @MapsId("behaviorGroupId")
+    @JoinColumn(name = "behavior_group_id")
+    private BehaviorGroup behaviorGroup;
+
+    public EventTypeBehavior() {
+    }
+
+    public EventTypeBehavior(EventType eventType, BehaviorGroup behaviorGroup) {
+        id = new EventTypeBehaviorId(); // Required to prevent a Hibernate NPE at persistence time.
+        this.eventType = eventType;
+        this.behaviorGroup = behaviorGroup;
+    }
+
+    public EventTypeBehaviorId getId() {
+        return id;
+    }
+
+    public void setId(EventTypeBehaviorId id) {
+        this.id = id;
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(EventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public BehaviorGroup getBehaviorGroup() {
+        return behaviorGroup;
+    }
+
+    public void setBehaviorGroup(BehaviorGroup behaviorGroup) {
+        this.behaviorGroup = behaviorGroup;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof EventTypeBehavior) {
+            EventTypeBehavior other = (EventTypeBehavior) o;
+            return Objects.equals(id, other.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/models/EventTypeBehaviorId.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/EventTypeBehaviorId.java
@@ -6,31 +6,30 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
 
-// TODO [BG Phase 2] Delete this class
 @Embeddable
-public class EndpointDefaultId implements Serializable {
+public class EventTypeBehaviorId implements Serializable {
 
     @NotNull
-    public String accountId;
+    public UUID eventTypeId;
 
     @NotNull
-    public UUID endpointId;
+    public UUID behaviorGroupId;
 
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o instanceof EndpointDefaultId) {
-            EndpointDefaultId other = (EndpointDefaultId) o;
-            return Objects.equals(accountId, other.accountId) &&
-                    Objects.equals(endpointId, other.endpointId);
+        if (o instanceof EventTypeBehaviorId) {
+            EventTypeBehaviorId other = (EventTypeBehaviorId) o;
+            return Objects.equals(eventTypeId, other.eventTypeId) &&
+                    Objects.equals(behaviorGroupId, other.behaviorGroupId);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountId, endpointId);
+        return Objects.hash(eventTypeId, behaviorGroupId);
     }
 }

--- a/src/main/java/com/redhat/cloud/notifications/models/filter/ApiResponseFilter.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/filter/ApiResponseFilter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.EventType;
 import org.jboss.logging.Logger;
 
@@ -34,6 +35,20 @@ public class ApiResponseFilter extends SimpleBeanPropertyFilter {
                      */
                     if (eventType.isFilterOutApplication()) {
                         logFilterOut(EventType.class.getName(), "application");
+                        // This will prevent the serialization of the property.
+                        return;
+                    }
+                    break;
+                default:
+                    // Do nothing.
+                    break;
+            }
+        } else if (pojo instanceof BehaviorGroup) {
+            BehaviorGroup behaviorGroup = (BehaviorGroup) pojo;
+            switch (writer.getName()) {
+                case "actions":
+                    if (behaviorGroup.isFilterOutActions()) {
+                        logFilterOut(BehaviorGroup.class.getName(), "actions");
                         // This will prevent the serialization of the property.
                         return;
                     }

--- a/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.routers;
 
+import com.redhat.cloud.notifications.db.BehaviorGroupResources;
 import com.redhat.cloud.notifications.db.BundleResources;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
@@ -13,6 +14,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -29,6 +31,9 @@ public class BundlesService {
 
     @Inject
     BundleResources bundleResources;
+
+    @Inject
+    BehaviorGroupResources behaviorGroupResources;
 
     @GET
     public Multi<Bundle> getBundles() {
@@ -68,4 +73,9 @@ public class BundlesService {
         return bundleResources.getApplications(bundleId);
     }
 
+    @PUT
+    @Path("/{id}/behaviorGroups/{behaviorGroupId}/default")
+    public Uni<Boolean> setDefaultBehaviorGroup(@PathParam("id") UUID bundleId, @PathParam("behaviorGroupId") UUID behaviorGroupId) {
+        return behaviorGroupResources.setDefaultBehaviorGroup(bundleId, behaviorGroupId);
+    }
 }

--- a/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -103,6 +103,7 @@ public class EndpointService {
                         .onItem().transform(endpointsCount -> new EndpointPage(endpointsList, new HashMap<>(), new Meta(endpointsCount))));
     }
 
+    // TODO [BG Phase 2] Delete this method
     @POST
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public Uni<Endpoint> createEndpoint(@Context SecurityContext sec, @NotNull @Valid Endpoint endpoint) {
@@ -118,6 +119,21 @@ public class EndpointService {
                     .onItem()
                     .ifNull()
                     .switchTo(resources.createEndpoint(endpoint));
+        }
+
+        return resources.createEndpoint(endpoint);
+    }
+
+    @POST
+    @Path("/bg") // TODO [BG Phase 2] Delete this path
+    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    // TODO [BG Phase 2] Remove '_BG' suffix
+    public Uni<Endpoint> createEndpoint_BG(@Context SecurityContext sec, @NotNull @Valid Endpoint endpoint) {
+        RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
+        endpoint.setAccountId(principal.getAccount());
+
+        if (endpoint.getProperties() == null) {
+            throw new BadRequestException("Properties is required");
         }
 
         return resources.createEndpoint(endpoint);

--- a/src/main/resources/db/migration/V1.13.0__NOTIF-150_behavior_groups_phase1.sql
+++ b/src/main/resources/db/migration/V1.13.0__NOTIF-150_behavior_groups_phase1.sql
@@ -1,0 +1,31 @@
+CREATE TABLE behavior_group (
+    id UUID NOT NULL,
+    account_id VARCHAR(50) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    display_name VARCHAR NOT NULL,
+    bundle_id UUID NOT NULL,
+    default_behavior BOOLEAN NOT NULL DEFAULT FALSE,
+    created TIMESTAMP NOT NULL,
+    updated TIMESTAMP,
+    CONSTRAINT pk_behavior_group PRIMARY KEY (id),
+    CONSTRAINT uq_behavior_group_name UNIQUE (account_id, name),
+    CONSTRAINT fk_behavior_group_bundle_id FOREIGN KEY (bundle_id) REFERENCES bundles (id) ON DELETE CASCADE
+) WITH (OIDS=FALSE);
+
+CREATE TABLE event_type_behavior (
+    event_type_id UUID NOT NULL,
+    behavior_group_id UUID NOT NULL,
+    created TIMESTAMP NOT NULL,
+    CONSTRAINT pk_event_type_behavior PRIMARY KEY (event_type_id, behavior_group_id),
+    CONSTRAINT fk_event_type_behavior_event_type_id FOREIGN KEY (event_type_id) REFERENCES event_type (id) ON DELETE CASCADE,
+    CONSTRAINT fk_event_type_behavior_behavior_group_id FOREIGN KEY (behavior_group_id) REFERENCES behavior_group (id) ON DELETE CASCADE
+) WITH (OIDS=FALSE);
+
+CREATE TABLE behavior_group_action (
+    behavior_group_id UUID NOT NULL,
+    endpoint_id UUID NOT NULL,
+    created TIMESTAMP NOT NULL,
+    CONSTRAINT pk_behavior_group_action PRIMARY KEY (behavior_group_id, endpoint_id),
+    CONSTRAINT fk_behavior_group_action_behavior_group_id FOREIGN KEY (behavior_group_id) REFERENCES behavior_group (id) ON DELETE CASCADE,
+    CONSTRAINT fk_behavior_group_action_endpoint_id FOREIGN KEY (endpoint_id) REFERENCES endpoints (id) ON DELETE CASCADE
+) WITH (OIDS=FALSE);

--- a/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -17,13 +17,12 @@ import org.apache.commons.io.IOUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 
 public class TestHelpers {
@@ -43,13 +42,7 @@ public class TestHelpers {
         JsonObject header = new JsonObject();
         header.put("identity", identity);
 
-        String xRhEncoded = null;
-        try {
-            xRhEncoded = new String(Base64.getEncoder().encode(header.encode().getBytes("UTF-8")));
-        } catch (UnsupportedEncodingException e) {
-            fail();
-        }
-        return xRhEncoded;
+        return new String(Base64.getEncoder().encode(header.encode().getBytes(UTF_8)));
     }
 
     public static Header createIdentityHeader(String tenant, String username) {
@@ -63,7 +56,7 @@ public class TestHelpers {
     public static String getFileAsString(String filename) {
         try {
             InputStream is = TestHelpers.class.getClassLoader().getResourceAsStream(filename);
-            return IOUtils.toString(is, StandardCharsets.UTF_8);
+            return IOUtils.toString(is, UTF_8);
         } catch (Exception e) {
             fail("Failed to read rhid example file: " + e.getMessage());
             return "";
@@ -116,7 +109,7 @@ public class TestHelpers {
         writer.write(action, jsonEncoder);
         jsonEncoder.flush();
 
-        return baos.toString(StandardCharsets.UTF_8);
+        return baos.toString(UTF_8);
     }
 
     public static Action createPoliciesAction(String accountId, String bundle, String application, String hostDisplayName) {

--- a/src/test/java/com/redhat/cloud/notifications/db/BehaviorGroupResourcesTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/BehaviorGroupResourcesTest.java
@@ -1,0 +1,367 @@
+package com.redhat.cloud.notifications.db;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.models.BehaviorGroup;
+import com.redhat.cloud.notifications.models.BehaviorGroupAction;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.EventTypeBehavior;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.pgclient.PgException;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.persistence.PersistenceException;
+import javax.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class BehaviorGroupResourcesTest extends DbIsolatedTest {
+
+    private static final String ACCOUNT_ID = "root";
+
+    @Inject
+    Mutiny.Session session;
+
+    @Inject
+    BundleResources bundleResources;
+
+    @Inject
+    EndpointResources endpointResources;
+
+    @Inject
+    BehaviorGroupResources behaviorGroupResources;
+
+    @Test
+    public void testCreateAndUpdateAndDeleteBehaviorGroup() {
+        Bundle bundle = createBundle();
+
+        // Create behavior group.
+        BehaviorGroup behaviorGroup = createBehaviorGroup("name", "displayName", bundle.getId());
+        List<BehaviorGroup> behaviorGroups = findBehaviorGroupsByBundleId(bundle.getId());
+        assertEquals(1, behaviorGroups.size());
+        assertEquals(behaviorGroup, behaviorGroups.get(0));
+        assertEquals(behaviorGroup.getName(), behaviorGroups.get(0).getName());
+        assertEquals(behaviorGroup.getDisplayName(), behaviorGroups.get(0).getDisplayName());
+        assertEquals(bundle.getId(), behaviorGroups.get(0).getBundle().getId());
+        assertNotNull(bundle.getCreated());
+
+        // Update behavior group.
+        String newName = "new-name";
+        String newDisplayName = "newDisplayName";
+        Boolean updated = updateBehaviorGroup(behaviorGroup.getId(), newName, newDisplayName, bundle.getId());
+        assertTrue(updated);
+        session.clear(); // We need to clear the session L1 cache before checking the update result.
+        behaviorGroups = findBehaviorGroupsByBundleId(bundle.getId());
+        assertEquals(1, behaviorGroups.size());
+        assertEquals(behaviorGroup.getId(), behaviorGroups.get(0).getId());
+        assertEquals(newName, behaviorGroups.get(0).getName());
+        assertEquals(newDisplayName, behaviorGroups.get(0).getDisplayName());
+        assertEquals(bundle.getId(), behaviorGroups.get(0).getBundle().getId());
+
+        // Delete behavior group.
+        Boolean deleted = deleteBehaviorGroup(behaviorGroup.getId());
+        assertTrue(deleted);
+        behaviorGroups = findBehaviorGroupsByBundleId(bundle.getId());
+        assertTrue(behaviorGroups.isEmpty());
+    }
+
+    @Test
+    public void testCreateBehaviorGroupWithNullName() {
+        Bundle bundle = createBundle();
+        PersistenceException e = assertThrows(PersistenceException.class, () -> {
+            createBehaviorGroup(null, "displayName", bundle.getId());
+        });
+        assertSame(ConstraintViolationException.class, e.getCause().getCause().getClass());
+        assertTrue(e.getCause().getCause().getMessage().contains("propertyPath=name"));
+    }
+
+    @Test
+    public void testCreateBehaviorGroupWithInvalidName() {
+        Bundle bundle = createBundle();
+        PersistenceException e = assertThrows(PersistenceException.class, () -> {
+            createBehaviorGroup("I am not valid", "displayName", bundle.getId());
+        });
+        assertSame(ConstraintViolationException.class, e.getCause().getCause().getClass());
+        assertTrue(e.getCause().getCause().getMessage().contains("propertyPath=name"));
+    }
+
+    @Test
+    public void testCreateBehaviorGroupWithNullDisplayName() {
+        Bundle bundle = createBundle();
+        PersistenceException e = assertThrows(PersistenceException.class, () -> {
+            createBehaviorGroup("name", null, bundle.getId());
+        });
+        assertSame(ConstraintViolationException.class, e.getCause().getCause().getClass());
+        assertTrue(e.getCause().getCause().getMessage().contains("propertyPath=displayName"));
+    }
+
+    @Test
+    public void testCreateBehaviorGroupWithNullBundleId() {
+        PersistenceException e = assertThrows(PersistenceException.class, () -> {
+            createBehaviorGroup("name", "displayName", null);
+        });
+        assertSame(IllegalArgumentException.class, e.getCause().getCause().getClass());
+    }
+
+    @Test
+    public void testCreateBehaviorGroupWithUnknownBundleId() {
+        PersistenceException e = assertThrows(PersistenceException.class, () -> {
+            createBehaviorGroup("name", "displayName", UUID.randomUUID());
+        });
+        assertSame(PgException.class, e.getCause().getCause().getClass()); // FK constraint violation
+    }
+
+    @Test
+    public void testfindByBundleIdOrdering() {
+        Bundle bundle = createBundle();
+        BehaviorGroup behaviorGroup1 = createBehaviorGroup("name1", "displayName", bundle.getId());
+        BehaviorGroup behaviorGroup2 = createBehaviorGroup("name2", "displayName", bundle.getId());
+        BehaviorGroup behaviorGroup3 = createBehaviorGroup("name3", "displayName", bundle.getId());
+        setDefaultBehaviorGroup(bundle.getId(), behaviorGroup2.getId());
+        List<BehaviorGroup> behaviorGroups = findBehaviorGroupsByBundleId(bundle.getId());
+        assertEquals(3, behaviorGroups.size());
+        assertSame(behaviorGroup2, behaviorGroups.get(0), "Default behavior group should come first");
+        assertSame(behaviorGroup3, behaviorGroups.get(1), "Non-default behavior groups should be sorted on descending creation date");
+        assertSame(behaviorGroup1, behaviorGroups.get(2), "Non-default behavior groups should be sorted on descending creation date");
+    }
+
+    @Test
+    public void testAddAndDeleteEventTypeBehaviorAndMuteEventType() {
+        Bundle bundle = createBundle();
+        EventType eventType = createEventType();
+
+        // Add behaviorGroup1 to eventType behaviors.
+        BehaviorGroup behaviorGroup1 = createBehaviorGroup("name1", "displayName", bundle.getId());
+        Boolean added = addEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup1.getId());
+        assertTrue(added);
+
+        // Doing it again should not throw any exception but return false.
+        added = addEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup1.getId());
+        assertFalse(added);
+
+        // Add behaviorGroup2 to eventType behaviors.
+        BehaviorGroup behaviorGroup2 = createBehaviorGroup("name2", "displayName", bundle.getId());
+        added = addEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup2.getId());
+        assertTrue(added);
+
+        // Add behaviorGroup3 to eventType behaviors.
+        BehaviorGroup behaviorGroup3 = createBehaviorGroup("name3", "displayName", bundle.getId());
+        added = addEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup3.getId());
+        assertTrue(added);
+
+        // Check all behaviors were correctly persisted.
+        List<EventTypeBehavior> behaviors = findEventTypeBehaviorByEventTypeId(eventType.getId());
+        assertEquals(3, behaviors.size());
+        assertTrue(behaviors.stream().anyMatch(behavior -> behavior.getId().behaviorGroupId.equals(behaviorGroup1.getId())));
+        assertTrue(behaviors.stream().anyMatch(behavior -> behavior.getId().behaviorGroupId.equals(behaviorGroup2.getId())));
+        assertTrue(behaviors.stream().anyMatch(behavior -> behavior.getId().behaviorGroupId.equals(behaviorGroup3.getId())));
+
+        // Remove behaviorGroup2 from eventType behaviors.
+        Boolean deleted = deleteEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup2.getId());
+        assertTrue(deleted);
+        behaviors = findEventTypeBehaviorByEventTypeId(eventType.getId());
+        assertEquals(2, behaviors.size());
+        assertTrue(behaviors.stream().noneMatch(action -> action.getId().behaviorGroupId.equals(behaviorGroup2.getId())));
+
+        // Doing it again should not throw any exception but return false.
+        deleted = deleteEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup2.getId());
+        assertFalse(deleted);
+        behaviors = findEventTypeBehaviorByEventTypeId(eventType.getId());
+        assertEquals(2, behaviors.size());
+
+        // Mute eventType, removing all its behaviors.
+        Boolean muted = muteEventType(ACCOUNT_ID, eventType.getId());
+        assertTrue(muted);
+        behaviors = findEventTypeBehaviorByEventTypeId(eventType.getId());
+        assertTrue(behaviors.isEmpty());
+    }
+
+    @Test
+    public void testAddEventTypeBehaviorWithWrongAccountId() {
+        Bundle bundle = createBundle();
+        EventType eventType = createEventType();
+        BehaviorGroup behaviorGroup = createBehaviorGroup("name", "displayName", bundle.getId());
+        Boolean added = addEventTypeBehavior("unknownAccountId", eventType.getId(), behaviorGroup.getId());
+        assertFalse(added);
+    }
+
+    @Test
+    public void testFindEventTypesByBehaviorGroupId() {
+        Bundle bundle = createBundle();
+        EventType eventType = createEventType();
+        BehaviorGroup behaviorGroup = createBehaviorGroup("name", "displayName", bundle.getId());
+        addEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup.getId());
+        List<EventType> eventTypes = findEventTypesByBehaviorGroupId(ACCOUNT_ID, behaviorGroup.getId());
+        assertEquals(1, eventTypes.size());
+        assertEquals(eventType.getId(), eventTypes.get(0).getId());
+    }
+
+    @Test
+    public void testFindBehaviorGroupsByEventTypeId() {
+        Bundle bundle = createBundle();
+        EventType eventType = createEventType();
+        BehaviorGroup behaviorGroup = createBehaviorGroup("name", "displayName", bundle.getId());
+        addEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup.getId());
+        List<BehaviorGroup> behaviorGroups = findBehaviorGroupsByEventTypeId(ACCOUNT_ID, eventType.getId());
+        assertEquals(1, behaviorGroups.size());
+        assertEquals(behaviorGroup.getId(), behaviorGroups.get(0).getId());
+    }
+
+    @Test
+    public void testAddAndDeleteBehaviorGroupAction() {
+        Bundle bundle = createBundle();
+        BehaviorGroup behaviorGroup = createBehaviorGroup("name", "displayName", bundle.getId());
+
+        // Add endpoint1 to behaviorGroup actions.
+        Endpoint endpoint1 = createEndpoint();
+        Boolean added = addBehaviorGroupAction(ACCOUNT_ID, behaviorGroup.getId(), endpoint1.getId());
+        assertTrue(added);
+
+        // Doing it again should not throw any exception but return false.
+        added = addBehaviorGroupAction(ACCOUNT_ID, behaviorGroup.getId(), endpoint1.getId());
+        assertFalse(added);
+
+        // Add endpoint2 to behaviorGroup actions.
+        Endpoint endpoint2 = createEndpoint();
+        added = addBehaviorGroupAction(ACCOUNT_ID, behaviorGroup.getId(), endpoint2.getId());
+        assertTrue(added);
+
+        // Check all actions were correctly persisted.
+        List<BehaviorGroupAction> actions = findBehaviorGroupActionsByBehaviorGroupId(behaviorGroup.getId());
+        assertEquals(2, actions.size());
+        assertTrue(actions.stream().anyMatch(action -> action.getId().endpointId.equals(endpoint1.getId())));
+        assertTrue(actions.stream().anyMatch(action -> action.getId().endpointId.equals(endpoint2.getId())));
+
+        // Remove endpoint2 from behaviorGroup actions.
+        Boolean deleted = deleteBehaviorGroupAction(ACCOUNT_ID, behaviorGroup.getId(), endpoint2.getId());
+        assertTrue(deleted);
+        actions = findBehaviorGroupActionsByBehaviorGroupId(behaviorGroup.getId());
+        assertEquals(1, actions.size());
+        assertTrue(actions.stream().noneMatch(action -> action.getId().endpointId.equals(endpoint2.getId())));
+
+        // Doing it again should not throw any exception but return false.
+        deleted = deleteBehaviorGroupAction(ACCOUNT_ID, behaviorGroup.getId(), endpoint2.getId());
+        assertFalse(deleted);
+        actions = findBehaviorGroupActionsByBehaviorGroupId(behaviorGroup.getId());
+        assertEquals(1, actions.size());
+    }
+
+    @Test
+    public void testAddBehaviorGroupActionWithWrongAccountId() {
+        Bundle bundle = createBundle();
+        BehaviorGroup behaviorGroup = createBehaviorGroup("name", "displayName", bundle.getId());
+        Endpoint endpoint = createEndpoint();
+        Boolean added = addBehaviorGroupAction("unknownAccountId", behaviorGroup.getId(), endpoint.getId());
+        assertFalse(added);
+    }
+
+    private Bundle createBundle() {
+        Bundle bundle = new Bundle();
+        bundle.setName("name");
+        bundle.setDisplayName("displayName");
+        return bundleResources.createBundle(bundle).await().indefinitely();
+    }
+
+    private EventType createEventType() {
+        EventType eventType = new EventType();
+        eventType.setName("name");
+        eventType.setDisplayName("displayName");
+        return session.persist(eventType).call(session::flush).replaceWith(eventType).await().indefinitely();
+    }
+
+    private Endpoint createEndpoint() {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setAccountId(ACCOUNT_ID);
+        endpoint.setName("name");
+        endpoint.setDescription("description");
+        endpoint.setType(EndpointType.WEBHOOK);
+        return endpointResources.createEndpoint(endpoint).await().indefinitely();
+    }
+
+    private BehaviorGroup createBehaviorGroup(String name, String displayName, UUID bundleId) {
+        BehaviorGroup behaviorGroup = new BehaviorGroup();
+        behaviorGroup.setName(name);
+        behaviorGroup.setDisplayName(displayName);
+        behaviorGroup.setBundleId(bundleId);
+        return behaviorGroupResources.create(ACCOUNT_ID, behaviorGroup).await().indefinitely();
+    }
+
+    private Boolean updateBehaviorGroup(UUID behaviorGroupId, String name, String displayName, UUID bundleId) {
+        BehaviorGroup behaviorGroup = new BehaviorGroup();
+        behaviorGroup.setId(behaviorGroupId);
+        behaviorGroup.setName(name);
+        behaviorGroup.setDisplayName(displayName);
+        behaviorGroup.setBundleId(UUID.randomUUID()); // This should not have any effect, the bundle is not updatable.
+        return behaviorGroupResources.update(ACCOUNT_ID, behaviorGroup).await().indefinitely();
+    }
+
+    private Boolean deleteBehaviorGroup(UUID behaviorGroupId) {
+        return behaviorGroupResources.delete(ACCOUNT_ID, behaviorGroupId).await().indefinitely();
+    }
+
+    private void setDefaultBehaviorGroup(UUID bundleId, UUID behaviorGroupId) {
+        behaviorGroupResources.setDefaultBehaviorGroup(bundleId, behaviorGroupId).await().indefinitely();
+    }
+
+    private List<BehaviorGroup> findBehaviorGroupsByBundleId(UUID bundleId) {
+        return behaviorGroupResources.findByBundleId(ACCOUNT_ID, bundleId).await().indefinitely();
+    }
+
+    private Boolean addEventTypeBehavior(String accountId, UUID eventTypeId, UUID behaviorGroupId) {
+        return behaviorGroupResources.addEventTypeBehavior(accountId, eventTypeId, behaviorGroupId).await().indefinitely();
+    }
+
+    private List<EventTypeBehavior> findEventTypeBehaviorByEventTypeId(UUID eventTypeId) {
+        String query = "FROM EventTypeBehavior WHERE eventType.id = :eventTypeId";
+        return session.createQuery(query, EventTypeBehavior.class)
+                .setParameter("eventTypeId", eventTypeId)
+                .getResultList()
+                .await().indefinitely();
+    }
+
+    private Boolean deleteEventTypeBehavior(String accountId, UUID eventTypeId, UUID behaviorGroupId) {
+        return behaviorGroupResources.deleteEventTypeBehavior(accountId, eventTypeId, behaviorGroupId).await().indefinitely();
+    }
+
+    private Boolean muteEventType(String accountId, UUID eventTypeId) {
+        return behaviorGroupResources.muteEventType(accountId, eventTypeId).await().indefinitely();
+    }
+
+    private List<EventType> findEventTypesByBehaviorGroupId(String accountId, UUID behaviorGroupId) {
+        return behaviorGroupResources.findEventTypesByBehaviorGroupId(accountId, behaviorGroupId).await().indefinitely();
+    }
+
+    private List<BehaviorGroup> findBehaviorGroupsByEventTypeId(String accountId, UUID eventTypeId) {
+        return behaviorGroupResources.findBehaviorGroupsByEventTypeId(accountId, eventTypeId, new Query()).await().indefinitely();
+    }
+
+    private Boolean addBehaviorGroupAction(String accountId, UUID behaviorGroupId, UUID endpointId) {
+        return behaviorGroupResources.addBehaviorGroupAction(accountId, behaviorGroupId, endpointId).await().indefinitely();
+    }
+
+    private List<BehaviorGroupAction> findBehaviorGroupActionsByBehaviorGroupId(UUID behaviorGroupId) {
+        String query = "FROM BehaviorGroupAction WHERE behaviorGroup.id = :behaviorGroupId";
+        return session.createQuery(query, BehaviorGroupAction.class)
+                .setParameter("behaviorGroupId", behaviorGroupId)
+                .getResultList()
+                .await().indefinitely();
+    }
+
+    private Boolean deleteBehaviorGroupAction(String accountId, UUID behaviorGroupId, UUID endpointId) {
+        return behaviorGroupResources.deleteBehaviorGroupAction(accountId, behaviorGroupId, endpointId).await().indefinitely();
+    }
+}

--- a/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
@@ -1,6 +1,8 @@
 package com.redhat.cloud.notifications.db;
 
 import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.BehaviorGroup;
+import com.redhat.cloud.notifications.models.BehaviorGroupAction;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.models.EmailSubscription;
@@ -9,6 +11,7 @@ import com.redhat.cloud.notifications.models.EndpointDefault;
 import com.redhat.cloud.notifications.models.EndpointTarget;
 import com.redhat.cloud.notifications.models.EndpointWebhook;
 import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.EventTypeBehavior;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import io.smallrye.mutiny.Uni;
 import org.hibernate.reactive.mutiny.Mutiny;
@@ -51,10 +54,13 @@ public class DbCleaner {
         session.withTransaction(transaction -> deleteAllFrom(EmailAggregation.class)
                 .chain(() -> deleteAllFrom(EmailSubscription.class))
                 .chain(() -> deleteAllFrom(NotificationHistory.class))
-                .chain(() -> deleteAllFrom(EndpointDefault.class))
-                .chain(() -> deleteAllFrom(EndpointTarget.class))
+                .chain(() -> deleteAllFrom(EndpointDefault.class)) // TODO [BG Phase 2] Delete this line
+                .chain(() -> deleteAllFrom(EndpointTarget.class)) // TODO [BG Phase 2] Delete this line
+                .chain(() -> deleteAllFrom(BehaviorGroupAction.class))
                 .chain(() -> deleteAllFrom(EndpointWebhook.class))
                 .chain(() -> deleteAllFrom(Endpoint.class))
+                .chain(() -> deleteAllFrom(EventTypeBehavior.class))
+                .chain(() -> deleteAllFrom(BehaviorGroup.class))
                 .chain(() -> deleteAllFrom(EventType.class))
                 .chain(() -> deleteAllFrom(Application.class))
                 .chain(() -> deleteAllFrom(Bundle.class))

--- a/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -53,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockserver.model.HttpResponse.response;
 
+// TODO [BG Phase 2] Delete this file
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/com/redhat/cloud/notifications/events/Lifecycle_BG_ITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/Lifecycle_BG_ITest.java
@@ -1,0 +1,601 @@
+package com.redhat.cloud.notifications.events;
+
+import com.redhat.cloud.notifications.CounterAssertionHelper;
+import com.redhat.cloud.notifications.MockServerClientConfig;
+import com.redhat.cloud.notifications.MockServerConfig;
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.BehaviorGroup;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.HttpType;
+import com.redhat.cloud.notifications.models.NotificationHistory;
+import com.redhat.cloud.notifications.models.WebhookAttributes;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Test;
+import org.mockserver.model.HttpRequest;
+
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.redhat.cloud.notifications.MockServerClientConfig.RbacAccess;
+import static com.redhat.cloud.notifications.TestConstants.API_INTEGRATIONS_V_1_0;
+import static com.redhat.cloud.notifications.TestConstants.API_NOTIFICATIONS_V_1_0;
+import static com.redhat.cloud.notifications.TestHelpers.serializeAction;
+import static com.redhat.cloud.notifications.events.EndpointProcessor.PROCESSED_ENDPOINTS_COUNTER_NAME;
+import static com.redhat.cloud.notifications.events.EndpointProcessor.PROCESSED_MESSAGES_COUNTER_NAME;
+import static com.redhat.cloud.notifications.events.EventConsumer.REJECTED_COUNTER_NAME;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockserver.model.HttpResponse.response;
+
+// TODO [BG Phase 2] Remove '_BG_' from the class name
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class Lifecycle_BG_ITest extends DbIsolatedTest {
+
+    /*
+     * In the tests below, most JSON responses are verified using JsonObject/JsonArray instead of deserializing these
+     * responses into model instances and checking their attributes values. That's because the model classes contain
+     * attributes annotated with @JsonProperty(access = READ_ONLY) which can't be deserialized and therefore verified
+     * here. The deserialization is still performed only to verify that the JSON responses data structure is correct.
+     */
+
+    private static final String APP_NAME = "policies-lifecycle-test";
+    private static final String BUNDLE_NAME = "my-bundle";
+    private static final String EVENT_TYPE_NAME = "all";
+    private static final String INTERNAL_BASE_PATH = "/";
+    private static final String WEBHOOK_MOCK_PATH = "/test/lifecycle";
+    private static final String SECRET_TOKEN = "super-secret-token";
+
+    @MockServerConfig
+    MockServerClientConfig mockServerConfig;
+
+    @Inject
+    @Any
+    InMemoryConnector inMemoryConnector;
+
+    @Inject
+    CounterAssertionHelper counterAssertionHelper;
+
+    private Header initRbacMock(String tenant, String username, MockServerClientConfig.RbacAccess access) {
+        String identityHeaderValue = TestHelpers.encodeIdentityInfo(tenant, username);
+        mockServerConfig.addMockRbacAccess(identityHeaderValue, access);
+        return TestHelpers.createIdentityHeader(identityHeaderValue);
+    }
+
+    @Test
+    void test() throws IOException, InterruptedException {
+        // Identity header used for all public APIs calls. Internal APIs calls don't need that.
+        Header identityHeader = initRbacMock("tenant", "user", RbacAccess.FULL_ACCESS);
+
+        // First, we need a bundle, an app and an event type. Let's create them!
+        String bundleId = createBundle();
+        String appId = createApp(bundleId);
+        String eventTypeId = createEventType(appId);
+        checkAllEventTypes(identityHeader);
+
+        /*
+         * Then, we'll create two behavior groups which will be part of the bundle created above. One will be the
+         * default behavior group, the other one will be a custom behavior group.
+         */
+        String defaultBehaviorGroupId = createBehaviorGroup(identityHeader, "default-behavior-group", "Default behavior group", bundleId);
+        String customBehaviorGroupId = createBehaviorGroup(identityHeader, "custom-behavior-group", "Custom behavior group", bundleId);
+        setDefaultBehaviorGroup(identityHeader, bundleId, defaultBehaviorGroupId);
+
+        // We need actions for our behavior groups.
+        String endpointId1 = createWebhookEndpoint(identityHeader, "positive feeling", "needle in the haystack", SECRET_TOKEN);
+        String endpointId2 = createWebhookEndpoint(identityHeader, "negative feeling", "I feel like dying", "wrong-secret-token");
+        checkEndpoints(identityHeader, endpointId1, endpointId2);
+
+        // The actions must be added to the behavior groups.
+        addBehaviorGroupActions(identityHeader, defaultBehaviorGroupId, endpointId1);
+        // Adding the same action twice must not raise an exception.
+        addBehaviorGroupActions(identityHeader, defaultBehaviorGroupId, endpointId1, endpointId2);
+
+        /*
+         * Let's push a first message! It should not trigger any webhook call since we didn't link the event type with
+         * any behavior group.
+         */
+        pushMessage(0);
+
+        /*
+         * Now we'll link the event type with the default behavior group.
+         * Pushing a new message should trigger one webhook call.
+         */
+        addEventTypeBehaviorGroup(identityHeader, eventTypeId, defaultBehaviorGroupId, 1);
+        // Adding the same behavior group twice must not raise an exception.
+        addEventTypeBehaviorGroup(identityHeader, eventTypeId, defaultBehaviorGroupId, 1);
+        checkEventTypeBehaviorGroups(identityHeader, eventTypeId, defaultBehaviorGroupId);
+        // pushMessage(1); TODO [BG Phase 2] Uncomment (it does not work here because EndpointProcessor does not use behavior groups)
+
+        /*
+         * Let's also link the same event type with the custom behavior group.
+         * Pushing a new message should trigger two webhook calls.
+         */
+        addEventTypeBehaviorGroup(identityHeader, eventTypeId, customBehaviorGroupId, 2);
+        checkEventTypeBehaviorGroups(identityHeader, eventTypeId, defaultBehaviorGroupId, customBehaviorGroupId);
+        // pushMessage(2); TODO [BG Phase 2] Uncomment (it does not work here because EndpointProcessor does not use behavior groups)
+
+        /*
+         * What happens if we mute the event type?
+         * Pushing a new message should not trigger any webhook call.
+         */
+        muteEventType(identityHeader, eventTypeId);
+        checkEventTypeBehaviorGroups(identityHeader, eventTypeId);
+        // pushMessage(0); TODO [BG Phase 2] Uncomment (it does not work here because EndpointProcessor does not use behavior groups)
+
+        // Enough messages! Now let's check the history of both endpoints.
+        /*
+        TODO [BG Phase 2] Uncomment (it does not work here because EndpointProcessor does not use behavior groups)
+        checkEndpointHistory(identityHeader, endpointId1, 2, true, 200);
+        checkEndpointHistory(identityHeader, endpointId2, 1, false, 400);
+         */
+
+        /*
+         * We'll finish with a bundle removal.
+         * Why would we do that here? I don't really know, it was there before the big test refactor... :)
+         */
+        deleteBundle(bundleId);
+    }
+
+    private String createBundle() {
+        Bundle bundle = new Bundle(BUNDLE_NAME, "A bundle");
+
+        String responseBody = given()
+                .basePath(INTERNAL_BASE_PATH)
+                .contentType(ContentType.JSON)
+                .body(Json.encode(bundle))
+                .when()
+                .post("/internal/bundles")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonObject jsonBundle = new JsonObject(responseBody);
+        jsonBundle.mapTo(Bundle.class);
+        assertNotNull(jsonBundle.getString("id"));
+        assertEquals(bundle.getName(), jsonBundle.getString("name"));
+        assertEquals(bundle.getDisplayName(), jsonBundle.getString("display_name"));
+        assertNotNull(jsonBundle.getString("created"));
+
+        return jsonBundle.getString("id");
+    }
+
+    private String createApp(String bundleId) {
+        Application app = new Application();
+        app.setName(APP_NAME);
+        app.setDisplayName("The best app in the life");
+        app.setBundleId(UUID.fromString(bundleId));
+
+        String responseBody = given()
+                .when()
+                .basePath(INTERNAL_BASE_PATH)
+                .contentType(ContentType.JSON)
+                .body(Json.encode(app))
+                .post("/internal/applications")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonObject jsonApp = new JsonObject(responseBody);
+        jsonApp.mapTo(Application.class);
+        assertNotNull(jsonApp.getString("id"));
+        assertEquals(app.getName(), jsonApp.getString("name"));
+        assertEquals(app.getDisplayName(), jsonApp.getString("display_name"));
+        assertEquals(app.getBundleId().toString(), jsonApp.getString("bundle_id"));
+        assertNotNull(jsonApp.getString("created"));
+
+        return jsonApp.getString("id");
+    }
+
+    private String createEventType(String appId) {
+        EventType eventType = new EventType();
+        eventType.setName(EVENT_TYPE_NAME);
+        eventType.setDisplayName("Policies will take care of the rules");
+        eventType.setDescription("Policies is super cool, you should use it");
+
+        String responseBody = given()
+                .when()
+                .basePath(INTERNAL_BASE_PATH)
+                .contentType(ContentType.JSON)
+                .body(Json.encode(eventType))
+                .pathParam("appId", appId)
+                .post("/internal/applications/{appId}/eventTypes")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonObject jsonEventType = new JsonObject(responseBody);
+        jsonEventType.mapTo(EventType.class);
+        assertNotNull(jsonEventType.getString("id"));
+        assertEquals(eventType.getName(), jsonEventType.getString("name"));
+        assertEquals(eventType.getDisplayName(), jsonEventType.getString("display_name"));
+        assertEquals(eventType.getDescription(), jsonEventType.getString("description"));
+
+        return jsonEventType.getString("id");
+    }
+
+    private void checkAllEventTypes(Header identityHeader) {
+        String responseBody = given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .when()
+                .get("/notifications/eventTypes")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonArray jsonEventTypes = new JsonArray(responseBody);
+        assertEquals(2, jsonEventTypes.size()); // One from the current test, one from the default DB records.
+    }
+
+    private String createBehaviorGroup(Header identityHeader, String name, String displayName, String bundleId) {
+        BehaviorGroup behaviorGroup = new BehaviorGroup();
+        behaviorGroup.setName(name);
+        behaviorGroup.setDisplayName(displayName);
+        behaviorGroup.setBundleId(UUID.fromString(bundleId));
+
+        String responseBody = given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .contentType(ContentType.JSON)
+                .body(Json.encode(behaviorGroup))
+                .when()
+                .post("/notifications/behaviorGroups")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonObject jsonBehaviorGroup = new JsonObject(responseBody);
+        jsonBehaviorGroup.mapTo(BehaviorGroup.class);
+        assertNotNull(jsonBehaviorGroup.getString("id"));
+        assertNull(jsonBehaviorGroup.getString("accountId"));
+        assertEquals(behaviorGroup.getName(), jsonBehaviorGroup.getString("name"));
+        assertEquals(behaviorGroup.getDisplayName(), jsonBehaviorGroup.getString("display_name"));
+        assertEquals(behaviorGroup.getBundleId().toString(), jsonBehaviorGroup.getString("bundle_id"));
+        assertNotNull(jsonBehaviorGroup.getString("created"));
+
+        return jsonBehaviorGroup.getString("id");
+    }
+
+    private void setDefaultBehaviorGroup(Header identityHeader, String bundleId, String behaviorGroupId) {
+        // Sets the default behavior group.
+        given()
+                .basePath(INTERNAL_BASE_PATH)
+                .pathParam("bundleId", bundleId)
+                .pathParam("behaviorGroupId", behaviorGroupId)
+                .when()
+                .put("/internal/bundles/{bundleId}/behaviorGroups/{behaviorGroupId}/default")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        // Now let's verify which behavior group is marked as default in the database.
+        String responseBody = given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .pathParam("bundleId", bundleId)
+                .when()
+                .get("/notifications/bundles/{bundleId}/behaviorGroups")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonArray jsonBehaviorGroups = new JsonArray(responseBody);
+        assertEquals(2, jsonBehaviorGroups.size());
+        for (int i = 0; i < jsonBehaviorGroups.size(); i++) {
+            JsonObject jsonBehaviorGroup = jsonBehaviorGroups.getJsonObject(i);
+            jsonBehaviorGroup.mapTo(BehaviorGroup.class);
+            if (jsonBehaviorGroup.getString("id").equals(behaviorGroupId)) {
+                assertTrue(jsonBehaviorGroup.getBoolean("default_behavior"));
+            } else {
+                assertFalse(jsonBehaviorGroup.getBoolean("default_behavior"));
+            }
+        }
+    }
+
+    private String createWebhookEndpoint(Header identityHeader, String name, String description, String secretToken) {
+        WebhookAttributes webAttr = new WebhookAttributes();
+        webAttr.setMethod(HttpType.POST);
+        webAttr.setDisableSSLVerification(true);
+        webAttr.setSecretToken(secretToken);
+        webAttr.setUrl("http://" + mockServerConfig.getRunningAddress() +  WEBHOOK_MOCK_PATH);
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setType(EndpointType.WEBHOOK);
+        endpoint.setName(name);
+        endpoint.setDescription(description);
+        endpoint.setEnabled(true);
+        endpoint.setProperties(webAttr);
+
+        String responseBody = given()
+                .basePath(API_INTEGRATIONS_V_1_0)
+                .header(identityHeader)
+                .contentType(ContentType.JSON)
+                .body(Json.encode(endpoint))
+                .when()
+                .post("/endpoints")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonObject jsonEndpoint = new JsonObject(responseBody);
+        jsonEndpoint.mapTo(Endpoint.class);
+        assertNotNull(jsonEndpoint.getString("id"));
+        assertNull(jsonEndpoint.getString("accountId"));
+        assertEquals(endpoint.getName(), jsonEndpoint.getString("name"));
+        assertEquals(endpoint.getDescription(), jsonEndpoint.getString("description"));
+        assertTrue(jsonEndpoint.getBoolean("enabled"));
+        assertEquals(EndpointType.WEBHOOK.name().toLowerCase(), jsonEndpoint.getString("type"));
+
+        JsonObject jsonWebhookAttributes = jsonEndpoint.getJsonObject("properties");
+        jsonWebhookAttributes.mapTo(WebhookAttributes.class);
+        assertEquals(webAttr.getMethod().name(), jsonWebhookAttributes.getString("method"));
+        assertEquals(webAttr.isDisableSSLVerification(), jsonWebhookAttributes.getBoolean("disable_ssl_verification"));
+        if (webAttr.getSecretToken() != null) {
+            assertEquals(webAttr.getSecretToken(), jsonWebhookAttributes.getString("secret_token"));
+        }
+        assertEquals(webAttr.getUrl(), jsonWebhookAttributes.getString("url"));
+
+        return jsonEndpoint.getString("id");
+    }
+
+    private void checkEndpoints(Header identityHeader, String... expectedEndpointIds) {
+        String responseBody = given()
+                .basePath(API_INTEGRATIONS_V_1_0)
+                .header(identityHeader)
+                .when()
+                .get("/endpoints")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonArray jsonEndpoints = new JsonObject(responseBody).getJsonArray("data");
+        assertEquals(expectedEndpointIds.length, jsonEndpoints.size());
+        jsonEndpoints.getJsonObject(0).mapTo(Endpoint.class);
+        jsonEndpoints.getJsonObject(0).getJsonObject("properties").mapTo(WebhookAttributes.class);
+
+        for (String endpointId : expectedEndpointIds) {
+            if (!responseBody.contains(endpointId)) {
+                fail("One of the expected endpoint could not be found in the database");
+            }
+        }
+    }
+
+    private void addBehaviorGroupActions(Header identityHeader, String behaviorGroupId, String... endpointIds) {
+        given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .contentType(ContentType.JSON)
+                .pathParam("behaviorGroupId", behaviorGroupId)
+                .body(Json.encode(Arrays.asList(endpointIds)))
+                .when()
+                .put("/notifications/behaviorGroups/{behaviorGroupId}/actions")
+                .then()
+                .statusCode(200);
+    }
+
+    /*
+     * Pushes a single message to the 'ingress' channel.
+     * Depending on the event type, behavior groups and endpoints configuration, it will trigger zero or more webhook calls.
+     */
+    private void pushMessage(int expectedWebhookCalls) throws IOException, InterruptedException {
+        counterAssertionHelper.saveCounterValuesBeforeTest(REJECTED_COUNTER_NAME, PROCESSED_MESSAGES_COUNTER_NAME, PROCESSED_ENDPOINTS_COUNTER_NAME);
+
+        CountDownLatch requestsCounter = new CountDownLatch(expectedWebhookCalls);
+        HttpRequest expectedRequestPattern = null;
+
+        if (expectedWebhookCalls > 0) {
+            expectedRequestPattern = setupWebhookMock(requestsCounter);
+        }
+
+        emitMockedIngressAction();
+
+        if (expectedWebhookCalls > 0) {
+            if (!requestsCounter.await(5, TimeUnit.SECONDS)) {
+                fail("HttpServer never received the requests");
+                HttpRequest[] httpRequests = mockServerConfig.getMockServerClient().retrieveRecordedRequests(expectedRequestPattern);
+                assertEquals(2, httpRequests.length);
+                // Verify calls were correct, sort first?
+            }
+            mockServerConfig.getMockServerClient().clear(expectedRequestPattern);
+        }
+
+        counterAssertionHelper.assertIncrement(REJECTED_COUNTER_NAME, 0);
+        counterAssertionHelper.assertIncrement(PROCESSED_MESSAGES_COUNTER_NAME, 1);
+        counterAssertionHelper.assertIncrement(PROCESSED_ENDPOINTS_COUNTER_NAME, expectedWebhookCalls);
+        counterAssertionHelper.clear();
+    }
+
+    private void emitMockedIngressAction() throws IOException {
+        Action action = new Action();
+        action.setAccountId("tenant");
+        action.setBundle(BUNDLE_NAME);
+        action.setApplication(APP_NAME);
+        action.setEventType(EVENT_TYPE_NAME);
+        action.setTimestamp(LocalDateTime.now());
+        action.setContext(Map.of());
+        action.setEvents(List.of(
+                Event.newBuilder()
+                        .setMetadataBuilder(Metadata.newBuilder())
+                        .setPayload(Map.of())
+                        .build()
+        ));
+
+        String serializedAction = serializeAction(action);
+        inMemoryConnector.source("ingress").send(serializedAction);
+    }
+
+    private HttpRequest setupWebhookMock(CountDownLatch requestsCounter) {
+        HttpRequest expectedRequestPattern = new HttpRequest()
+                .withPath(WEBHOOK_MOCK_PATH)
+                .withMethod("POST");
+
+        mockServerConfig.getMockServerClient()
+                .withSecure(false)
+                .when(expectedRequestPattern)
+                .respond(request -> {
+                    requestsCounter.countDown();
+                    List<String> header = request.getHeader("X-Insight-Token");
+                    if (header != null && header.size() == 1 && SECRET_TOKEN.equals(header.get(0))) {
+                        return response().withStatusCode(200)
+                                .withBody("Success");
+                    } else {
+                        return response().withStatusCode(400)
+                                .withBody("{ \"message\": \"Time is running out\" }");
+                    }
+                });
+
+        return expectedRequestPattern;
+    }
+
+    private void addEventTypeBehaviorGroup(Header identityHeader, String eventTypeId, String behaviorGroupId, int expectedEventTypeBehaviorGroups) {
+        given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .pathParam("eventTypeId", eventTypeId)
+                .pathParam("behaviorGroupId", behaviorGroupId)
+                .when()
+                .put("/notifications/eventTypes/{eventTypeId}/behaviorGroups/{behaviorGroupId}")
+                .then()
+                .statusCode(200);
+
+        String responseBody = given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .pathParam("eventTypeId", eventTypeId)
+                .when()
+                .get("/notifications/eventTypes/{eventTypeId}/behaviorGroups")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonArray jsonBehaviorGroups = new JsonArray(responseBody);
+        assertEquals(expectedEventTypeBehaviorGroups, jsonBehaviorGroups.size());
+        JsonObject jsonBehaviorGroup = jsonBehaviorGroups.getJsonObject(0);
+        assertEquals(behaviorGroupId, jsonBehaviorGroup.getString("id"));
+    }
+
+    private void checkEventTypeBehaviorGroups(Header identityHeader, String eventTypeId, String... expectedBehaviorGroupIds) {
+        String responseBody = given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .pathParam("eventTypeId", eventTypeId)
+                .when()
+                .get("/notifications/eventTypes/{eventTypeId}/behaviorGroups")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonArray jsonBehaviorGroups = new JsonArray(responseBody);
+        assertEquals(expectedBehaviorGroupIds.length, jsonBehaviorGroups.size());
+
+        for (String behaviorGroupId : expectedBehaviorGroupIds) {
+            if (!responseBody.contains(behaviorGroupId)) {
+                fail("One of the expected behavior groups is not linked to the event type");
+            }
+        }
+    }
+
+    private void muteEventType(Header identityHeader, String eventTypeId) {
+        given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .pathParam("eventTypeId", eventTypeId)
+                .when()
+                .delete("/notifications/eventTypes/{eventTypeId}/mute")
+                .then()
+                .statusCode(200);
+
+        String responseBody = given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .pathParam("eventTypeId", eventTypeId)
+                .when()
+                .get("/notifications/eventTypes/{eventTypeId}/behaviorGroups")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonArray jsonBehaviorGroups = new JsonArray(responseBody);
+        assertEquals(0, jsonBehaviorGroups.size());
+    }
+
+    private void checkEndpointHistory(Header identityHeader, String endpointId, int expectedHistoryEntries, boolean expectedInvocationResult, int expectedHttpStatus) {
+        String responseBody = given()
+                .basePath(API_INTEGRATIONS_V_1_0)
+                .header(identityHeader)
+                .pathParam("endpointId", endpointId)
+                .when()
+                .get("/endpoints/{endpointId}/history")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        JsonArray jsonEndpointHistory = new JsonArray(responseBody);
+        assertEquals(expectedHistoryEntries, jsonEndpointHistory.size());
+
+        for (int i = 0; i < jsonEndpointHistory.size(); i++) {
+            JsonObject jsonNotificationHistory = jsonEndpointHistory.getJsonObject(i);
+            jsonNotificationHistory.mapTo(NotificationHistory.class);
+            assertEquals(expectedInvocationResult, jsonNotificationHistory.getBoolean("invocationResult"));
+
+            if (!expectedInvocationResult) {
+                responseBody = given()
+                        .basePath(API_INTEGRATIONS_V_1_0)
+                        .header(identityHeader)
+                        .pathParam("endpointId", endpointId)
+                        .pathParam("historyId", jsonNotificationHistory.getString("id"))
+                        .when()
+                        .get("/endpoints/{endpointId}/history/{historyId}/details")
+                        .then()
+                        .statusCode(200)
+                        .extract().body().asString();
+
+                JsonObject jsonDetails = new JsonObject(responseBody);
+                assertFalse(jsonDetails.isEmpty());
+                assertEquals(expectedHttpStatus, jsonDetails.getInteger("code"));
+                assertNotNull(jsonDetails.getString("url"));
+                assertNotNull(jsonDetails.getString("method"));
+            }
+        }
+    }
+
+    private void deleteBundle(String bundleId) {
+        given()
+                .basePath("/")
+                .when()
+                .pathParam("bundleId", bundleId)
+                .delete("/internal/bundles/{bundleId}")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/src/test/java/com/redhat/cloud/notifications/models/TestEndpointType.java
+++ b/src/test/java/com/redhat/cloud/notifications/models/TestEndpointType.java
@@ -18,6 +18,7 @@ public class TestEndpointType {
         assertEquals(1, EndpointType.EMAIL_SUBSCRIPTION.ordinal());
     }
 
+    // TODO [BG Phase 2] Delete this test
     @Test
     void endpointTypeDefaultIs2() {
         assertEquals(2, EndpointType.DEFAULT.ordinal());

--- a/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -448,6 +448,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
         assertEquals(29, endpointPage.getMeta().getCount());
     }
 
+    // TODO [BG Phase 2] Delete this test
     @Test
     void testDefaultEndpointRegistering() {
         String tenant = "defaultRegister";
@@ -607,9 +608,16 @@ public class EndpointServiceTest extends DbIsolatedTest {
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
         endpoints = endpointPage.getData().toArray(new Endpoint[0]);
         assertEquals(20, endpoints.length);
+        // TODO [BG Phase 2] Delete the 3 following lines
         assertEquals("Default endpoint", endpoints[endpoints.length - 1].getName());
         assertEquals("Endpoint 1", endpoints[endpoints.length - 2].getName());
         assertEquals("Endpoint 26", endpoints[0].getName());
+        // TODO [BG Phase 2] Uncomment this:
+        /*
+        assertEquals("Endpoint 1", endpoints[endpoints.length - 1].getName());
+        assertEquals("Endpoint 10", endpoints[endpoints.length - 2].getName());
+        assertEquals("Endpoint 27", endpoints[0].getName());
+        */
     }
 
     @Test

--- a/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -179,6 +179,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
         assertEquals(100, eventTypes.size());
     }
 
+    // TODO [BG Phase 2] Delete this test
     @Test
     void testAddToDefaultsWithInsufficientPrivileges() {
         helpers.createTestAppAndEventTypes();
@@ -197,6 +198,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .statusCode(403);
     }
 
+    // TODO [BG Phase 2] Delete this test
     @Test
     void testDeleteFromDefaultsWithInsufficientPrivileges() {
         helpers.createTestAppAndEventTypes();
@@ -215,6 +217,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .statusCode(403);
     }
 
+    // TODO [BG Phase 2] Delete this test
     @Test
     void testNonExistantDefaults() {
         helpers.createTestAppAndEventTypes();
@@ -256,6 +259,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .statusCode(400);
     }
 
+    // TODO [BG Phase 2] Delete this test
     @Test
     void testPutGetAndDeleteDefaults() {
         helpers.createTestAppAndEventTypes();
@@ -503,4 +507,120 @@ public class NotificationServiceTest extends DbIsolatedTest {
         assertEquals("Red Hat Enterprise Linux", rhel.get().getDisplayName());
     }
 
+    @Test
+    void testInsufficientPrivileges() {
+        Header noAccessIdentityHeader = initRbacMock("tenant", "noAccess", RbacAccess.NO_ACCESS);
+        Header readAccessIdentityHeader = initRbacMock("tenant", "readAccess", RbacAccess.READ_ACCESS);
+
+        given()
+                .header(noAccessIdentityHeader)
+                .when()
+                .get("/notifications/eventTypes")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(noAccessIdentityHeader)
+                .pathParam("endpointId", UUID.randomUUID())
+                .when()
+                // TODO [BG Phase 2] Remove '/bg' from path
+                .get("/notifications/bg/eventTypes/affectedByRemovalOfEndpoint/{endpointId}")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(noAccessIdentityHeader)
+                .pathParam("behaviorGroupId", UUID.randomUUID())
+                .when()
+                .get("/notifications/eventTypes/affectedByRemovalOfBehaviorGroup/{behaviorGroupId}")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(readAccessIdentityHeader)
+                .pathParam("eventTypeId", UUID.randomUUID())
+                .pathParam("behaviorGroupId", UUID.randomUUID())
+                .when()
+                .put("/notifications/eventTypes/{eventTypeId}/behaviorGroups/{behaviorGroupId}")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(readAccessIdentityHeader)
+                .pathParam("eventTypeId", UUID.randomUUID())
+                .pathParam("behaviorGroupId", UUID.randomUUID())
+                .when()
+                .delete("/notifications/eventTypes/{eventTypeId}/behaviorGroups/{behaviorGroupId}")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(noAccessIdentityHeader)
+                .pathParam("eventTypeId", UUID.randomUUID())
+                .when()
+                .get("/notifications/eventTypes/{eventTypeId}/behaviorGroups")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(readAccessIdentityHeader)
+                .pathParam("eventTypeId", UUID.randomUUID())
+                .when()
+                .delete("/notifications/eventTypes/{eventTypeId}/mute")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(readAccessIdentityHeader)
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/notifications/behaviorGroups")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(readAccessIdentityHeader)
+                .contentType(ContentType.JSON)
+                .pathParam("id", UUID.randomUUID())
+                .when()
+                .put("/notifications/behaviorGroups/{id}")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(readAccessIdentityHeader)
+                .pathParam("id", UUID.randomUUID())
+                .when()
+                .delete("/notifications/behaviorGroups/{id}")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(readAccessIdentityHeader)
+                .contentType(ContentType.JSON)
+                .pathParam("behaviorGroupId", UUID.randomUUID())
+                .body(Json.encode(List.of(UUID.randomUUID())))
+                .when()
+                .put("/notifications/behaviorGroups/{behaviorGroupId}/actions")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(readAccessIdentityHeader)
+                .contentType(ContentType.JSON)
+                .pathParam("behaviorGroupId", UUID.randomUUID())
+                .body(Json.encode(List.of(UUID.randomUUID())))
+                .when()
+                .delete("/notifications/behaviorGroups/{behaviorGroupId}/actions")
+                .then()
+                .statusCode(403);
+
+        given()
+                .header(noAccessIdentityHeader)
+                .pathParam("bundleId", UUID.randomUUID())
+                .when()
+                .get("/notifications/bundles/{bundleId}/behaviorGroups")
+                .then()
+                .statusCode(403);
+    }
 }


### PR DESCRIPTION
This is phase 1 of #170. It's meant to be non-breaking, without any effect on the production.

It can be used to test the behavior groups on CI/QA.

`notifications-frontend` does not have to be updated right away, this PR can be merged without breaking the UI.