### PR TITLE
NOTIF-55 Migrate to resteasy-reactive and rest-client-reactive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,23 +54,19 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-resteasy-reactive-qute</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jackson</artifactId>
+            <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-mutiny</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-mutiny</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -111,10 +107,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-cache</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-qute</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -11,6 +11,7 @@ import io.smallrye.mutiny.Uni;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -18,11 +19,16 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
 @Path("/internal")
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 public class InternalService {
 
     @Inject

--- a/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -9,6 +9,7 @@ import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.EventType;
@@ -573,6 +574,8 @@ public class NotificationServiceTest extends DbIsolatedTest {
         given()
                 .header(readAccessIdentityHeader)
                 .contentType(ContentType.JSON)
+                // TODO Remove the body when https://github.com/quarkusio/quarkus/issues/16897 is fixed
+                .body(Json.encode(new BehaviorGroup()))
                 .when()
                 .post("/notifications/behaviorGroups")
                 .then()
@@ -582,6 +585,8 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .header(readAccessIdentityHeader)
                 .contentType(ContentType.JSON)
                 .pathParam("id", UUID.randomUUID())
+                // TODO Remove the body when https://github.com/quarkusio/quarkus/issues/16897 is fixed
+                .body(Json.encode(new BehaviorGroup()))
                 .when()
                 .put("/notifications/behaviorGroups/{id}")
                 .then()


### PR DESCRIPTION
Blocked by https://github.com/quarkusio/quarkus/issues/16577: the `x-rh-identity` header is not sent because of a Quarkus bug, which leads to a failed RBAC call.

It should be fixed in Quarkus `1.13.3.Final`.