### PR TITLE
Process Kafka messages with a StatelessSession

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/EndpointEmailSubscriptionResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EndpointEmailSubscriptionResources.java
@@ -15,6 +15,9 @@ public class EndpointEmailSubscriptionResources {
     @Inject
     Mutiny.Session session;
 
+    @Inject
+    Mutiny.StatelessSession statelessSession;
+
     public Uni<Boolean> subscribe(String accountNumber, String username, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
         String query = "INSERT INTO endpoint_email_subscriptions(account_id, user_id, application_id, subscription_type) " +
                 "SELECT :accountId, :userId, a.id, :subscriptionType " +
@@ -71,7 +74,7 @@ public class EndpointEmailSubscriptionResources {
     public Uni<Long> getEmailSubscribersCount(String accountNumber, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
         String query = "SELECT COUNT(id.userId) FROM EmailSubscription WHERE id.accountId = :accountId " +
                 "AND application.bundle.name = :bundleName AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
-        return session.createQuery(query, Long.class)
+        return statelessSession.createQuery(query, Long.class)
                 .setParameter("accountId", accountNumber)
                 .setParameter("bundleName", bundleName)
                 .setParameter("applicationName", applicationName)
@@ -82,7 +85,7 @@ public class EndpointEmailSubscriptionResources {
     public Uni<List<EmailSubscription>> getEmailSubscribers(String accountNumber, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
         String query = "FROM EmailSubscription WHERE id.accountId = :accountId AND application.bundle.name = :bundleName " +
                 "AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
-        return session.createQuery(query, EmailSubscription.class)
+        return statelessSession.createQuery(query, EmailSubscription.class)
                 .setParameter("accountId", accountNumber)
                 .setParameter("bundleName", bundleName)
                 .setParameter("applicationName", applicationName)

--- a/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
@@ -17,10 +17,12 @@ public class NotificationResources {
     @Inject
     Mutiny.Session session;
 
+    @Inject
+    Mutiny.StatelessSession statelessSession;
+
     public Uni<NotificationHistory> createNotificationHistory(NotificationHistory history) {
-        return Uni.createFrom().item(history)
-                .onItem().transformToUni(session::persist)
-                .call(session::flush)
+        history.prePersist(); // This method must be called manually while using a StatelessSession.
+        return statelessSession.insert(history)
                 .replaceWith(history);
     }
 

--- a/src/main/java/com/redhat/cloud/notifications/db/session/StatelessSessionProducer.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/session/StatelessSessionProducer.java
@@ -1,0 +1,26 @@
+package com.redhat.cloud.notifications.db.session;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Disposes;
+import javax.inject.Inject;
+import javax.ws.rs.Produces;
+
+public class StatelessSessionProducer {
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @Produces
+    @RequestScoped
+    public Mutiny.StatelessSession produceStatelessSession() {
+        return sessionFactory.openStatelessSession();
+    }
+
+    public void disposeStatelessSession(@Disposes Mutiny.StatelessSession session) {
+        if (session != null) {
+            session.close();
+        }
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/events/DefaultProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/DefaultProcessor.java
@@ -30,7 +30,7 @@ public class DefaultProcessor {
 
     public Multi<Endpoint> getDefaultEndpoints(Endpoint defaultEndpoint) {
         processedItems.increment();
-        return resources.getDefaultEndpoints(defaultEndpoint.getAccountId())
+        return resources.getDefaultEndpointsStateless(defaultEndpoint.getAccountId())
                 .onItem().transformToMulti(Multi.createFrom()::iterable)
                 .select().where(Endpoint::isEnabled)
                 .onItem().invoke(() -> enrichedEndpoints.increment());

--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -13,7 +13,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import org.hibernate.reactive.mutiny.Mutiny;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -28,9 +27,6 @@ public class EndpointProcessor {
     public static final String PROCESSED_ENDPOINTS_COUNTER_NAME = "processor.input.endpoint.processed";
 
     private static final Logger LOGGER = Logger.getLogger(EndpointProcessor.class.getName());
-
-    @Inject
-    Mutiny.Session session;
 
     @Inject
     EndpointResources resources;
@@ -77,8 +73,7 @@ public class EndpointProcessor {
                 .onItem().transformToUniAndConcatenate(history -> notifResources.createNotificationHistory(history)
                         .onFailure().invoke(failure -> LOGGER.severe("Notification history creation failed for " + history.getEndpoint()))
                 )
-                .onItem().ignoreAsUni()
-                .onItemOrFailure().call(() -> Uni.createFrom().item(() -> session.clear()));
+                .onItem().ignoreAsUni();
     }
 
     public EndpointTypeProcessor endpointTypeToProcessor(EndpointType endpointType) {

--- a/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -32,7 +32,7 @@ public class EventConsumer {
     MeterRegistry registry;
 
     @Inject
-    EndpointProcessor destinations;
+    EndpointProcessor endpointProcessor;
 
     private Counter rejectedCount;
     private Counter processingErrorCount;
@@ -56,7 +56,7 @@ public class EventConsumer {
                 .stage(self -> self
                                 // Second pipeline stage - enrich from input to destination (webhook) processor format
                                 .onItem()
-                                .transformToUni(action -> destinations.process(action)
+                                .transformToUni(action -> endpointProcessor.process(action)
                                         .onFailure().invoke(t -> processingErrorCount.increment())
                                 )
                         // Receive only notification of completion


### PR DESCRIPTION
This PR replaces the Hibernate Reactive regular session with a `StatelessSession` for all database queries executed during a Kafka message processing.

> A stateless session:
>- doesn’t have a first-level cache (persistence context), nor does it interact with any second-level caches, and
>- doesn’t implement transactional write-behind or automatic dirty checking, so all operations are executed immediately when they’re explicitly called.

https://hibernate.org/reactive/documentation/1.0/reference/html_single/#_stateless_sessions

⚠️ Persistence operations never cascade to associated instances with a `StatelessSession` (it's not a problem in this PR).

Why do that? Because:

1. The regular session is supposed to be short-lived and discarded at the end of a single logical unit of work. In other words, it should be discarded each time a Kafka message has been processed. We couldn't do that automatically in `EndpointProcessor` because the session produced by Quarkus is `@RequestScoped` and SM Reactive Messaging uses a single request to process all messages received by a method annotated with `@Incoming`. That's why we had the `session.clear()` workaround in `EndpointProcessor` until now.

2. We have a lot of persistence issues on stage at the end of Kafka messages processing. I'm not 100% sure of the cause but I think that's related to the `session.clear()` workaround which may not be working very well when endpoints are deleted.

This may (I hope so) or may not fix the stage issues. Using a `StatelessSession` is a much better practice than clearing the session so this is an improvement anyway.