### PR TITLE
Stop transforming Uni to Multi when not relevant

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
@@ -108,7 +108,7 @@ public class ApplicationResources {
                 .onItem().transform(rowCount -> rowCount > 0);
     }
 
-    public Multi<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId) {
+    public Uni<List<EventType>> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId) {
         String query = "SELECT e FROM EventType e LEFT JOIN FETCH e.application";
 
         List<String> conditions = new ArrayList<>();
@@ -139,8 +139,7 @@ public class ApplicationResources {
                     .setFirstResult(limiter.getLimit().getOffset());
         }
 
-        return mutinyQuery.getResultList()
-                .onItem().transformToMulti(Multi.createFrom()::iterable);
+        return mutinyQuery.getResultList();
     }
 
     // TODO [BG Phase 2] Delete this method

--- a/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
@@ -8,6 +8,7 @@ import org.hibernate.reactive.mutiny.Mutiny;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -64,12 +65,11 @@ public class BundleResources {
                 .onItem().transform(rowCount -> rowCount > 0);
     }
 
-    public Multi<Application> getApplications(UUID id) {
+    public Uni<List<Application>> getApplications(UUID id) {
         String query = "FROM Application WHERE bundle.id = :id";
         return session.createQuery(query, Application.class)
                 .setParameter("id", id)
-                .getResultList()
-                .onItem().transformToMulti(Multi.createFrom()::iterable);
+                .getResultList();
     }
 
     public Uni<Application> addApplicationToBundle(UUID bundleId, Application app) {

--- a/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
@@ -2,13 +2,13 @@ package com.redhat.cloud.notifications.db;
 
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.NotificationHistory;
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -26,14 +26,13 @@ public class NotificationResources {
                 .replaceWith(history);
     }
 
-    public Multi<NotificationHistory> getNotificationHistory(String tenant, UUID endpoint) {
+    public Uni<List<NotificationHistory>> getNotificationHistory(String tenant, UUID endpoint) {
         String query = "SELECT NEW NotificationHistory(nh.id, nh.accountId, nh.invocationTime, nh.invocationResult, nh.eventId, nh.endpoint, nh.created) " +
                 "FROM NotificationHistory nh WHERE nh.accountId = :accountId AND nh.endpoint.id = :endpointId";
         return session.createQuery(query, NotificationHistory.class)
                 .setParameter("accountId", tenant)
                 .setParameter("endpointId", endpoint)
-                .getResultList()
-                .onItem().transformToMulti(Multi.createFrom()::iterable);
+                .getResultList();
     }
 
     public Uni<JsonObject> getNotificationDetails(String tenant, Query limiter, UUID endpoint, UUID historyId) {

--- a/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/BundlesService.java
@@ -18,6 +18,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -78,7 +79,7 @@ public class BundlesService {
 
     @GET
     @Path("/{id}/applications")
-    public Multi<Application> getApplications(@PathParam("id") UUID bundleId) {
+    public Uni<List<Application>> getApplications(@PathParam("id") UUID bundleId) {
         return bundleResources.getApplications(bundleId);
     }
 

--- a/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -45,6 +45,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 
 @Path(Constants.API_INTEGRATIONS_V_1_0 + "/endpoints")
@@ -194,7 +195,7 @@ public class EndpointService {
     @GET
     @Path("/{id}/history")
     @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
-    public Multi<NotificationHistory> getEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID id) {
+    public Uni<List<NotificationHistory>> getEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID id) {
         // TODO We need globally limitations (Paging support and limits etc)
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return notifResources.getNotificationHistory(principal.getAccount(), id);

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -115,7 +115,7 @@ public class NotificationService {
     @Path("/eventTypes")
     @Operation(summary = "Retrieve all event types. The returned list can be filtered by bundle or application.")
     @RolesAllowed(RbacIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public Multi<EventType> getEventTypes(@BeanParam Query query, @QueryParam("applicationIds") Set<UUID> applicationIds, @QueryParam("bundleId") UUID bundleId) {
+    public Uni<List<EventType>> getEventTypes(@BeanParam Query query, @QueryParam("applicationIds") Set<UUID> applicationIds, @QueryParam("bundleId") UUID bundleId) {
         return apps.getEventTypes(query, applicationIds, bundleId);
     }
 


### PR DESCRIPTION
Hibernate Reactive result sets are emitted as a `Uni` item. We should not transform them to `Multi` when we don't need to.