### PR TITLE
Disable the flyway_schema_history repair on startup

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
@@ -29,7 +29,6 @@ public class FlywayWorkaround {
     public void runFlywayMigration(@Observes StartupEvent event) {
         LOGGER.warn("Starting Flyway workaround... remove it ASAP!");
         Flyway flyway = Flyway.configure().dataSource("jdbc:" + datasourceUrl, datasourceUsername, datasourcePassword).load();
-        flyway.repair();
         flyway.migrate();
     }
 }


### PR DESCRIPTION
The prod schema was successfully migrated today, we no longer need that.