### PR TITLE
NOTIF-166 Add API to modify an Application

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
@@ -30,6 +30,16 @@ public class ApplicationResources {
                 .replaceWith(app);
     }
 
+    public Uni<Integer> updateApplication(UUID id, Application app) {
+        String query = "UPDATE Application SET name = :name, displayName = :displayName WHERE id = :id";
+        return session.createQuery(query)
+                .setParameter("name", app.getName())
+                .setParameter("displayName", app.getDisplayName())
+                .setParameter("id", id)
+                .executeUpdate()
+                .call(session::flush);
+    }
+
     public Uni<Boolean> deleteApplication(UUID id) {
         String query = "DELETE FROM Application WHERE id = :id";
         return session.createQuery(query)

--- a/src/main/java/com/redhat/cloud/notifications/routers/ApplicationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/ApplicationService.java
@@ -8,23 +8,21 @@ import io.smallrye.mutiny.Uni;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
 
 @Path("/internal/applications")
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public class ApplicationService {
 
     @Inject
@@ -45,9 +43,21 @@ public class ApplicationService {
     }
 
     @POST
-    public Uni<Application> addApplication(@Valid Application application) {
-        // We need to ensure that the x-rh-identity isn't present here
+    public Uni<Application> addApplication(@NotNull @Valid Application application) {
         return appResources.createApplication(application);
+    }
+
+    @PUT
+    @Path("/{id}")
+    public Uni<Response> updateBundle(@PathParam("id") UUID id, @NotNull @Valid Application bundle) {
+        return appResources.updateApplication(id, bundle)
+                .onItem().transform(rowCount -> {
+                    if (rowCount == 0) {
+                        return Response.status(Response.Status.NOT_FOUND).build();
+                    } else {
+                        return Response.ok().build();
+                    }
+                });
     }
 
     @DELETE

--- a/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/ApplicationServiceTest.java
@@ -326,7 +326,7 @@ public class ApplicationServiceTest extends DbIsolatedTest {
                 .statusCode(404);
     }
 
-    private void updateApplication(String id, String bundleId, int expectedStatusCode) {
+    private void updateApplication(String applicationId, String bundleId, int expectedStatusCode) {
         String updatedName = "updated-name";
         String updatedDisplayName = "updatedDisplayName";
 
@@ -337,7 +337,7 @@ public class ApplicationServiceTest extends DbIsolatedTest {
 
         given()
                 .contentType(ContentType.JSON)
-                .pathParam("id", id)
+                .pathParam("id", applicationId)
                 .body(Json.encode(app))
                 .put("/internal/applications/{id}")
                 .then()
@@ -345,7 +345,7 @@ public class ApplicationServiceTest extends DbIsolatedTest {
 
         if (expectedStatusCode >= 200 && expectedStatusCode < 300) {
             String responseBody = given()
-                    .pathParam("id", id)
+                    .pathParam("id", applicationId)
                     .get("/internal/applications/{id}")
                     .then()
                     .statusCode(200)


### PR DESCRIPTION
If an Application `name` is modified, the integration with onboarded apps will break. As suggested by @theute, we need some kind of alias for the name to give the apps the opportunity to migrate from the old one to the new one. This will be taken care of in a separate PR.