### PR TITLE
Mark endpoints that return a string as text/plain

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -154,6 +154,7 @@ public class EndpointService {
     @Path("/{id}")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "204", description = "The integration has been deleted", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.deleteEndpoint(principal.getAccount(), id)
@@ -165,6 +166,7 @@ public class EndpointService {
     @Path("/{id}/enable")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.enableEndpoint(principal.getAccount(), id)
@@ -175,6 +177,7 @@ public class EndpointService {
     @Path("/{id}/enable")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "204", description = "The integration has been disabled", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.disableEndpoint(principal.getAccount(), id)
@@ -185,6 +188,7 @@ public class EndpointService {
     @Path("/{id}")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> updateEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id, @NotNull @Valid Endpoint endpoint) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         endpoint.setAccountId(principal.getAccount());
@@ -220,6 +224,7 @@ public class EndpointService {
             )
     })
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> getDetailedEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID id, @PathParam("history_id") UUID historyId, @BeanParam Query query) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return notifResources.getNotificationDetails(principal.getAccount(), query, id, historyId)

--- a/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -154,7 +154,6 @@ public class EndpointService {
     @Path("/{id}")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "204", description = "The integration has been deleted", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.deleteEndpoint(principal.getAccount(), id)
@@ -177,7 +176,6 @@ public class EndpointService {
     @Path("/{id}/enable")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "204", description = "The integration has been disabled", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.disableEndpoint(principal.getAccount(), id)

--- a/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
 @Path("/internal")
 @Consumes(APPLICATION_JSON)
@@ -62,6 +63,7 @@ public class InternalService {
 
     @PUT
     @Path("/bundles/{bundleId}")
+    @Produces(TEXT_PLAIN)
     public Uni<Response> updateBundle(@PathParam("bundleId") UUID bundleId, @NotNull @Valid Bundle bundle) {
         return bundleResources.updateBundle(bundleId, bundle)
                 .onItem().transform(rowCount -> {
@@ -75,6 +77,7 @@ public class InternalService {
 
     @PUT
     @Path("/bundles/{bundleId}/behaviorGroups/{behaviorGroupId}/default")
+    @Produces(TEXT_PLAIN)
     public Uni<Response> setDefaultBehaviorGroup(@PathParam("bundleId") UUID bundleId, @PathParam("behaviorGroupId") UUID behaviorGroupId) {
         return behaviorGroupResources.setDefaultBehaviorGroup(bundleId, behaviorGroupId)
                 .onItem().transform(rowCount -> {
@@ -113,6 +116,7 @@ public class InternalService {
 
     @PUT
     @Path("/applications/{appId}")
+    @Produces(TEXT_PLAIN)
     public Uni<Response> updateApplication(@PathParam("appId") UUID appId, @NotNull @Valid Application app) {
         return appResources.updateApplication(appId, app)
                 .onItem().transform(rowCount -> {

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -102,6 +102,7 @@ public class NotificationService {
     @DELETE
     @Path("/{id}")
     @APIResponse(responseCode = "204", description = "Notification has been marked as read", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> markRead(@Context SecurityContext sec, @PathParam("id") Integer id) {
         // Mark the notification id for <tenantId><userId> 's subscription as read
         return Uni.createFrom().nullItem();
@@ -185,6 +186,7 @@ public class NotificationService {
     @Path("/eventTypes/{eventTypeId}/{endpointId}")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> linkEndpointToEventType(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId, @PathParam("eventTypeId") UUID eventTypeId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.linkEndpoint(principal.getAccount(), endpointId, eventTypeId)
@@ -196,6 +198,7 @@ public class NotificationService {
     @Path("/eventTypes/{eventTypeId}/{endpointId}")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "204", description = "Integration has been removed from the event type", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> unlinkEndpointFromEventType(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId, @PathParam("eventTypeId") UUID eventTypeId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.unlinkEndpoint(principal.getAccount(), endpointId, eventTypeId)
@@ -216,6 +219,7 @@ public class NotificationService {
     @Operation(summary = "Link a behavior group to an event type.", hidden = true)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> linkBehaviorGroupToEventType(@Context SecurityContext sec, @PathParam("eventTypeId") UUID eventTypeId, @PathParam("behaviorGroupId") UUID behaviorGroupId) {
         return getAccountId(sec)
                 .onItem().transformToUni(accountId -> behaviorGroupResources.addEventTypeBehavior(accountId, eventTypeId, behaviorGroupId))
@@ -227,6 +231,7 @@ public class NotificationService {
     @Operation(summary = "Unlink a behavior group from an event type.", hidden = true)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "204", description = "Behavior group has been removed from the event type", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> unlinkBehaviorGroupFromEventType(@Context SecurityContext sec, @PathParam("eventTypeId") UUID eventTypeId, @PathParam("behaviorGroupId") UUID behaviorGroupId) {
         return getAccountId(sec)
                 .onItem().transformToUni(accountId -> behaviorGroupResources.deleteEventTypeBehavior(accountId, eventTypeId, behaviorGroupId))
@@ -258,6 +263,7 @@ public class NotificationService {
     @Operation(summary = "Add an integration to the list of configured default actions.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> addEndpointToDefaults(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.addEndpointToDefaults(principal.getAccount(), endpointId)
@@ -270,6 +276,7 @@ public class NotificationService {
     @Operation(summary = "Remove an integration from the list of configured default actions.")
     @APIResponse(responseCode = "204", description = "Integration has been removed from the default actions", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> deleteEndpointFromDefaults(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.deleteEndpointFromDefaults(principal.getAccount(), endpointId)
@@ -342,6 +349,7 @@ public class NotificationService {
     @Operation(summary = "Update the list of actions of a behavior group.", hidden = true)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> updateBehaviorGroupActions(@Context SecurityContext sec, @PathParam("behaviorGroupId") UUID behaviorGroupId, List<UUID> endpointIds) {
         // RESTEasy does not reject an invalid List<UUID> body (even when @Valid is used) so we have to do an additional check here.
         if (endpointIds.contains(null)) {

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -102,7 +102,6 @@ public class NotificationService {
     @DELETE
     @Path("/{id}")
     @APIResponse(responseCode = "204", description = "Notification has been marked as read", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> markRead(@Context SecurityContext sec, @PathParam("id") Integer id) {
         // Mark the notification id for <tenantId><userId> 's subscription as read
         return Uni.createFrom().nullItem();
@@ -198,7 +197,6 @@ public class NotificationService {
     @Path("/eventTypes/{eventTypeId}/{endpointId}")
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "204", description = "Integration has been removed from the event type", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> unlinkEndpointFromEventType(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId, @PathParam("eventTypeId") UUID eventTypeId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.unlinkEndpoint(principal.getAccount(), endpointId, eventTypeId)
@@ -231,7 +229,6 @@ public class NotificationService {
     @Operation(summary = "Unlink a behavior group from an event type.", hidden = true)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "204", description = "Behavior group has been removed from the event type", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> unlinkBehaviorGroupFromEventType(@Context SecurityContext sec, @PathParam("eventTypeId") UUID eventTypeId, @PathParam("behaviorGroupId") UUID behaviorGroupId) {
         return getAccountId(sec)
                 .onItem().transformToUni(accountId -> behaviorGroupResources.deleteEventTypeBehavior(accountId, eventTypeId, behaviorGroupId))
@@ -276,7 +273,6 @@ public class NotificationService {
     @Operation(summary = "Remove an integration from the list of configured default actions.")
     @APIResponse(responseCode = "204", description = "Integration has been removed from the default actions", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    @Produces(MediaType.TEXT_PLAIN)
     public Uni<Response> deleteEndpointFromDefaults(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return resources.deleteEndpointFromDefaults(principal.getAccount(), endpointId)

--- a/src/test/java/com/redhat/cloud/notifications/events/Lifecycle_BG_ITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/Lifecycle_BG_ITest.java
@@ -295,6 +295,7 @@ public class Lifecycle_BG_ITest extends DbIsolatedTest {
                 .put("/internal/bundles/{bundleId}/behaviorGroups/{behaviorGroupId}/default")
                 .then()
                 .statusCode(200)
+                .contentType(ContentType.TEXT)
                 .extract().body().asString();
 
         // Now let's verify which behavior group is marked as default in the database.
@@ -399,7 +400,8 @@ public class Lifecycle_BG_ITest extends DbIsolatedTest {
                 .when()
                 .put("/notifications/behaviorGroups/{behaviorGroupId}/actions")
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .contentType(ContentType.TEXT);
     }
 
     /*
@@ -485,7 +487,8 @@ public class Lifecycle_BG_ITest extends DbIsolatedTest {
                 .when()
                 .put("/notifications/eventTypes/{eventTypeId}/behaviorGroups/{behaviorGroupId}")
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .contentType(ContentType.TEXT);
     }
 
     private void checkEventTypeBehaviorGroups(Header identityHeader, String eventTypeId, String... expectedBehaviorGroupIds) {

--- a/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -143,7 +143,8 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when().put("/endpoints/" + responsePoint.getString("id") + "/enable")
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .contentType(ContentType.TEXT);
 
         responsePointSingle = fetchSingle(responsePoint.getString("id"), identityHeader);
         assertNotNull(responsePoint.getJsonObject("properties"));
@@ -744,13 +745,15 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .put("/endpoints/email/subscription/rhel/" + ResourceHelpers.TEST_APP_NAME + "/instant")
-                .then().statusCode(404);
+                .then().statusCode(404)
+                .contentType(ContentType.JSON);
         given()
                 .header(identityHeader)
                 .when()
                 .contentType(ContentType.JSON)
                 .put("/endpoints/email/subscription/" + ResourceHelpers.TEST_BUNDLE_NAME + "/policies/instant")
-                .then().statusCode(404);
+                .then().statusCode(404)
+                .contentType(ContentType.JSON);
 
         // Unknown bundle/apps give 404
         given()
@@ -764,7 +767,8 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .put("/endpoints/email/subscription/idontexist/meneither/instant")
-                .then().statusCode(404);
+                .then().statusCode(404)
+                .contentType(ContentType.JSON);
 
         // Disable everything as preparation
         // rhel/policies instant and daily
@@ -805,7 +809,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .put("/endpoints/email/subscription/rhel/policies/instant")
-                .then().statusCode(200);
+                .then().statusCode(200).contentType(ContentType.JSON);
 
         assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
         assertNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
@@ -818,7 +822,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .put("/endpoints/email/subscription/rhel/policies/daily")
-                .then().statusCode(200);
+                .then().statusCode(200).contentType(ContentType.JSON);
 
         assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
         assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
@@ -831,7 +835,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .put("/endpoints/email/subscription/" + ResourceHelpers.TEST_BUNDLE_NAME + "/" + ResourceHelpers.TEST_APP_NAME + "/instant")
-                .then().statusCode(200);
+                .then().statusCode(200).contentType(ContentType.JSON);
 
         assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
         assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));

--- a/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -331,7 +332,8 @@ public class InternalServiceTest extends DbIsolatedTest {
                 .when()
                 .put("/internal/bundles/{bundleId}/behaviorGroups/{behaviorGroupId}/default")
                 .then()
-                .statusCode(expectedStatusCode);
+                .statusCode(expectedStatusCode)
+                .contentType(ContentType.TEXT);
     }
 
     private static void deleteBundle(String bundleId, boolean expectedResult) {

--- a/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -294,7 +294,8 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .pathParam("endpointId", persistedEndpoint.getString("id"))
                 .put("/notifications/defaults/{endpointId}")
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .contentType(ContentType.TEXT);
 
         // Check if the endpoint appears in the list of defaults.
         response = given()
@@ -317,7 +318,8 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .pathParam("endpointId", persistedEndpoint.getString("id"))
                 .put("/notifications/defaults/{endpointId}")
                 .then()
-                .statusCode(400);
+                .statusCode(400)
+                .contentType(ContentType.TEXT);
 
         // Delete the endpoint from defaults, it should work.
         given()
@@ -544,7 +546,8 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .put("/notifications/eventTypes/{eventTypeId}/behaviorGroups/{behaviorGroupId}")
                 .then()
-                .statusCode(403);
+                .statusCode(403)
+                .contentType(ContentType.TEXT);
 
         given()
                 .header(readAccessIdentityHeader)
@@ -590,7 +593,8 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .put("/notifications/behaviorGroups/{id}")
                 .then()
-                .statusCode(403);
+                .statusCode(403)
+                .contentType(ContentType.JSON);
 
         given()
                 .header(readAccessIdentityHeader)
@@ -608,7 +612,8 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .put("/notifications/behaviorGroups/{behaviorGroupId}/actions")
                 .then()
-                .statusCode(403);
+                .statusCode(403)
+                .contentType(ContentType.TEXT);
 
         given()
                 .header(noAccessIdentityHeader)


### PR DESCRIPTION
So this is probably be cause of the recent migration to reasteasy-reactive-*.

The UI code started failing because it was receiving empty/string responses with the "application/json" content-type in the response. It looks like we need to annotate each method. I think that the previous implementation used the `@Schema` annotation to decide.