### PR TITLE
Add internal API to investigate stage endpoint issue

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -364,8 +364,10 @@ public class EndpointResources {
             return session
                     .find(typedEndpointClass, endpointsMap.keySet().toArray())
                     .onItem().invoke(propList -> propList.forEach(props -> {
-                        Endpoint endpoint = endpointsMap.get(props.getId());
-                        endpoint.setProperties(props);
+                        if (props != null) {
+                            Endpoint endpoint = endpointsMap.get(props.getId());
+                            endpoint.setProperties(props);
+                        }
                     })).replaceWith(Uni.createFrom().voidItem());
         }
 

--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -69,6 +69,7 @@ public class EndpointProcessor {
                 action.getApplication(),
                 action.getEventType())
                 .onItem().transformToUniAndConcatenate(endpoint -> {
+                    LOGGER.fine(() -> "Sending notification to " + endpoint);
                     endpointTargeted.increment();
                     Notification endpointNotif = new Notification(action, endpoint);
                     return endpointTypeToProcessor(endpoint.getType()).process(endpointNotif);

--- a/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -1,10 +1,11 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.db.ApplicationResources;
-import com.redhat.cloud.notifications.db.BehaviorGroupResources;
 import com.redhat.cloud.notifications.db.BundleResources;
+import com.redhat.cloud.notifications.db.EndpointResources;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EventType;
 import io.smallrye.mutiny.Uni;
 
@@ -20,6 +21,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
@@ -34,10 +36,10 @@ public class InternalService {
     BundleResources bundleResources;
 
     @Inject
-    BehaviorGroupResources behaviorGroupResources;
+    ApplicationResources appResources;
 
     @Inject
-    ApplicationResources appResources;
+    EndpointResources endpointResoures;
 
     @POST
     @Path("/bundles")
@@ -150,5 +152,13 @@ public class InternalService {
     @Produces(APPLICATION_JSON)
     public Uni<Boolean> deleteEventType(@PathParam("eventTypeId") UUID eventTypeId) {
         return appResources.deleteEventTypeById(eventTypeId);
+    }
+
+    // TODO: Remove this when we're done investigating the Stage ghost endpoint issue.
+    @GET
+    @Path("/endpoints/{endpointId}")
+    @Produces(APPLICATION_JSON)
+    public Uni<Endpoint> getEndpoint(@PathParam("endpointId") UUID endpointId, @NotNull @QueryParam("account") String account) {
+        return endpointResoures.getEndpoint(account, endpointId);
     }
 }


### PR DESCRIPTION
The goal of this PR is to investigate the following error on stage:
```
2021-06-01 06:01:42,520 INFO  [com.red.clo.not.eve.EventConsumer] (vert.x-eventloop-thread-0) Could not process the payload: [...]: javax.persistence.PersistenceException: org.hibernate.HibernateException: io.vertx.pgclient.PgException: insert or update on table "notification_history" violates foreign key constraint "notification_history_endpoint_id_fkey"
```