### PR TITLE
Exposing private api internally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,8 @@ jobs:
         with:
           name: openapi.integrations.json
           path: target/openapi.integrations.json
+      - uses: actions/upload-artifact@v2
+        name: Upload private openapi.json
+        with:
+          name: openapi.private.json
+          path: target/openapi.private.json

--- a/src/main/java/com/redhat/cloud/notifications/auth/rhid/RHIdentityAuthMechanism.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rhid/RHIdentityAuthMechanism.java
@@ -44,7 +44,7 @@ public class RHIdentityAuthMechanism implements HttpAuthenticationMechanism {
             boolean good = false;
 
             // We block access unless the openapi file is requested.
-            if (path.startsWith("/api/notifications") || path.startsWith("/api/integrations")) {
+            if (path.startsWith("/api/notifications") || path.startsWith("/api/integrations") || path.startsWith("/api/private")) {
                 if (path.endsWith("openapi.json")) {
                     good = true;
                 }

--- a/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/NotificationService.java
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
@@ -165,7 +166,8 @@ public class NotificationService {
     @GET
     @Path("/bg/eventTypes/affectedByRemovalOfEndpoint/{endpointId}") // TODO [BG Phase 2] Remove '/bg' path prefix
     @Produces(APPLICATION_JSON)
-    @Operation(summary = "Retrieve the event types affected by the removal of an integration.", hidden = true)
+    @Operation(summary = "Retrieve the event types affected by the removal of an integration.")
+    @Tag(name = OApiService.PRIVATE)
     @RolesAllowed(RbacIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public Uni<List<EventType>> getEventTypesAffectedByRemovalOfEndpoint(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         return getAccountId(sec)
@@ -179,7 +181,8 @@ public class NotificationService {
     @GET
     @Path("/eventTypes/affectedByRemovalOfBehaviorGroup/{behaviorGroupId}")
     @Produces(APPLICATION_JSON)
-    @Operation(summary = "Retrieve the event types affected by the removal of a behavior group.", hidden = true)
+    @Operation(summary = "Retrieve the event types affected by the removal of a behavior group.")
+    @Tag(name = OApiService.PRIVATE)
     @RolesAllowed(RbacIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public Uni<List<EventType>> getEventTypesAffectedByRemovalOfBehaviorGroup(@Context SecurityContext sec, @PathParam("behaviorGroupId") UUID behaviorGroupId) {
         return getAccountId(sec)
@@ -222,7 +225,8 @@ public class NotificationService {
     @GET
     @Path("/eventTypes/{eventTypeId}/behaviorGroups")
     @Produces(APPLICATION_JSON)
-    @Operation(summary = "Retrieve the behavior groups linked to an event type.", hidden = true)
+    @Operation(summary = "Retrieve the behavior groups linked to an event type.")
+    @Tag(name = OApiService.PRIVATE)
     @RolesAllowed(RbacIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public Uni<List<BehaviorGroup>> getLinkedBehaviorGroups(@Context SecurityContext sec, @PathParam("eventTypeId") UUID eventTypeId, @BeanParam Query query) {
         return getAccountId(sec)
@@ -293,7 +297,8 @@ public class NotificationService {
     @Path("/behaviorGroups")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    @Operation(summary = "Create a behavior group.", hidden = true)
+    @Operation(summary = "Create a behavior group.")
+    @Tag(name = OApiService.PRIVATE)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     public Uni<BehaviorGroup> createBehaviorGroup(@Context SecurityContext sec, @NotNull @Valid BehaviorGroup behaviorGroup) {
         return getAccountId(sec)
@@ -304,7 +309,8 @@ public class NotificationService {
     @Path("/behaviorGroups/{id}")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    @Operation(summary = "Update a behavior group.", hidden = true)
+    @Operation(summary = "Update a behavior group.")
+    @Tag(name = OApiService.PRIVATE)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     public Uni<Boolean> updateBehaviorGroup(@Context SecurityContext sec, @PathParam("id") UUID id, @NotNull @Valid BehaviorGroup behaviorGroup) {
         return getAccountId(sec)
@@ -317,7 +323,8 @@ public class NotificationService {
     @DELETE
     @Path("/behaviorGroups/{id}")
     @Produces(APPLICATION_JSON)
-    @Operation(summary = "Delete a behavior group.", hidden = true)
+    @Operation(summary = "Delete a behavior group.")
+    @Tag(name = OApiService.PRIVATE)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     public Uni<Boolean> deleteBehaviorGroup(@Context SecurityContext sec, @PathParam("id") UUID behaviorGroupId) {
         return getAccountId(sec)
@@ -328,7 +335,8 @@ public class NotificationService {
     @Path("/behaviorGroups/{behaviorGroupId}/actions")
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
-    @Operation(summary = "Update the list of actions of a behavior group.", hidden = true)
+    @Operation(summary = "Update the list of actions of a behavior group.")
+    @Tag(name = OApiService.PRIVATE)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> updateBehaviorGroupActions(@Context SecurityContext sec, @PathParam("behaviorGroupId") UUID behaviorGroupId, List<UUID> endpointIds) {
@@ -351,7 +359,8 @@ public class NotificationService {
     @Path("/eventTypes/{eventTypeId}/behaviorGroups")
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
-    @Operation(summary = "Update the list of behavior groups of an event type.", hidden = true)
+    @Operation(summary = "Update the list of behavior groups of an event type.")
+    @Tag(name = OApiService.PRIVATE)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> updateEventTypeBehaviors(@Context SecurityContext sec, @PathParam("eventTypeId") UUID eventTypeId, Set<UUID> behaviorGroupIds) {
@@ -373,7 +382,8 @@ public class NotificationService {
     @GET
     @Path("/bundles/{bundleId}/behaviorGroups")
     @Produces(APPLICATION_JSON)
-    @Operation(summary = "Retrieve the behavior groups of a bundle.", hidden = true)
+    @Operation(summary = "Retrieve the behavior groups of a bundle.")
+    @Tag(name = OApiService.PRIVATE)
     @RolesAllowed(RbacIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public Uni<List<BehaviorGroup>> findBehaviorGroupsByBundleId(@Context SecurityContext sec, @PathParam("bundleId") UUID bundleId) {
         return getAccountId(sec)

--- a/src/main/java/com/redhat/cloud/notifications/routers/OApiService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/OApiService.java
@@ -17,7 +17,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,13 +30,7 @@ public class OApiService {
     public static final String INTEGRATIONS = "integrations";
     public static final String PRIVATE = "private";
 
-    static List<String> whats = new ArrayList<>(3);
-
-    static {
-        whats.add(INTEGRATIONS);
-        whats.add(NOTIFICATIONS);
-        whats.add(PRIVATE);
-    }
+    static List<String> whats = List.of(INTEGRATIONS, NOTIFICATIONS, PRIVATE);
 
     @Inject
     Vertx vertx;

--- a/src/main/java/com/redhat/cloud/notifications/routers/OApiService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/OApiService.java
@@ -19,6 +19,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Serve the final OpenAPI documents.
@@ -28,12 +29,14 @@ public class OApiService {
 
     public static final String NOTIFICATIONS = "notifications";
     public static final String INTEGRATIONS = "integrations";
+    public static final String PRIVATE = "private";
 
-    static List<String> whats = new ArrayList<>(2);
+    static List<String> whats = new ArrayList<>(3);
 
     static {
         whats.add(INTEGRATIONS);
         whats.add(NOTIFICATIONS);
+        whats.add(PRIVATE);
     }
 
     @Inject
@@ -81,6 +84,16 @@ public class OApiService {
                     // We just copy all of them even if they may only apply to one
                     root.put(key, entry.getValue());
                     break;
+                case "tags":
+                    JsonArray tags = (JsonArray) entry.getValue();
+                    JsonArray filteredTags = new JsonArray(tags
+                            .stream()
+                            .filter(o -> !((JsonObject) o).getString("name").equals(PRIVATE))
+                            .collect(Collectors.toList()));
+                    if (filteredTags.size() > 0) {
+                        root.put(key, filteredTags);
+                    }
+                    break;
                 case "paths":
                     JsonObject pathObject2 = new JsonObject();
                     JsonObject pathsObjectIn = (JsonObject) entry.getValue();
@@ -89,12 +102,20 @@ public class OApiService {
 
                         JsonObject pathValue = (JsonObject) pathEntry.getValue();
                         if (!path.endsWith("openapi.json")) { // Skip the openapi endpoint
+                            JsonObject newPathValue = null;
+                            String mangledPath = mangle(path);
 
                             if (NOTIFICATIONS.equals(what) && path.startsWith(Constants.API_NOTIFICATIONS_V_1_0)) {
-                                pathObject2.put(mangle(path), pathValue);
+                                newPathValue = filterPrivateOperation(pathValue, true);
+                            } else if (INTEGRATIONS.equals(what) && path.startsWith(Constants.API_INTEGRATIONS_V_1_0)) {
+                                newPathValue = filterPrivateOperation(pathValue, true);
+                            } else if (PRIVATE.equals(what)) {
+                                newPathValue = filterPrivateOperation(pathValue, false);
+                                mangledPath = path;
                             }
-                            if (INTEGRATIONS.equals(what) && path.startsWith(Constants.API_INTEGRATIONS_V_1_0)) {
-                                pathObject2.put(mangle(path), pathValue);
+
+                            if (newPathValue != null) {
+                                pathObject2.put(mangledPath, newPathValue);
                             }
                         }
                     });
@@ -121,7 +142,7 @@ public class OApiService {
         if (what.equals(NOTIFICATIONS)) {
             serversArray.add(createServer(true, NOTIFICATIONS));
             serversArray.add(createServer(false, NOTIFICATIONS));
-        } else {
+        } else if (what.equals(INTEGRATIONS)) {
             serversArray.add(createServer(true, INTEGRATIONS));
             serversArray.add(createServer(false, INTEGRATIONS));
         }
@@ -133,6 +154,24 @@ public class OApiService {
 
     private String uppify(String what) {
         return what.substring(0, 1).toUpperCase() + what.substring(1);
+    }
+
+    private JsonObject filterPrivateOperation(JsonObject pathObject, boolean removePrivate) {
+        JsonObject newPathObject = new JsonObject();
+        pathObject.stream().forEach(entry -> {
+            String verb = entry.getKey();
+            JsonObject operation = (JsonObject) entry.getValue();
+            boolean isPrivate = operation.containsKey("tags") && operation.getJsonArray("tags").contains(PRIVATE);
+            if (isPrivate != removePrivate) {
+                newPathObject.put(verb, operation);
+            }
+        });
+
+        if (newPathObject.size() == 0) {
+            return null;
+        }
+
+        return newPathObject;
     }
 
     private JsonObject createServer(boolean isProd, String what) {

--- a/src/test/java/com/redhat/cloud/notifications/openapi/OpenApiTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/openapi/OpenApiTest.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.openapi;
 
 import com.redhat.cloud.notifications.TestConstants;
+import com.redhat.cloud.notifications.routers.OApiService;
 import com.reprezen.kaizen.oasparser.OpenApi3Parser;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
@@ -37,13 +38,16 @@ public class OpenApiTest {
     @TestHTTPResource(TestConstants.API_INTEGRATIONS_V_1 + "/openapi.json")
     URL iUrl1;
 
+    @TestHTTPResource("/api/" + OApiService.PRIVATE + "/v1.0/openapi.json")
+    URL privateUrl;
+
     @TestHTTPResource("/api/doesNotExist/v1.0/openapi.json")
     URL badUrl;
 
     @Test
     public void validateOpenApi() throws Exception {
 
-        URL[] urls = {nUrl, iUrl, nUrl1, iUrl1};
+        URL[] urls = {nUrl, iUrl, nUrl1, iUrl1, privateUrl};
 
         for (URL url : urls) {
             OpenApi3 model = new OpenApi3Parser().parse(url, true);

--- a/src/test/java/com/redhat/cloud/notifications/openapi/OpenApiTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/openapi/OpenApiTest.java
@@ -80,5 +80,9 @@ public class OpenApiTest {
         try (InputStream in = iUrl.openStream()) {
             Files.copy(in, Paths.get("./target/openapi.integrations.json"), StandardCopyOption.REPLACE_EXISTING);
         }
+
+        try (InputStream in = privateUrl.openStream()) {
+            Files.copy(in, Paths.get("./target/openapi.private.json"), StandardCopyOption.REPLACE_EXISTING);
+        }
     }
 }


### PR DESCRIPTION
 - This is most for dev usage on features that are not "released" yet.
   Allows the UI to read and generate the types required for querying
   the server.