### PR TITLE
Fix RbacIdentityProvider when rbac.enabled=false

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacIdentityProvider.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacIdentityProvider.java
@@ -49,6 +49,7 @@ public class RbacIdentityProvider implements IdentityProvider<RhIdentityAuthenti
     public Uni<SecurityIdentity> authenticate(RhIdentityAuthenticationRequest rhAuthReq, AuthenticationRequestContext authenticationRequestContext) {
         if (!isRbacEnabled) {
             return Uni.createFrom().item(() -> QuarkusSecurityIdentity.builder()
+                    .setPrincipal(new RhIdPrincipal("-noauth-", "-1"))
                     .addRole(RBAC_READ_NOTIFICATIONS)
                     .addRole(RBAC_WRITE_NOTIFICATIONS)
                     .addRole(RBAC_READ_INTEGRATIONS_ENDPOINTS)


### PR DESCRIPTION
Quarkus throws the following exception if a try to access an API which requires authentication and `rbac.enabled=false`:

```
2021-05-07 13:00:23,526 ERROR [io.qua.ver.htt.run.QuarkusErrorHandler] (vert.x-eventloop-thread-11) HTTP Request to /api/integrations/v1.0/endpoints failed, error id: 4e3cef90-66e9-4caf-8872-a5e1c995a26d-1: java.lang.IllegalStateException: Principal is null but anonymous status is false
        at io.quarkus.security.runtime.QuarkusSecurityIdentity$Builder.build(QuarkusSecurityIdentity.java:235)
        at com.redhat.cloud.notifications.auth.rbac.RbacIdentityProvider.lambda$authenticate$0(RbacIdentityProvider.java:56)
[...]
```

Since we're not performing any authentication and we're giving full permissions when `rbac.enabled=false`, using `new RhIdPrincipal("-noauth-", "-1")` seems appropriate.