### PR TITLE
Limit what we show in logs

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -65,7 +65,7 @@ public class EventConsumer {
                 .onItemOrFailure()
                 .transformToUni((unused, t) -> {
                     if (t != null) {
-                        log.log(Level.INFO, "Could not process the payload", t);
+                        log.log(Level.INFO, "Could not process the payload: " + input.getPayload(), t);
                     }
                     return Uni.createFrom().voidItem();
                 });

--- a/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -48,10 +48,9 @@ public class EventConsumer {
     // Can be modified to use Multi<Message<String>> input also for more concurrency
     public Uni<Void> processAsync(Message<String> input) {
         return Uni.createFrom().item(() -> input.getPayload())
-                .onItem().invoke(payload -> log.fine(() -> "Processing: " + payload))
                 .stage(self -> self
-                                // First pipeline stage - modify from Kafka message to processable entity
                                 .onItem().transform(this::extractPayload)
+                                .onItem().invoke(payload -> log.info(() -> "Processing received payload: (" + payload.getAccountId() + ") " + payload.getBundle() + "/" + payload.getApplication() + "/" + payload.getEventType()))
                                 .onFailure().invoke(t -> rejectedCount.increment())
                 )
                 .stage(self -> self


### PR DESCRIPTION
This is a proposal to not log potentially private info but the info that would be useful to us.
A log line would look like:
`Processing received payload: (123456) rhel/policies/triggered-policy`

Additional I changed from DEBUG to INFO