### PR TITLE
NOTIF-150 Add behavior groups data migration API

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/models/EndpointTarget.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/EndpointTarget.java
@@ -36,6 +36,18 @@ public class EndpointTarget {
         this.eventType = eventType;
     }
 
+    public EndpointTargetId getId() {
+        return id;
+    }
+
+    public Endpoint getEndpoint() {
+        return endpoint;
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/redhat/cloud/notifications/routers/BehaviorGroupMigrationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/BehaviorGroupMigrationService.java
@@ -1,0 +1,317 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.redhat.cloud.notifications.models.BehaviorGroup;
+import com.redhat.cloud.notifications.models.BehaviorGroupAction;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointTarget;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.EventTypeBehavior;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@RequestScoped
+@Path("/internal/behaviorGroups/migrate")
+public class BehaviorGroupMigrationService {
+
+    public static final String CONFIRMATION_TOKEN = "ready-set-go";
+
+    private static final Logger LOGGER = Logger.getLogger(BehaviorGroupMigrationService.class.getName());
+
+    /*
+     * This is used to dynamically create behavior groups names at persistence time.
+     * See calling point for more details.
+     */
+    private final Map<String, AtomicInteger> accountBehaviorGroupIndexes = new ConcurrentHashMap<>();
+
+    private volatile MigrationReport report = new MigrationReport();
+
+    @Inject
+    Mutiny.Session session;
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Uni<MigrationReport> migrate(@QueryParam("confirmation-token") String confirmationToken) {
+        long start = System.currentTimeMillis();
+        if (!CONFIRMATION_TOKEN.equals(confirmationToken)) {
+            throw new BadRequestException("You forgot to confirm the migration!");
+        }
+        // All DB changes will be rolled-back if anything goes wrong.
+        return session.withTransaction(tx -> {
+            LOGGER.debug("[BG MIGRATION] Start");
+            return Uni.createFrom().item(new AccountBehaviorGroupsAggregator())
+                    .onItem().transformToUni(aggregator -> {
+                        LOGGER.debug("[BG MIGRATION] Migrating global default actions");
+                        // Let's iterate over all accounts that saved default actions.
+                        return session.createQuery("SELECT DISTINCT id.accountId FROM EndpointDefault", String.class)
+                                .getResultList()
+                                .onItem().invoke(accounts -> LOGGER.debugf("[BG MIGRATION] __ %d account(s) with global default actions found", accounts.size()))
+                                .onItem().transformToMulti(Multi.createFrom()::iterable)
+                                .onItem().transformToUniAndConcatenate(accountId -> {
+                                    report.accountsWithDefaults.incrementAndGet();
+                                    LOGGER.debugf("[BG MIGRATION] __ Account '%s'", accountId);
+                                    /*
+                                     * The current default actions are not bound to a specific bundle, so we have to create a
+                                     * behavior group that will contain the default actions for each existing bundle.
+                                     */
+                                    return session.createQuery("FROM Bundle", Bundle.class)
+                                            .getResultList()
+                                            .onItem().invoke(bundles -> LOGGER.debugf("[BG MIGRATION] ____ %d bundle(s) found", bundles.size()))
+                                            .onItem().transformToMulti(Multi.createFrom()::iterable)
+                                            .onItem().transformToUniAndConcatenate(bundle -> {
+                                                LOGGER.debugf("[BG MIGRATION] ____ Building behavior group for bundle '%s'", bundle.getName());
+                                                MigrationBehaviorGroup mBehaviorGroup = new MigrationBehaviorGroup();
+                                                mBehaviorGroup.accountId = accountId;
+                                                mBehaviorGroup.bundle = bundle;
+                                                // Let's iterate over the current global default actions of the account.
+                                                return session.createQuery("FROM Endpoint e WHERE e.accountId = :accountId AND EXISTS(FROM EndpointDefault WHERE endpoint = e AND id.accountId = :accountId)", Endpoint.class)
+                                                        .setParameter("accountId", accountId)
+                                                        .getResultList()
+                                                        .onItem().invoke(endpoints -> {
+                                                            for (Endpoint endpoint : endpoints) {
+                                                                mBehaviorGroup.actions.add(endpoint);
+                                                            }
+                                                            LOGGER.debugf("[BG MIGRATION] ______ %d action(s) added", endpoints.size());
+                                                        })
+                                                        // Let's iterate over the event types from the current bundle that are linked with the global default actions.
+                                                        .replaceWith(session.createQuery("FROM EventType et WHERE et.application.bundle = :bundle AND EXISTS(FROM EndpointTarget WHERE eventType = et AND id.accountId = :accountId AND endpoint.type = :endpointType)", EventType.class)
+                                                                .setParameter("bundle", bundle)
+                                                                .setParameter("accountId", accountId)
+                                                                .setParameter("endpointType", EndpointType.DEFAULT)
+                                                                .getResultList()
+                                                                .onItem().invoke(eventTypes -> {
+                                                                    if (eventTypes.isEmpty()) {
+                                                                        aggregator.aggregate(mBehaviorGroup, Optional.empty(), report);
+                                                                        LOGGER.debug("[BG MIGRATION] ______ 0 event type linked, the behavior group will be created anyway");
+                                                                    } else {
+                                                                        for (EventType eventType : eventTypes) {
+                                                                            aggregator.aggregate(mBehaviorGroup, Optional.of(eventType), report);
+                                                                        }
+                                                                        LOGGER.debugf("[BG MIGRATION] ______ %d event type(s) added to the links set", eventTypes.size());
+                                                                    }
+                                                                })
+                                                        )
+                                                        .onItem().invoke(ignored -> LOGGER.debug("[BG MIGRATION] ____ Done"));
+                                            })
+                                            .onItem().ignoreAsUni()
+                                            .onItem().invoke(ignored -> LOGGER.debug("[BG MIGRATION] __ Done"));
+                                })
+                                .onItem().ignoreAsUni()
+                                .onItem().invoke(ignored -> {
+                                    LOGGER.debug("[BG MIGRATION] Done");
+                                    LOGGER.debug("[BG MIGRATION] Migrating non-default actions");
+                                })
+                                // Let's iterate over all accounts that saved non-default actions.
+                                .replaceWith(session.createQuery("SELECT DISTINCT id.accountId FROM EndpointTarget WHERE endpoint.type <> :endpointType", String.class)
+                                        .setParameter("endpointType", EndpointType.DEFAULT)
+                                        .getResultList()
+                                        .onItem().invoke(accounts -> LOGGER.debugf("[BG MIGRATION] __ %d account(s) with non-default actions found", accounts.size()))
+                                        .onItem().transformToMulti(Multi.createFrom()::iterable)
+                                        .onItem().transformToUniAndConcatenate(accountId -> {
+                                            report.accountsWithNonDefaults.incrementAndGet();
+                                            LOGGER.debugf("[BG MIGRATION] __ Account '%s'", accountId);
+                                            /*
+                                             * Let's iterate over the event types that are linked with non-default actions.
+                                             * We can't iterate directly over the EndpointTarget records because we need to group the actions by event type for the behavior group creation.
+                                             */
+                                            return session.createQuery("FROM EventType et WHERE EXISTS(FROM EndpointTarget WHERE eventType = et AND id.accountId = :accountId AND endpoint.type <> :endpointType)", EventType.class)
+                                                    .setParameter("accountId", accountId)
+                                                    .setParameter("endpointType", EndpointType.DEFAULT)
+                                                    .getResultList()
+                                                    .onItem().invoke(eventTypes -> LOGGER.debugf("[BG MIGRATION] ____ %d event type(s) linked with non-default actions found", eventTypes.size()))
+                                                    .onItem().transformToMulti(Multi.createFrom()::iterable)
+                                                    .onItem().transformToUniAndConcatenate(eventType -> {
+                                                        LOGGER.debugf("[BG MIGRATION] ____ Building behavior group for event type '%s'", eventType.getName());
+                                                        MigrationBehaviorGroup mBehaviorGroup = new MigrationBehaviorGroup();
+                                                        mBehaviorGroup.accountId = accountId;
+                                                        // Fetching the bundle from the event type does not work for a mysterious reason (probably an Hibernate Reactive bug) so let's retrieve it manually...
+                                                        return session.createQuery("FROM Bundle b WHERE EXISTS(FROM EventType et JOIN et.application a WHERE et = :eventType AND a.bundle = b)", Bundle.class)
+                                                                .setParameter("eventType", eventType)
+                                                                .getSingleResult()
+                                                                .onItem().transformToUni(bundle -> {
+                                                                    mBehaviorGroup.bundle = bundle;
+                                                                    // We can now iterate over the links for the current event type.
+                                                                    return session.createQuery("FROM EndpointTarget t LEFT JOIN FETCH t.endpoint e WHERE t.eventType = :eventType AND t.id.accountId = :accountId AND e.type <> :endpointType", EndpointTarget.class)
+                                                                            .setParameter("eventType", eventType)
+                                                                            .setParameter("accountId", accountId)
+                                                                            .setParameter("endpointType", EndpointType.DEFAULT)
+                                                                            .getResultList()
+                                                                            .onItem().invoke(targets -> {
+                                                                                for (EndpointTarget target : targets) {
+                                                                                    mBehaviorGroup.actions.add(target.getEndpoint());
+                                                                                }
+                                                                                LOGGER.debugf("[BG MIGRATION] ______ %d action(s) added", targets.size());
+                                                                                aggregator.aggregate(mBehaviorGroup, Optional.of(eventType), report);
+                                                                                LOGGER.debugf("[BG MIGRATION] ______ 1 event type added to the links set", targets.size());
+                                                                            });
+                                                                });
+                                                    })
+                                                    .onItem().ignoreAsUni()
+                                                    .onItem().invoke(ignored -> LOGGER.debug("[BG MIGRATION] ____ Done"));
+                                        })
+                                        .onItem().ignoreAsUni()
+                                        .onItem().invoke(ignored -> LOGGER.debug("[BG MIGRATION] __ Done"))
+                                )
+                                .onItem().invoke(ignored -> {
+                                    LOGGER.debug("[BG MIGRATION] Done");
+                                    LOGGER.debug("[BG MIGRATION] Starting DB behavior groups creation");
+                                })
+                                /*
+                                 * Now we'll iterate over the aggregator entries.
+                                 * Each entry key is a behavior group and its value is a Set containing all event types that should be linked with the behavior group.
+                                 */
+                                .replaceWith(aggregator.entrySet())
+                                .onItem().transformToMulti(aggregatorEntries -> Multi.createFrom().iterable(aggregatorEntries))
+                                .onItem().transformToUniAndConcatenate(aggregatorEntry -> {
+                                    // It's time to finally persist a behavior group.
+                                    BehaviorGroup behaviorGroup = new BehaviorGroup();
+                                    behaviorGroup.setAccountId(aggregatorEntry.getKey().accountId);
+                                    behaviorGroup.setBundle(aggregatorEntry.getKey().bundle);
+                                    behaviorGroup.setBundleId(aggregatorEntry.getKey().bundle.getId()); // Yes, we need to set that even if the bundle was already set.
+                                    // We have to generate a dynamic display name for the behavior group.
+                                    int displayNameIndex = accountBehaviorGroupIndexes.computeIfAbsent(behaviorGroup.getAccountId(), key -> new AtomicInteger()).incrementAndGet();
+                                    behaviorGroup.setDisplayName("Behavior group " + displayNameIndex);
+                                    // Endpoints need to be ordered to determine the actions positions in the UI.
+                                    List<Endpoint> orderedEndpoints = new ArrayList<>(aggregatorEntry.getKey().actions);
+                                    LOGGER.debugf("[BG MIGRATION] __ Persisting BehaviorGroup[account=%s, bundle=%s, displayName=%s] created", behaviorGroup.getAccountId(), behaviorGroup.getBundle().getName(), behaviorGroup.getDisplayName());
+                                    return session.persist(behaviorGroup)
+                                            .onItem().invoke(ignored -> report.behaviorGroupsPersisted.incrementAndGet())
+                                            .onItem().transformToMulti(ignored -> Multi.createFrom().iterable(orderedEndpoints))
+                                            .onItem().transformToUniAndConcatenate(endpoint -> {
+                                                BehaviorGroupAction action = new BehaviorGroupAction(behaviorGroup, endpoint);
+                                                action.setPosition(orderedEndpoints.indexOf(endpoint));
+                                                return session.persist(action)
+                                                        .onItem().invoke(ignored -> {
+                                                            report.actionsPersisted.incrementAndGet();
+                                                            LOGGER.debugf("[BG MIGRATION] ____ BehaviorGroupAction[endpoint=%s, position=%s] persisted", endpoint.getName(), action.getPosition());
+                                                        });
+                                            })
+                                            .onItem().ignoreAsUni()
+                                            .onItem().transformToMulti(ignored -> Multi.createFrom().iterable(aggregatorEntry.getValue()))
+                                            .onItem().transformToUniAndConcatenate(eventType -> {
+                                                EventTypeBehavior behavior = new EventTypeBehavior(eventType, behaviorGroup);
+                                                return session.persist(behavior)
+                                                        .onItem().invoke(ignored -> {
+                                                            report.behaviorsPersisted.incrementAndGet();
+                                                            LOGGER.debugf("[BG MIGRATION] ____ EventTypeBehavior[eventType=%s] persisted", eventType.getName());
+                                                        });
+                                            })
+                                            .onItem().ignoreAsUni()
+                                            .onItem().invoke(ignored -> LOGGER.debug("[BG MIGRATION] __ Done"));
+                                })
+                                .onItem().ignoreAsUni()
+                                .onItem().invoke(ignored -> LOGGER.debug("[BG MIGRATION] Done"));
+                    });
+        })
+        .onItem().invoke(ignored -> {
+            report.durationInMs.set(System.currentTimeMillis() - start);
+            LOGGER.debug("[BG MIGRATION] End");
+        })
+        .replaceWith(report);
+    }
+
+    private static class MigrationBehaviorGroup {
+
+        private String accountId;
+        private Bundle bundle;
+        private Set<Endpoint> actions = new HashSet<>();
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o instanceof MigrationBehaviorGroup) {
+                MigrationBehaviorGroup other = (MigrationBehaviorGroup) o;
+                return Objects.equals(accountId, other.accountId) &&
+                        Objects.equals(bundle, other.bundle) &&
+                        Objects.equals(actions, other.actions);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(accountId, bundle, actions);
+        }
+    }
+
+    private static class AccountBehaviorGroupsAggregator extends ConcurrentHashMap<MigrationBehaviorGroup, Set<EventType>> {
+
+        public void aggregate(MigrationBehaviorGroup behaviorGroup, Optional<EventType> eventType, MigrationReport report) {
+            Set<EventType> singletonOrEmptySet = eventType.isPresent() ? Set.of(eventType.get()) : Collections.emptySet();
+            merge(behaviorGroup, singletonOrEmptySet, (existingSet, newSet) -> {
+                report.behaviorGroupsAggregated.incrementAndGet();
+                LOGGER.debug("[BG MIGRATION] ______ Reusing existing behavior group");
+                Set<EventType> eventTypes = new HashSet<>(existingSet);
+                eventTypes.addAll(newSet);
+                return eventTypes;
+            });
+        }
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    private static class MigrationReport {
+        AtomicLong durationInMs = new AtomicLong();
+        AtomicLong accountsWithDefaults = new AtomicLong();
+        AtomicLong accountsWithNonDefaults = new AtomicLong();
+        AtomicLong behaviorGroupsAggregated = new AtomicLong();
+        AtomicLong behaviorGroupsPersisted = new AtomicLong();
+        AtomicLong actionsPersisted = new AtomicLong();
+        AtomicLong behaviorsPersisted = new AtomicLong();
+
+        public AtomicLong getDurationInMs() {
+            return durationInMs;
+        }
+
+        public AtomicLong getAccountsWithDefaults() {
+            return accountsWithDefaults;
+        }
+
+        public AtomicLong getAccountsWithNonDefaults() {
+            return accountsWithNonDefaults;
+        }
+
+        public AtomicLong getBehaviorGroupsAggregated() {
+            return behaviorGroupsAggregated;
+        }
+
+        public AtomicLong getBehaviorGroupsPersisted() {
+            return behaviorGroupsPersisted;
+        }
+
+        public AtomicLong getActionsPersisted() {
+            return actionsPersisted;
+        }
+
+        public AtomicLong getBehaviorsPersisted() {
+            return behaviorsPersisted;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,7 @@ quarkus.http.access-log.enabled=true
 quarkus.http.access-log.category=access_log
 quarkus.http.access-log.pattern=combined
 quarkus.log.category."com.redhat.cloud.notifications".level=INFO
+quarkus.log.category."com.redhat.cloud.notifications.routers.BehaviorGroupMigrationService".level=DEBUG
 
 %test.quarkus.http.access-log.category=info
 

--- a/src/test/java/com/redhat/cloud/notifications/routers/BehaviorGroupMigrationServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/BehaviorGroupMigrationServiceTest.java
@@ -1,0 +1,336 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.BehaviorGroup;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointDefault;
+import com.redhat.cloud.notifications.models.EndpointTarget;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.EventType;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.routers.BehaviorGroupMigrationService.CONFIRMATION_TOKEN;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class BehaviorGroupMigrationServiceTest extends DbIsolatedTest {
+
+    private static final String ACCOUNT1 = "account-1";
+    private static final String ACCOUNT2 = "account-2";
+    private static final String ACCOUNT3 = "account-3";
+    private static final String ACCOUNT4 = "account-4";
+
+    @Inject
+    Mutiny.Session session;
+
+    @Test
+    void testFullMigration() {
+
+        /**************************************
+         * Bundle > App > EventType hierarchy *
+         **************************************/
+
+        /*
+         * - Bundle: test-bundle-1
+         *   - App: test-app-1
+         *     - EventType: test-event-type-1
+         *     - EventType: test-event-type-2
+         *   - App: test-app-2
+         *     - EventType: test-event-type-3
+         * - Bundle: test-bundle-2
+         *   - App: test-app-3
+         *     - EventType: test-event-type-4
+         */
+
+        Bundle bundle1 = createBundle("test-bundle-1");
+        Application app1 = createApp(bundle1, "test-app-1");
+        EventType eventType1 = createEventType(app1, "test-event-type-1");
+        EventType eventType2 = createEventType(app1, "test-event-type-2");
+        Application app2 = createApp(bundle1, "test-app-2");
+        EventType eventType3 = createEventType(app2, "test-event-type-3");
+        Bundle bundle2 = createBundle("test-bundle-2");
+        Application app3 = createApp(bundle2, "test-app-3");
+        EventType eventType4 = createEventType(app3, "test-event-type-4");
+
+        /*************
+         * Account 1 *
+         *************/
+
+        Endpoint endpoint1 = createEndpoint(ACCOUNT1, EndpointType.EMAIL_SUBSCRIPTION, "test-endpoint-1");
+        Endpoint endpoint2 = createEndpoint(ACCOUNT1, EndpointType.WEBHOOK, "test-endpoint-2");
+
+        /*
+         * Default actions creation.
+         * This inserts records into the 'endpoint_defaults' table.
+         */
+        addEndpointToDefaults(ACCOUNT1, endpoint1);
+        addEndpointToDefaults(ACCOUNT1, endpoint2);
+
+        /*
+         * Default actions activation.
+         * This inserts records into the 'endpoint_targets' table.
+         */
+        Endpoint defaultEndpoint1 = createEndpoint(ACCOUNT1, EndpointType.DEFAULT, "default-endpoint-1");
+        linkEndpointToEventType(ACCOUNT1, defaultEndpoint1, eventType1);
+        linkEndpointToEventType(ACCOUNT1, defaultEndpoint1, eventType4);
+
+        /*
+         * Non-default actions creation.
+         * This inserts records into the 'endpoint_targets' table.
+         */
+        linkEndpointToEventType(ACCOUNT1, endpoint1, eventType3);
+        linkEndpointToEventType(ACCOUNT1, endpoint2, eventType3);
+
+        /*************
+         * Account 2 *
+         *************/
+
+        Endpoint endpoint3 = createEndpoint(ACCOUNT2, EndpointType.EMAIL_SUBSCRIPTION, "test-endpoint-3");
+        Endpoint endpoint4 = createEndpoint(ACCOUNT2, EndpointType.WEBHOOK, "test-endpoint-4");
+        Endpoint endpoint5 = createEndpoint(ACCOUNT2, EndpointType.WEBHOOK, "test-endpoint-5");
+
+        /*
+         * Default action creation.
+         * This inserts a record into the 'endpoint_defaults' table.
+         */
+        addEndpointToDefaults(ACCOUNT2, endpoint3);
+
+        /*
+         * Default actions activation.
+         * This inserts a record into the 'endpoint_targets' table.
+         */
+        Endpoint defaultEndpoint2 = createEndpoint(ACCOUNT2, EndpointType.DEFAULT, "default-endpoint-2");
+        linkEndpointToEventType(ACCOUNT2, defaultEndpoint2, eventType1);
+
+        /*
+         * Non-default actions creation.
+         * This inserts records into the 'endpoint_targets' table.
+         */
+        linkEndpointToEventType(ACCOUNT2, endpoint4, eventType2);
+        linkEndpointToEventType(ACCOUNT2, endpoint5, eventType2);
+        linkEndpointToEventType(ACCOUNT2, endpoint4, eventType3);
+
+        /*************
+         * Account 3 *
+         *************/
+
+        Endpoint endpoint6 = createEndpoint(ACCOUNT3, EndpointType.WEBHOOK, "test-endpoint-6");
+
+        /*
+         * Default action creation.
+         * This inserts a record into the 'endpoint_defaults' table.
+         */
+        addEndpointToDefaults(ACCOUNT3, endpoint6);
+
+        /*************
+         * Account 4 *
+         *************/
+
+        Endpoint endpoint7 = createEndpoint(ACCOUNT4, EndpointType.WEBHOOK, "test-endpoint-7");
+        Endpoint endpoint8 = createEndpoint(ACCOUNT4, EndpointType.WEBHOOK, "test-endpoint-8");
+
+        /*
+         * Non-default actions creation.
+         * This inserts records into the 'endpoint_targets' table.
+         */
+        linkEndpointToEventType(ACCOUNT4, endpoint7, eventType1);
+        linkEndpointToEventType(ACCOUNT4, endpoint8, eventType1);
+        linkEndpointToEventType(ACCOUNT4, endpoint7, eventType2);
+        linkEndpointToEventType(ACCOUNT4, endpoint7, eventType3);
+        linkEndpointToEventType(ACCOUNT4, endpoint8, eventType3);
+        linkEndpointToEventType(ACCOUNT4, endpoint7, eventType4);
+
+        /*************
+         * Migration *
+         *************/
+
+        migrate();
+
+        /**************
+         * Assertions *
+         **************/
+
+        /*
+         * First, let's check that all links established between event types and endpoints using the old tables are
+         * still working with the behavior groups tables.
+         */
+        assertEndpoints(ACCOUNT1, eventType1.getId(), endpoint1, endpoint2);
+        assertEndpoints(ACCOUNT1, eventType3.getId(), endpoint1, endpoint2);
+        assertEndpoints(ACCOUNT1, eventType4.getId(), endpoint1, endpoint2);
+        assertEndpoints(ACCOUNT2, eventType1.getId(), endpoint3);
+        assertEndpoints(ACCOUNT2, eventType2.getId(), endpoint4, endpoint5);
+        assertEndpoints(ACCOUNT2, eventType3.getId(), endpoint4);
+        assertEndpoints(ACCOUNT4, eventType1.getId(), endpoint7, endpoint8);
+        assertEndpoints(ACCOUNT4, eventType2.getId(), endpoint7);
+        assertEndpoints(ACCOUNT4, eventType3.getId(), endpoint7, endpoint8);
+        assertEndpoints(ACCOUNT4, eventType4.getId(), endpoint7);
+
+        // Now let's check the behavior groups that were created during the migration.
+        List<BehaviorGroup> behaviorGroups = getAllBehaviorGroups();
+
+        /*
+         * There are 3 bundles in the DB (bundle1, bundle2 and rhel from DbCleaner) and 3 accounts with default actions
+         * (accounts 1, 2 and 3) so 9 behavior groups should be created from the default actions.
+         * Account 1 also has non-default actions but these match an existing behavior group which is reused.
+         * Account 2 also has non-default actions linked with 2 different event types, so 2 more behavior groups should
+         * be created for that account.
+         * Account 4 only has non-default actions linked with 4 different event types, but there should be 1 behavior
+         * group aggregation and 3 behavior groups should be created in the end.
+         * 3 x 3 + 2 + 3 = 14
+         */
+        assertEquals(14, behaviorGroups.size());
+
+        // Account 1 should have 3 behavior groups created from both default and non-default actions.
+        assertEquals(3, behaviorGroups.stream().filter(behaviorGroup -> behaviorGroup.getAccountId().equals(ACCOUNT1)).count());
+
+        // Account 2 should have 3 behavior groups created from default actions and 2 behavior groups created from non-default actions.
+        assertEquals(5, behaviorGroups.stream().filter(behaviorGroup -> behaviorGroup.getAccountId().equals(ACCOUNT2)).count());
+
+        // Account 3 should have 3 behavior groups created from default actions.
+        assertEquals(3, behaviorGroups.stream().filter(behaviorGroup -> behaviorGroup.getAccountId().equals(ACCOUNT3)).count());
+
+        // Account 4 should have 3 behavior groups created from non-default actions.
+        assertEquals(3, behaviorGroups.stream().filter(behaviorGroup -> behaviorGroup.getAccountId().equals(ACCOUNT4)).count());
+
+        assertEquals(7, behaviorGroups.stream().filter(behaviorGroup -> behaviorGroup.getBundle().equals(bundle1)).count());
+        assertEquals(4, behaviorGroups.stream().filter(behaviorGroup -> behaviorGroup.getBundle().equals(bundle2)).count());
+    }
+
+    @Test
+    void testMigrateWithoutConfirmationToken() {
+        given()
+                .when()
+                .get("/internal/behaviorGroups/migrate")
+                .then()
+                .statusCode(400);
+        assertTrue(getAllBehaviorGroups().isEmpty());
+    }
+
+    @Test
+    void testMigrateEmptyBundle() {
+        // This test checks that no exception is thrown if the migration is run with an empty bundle (no app).
+        createBundle("empty-bundle");
+        migrate();
+        assertTrue(getAllBehaviorGroups().isEmpty());
+    }
+
+    @Test
+    void testMigrateEmptyApp() {
+        // This test checks that no exception is thrown if the migration is run with an empty app (no event type).
+        Bundle bundle = createBundle("migration-bundle");
+        createApp(bundle, "empty-app");
+        migrate();
+        assertTrue(getAllBehaviorGroups().isEmpty());
+    }
+
+    @Test
+    void testMigrateNotLinkedEventType() {
+        // This test checks that no exception is thrown if the migration is run with an event type not linked to anything.
+        Bundle bundle = createBundle("migration-bundle");
+        Application app = createApp(bundle, "migration-app");
+        createEventType(app, "migration-event-type");
+        migrate();
+        assertTrue(getAllBehaviorGroups().isEmpty());
+    }
+
+    private Bundle createBundle(String name) {
+        Bundle bundle = new Bundle();
+        bundle.setName(name);
+        bundle.setDisplayName("Migration bundle");
+        session.persist(bundle)
+                .call(session::flush)
+                .await().indefinitely();
+        return bundle;
+    }
+
+    private Application createApp(Bundle bundle, String name) {
+        Application app = new Application();
+        app.setBundle(bundle);
+        app.setBundleId(bundle.getId());
+        app.setName(name);
+        app.setDisplayName("Migration app");
+        session.persist(app)
+                .call(session::flush)
+                .await().indefinitely();
+        return app;
+    }
+
+    private EventType createEventType(Application app, String name) {
+        EventType eventType = new EventType();
+        eventType.setApplication(app);
+        eventType.setApplicationId(app.getId());
+        eventType.setName(name);
+        eventType.setDisplayName("Migration event type");
+        session.persist(eventType)
+                .call(session::flush)
+                .await().indefinitely();
+        return eventType;
+    }
+
+    private Endpoint createEndpoint(String accountId, EndpointType type, String name) {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setAccountId(accountId);
+        endpoint.setType(type);
+        endpoint.setName(name);
+        endpoint.setDescription("Migration endpoint");
+        session.persist(endpoint)
+                .call(session::flush)
+                .await().indefinitely();
+        return endpoint;
+    }
+
+    private void addEndpointToDefaults(String accountId, Endpoint endpoint) {
+        EndpointDefault endpointDefault = new EndpointDefault(accountId, endpoint);
+        session.persist(endpointDefault)
+                .call(session::flush)
+                .await().indefinitely();
+    }
+
+    private void linkEndpointToEventType(String accountId, Endpoint endpoint, EventType eventType) {
+        EndpointTarget endpointTarget = new EndpointTarget(accountId, endpoint, eventType);
+        session.persist(endpointTarget)
+                .call(session::flush)
+                .await().indefinitely();
+    }
+
+    private void migrate() {
+        given()
+                .queryParam("confirmation-token", CONFIRMATION_TOKEN)
+                .when()
+                .get("/internal/behaviorGroups/migrate")
+                .then()
+                .statusCode(200);
+    }
+
+    private void assertEndpoints(String accountId, UUID eventTypeId, Endpoint... expectedEndpoints) {
+        String query = "SELECT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
+                "WHERE bga.behaviorGroup.accountId = :accountId AND b.eventType.id = :eventTypeId";
+        List<Endpoint> actualEndpoints = session.createQuery(query, Endpoint.class)
+                .setParameter("accountId", accountId)
+                .setParameter("eventTypeId", eventTypeId)
+                .getResultList()
+                .await().indefinitely();
+        assertEquals(expectedEndpoints.length, actualEndpoints.size());
+        assertTrue(actualEndpoints.containsAll(Arrays.asList(expectedEndpoints)));
+    }
+
+    private List<BehaviorGroup> getAllBehaviorGroups() {
+        return session.createQuery("FROM BehaviorGroup", BehaviorGroup.class)
+                .getResultList()
+                .await().indefinitely();
+    }
+}


### PR DESCRIPTION
This PR:
- introduces the API that will be used to trigger the behavior groups data migration
- does _not_ enable the Kafka messages processing using behavior groups
- does _not_ modify any existing DB data (the migration only consists in adding new data)
- does _not_ delete the `endpoint_targets` and `endpoint_defaults` DB tables (we'll do that later, there's no rush)

ℹ️ Merging it won't have any effect on the app or the database as long as the migration isn't triggered.

To trigger the migration, simply call `GET /internal/behaviorGroups/migrate?confirmation-token=ready-set-go`. The confirmation token may be removed before this is merged.

If the migration is successful, the HTTP response will contain a small report about what's been migrated:
```
{
    "duration_in_ms": 262,
    "accounts_with_defaults": 3,
    "accounts_with_non_defaults": 3,
    "behavior_groups_aggregated": 2,
    "behavior_groups_persisted": 11,
    "actions_persisted": 15,
    "behaviors_persisted": 10
}
```

Here is some important information about the data migration:

▶️ The persisted behavior groups are automatically named to `"Behavior group " + i` with `i` the current value of an isolated counter for each account. For example, if the migration created 5 behavior groups which were owned by 2 different accounts, the display name would look like this:
| Account | Behavior group display name |
| - | - |
| Account 1 | Behavior group 1 |
| Account 1 | Behavior group 2 |
| Account 2 | Behavior group 1 |
| Account 1 | Behavior group 3 |
| Account 2 | Behavior group 2 |

▶️ Behavior groups are aggregated during the migration. It means that for a single account and a single bundle, if two event types are linked with the same set of actions (the actions order doesn't matter), the migration will only create one behavior group instead of two and that group will be linked with both event types. This works for both former default actions and non-default actions as well.

👇 I added two comments below that should be really helpful to understand what the migration does.