### PR TITLE
Build applications with mvn verify

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           java-version: 11
       - name: Build with Maven
-        run: ./mvnw install
+        run: ./mvnw verify
       - uses: actions/upload-artifact@v2
         name: Upload notifications openapi.json
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <openapi-parser.version>4.0.4</openapi-parser.version>
         <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
         <insights-notification-schemas-java.version>0.3</insights-notification-schemas-java.version>
-        <clowder-quarkus-config-source.version>0.1.1</clowder-quarkus-config-source.version>
+        <clowder-quarkus-config-source.version>0.1.2</clowder-quarkus-config-source.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
I think we don't need to call "mvn install" here. As far as I understand our code, it is not necessary to put the build artefacts in the local .m2/repository folder. So "mvn verify" should be enough, faster and the better option in this case.