### PR TITLE
Fix OpenShift spelling in email templates

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/templates/AdvisorOpenshift.java
+++ b/src/main/java/com/redhat/cloud/notifications/templates/AdvisorOpenshift.java
@@ -18,7 +18,7 @@ public class AdvisorOpenshift implements EmailTemplate {
         }
 
         throw new UnsupportedOperationException(String.format(
-                "No email title template for Openshift Advisor event_type: %s and EmailSubscription: %s found.",
+                "No email title template for OpenShift Advisor event_type: %s and EmailSubscription: %s found.",
                 eventType, type
         ));
     }
@@ -34,7 +34,7 @@ public class AdvisorOpenshift implements EmailTemplate {
         }
 
         throw new UnsupportedOperationException(String.format(
-                "No email body template for Openshift Advisor event_type: %s and EmailSubscription: %s found.",
+                "No email body template for OpenShift Advisor event_type: %s and EmailSubscription: %s found.",
                 eventType, type
         ));
     }

--- a/src/main/resources/templates/AdvisorOpenshift/newRecommendationInstantEmailBody.html
+++ b/src/main/resources/templates/AdvisorOpenshift/newRecommendationInstantEmailBody.html
@@ -1,5 +1,5 @@
 {#include AdvisorOpenshift/insightsEmailBody}
-{#content-title}Openshift - Advisor Instant Notification - {action.timestamp.format('d MMM uuuu')}{/content-title}
+{#content-title}OpenShift - Advisor Instant Notification - {action.timestamp.format('d MMM uuuu')}{/content-title}
 {#content-body}
 <tr>
     <td class="rh-body rh-multi-column">

--- a/src/main/resources/templates/AdvisorOpenshift/newRecommendationInstantEmailTitle.txt
+++ b/src/main/resources/templates/AdvisorOpenshift/newRecommendationInstantEmailTitle.txt
@@ -1,1 +1,1 @@
-Openshift - Advisor Instant Notification - {action.timestamp.format('d MMM uuuu')}
+OpenShift - Advisor Instant Notification - {action.timestamp.format('d MMM uuuu')}

--- a/src/main/resources/templates/AdvisorOpenshift/weeklyDigestEmailBody.html
+++ b/src/main/resources/templates/AdvisorOpenshift/weeklyDigestEmailBody.html
@@ -1,5 +1,5 @@
 {#include AdvisorOpenshift/insightsEmailBody}
-{#content-title}Openshift - Advisor Weekly Report - {action.timestamp.format('d MMM uuuu')}{/content-title}
+{#content-title}OpenShift - Advisor Weekly Report - {action.timestamp.format('d MMM uuuu')}{/content-title}
 {#content-body}
 <tr>
     <td align="center" valign="top" class="rh-body-cell"

--- a/src/main/resources/templates/AdvisorOpenshift/weeklyDigestEmailTitle.txt
+++ b/src/main/resources/templates/AdvisorOpenshift/weeklyDigestEmailTitle.txt
@@ -1,1 +1,1 @@
-Openshift - Advisor Weekly Report - {action.timestamp.format('d MMM uuuu')}
+OpenShift - Advisor Weekly Report - {action.timestamp.format('d MMM uuuu')}

--- a/src/test/java/com/redhat/cloud/notifications/templates/TestOpenshiftAdvisorTemplate.java
+++ b/src/test/java/com/redhat/cloud/notifications/templates/TestOpenshiftAdvisorTemplate.java
@@ -19,7 +19,7 @@ public class TestOpenshiftAdvisorTemplate {
                 .data("action", action)
                 .render();
 
-        assertEquals("Openshift - Advisor Instant Notification - 20 May 2021", result, "Title is the expected.");
+        assertEquals("OpenShift - Advisor Instant Notification - 20 May 2021", result, "Title is the expected.");
     }
 
     @Test
@@ -70,7 +70,7 @@ public class TestOpenshiftAdvisorTemplate {
                 .data("action", action)
                 .render();
 
-        assertEquals("Openshift - Advisor Weekly Report - 20 May 2021", result, "Title is the expected.");
+        assertEquals("OpenShift - Advisor Weekly Report - 20 May 2021", result, "Title is the expected.");
     }
 
     @Test


### PR DESCRIPTION
I just spotted and fixed that spelling issue in the templates that were recently added.

I only fixed the "public" part of the templates (the one that is displayed to the end user). There are still many occurrences of `Openshift` (without a capital `S`) in the code but that's only code so it's less important.