### PR TITLE
NOTIF-55 Use Multi when relevant, replace with Uni<List> otherwise

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/EndpointEmailSubscriptionResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EndpointEmailSubscriptionResources.java
@@ -2,12 +2,12 @@ package com.redhat.cloud.notifications.db;
 
 import com.redhat.cloud.notifications.models.EmailSubscription;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.util.List;
 
 @ApplicationScoped
 public class EndpointEmailSubscriptionResources {
@@ -59,14 +59,13 @@ public class EndpointEmailSubscriptionResources {
                 .getSingleResultOrNull();
     }
 
-    public Multi<EmailSubscription> getEmailSubscriptionsForUser(String accountNumber, String username) {
+    public Uni<List<EmailSubscription>> getEmailSubscriptionsForUser(String accountNumber, String username) {
         String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
                 "WHERE es.id.accountId = :accountId AND es.id.userId = :userId";
         return session.createQuery(query, EmailSubscription.class)
                 .setParameter("accountId", accountNumber)
                 .setParameter("userId", username)
-                .getResultList()
-                .onItem().transformToMulti(Multi.createFrom()::iterable);
+                .getResultList();
     }
 
     public Uni<Long> getEmailSubscribersCount(String accountNumber, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
@@ -80,7 +79,7 @@ public class EndpointEmailSubscriptionResources {
                 .getSingleResult();
     }
 
-    public Multi<EmailSubscription> getEmailSubscribers(String accountNumber, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
+    public Uni<List<EmailSubscription>> getEmailSubscribers(String accountNumber, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
         String query = "FROM EmailSubscription WHERE id.accountId = :accountId AND application.bundle.name = :bundleName " +
                 "AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
         return session.createQuery(query, EmailSubscription.class)
@@ -88,7 +87,6 @@ public class EndpointEmailSubscriptionResources {
                 .setParameter("bundleName", bundleName)
                 .setParameter("applicationName", applicationName)
                 .setParameter("subscriptionType", subscriptionType)
-                .getResultList()
-                .onItem().transformToMulti(Multi.createFrom()::iterable);
+                .getResultList();
     }
 }

--- a/src/main/java/com/redhat/cloud/notifications/events/DefaultProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/DefaultProcessor.java
@@ -31,6 +31,7 @@ public class DefaultProcessor {
     public Multi<Endpoint> getDefaultEndpoints(Endpoint defaultEndpoint) {
         processedItems.increment();
         return resources.getDefaultEndpoints(defaultEndpoint.getAccountId())
+                .onItem().transformToMulti(Multi.createFrom()::iterable)
                 .select().where(Endpoint::isEnabled)
                 .onItem().invoke(() -> enrichedEndpoints.increment());
     }

--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -16,7 +16,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import org.hibernate.reactive.mutiny.Mutiny;
-import org.reactivestreams.Publisher;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -108,7 +107,7 @@ public class EndpointProcessor {
     // TODO [BG Phase 2] Delete this method
     public Multi<Endpoint> getEndpoints(String tenant, String bundleName, String applicationName, String eventTypeName) {
         return resources.getTargetEndpoints(tenant, bundleName, applicationName, eventTypeName)
-                .onItem().transformToMultiAndConcatenate((Function<Endpoint, Publisher<Endpoint>>) endpoint -> {
+                .onItem().transformToMultiAndConcatenate((Function<Endpoint, Multi<Endpoint>>) endpoint -> {
                     // If the tenant has a default endpoint for the eventType, then add the target endpoints here
                     if (endpoint.getType() == EndpointType.DEFAULT) {
                         return defaultProcessor.getDefaultEndpoints(endpoint);

--- a/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -6,7 +6,6 @@ import com.redhat.cloud.notifications.db.BundleResources;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 import javax.inject.Inject;
@@ -127,7 +126,7 @@ public class InternalService {
 
     @GET
     @Path("/applications/{appId}/eventTypes")
-    public Multi<EventType> getEventTypes(@PathParam("appId") UUID appId) {
+    public Uni<List<EventType>> getEventTypes(@PathParam("appId") UUID appId) {
         return appResources.getEventTypes(appId);
     }
 

--- a/src/test/java/com/redhat/cloud/notifications/db/EmailAggregationResourcesTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/EmailAggregationResourcesTest.java
@@ -97,12 +97,12 @@ public class EmailAggregationResourcesTest extends DbIsolatedTest {
 
     private List<EmailAggregation> getEmailAggregation(EmailAggregationKey key, LocalDateTime start, LocalDateTime end) {
         return emailAggregationResources.getEmailAggregation(key, start, end)
-                .collect().asList().await().indefinitely();
+                .await().indefinitely();
     }
 
     private List<EmailAggregationKey> getApplicationsWithPendingAggregation(LocalDateTime start, LocalDateTime end) {
         return emailAggregationResources.getApplicationsWithPendingAggregation(start, end)
-                .collect().asList().await().indefinitely();
+                .await().indefinitely();
     }
 
     private Integer purgeOldAggregation(EmailAggregationKey key, LocalDateTime lastUsedTime) {

--- a/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -41,7 +41,7 @@ public class ResourceHelpers {
     EmailAggregationResources emailAggregationResources;
 
     public List<Application> getApplications(String bundleName) {
-        return appResources.getApplications(bundleName).collect().asList().await().indefinitely();
+        return appResources.getApplications(bundleName).await().indefinitely();
     }
 
     public EmailSubscription getSubscription(String accountNumber, String username, String bundle, String application, EmailSubscriptionType type) {
@@ -164,6 +164,6 @@ public class ResourceHelpers {
     }
 
     public List<EventType> getEventTypesForApplication(UUID applicationId) {
-        return appResources.getEventTypes(applicationId).collect().asList().await().indefinitely();
+        return appResources.getEventTypes(applicationId).await().indefinitely();
     }
 }


### PR DESCRIPTION
This is preparation work for #202.

I found something about the response time issue with `quarkus-resteasy-reactive`: the response time can be bad only with APIs that return `Multi`. There's no problem with methods returning `Uni<List>`, which should always be the type we use anyway because we never need to stream data back to the client. I created https://github.com/quarkusio/quarkus/issues/17094 to report the issue with `Multi` to the Quarkus team.

Since we're using `Multi` in many places for wrong reasons, I did some spring cleaning and replaced `Multi` with `Uni<List>`. A few methods could be cleaned further but I chose not to because they will be removed with phase 2 of behavior groups.

Here are some ground rules for future developments:
- The persistence layer (`*Resources` classes) should not return `Multi` unless there's a _very good_ reason to do so (usually, there's not).
- The API layer (`*Service` classes) should not return `Multi` unless we need to stream data back to the client (that's very unlikely in this app).
- We should refrain from using `Multi` to transform items from `Uni<List>`. There are situations when it makes sense but most of the time it doesn't. In particular, side-effects should be implemented with `onItem().invoke()` (synchronous, for code that will not block the I/O thread) or `onItem().call()` (asynchronous, for DB queries for example).