### PR TITLE
Insert, update and delete behavior group actions with a single REST call

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -20,6 +20,7 @@ import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -71,7 +72,7 @@ public class BehaviorGroup extends CreationUpdateTimestamped {
 
     @OneToMany(mappedBy = "behaviorGroup", cascade = CascadeType.REMOVE)
     @JsonInclude(Include.NON_NULL)
-    private Set<BehaviorGroupAction> actions;
+    private List<BehaviorGroupAction> actions;
 
     @Transient
     @JsonIgnore
@@ -140,11 +141,11 @@ public class BehaviorGroup extends CreationUpdateTimestamped {
         this.defaultBehavior = defaultBehavior;
     }
 
-    public Set<BehaviorGroupAction> getActions() {
+    public List<BehaviorGroupAction> getActions() {
         return actions;
     }
 
-    public void setActions(Set<BehaviorGroupAction> actions) {
+    public void setActions(List<BehaviorGroupAction> actions) {
         this.actions = actions;
     }
 

--- a/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroupAction.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroupAction.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import javax.persistence.EmbeddedId;
@@ -30,6 +31,10 @@ public class BehaviorGroupAction extends CreationTimestamped {
     @MapsId("endpointId")
     @JoinColumn(name = "endpoint_id")
     private Endpoint endpoint;
+
+    // The position determines the display order of a behavior group actions in the UI.
+    @JsonIgnore
+    private int position;
 
     public BehaviorGroupAction() {
     }
@@ -62,6 +67,14 @@ public class BehaviorGroupAction extends CreationTimestamped {
 
     public void setEndpoint(Endpoint endpoint) {
         this.endpoint = endpoint;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
     }
 
     @Override

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -318,29 +318,13 @@ public class NotificationService {
 
     @PUT
     @Path("/behaviorGroups/{behaviorGroupId}/actions")
-    @Operation(summary = "Add a list of actions to a behavior group.")
+    @Operation(summary = "Update the list of actions of a behavior group.")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    public Uni<Response> addBehaviorGroupActions(@Context SecurityContext sec, @PathParam("behaviorGroupId") UUID behaviorGroupId, List<UUID> endpointIds) {
+    public Uni<Response> updateBehaviorGroupActions(@Context SecurityContext sec, @PathParam("behaviorGroupId") UUID behaviorGroupId, List<UUID> endpointIds) {
         return getAccountId(sec)
-                .onItem().transformToUni(accountId -> Multi.createFrom().iterable(endpointIds)
-                        .onItem().transformToUniAndConcatenate(endpointId -> behaviorGroupResources.addBehaviorGroupAction(accountId, behaviorGroupId, endpointId))
-                        .collect().asList()
-                )
+                .onItem().transformToUni(accountId -> behaviorGroupResources.updateBehaviorGroupActions(accountId, behaviorGroupId, endpointIds))
                 .replaceWith(Response.ok().build());
-    }
-
-    @DELETE
-    @Path("/behaviorGroups/{behaviorGroupId}/actions")
-    @Operation(summary = "Delete a list of actions from a behavior group.")
-    @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    public Uni<Boolean> deleteBehaviorGroupActions(@Context SecurityContext sec, @PathParam("behaviorGroupId") UUID behaviorGroupId, List<UUID> endpointIds) {
-        return getAccountId(sec)
-                .onItem().transformToUni(accountId -> Multi.createFrom().iterable(endpointIds)
-                        .onItem().transformToUniAndConcatenate(endpointId -> behaviorGroupResources.deleteBehaviorGroupAction(accountId, behaviorGroupId, endpointId))
-                        .collect().asList()
-                        .onItem().transform(deleteResults -> deleteResults.stream().allMatch(Boolean.TRUE::equals))
-                );
     }
 
     @GET

--- a/src/main/resources/db/migration/V1.15.0__behavior_group_actions.sql
+++ b/src/main/resources/db/migration/V1.15.0__behavior_group_actions.sql
@@ -1,0 +1,5 @@
+ALTER TABLE behavior_group_action
+    ADD COLUMN position INTEGER NOT NULL DEFAULT 0; -- The default value is required to migrate existing actions.
+
+ALTER TABLE behavior_group_action
+    ALTER COLUMN position DROP DEFAULT; -- Migration done, we can drop the default value.

--- a/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -606,16 +606,6 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .statusCode(403);
 
         given()
-                .header(readAccessIdentityHeader)
-                .contentType(ContentType.JSON)
-                .pathParam("behaviorGroupId", UUID.randomUUID())
-                .body(Json.encode(List.of(UUID.randomUUID())))
-                .when()
-                .delete("/notifications/behaviorGroups/{behaviorGroupId}/actions")
-                .then()
-                .statusCode(403);
-
-        given()
                 .header(noAccessIdentityHeader)
                 .pathParam("bundleId", UUID.randomUUID())
                 .when()


### PR DESCRIPTION
@josejulio: Here's what we talked about last week.

`DELETE /api/notifications/v1.0/notifications/behaviorGroups/{behaviorGroupId}/actions` no longer exists.

`PUT /api/notifications/v1.0/notifications/behaviorGroups/{behaviorGroupId}/actions` now takes care of actions addition, removal and order in the UI. I couldn't use `order` since it's a SQL reserved word so I used `BehaviorGroupAction.position` instead, but I hesitated with `rank`. This is super easy to rename so don't hesitate to suggest a different name.