### PR TITLE
NOTIF-165 Add API to modify a Bundle

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
@@ -45,6 +45,16 @@ public class BundleResources {
                 .getSingleResultOrNull();
     }
 
+    public Uni<Integer> updateBundle(UUID id, Bundle bundle) {
+        String query = "UPDATE Bundle SET name = :name, displayName = :displayName WHERE id = :id";
+        return session.createQuery(query)
+                .setParameter("name", bundle.getName())
+                .setParameter("displayName", bundle.getDisplayName())
+                .setParameter("id", id)
+                .executeUpdate()
+                .call(session::flush);
+    }
+
     public Uni<Boolean> deleteBundle(UUID id) {
         String query = "DELETE FROM Bundle WHERE id = :id";
         return session.createQuery(query)

--- a/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
@@ -9,7 +9,7 @@ import io.smallrye.mutiny.Uni;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
-import javax.ws.rs.Consumes;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -17,16 +17,13 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 /**
  * Deal with bundles
  */
 @Path("/internal/bundles")
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public class BundlesService {
 
     @Inject
@@ -42,9 +39,21 @@ public class BundlesService {
     }
 
     @POST
-    public Uni<Bundle> addBundle(@Valid Bundle bundle) {
-        // We need to ensure that the x-rh-identity isn't present here
+    public Uni<Bundle> addBundle(@NotNull @Valid Bundle bundle) {
         return bundleResources.createBundle(bundle);
+    }
+
+    @PUT
+    @Path("/{id}")
+    public Uni<Response> updateBundle(@PathParam("id") UUID id, @NotNull @Valid Bundle bundle) {
+        return bundleResources.updateBundle(id, bundle)
+                .onItem().transform(rowCount -> {
+                    if (rowCount == 0) {
+                        return Response.status(Response.Status.NOT_FOUND).build();
+                    } else {
+                        return Response.ok().build();
+                    }
+                });
     }
 
     @DELETE


### PR DESCRIPTION
If a Bundle `name` is modified, the integration with onboarded apps will break. As suggested by @theute, we need some kind of alias for the name to give the apps the opportunity to migrate from the old one to the new one. This will be taken care of in a separate PR.