### PR TITLE
Clear the Hibernate session when a message processing fails

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -86,7 +86,7 @@ public class EndpointProcessor {
                 .onItem().ignoreAsUni()
                 .replaceWith(notificationResult)
                 .replaceWith(Uni.createFrom().voidItem())
-                .onItem().invoke(ignored -> session.clear());
+                .onItemOrFailure().call(() -> Uni.createFrom().item(() -> session.clear()));
     }
 
     public EndpointTypeProcessor endpointTypeToProcessor(EndpointType endpointType) {


### PR DESCRIPTION
Not related to the production exception, but still important.

Currently, when a Kafka message is processed, the Hibernate session is not cleared in case of failure during the message processing. Also, in case of success, the clear is done in a blocking way.

This PR fixes both of these issues: the session is now _always_ cleared and it's done in a non-blocking way.