### PR TITLE
Enforce UTF_8 for all Base64 encoding/decoding

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacIdentityProvider.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacIdentityProvider.java
@@ -19,6 +19,7 @@ import java.util.Base64;
 import java.util.logging.Logger;
 
 import static com.redhat.cloud.notifications.auth.rhid.RHIdentityAuthMechanism.IDENTITY_HEADER;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Authorizes the data from the insight's RBAC-server and adds the appropriate roles
@@ -97,7 +98,7 @@ public class RbacIdentityProvider implements IdentityProvider<RhIdentityAuthenti
     }
 
     private static RhIdentity getRhIdentityFromString(String xRhIdHeader) {
-        String xRhDecoded = new String(Base64.getDecoder().decode(xRhIdHeader));
+        String xRhDecoded = new String(Base64.getDecoder().decode(xRhIdHeader.getBytes(UTF_8)), UTF_8);
         return Json.decodeValue(xRhDecoded, RhIdentity.class);
     }
 }

--- a/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacRestClientRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacRestClientRequestFilter.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Base64;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Filter to optionally add data on outgoing requests to the RBAC service.
  * This is meant for local development and not production.
@@ -17,7 +19,7 @@ public class RbacRestClientRequestFilter implements ClientRequestFilter {
     public RbacRestClientRequestFilter() {
         String tmp = System.getProperty("develop.exceptional.user.auth.info");
         if (tmp != null && !tmp.isEmpty()) {
-            authInfo = Base64.getEncoder().encodeToString(tmp.getBytes());
+            authInfo = new String(Base64.getEncoder().encode(tmp.getBytes(UTF_8)), UTF_8);
         }
     }
 

--- a/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -42,7 +42,7 @@ public class TestHelpers {
         JsonObject header = new JsonObject();
         header.put("identity", identity);
 
-        return new String(Base64.getEncoder().encode(header.encode().getBytes(UTF_8)));
+        return new String(Base64.getEncoder().encode(header.encode().getBytes(UTF_8)), UTF_8);
     }
 
     public static Header createIdentityHeader(String tenant, String username) {


### PR DESCRIPTION
`UTF_8` should always be enforced when the `String` constructor is called. Same for `String.getBytes`.