### PR TITLE
add separate packages for rhid and rbac auth

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.auth;
+package com.redhat.cloud.notifications.auth.rbac;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;

--- a/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacIdentityProvider.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacIdentityProvider.java
@@ -1,5 +1,8 @@
-package com.redhat.cloud.notifications.auth;
+package com.redhat.cloud.notifications.auth.rbac;
 
+import com.redhat.cloud.notifications.auth.rhid.RhIdPrincipal;
+import com.redhat.cloud.notifications.auth.rhid.RhIdentity;
+import com.redhat.cloud.notifications.auth.rhid.RhIdentityAuthenticationRequest;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.IdentityProvider;
@@ -15,7 +18,7 @@ import javax.inject.Inject;
 import java.util.Base64;
 import java.util.logging.Logger;
 
-import static com.redhat.cloud.notifications.auth.RHIdentityAuthMechanism.IDENTITY_HEADER;
+import static com.redhat.cloud.notifications.auth.rhid.RHIdentityAuthMechanism.IDENTITY_HEADER;
 
 /**
  * Authorizes the data from the insight's RBAC-server and adds the appropriate roles

--- a/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacRaw.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacRaw.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.auth;
+package com.redhat.cloud.notifications.auth.rbac;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacRestClientRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacRestClientRequestFilter.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.auth;
+package com.redhat.cloud.notifications.auth.rbac;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;

--- a/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
@@ -1,5 +1,6 @@
-package com.redhat.cloud.notifications.auth;
+package com.redhat.cloud.notifications.auth.rbac;
 
+import com.redhat.cloud.notifications.auth.rhid.RHIdentityAuthMechanism;
 import io.quarkus.cache.CacheResult;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;

--- a/src/main/java/com/redhat/cloud/notifications/auth/rhid/RHIdentityAuthMechanism.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rhid/RHIdentityAuthMechanism.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.auth;
+package com.redhat.cloud.notifications.auth.rhid;
 
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.IdentityProviderManager;

--- a/src/main/java/com/redhat/cloud/notifications/auth/rhid/RhIdPrincipal.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rhid/RhIdPrincipal.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.auth;
+package com.redhat.cloud.notifications.auth.rhid;
 
 import java.security.Principal;
 

--- a/src/main/java/com/redhat/cloud/notifications/auth/rhid/RhIdentity.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rhid/RhIdentity.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.auth;
+package com.redhat.cloud.notifications.auth.rhid;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/redhat/cloud/notifications/auth/rhid/RhIdentityAuthenticationRequest.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rhid/RhIdentityAuthenticationRequest.java
@@ -1,8 +1,8 @@
-package com.redhat.cloud.notifications.auth;
+package com.redhat.cloud.notifications.auth.rhid;
 
 import io.quarkus.security.identity.request.BaseAuthenticationRequest;
 
-import static com.redhat.cloud.notifications.auth.RHIdentityAuthMechanism.IDENTITY_HEADER;
+import static com.redhat.cloud.notifications.auth.rhid.RHIdentityAuthMechanism.IDENTITY_HEADER;
 
 public class RhIdentityAuthenticationRequest extends BaseAuthenticationRequest {
 

--- a/src/main/java/com/redhat/cloud/notifications/routers/AdminService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/AdminService.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.StuffHolder;
-import com.redhat.cloud.notifications.auth.RbacRaw;
-import com.redhat.cloud.notifications.auth.RbacServer;
+import com.redhat.cloud.notifications.auth.rbac.RbacRaw;
+import com.redhat.cloud.notifications.auth.rbac.RbacServer;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 

--- a/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.Constants;
-import com.redhat.cloud.notifications.auth.RbacIdentityProvider;
-import com.redhat.cloud.notifications.auth.RhIdPrincipal;
+import com.redhat.cloud.notifications.auth.rbac.RbacIdentityProvider;
+import com.redhat.cloud.notifications.auth.rhid.RhIdPrincipal;
 import com.redhat.cloud.notifications.db.ApplicationResources;
 import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.EndpointResources;

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.Constants;
-import com.redhat.cloud.notifications.auth.RbacIdentityProvider;
-import com.redhat.cloud.notifications.auth.RhIdPrincipal;
+import com.redhat.cloud.notifications.auth.rbac.RbacIdentityProvider;
+import com.redhat.cloud.notifications.auth.rhid.RhIdPrincipal;
 import com.redhat.cloud.notifications.db.ApplicationResources;
 import com.redhat.cloud.notifications.db.BundleResources;
 import com.redhat.cloud.notifications.db.EndpointResources;

--- a/src/main/java/com/redhat/cloud/notifications/routers/UserConfigService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/UserConfigService.java
@@ -2,7 +2,7 @@ package com.redhat.cloud.notifications.routers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.redhat.cloud.notifications.auth.RhIdPrincipal;
+import com.redhat.cloud.notifications.auth.rhid.RhIdPrincipal;
 import com.redhat.cloud.notifications.db.ApplicationResources;
 import com.redhat.cloud.notifications.db.BundleResources;
 import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;

--- a/src/test/java/com/redhat/cloud/notifications/MockServerClientConfig.java
+++ b/src/test/java/com/redhat/cloud/notifications/MockServerClientConfig.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications;
 
-import com.redhat.cloud.notifications.auth.RHIdentityAuthMechanism;
+import com.redhat.cloud.notifications.auth.rhid.RHIdentityAuthMechanism;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.ClearType;
 import org.mockserver.model.HttpRequest;

--- a/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications;
 
-import com.redhat.cloud.notifications.auth.RHIdentityAuthMechanism;
+import com.redhat.cloud.notifications.auth.rhid.RHIdentityAuthMechanism;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;

--- a/src/test/java/com/redhat/cloud/notifications/auth/rbac/RbacParsingTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/auth/rbac/RbacParsingTest.java
@@ -1,8 +1,7 @@
-package com.redhat.cloud.notifications;
+package com.redhat.cloud.notifications.auth.rbac;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.redhat.cloud.notifications.auth.RbacRaw;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -14,7 +13,7 @@ import java.io.InputStream;
  * Test RBAC parsing.
  * Brought over from policies-ui-backend and extended
  */
-public class RbacParsingTest {
+class RbacParsingTest {
 
     private static final ObjectReader RBAC_RAW_READER = new ObjectMapper().readerFor(RbacRaw.class);
     private static final String BASE = "src/test/resources/rbac-examples/";


### PR DESCRIPTION
add separate packages for rhid and rbac auth so we have a cleaner code base and don't violate the separation of concerns principle.