### PR TITLE
Run DbCleaner with a dedicated Session

### DIFF
--- a/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
@@ -15,10 +15,11 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
 
-@ApplicationScoped
+@Path("/internal/db-cleaner")
 public class DbCleaner {
 
     private static final String DEFAULT_BUNDLE_NAME = "rhel";
@@ -45,6 +46,7 @@ public class DbCleaner {
      * should do that with {@link io.quarkus.test.TestTransaction} but it doesn't work with Hibernate Reactive, so this
      * is a temporary workaround to make our tests more reliable and easy to maintain.
      */
+    @DELETE
     public void clean() {
         session.withTransaction(transaction -> deleteAllFrom(EmailAggregation.class)
                 .chain(() -> deleteAllFrom(EmailSubscription.class))

--- a/src/test/java/com/redhat/cloud/notifications/db/DbIsolatedTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/DbIsolatedTest.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.db;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import javax.inject.Inject;
+import static io.restassured.RestAssured.given;
 
 /**
  * When a test class extends {@link DbIsolatedTest}, all of its tests are individually preceded and followed by a
@@ -11,12 +11,13 @@ import javax.inject.Inject;
  */
 public abstract class DbIsolatedTest {
 
-    @Inject
-    DbCleaner dbCleaner;
-
     @BeforeEach
     @AfterEach
     void cleanDatabase() {
-        dbCleaner.clean();
+        given()
+                .basePath("/internal")
+                .delete("/db-cleaner")
+                .then()
+                .statusCode(204);
     }
 }


### PR DESCRIPTION
`DbCleaner` currently shares the `Mutiny.Session` of the tests (because they have a common CDI request context), which prevents us from testing DB exceptions (like constraints violations for example) because when such an exception is thrown, the Hibernate session becomes unusable (see [here](http://hibernate.org/reactive/documentation/1.0/reference/html_single/#_using_the_reactive_session)). As a consequence, the database cannot be cleaned if a `PgException` is thrown.

This PR fixes that issue. `DbCleaner` is now executed through a REST call which automatically creates a dedicated request context. The `DbCleaner` session is therefore isolated from the tests session.