### PR TITLE
Remove stage endpoint issue investigation API

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -65,7 +65,6 @@ public class EndpointProcessor {
                 action.getApplication(),
                 action.getEventType())
                 .onItem().transformToUniAndConcatenate(endpoint -> {
-                    LOGGER.fine(() -> "Sending notification to " + endpoint);
                     endpointTargeted.increment();
                     Notification endpointNotif = new Notification(action, endpoint);
                     return endpointTypeToProcessor(endpoint.getType()).process(endpointNotif);

--- a/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -2,10 +2,8 @@ package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.db.ApplicationResources;
 import com.redhat.cloud.notifications.db.BundleResources;
-import com.redhat.cloud.notifications.db.EndpointResources;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
-import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EventType;
 import io.smallrye.mutiny.Uni;
 
@@ -21,7 +19,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
@@ -37,9 +34,6 @@ public class InternalService {
 
     @Inject
     ApplicationResources appResources;
-
-    @Inject
-    EndpointResources endpointResoures;
 
     @POST
     @Path("/bundles")
@@ -152,13 +146,5 @@ public class InternalService {
     @Produces(APPLICATION_JSON)
     public Uni<Boolean> deleteEventType(@PathParam("eventTypeId") UUID eventTypeId) {
         return appResources.deleteEventTypeById(eventTypeId);
-    }
-
-    // TODO: Remove this when we're done investigating the Stage ghost endpoint issue.
-    @GET
-    @Path("/endpoints/{endpointId}")
-    @Produces(APPLICATION_JSON)
-    public Uni<Endpoint> getEndpoint(@PathParam("endpointId") UUID endpointId, @NotNull @QueryParam("account") String account) {
-        return endpointResoures.getEndpoint(account, endpointId);
     }
 }


### PR DESCRIPTION
The API served its purpose: the endpoint was never actually deleted from the database when we had a foreign key constraint violation.