### PR TITLE
Batch "properties endpoint" SQL queries

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.notifications.db;
 
-import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointDefault;
+import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.EndpointTarget;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.EventType;

--- a/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -350,9 +350,8 @@ public class EndpointResources {
         // Group endpoints in types and load in batches for each type.
         Set<Endpoint> endpointSet = new HashSet<>(endpoints);
 
-        return Uni.combine().all().unis(
-                this.loadTypedProperties(WebhookProperties.class, endpointSet, EndpointType.WEBHOOK)
-        ).discardItems();
+        return this.loadTypedProperties(WebhookProperties.class, endpointSet, EndpointType.WEBHOOK);
+        // use `.chain(() -> loadTyped...)` when adding other types
     }
 
     private <T extends EndpointProperties> Uni<Void> loadTypedProperties(Class<T> typedEndpointClass, Set<Endpoint> endpoints, EndpointType type) {

--- a/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
@@ -17,7 +17,6 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @Table(name = "endpoint_webhooks")
 @JsonNaming(SnakeCaseStrategy.class)
 public class WebhookProperties extends EndpointProperties {
-
     @NotNull
     private String url;
 

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -45,6 +45,7 @@ import javax.ws.rs.core.SecurityContext;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -370,6 +371,7 @@ public class NotificationService {
                         behaviorGroups
                                 .stream()
                                 .map(BehaviorGroup::getActions)
+                                .filter(Objects::nonNull)
                                 .flatMap(Collection::stream)
                                 .map(BehaviorGroupAction::getEndpoint)
                                 .collect(Collectors.toList())


### PR DESCRIPTION
@gwenneg This is an idea I had while working on https://github.com/RedHatInsights/notifications-backend/pull/242 to reduce the N-required queries to only 1 per type.

Could you review it does what I think it does? :) - Using only 1 extra SQL call per found type - 
