### PR TITLE
Shorten Application and EventType POST URLs

### DIFF
--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -5,10 +5,12 @@ import uuid
 def set_path_prefix(base_path):
     global applications_prefix
     global bundles_prefix
+    global event_types_prefix
     global integrations_prefix
     global notifications_prefix
     applications_prefix = base_path + "/internal/applications"
     bundles_prefix = base_path + "/internal/bundles"
+    event_types_prefix = base_path + "/internal/eventTypes"
     integrations_prefix = base_path + "/api/integrations/v1.0"
     notifications_prefix = base_path + "/api/notifications/v1.0"
 
@@ -46,7 +48,7 @@ def add_application(bundle_id, name, display_name):
                 "display_name": display_name,
                 "bundle_id": bundle_id}
 
-    r = requests.post(bundles_prefix + "/" + bundle_id + "/applications", json=app_json)
+    r = requests.post(applications_prefix, json=app_json)
     print(r.status_code)
     response_json = r.json()
     print(response_json)
@@ -83,9 +85,8 @@ def add_event_type(application_id, name, display_name):
 
     # It does not exist, so create it
 
-    et_json = {"name": name, "display_name": display_name}
-    r = requests.post(applications_prefix + "/" + application_id + "/eventTypes",
-                      json=et_json)
+    et_json = {"name": name, "display_name": display_name, "application_id": application_id}
+    r = requests.post(event_types_prefix, json=et_json)
     response_json = r.json()
     print(response_json)
     if r.status_code / 10 != 20:

--- a/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/BundleResources.java
@@ -74,16 +74,4 @@ public class BundleResources {
                                 .getResultList()
                 );
     }
-
-    public Uni<Application> addApplicationToBundle(UUID bundleId, Application app) {
-        return session.find(Bundle.class, bundleId)
-                .onItem().ifNull().failWith(new NotFoundException())
-                .onItem().transform(bundle -> {
-                    app.setBundle(bundle);
-                    return app;
-                })
-                .onItem().transformToUni(session::persist)
-                .call(session::flush)
-                .replaceWith(app);
-    }
 }

--- a/src/main/java/com/redhat/cloud/notifications/models/Application.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Application.java
@@ -44,14 +44,9 @@ public class Application extends CreationUpdateTimestamped {
     @Schema(name = "display_name")
     private String displayName;
 
-    /*
-     * This field is only used to return the bundleId in a REST API response.
-     * When an app is created, the bundleId from the REST API path is used to determine the relation between the app and a bundle.
-     * When an app is updated, the bundleId cannot be updated.
-     */
+    @NotNull
     @Transient
     @Schema(name = "bundle_id")
-    @JsonProperty(access = READ_ONLY)
     private UUID bundleId;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -52,6 +52,11 @@ public class EventType {
     @JsonInclude(NON_NULL)
     private String description;
 
+    @NotNull
+    @Transient
+    @Schema(name = "application_id")
+    private UUID applicationId;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "application_id")
     @JsonInclude(NON_NULL)
@@ -100,6 +105,17 @@ public class EventType {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public UUID getApplicationId() {
+        if (applicationId == null && application != null) {
+            applicationId = application.getId();
+        }
+        return applicationId;
+    }
+
+    public void setApplicationId(UUID applicationId) {
+        this.applicationId = applicationId;
     }
 
     public Application getApplication() {

--- a/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -87,16 +87,16 @@ public class InternalService {
         return bundleResources.deleteBundle(bundleId);
     }
 
-    @POST
-    @Path("/bundles/{bundleId}/applications")
-    public Uni<Application> createApplication(@PathParam("bundleId") UUID bundleId, @NotNull @Valid Application app) {
-        return bundleResources.addApplicationToBundle(bundleId, app);
-    }
-
     @GET
     @Path("/bundles/{bundleId}/applications")
     public Uni<List<Application>> getApplications(@PathParam("bundleId") UUID bundleId) {
         return bundleResources.getApplications(bundleId);
+    }
+
+    @POST
+    @Path("/applications")
+    public Uni<Application> createApplication(@NotNull @Valid Application app) {
+        return appResources.createApp(app);
     }
 
     @GET
@@ -125,16 +125,16 @@ public class InternalService {
         return appResources.deleteApplication(appId);
     }
 
-    @POST
-    @Path("/applications/{appId}/eventTypes")
-    public Uni<EventType> createEventType(@PathParam("appId") UUID appId, @NotNull @Valid EventType eventType) {
-        return appResources.addEventTypeToApplication(appId, eventType);
-    }
-
     @GET
     @Path("/applications/{appId}/eventTypes")
     public Multi<EventType> getEventTypes(@PathParam("appId") UUID appId) {
         return appResources.getEventTypes(appId);
+    }
+
+    @POST
+    @Path("/eventTypes")
+    public Uni<EventType> createEventType(@NotNull @Valid EventType eventType) {
+        return appResources.createEventType(eventType);
     }
 
     @DELETE

--- a/src/test/java/com/redhat/cloud/notifications/db/BehaviorGroupResourcesTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/BehaviorGroupResourcesTest.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.BehaviorGroupAction;
 import com.redhat.cloud.notifications.models.Bundle;
@@ -39,6 +40,9 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
 
     @Inject
     BundleResources bundleResources;
+
+    @Inject
+    ApplicationResources appResources;
 
     @Inject
     EndpointResources endpointResources;
@@ -143,7 +147,8 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
     @Test
     public void testAddAndDeleteEventTypeBehaviorAndMuteEventType() {
         Bundle bundle = createBundle();
-        EventType eventType = createEventType();
+        Application app = createApp(bundle.getId());
+        EventType eventType = createEventType(app.getId());
 
         // Add behaviorGroup1 to eventType behaviors.
         BehaviorGroup behaviorGroup1 = createBehaviorGroup("name1", "displayName", bundle.getId());
@@ -194,7 +199,8 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
     @Test
     public void testAddEventTypeBehaviorWithWrongAccountId() {
         Bundle bundle = createBundle();
-        EventType eventType = createEventType();
+        Application app = createApp(bundle.getId());
+        EventType eventType = createEventType(app.getId());
         BehaviorGroup behaviorGroup = createBehaviorGroup("name", "displayName", bundle.getId());
         Boolean added = addEventTypeBehavior("unknownAccountId", eventType.getId(), behaviorGroup.getId());
         assertFalse(added);
@@ -203,7 +209,8 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
     @Test
     public void testFindEventTypesByBehaviorGroupId() {
         Bundle bundle = createBundle();
-        EventType eventType = createEventType();
+        Application app = createApp(bundle.getId());
+        EventType eventType = createEventType(app.getId());
         BehaviorGroup behaviorGroup = createBehaviorGroup("name", "displayName", bundle.getId());
         addEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup.getId());
         List<EventType> eventTypes = findEventTypesByBehaviorGroupId(ACCOUNT_ID, behaviorGroup.getId());
@@ -214,7 +221,8 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
     @Test
     public void testFindBehaviorGroupsByEventTypeId() {
         Bundle bundle = createBundle();
-        EventType eventType = createEventType();
+        Application app = createApp(bundle.getId());
+        EventType eventType = createEventType(app.getId());
         BehaviorGroup behaviorGroup = createBehaviorGroup("name", "displayName", bundle.getId());
         addEventTypeBehavior(ACCOUNT_ID, eventType.getId(), behaviorGroup.getId());
         List<BehaviorGroup> behaviorGroups = findBehaviorGroupsByEventTypeId(ACCOUNT_ID, eventType.getId());
@@ -253,8 +261,17 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
         return bundleResources.createBundle(bundle).await().indefinitely();
     }
 
-    private EventType createEventType() {
+    private Application createApp(UUID bundleId) {
+        Application app = new Application();
+        app.setBundleId(bundleId);
+        app.setName("name");
+        app.setDisplayName("displayName");
+        return appResources.createApp(app).await().indefinitely();
+    }
+
+    private EventType createEventType(UUID appID) {
         EventType eventType = new EventType();
+        eventType.setApplicationId(appID);
         eventType.setName("name");
         eventType.setDisplayName("displayName");
         return session.persist(eventType).call(session::flush).replaceWith(eventType).await().indefinitely();

--- a/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
@@ -70,17 +70,19 @@ public class DbCleaner {
                 })
                 .onItem().transformToUni(bundle -> {
                     Application app = new Application();
+                    app.setBundleId(bundle.getId());
                     app.setName(DEFAULT_APP_NAME);
                     app.setDisplayName(DEFAULT_APP_DISPLAY_NAME);
                     app.setBundleId(bundle.getId());
-                    return bundleResources.addApplicationToBundle(bundle.getId(), app);
+                    return appResources.createApp(app);
                 })
                 .onItem().transformToUni(app -> {
                     EventType eventType = new EventType();
+                    eventType.setApplicationId(app.getId());
                     eventType.setName(DEFAULT_EVENT_TYPE_NAME);
                     eventType.setDisplayName(DEFAULT_EVENT_TYPE_DISPLAY_NAME);
                     eventType.setDescription(DEFAULT_EVENT_TYPE_DESCRIPTION);
-                    return appResources.addEventTypeToApplication(app.getId(), eventType);
+                    return appResources.createEventType(eventType);
                 })
                 .replaceWith(Uni.createFrom().voidItem())
         );

--- a/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -53,30 +53,34 @@ public class ResourceHelpers {
         Bundle b = bundleResources.createBundle(bundle).await().indefinitely();
 
         Application app = new Application();
+        app.setBundleId(b.getId());
         app.setName(TEST_APP_NAME);
         app.setDisplayName("...");
         app.setBundleId(b.getId());
-        Application added = bundleResources.addApplicationToBundle(b.getId(), app).await().indefinitely();
+        Application added = appResources.createApp(app).await().indefinitely();
 
         for (int i = 0; i < 100; i++) {
             EventType eventType = new EventType();
+            eventType.setApplicationId(added.getId());
             eventType.setName(String.format(TEST_EVENT_TYPE_FORMAT, i));
             eventType.setDisplayName("... -> " + i);
             eventType.setDescription("Desc .. --> " + i);
-            appResources.addEventTypeToApplication(added.getId(), eventType).await().indefinitely();
+            appResources.createEventType(eventType).await().indefinitely();
         }
 
         Application app2 = new Application();
+        app2.setBundleId(b.getId());
         app2.setName(TEST_APP_NAME_2);
         app2.setDisplayName("...");
         app2.setBundleId(b.getId());
-        Application added2 = bundleResources.addApplicationToBundle(b.getId(), app2).await().indefinitely();
+        Application added2 = appResources.createApp(app2).await().indefinitely();
 
         for (int i = 0; i < 100; i++) {
             EventType eventType = new EventType();
+            eventType.setApplicationId(added2.getId());
             eventType.setName(String.format(TEST_EVENT_TYPE_FORMAT, i));
             eventType.setDisplayName("... -> " + i);
-            appResources.addEventTypeToApplication(added2.getId(), eventType).await().indefinitely();
+            appResources.createEventType(eventType).await().indefinitely();
         }
     }
 

--- a/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -39,6 +39,7 @@ import javax.inject.Inject;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -129,6 +130,7 @@ public class LifecycleITest extends DbIsolatedTest {
 
     void t01_testAdding() {
         Application app = new Application();
+        app.setBundleId(UUID.fromString(theBundle.getString("id")));
         app.setName(APP_NAME);
         app.setDisplayName("The best app in the life");
 
@@ -136,9 +138,8 @@ public class LifecycleITest extends DbIsolatedTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .basePath("/")
-                .pathParam("bundleId", theBundle.getString("id"))
                 .body(Json.encode(app))
-                .post("/internal/bundles/{bundleId}/applications")
+                .post("/internal/applications")
                 .then()
                 .statusCode(200)
                 .extract().response();
@@ -150,6 +151,7 @@ public class LifecycleITest extends DbIsolatedTest {
 
         // Create eventType
         EventType eventType = new EventType();
+        eventType.setApplicationId(UUID.fromString(appResponse.getString("id")));
         eventType.setName(EVENT_TYPE_NAME);
         eventType.setDisplayName("Policies will take care of the rules");
         eventType.setDescription("Policies is super cool, you should use it");
@@ -159,7 +161,7 @@ public class LifecycleITest extends DbIsolatedTest {
                 .contentType(ContentType.JSON)
                 .basePath("/")
                 .body(Json.encode(eventType))
-                .post(String.format("/internal/applications/%s/eventTypes", appResponse.getString("id")))
+                .post("/internal/eventTypes")
                 .then()
                 .statusCode(200)
                 .extract().response();

--- a/src/test/java/com/redhat/cloud/notifications/events/Lifecycle_BG_ITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/Lifecycle_BG_ITest.java
@@ -191,6 +191,7 @@ public class Lifecycle_BG_ITest extends DbIsolatedTest {
 
     private String createApp(String bundleId) {
         Application app = new Application();
+        app.setBundleId(UUID.fromString(bundleId));
         app.setName(APP_NAME);
         app.setDisplayName("The best app in the life");
         app.setBundleId(UUID.fromString(bundleId));
@@ -199,9 +200,8 @@ public class Lifecycle_BG_ITest extends DbIsolatedTest {
                 .when()
                 .basePath(INTERNAL_BASE_PATH)
                 .contentType(ContentType.JSON)
-                .pathParam("bundleId", bundleId)
                 .body(Json.encode(app))
-                .post("/internal/bundles/{bundleId}/applications")
+                .post("/internal/applications")
                 .then()
                 .statusCode(200)
                 .extract().body().asString();
@@ -219,6 +219,7 @@ public class Lifecycle_BG_ITest extends DbIsolatedTest {
 
     private String createEventType(String appId) {
         EventType eventType = new EventType();
+        eventType.setApplicationId(UUID.fromString(appId));
         eventType.setName(EVENT_TYPE_NAME);
         eventType.setDisplayName("Policies will take care of the rules");
         eventType.setDescription("Policies is super cool, you should use it");
@@ -228,8 +229,7 @@ public class Lifecycle_BG_ITest extends DbIsolatedTest {
                 .basePath(INTERNAL_BASE_PATH)
                 .contentType(ContentType.JSON)
                 .body(Json.encode(eventType))
-                .pathParam("appId", appId)
-                .post("/internal/applications/{appId}/eventTypes")
+                .post("/internal/eventTypes")
                 .then()
                 .statusCode(200)
                 .extract().body().asString();


### PR DESCRIPTION
@josejulio Sorry, I need your help again reviewing an internal APIs PR 😃

This one shortens:

- `POST /applications/{appId}/eventTypes` to `POST /eventTypes`
- `POST /bundles/{bundleId}/applications` to `POST /applications`

Helper scripts were updated.