### PR TITLE
NOTIF-226 Introduce maintenance mode

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/Constants.java
+++ b/src/main/java/com/redhat/cloud/notifications/Constants.java
@@ -6,4 +6,5 @@ package com.redhat.cloud.notifications;
 public interface Constants {
     String API_INTEGRATIONS_V_1_0 = "/api/integrations/v1.0";
     String API_NOTIFICATIONS_V_1_0 = "/api/notifications/v1.0";
+    String INTERNAL = "/internal";
 }

--- a/src/main/java/com/redhat/cloud/notifications/auth/rhid/RHIdentityAuthMechanism.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/rhid/RHIdentityAuthMechanism.java
@@ -15,6 +15,8 @@ import javax.enterprise.context.ApplicationScoped;
 import java.util.Collections;
 import java.util.Set;
 
+import static com.redhat.cloud.notifications.Constants.INTERNAL;
+
 /**
  * Implements Jakarta EE JSR-375 (Security API) HttpAuthenticationMechanism for the insight's
  * x-rh-identity header and RBAC
@@ -31,7 +33,7 @@ public class RHIdentityAuthMechanism implements HttpAuthenticationMechanism {
 
         // Those two come via Turnpike and have a different identity header.
         // Skip the header check for now
-        if (path.startsWith("/internal/")) {
+        if (path.startsWith(INTERNAL + "/")) {
             return Uni.createFrom().item(QuarkusSecurityIdentity.builder()
                 // Set a dummy principal, but add no roles.
                 .setPrincipal(new RhIdPrincipal("-noauth-", "-1"))
@@ -48,7 +50,7 @@ public class RHIdentityAuthMechanism implements HttpAuthenticationMechanism {
                 if (path.endsWith("openapi.json")) {
                     good = true;
                 }
-            } else if (path.startsWith("/openapi.json") || path.startsWith("/internal")
+            } else if (path.startsWith("/openapi.json") || path.startsWith(INTERNAL)
                     || path.startsWith("/admin") || path.startsWith("/health") || path.startsWith("/metrics")) {
                 good = true;
             }

--- a/src/main/java/com/redhat/cloud/notifications/db/StatusResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/StatusResources.java
@@ -1,0 +1,32 @@
+package com.redhat.cloud.notifications.db;
+
+import com.redhat.cloud.notifications.models.CurrentStatus;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class StatusResources {
+
+    @Inject
+    Mutiny.Session session;
+
+    public Uni<CurrentStatus> getCurrentStatus() {
+        String query = "FROM CurrentStatus";
+        return session.createQuery(query, CurrentStatus.class)
+                .getSingleResult();
+    }
+
+    public Uni<Void> setCurrentStatus(CurrentStatus currentStatus) {
+        String query = "UPDATE CurrentStatus SET status = :status, startTime = :startTime, endTime = :endTime";
+        return session.createQuery(query)
+                .setParameter("status", currentStatus.getStatus())
+                .setParameter("startTime", currentStatus.getStartTime())
+                .setParameter("endTime", currentStatus.getEndTime())
+                .executeUpdate()
+                .call(session::flush)
+                .replaceWith(Uni.createFrom().voidItem());
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/db/converters/StatusConverter.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/converters/StatusConverter.java
@@ -1,0 +1,28 @@
+package com.redhat.cloud.notifications.db.converters;
+
+import com.redhat.cloud.notifications.models.Status;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class StatusConverter implements AttributeConverter<Status, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Status status) {
+        if (status == null) {
+            return null;
+        } else {
+            return status.name();
+        }
+    }
+
+    @Override
+    public Status convertToEntityAttribute(String name) {
+        if (name == null) {
+            return null;
+        } else {
+            return Status.valueOf(name);
+        }
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/models/CurrentStatus.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/CurrentStatus.java
@@ -1,0 +1,76 @@
+package com.redhat.cloud.notifications.models;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.redhat.cloud.notifications.db.converters.StatusConverter;
+import com.redhat.cloud.notifications.models.validation.MaintenanceWithTimeInterval;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@Entity
+@Table(name = "status")
+@JsonNaming(SnakeCaseStrategy.class)
+@MaintenanceWithTimeInterval
+public class CurrentStatus {
+
+    /*
+     * We don't need this field in the Java code but Hibernate needs each @Entity to have a field annotated with @Id.
+     * This field has a real purpose in the database though: it is used to guarantee that the status table will never
+     * contain more than one row. This is done with a combination of PK and CHECK SQL constraints.
+     */
+    @Id
+    @JsonIgnore
+    private boolean preventMultipleRows = true;
+
+    @NotNull
+    @Convert(converter = StatusConverter.class)
+    @Column(name = "value")
+    public Status status;
+
+    @JsonInclude(NON_NULL)
+    @JsonFormat(shape = STRING)
+    @Schema(name = "start_time")
+    private LocalDateTime startTime;
+
+    @JsonInclude(NON_NULL)
+    @JsonFormat(shape = STRING)
+    @Schema(name = "end_time")
+    private LocalDateTime endTime;
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/models/Status.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/Status.java
@@ -1,0 +1,6 @@
+package com.redhat.cloud.notifications.models;
+
+public enum Status {
+    UP,
+    MAINTENANCE
+}

--- a/src/main/java/com/redhat/cloud/notifications/models/validation/MaintenanceWithTimeInterval.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/validation/MaintenanceWithTimeInterval.java
@@ -1,0 +1,30 @@
+package com.redhat.cloud.notifications.models.validation;
+
+import com.redhat.cloud.notifications.models.CurrentStatus;
+import com.redhat.cloud.notifications.models.Status;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Checks that {@link CurrentStatus#startTime} and {@link CurrentStatus#endTime} are not {@code null} and valid when
+ * {@link CurrentStatus#status CurrentStatus#status} is equal to {@link Status#MAINTENANCE MAINTENANCE}.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@Constraint(validatedBy = MaintenanceWithTimeIntervalValidator.class)
+@Documented
+public @interface MaintenanceWithTimeInterval {
+
+    String message() default "A valid time interval is mandatory for the maintenance status";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/redhat/cloud/notifications/models/validation/MaintenanceWithTimeIntervalValidator.java
+++ b/src/main/java/com/redhat/cloud/notifications/models/validation/MaintenanceWithTimeIntervalValidator.java
@@ -1,0 +1,26 @@
+package com.redhat.cloud.notifications.models.validation;
+
+import com.redhat.cloud.notifications.models.CurrentStatus;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import static com.redhat.cloud.notifications.models.Status.MAINTENANCE;
+
+public class MaintenanceWithTimeIntervalValidator implements ConstraintValidator<MaintenanceWithTimeInterval, CurrentStatus> {
+
+    @Override
+    public boolean isValid(CurrentStatus value, ConstraintValidatorContext context) {
+        if (value.getStatus() == MAINTENANCE) {
+            // The time interval is mandatory for maintenance.
+            if (value.getStartTime() == null || value.getEndTime() == null) {
+                return false;
+            }
+            // The time interval must be valid.
+            if (value.getStartTime().isAfter(value.getEndTime())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/routers/AdminService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/AdminService.java
@@ -15,13 +15,14 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.Optional;
 
+import static com.redhat.cloud.notifications.Constants.INTERNAL;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
 /**
  * Stuff around admin of the service and debugging
  */
-@Path("/internal/admin")
+@Path(INTERNAL + "/admin")
 public class AdminService {
 
     @Inject

--- a/src/main/java/com/redhat/cloud/notifications/routers/BehaviorGroupMigrationService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/BehaviorGroupMigrationService.java
@@ -34,10 +34,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import static com.redhat.cloud.notifications.Constants.INTERNAL;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @RequestScoped
-@Path("/internal/behaviorGroups/migrate")
+@Path(INTERNAL + "/behaviorGroups/migrate")
 public class BehaviorGroupMigrationService {
 
     public static final String CONFIRMATION_TOKEN = "ready-set-go";

--- a/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -2,8 +2,10 @@ package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.db.ApplicationResources;
 import com.redhat.cloud.notifications.db.BundleResources;
+import com.redhat.cloud.notifications.db.StatusResources;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.CurrentStatus;
 import com.redhat.cloud.notifications.models.EventType;
 import io.smallrye.mutiny.Uni;
 
@@ -23,10 +25,11 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
 
+import static com.redhat.cloud.notifications.Constants.INTERNAL;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
-@Path("/internal")
+@Path(INTERNAL)
 public class InternalService {
 
     @Inject
@@ -34,6 +37,9 @@ public class InternalService {
 
     @Inject
     ApplicationResources appResources;
+
+    @Inject
+    StatusResources statusResources;
 
     @POST
     @Path("/bundles")
@@ -146,5 +152,12 @@ public class InternalService {
     @Produces(APPLICATION_JSON)
     public Uni<Boolean> deleteEventType(@PathParam("eventTypeId") UUID eventTypeId) {
         return appResources.deleteEventTypeById(eventTypeId);
+    }
+
+    @PUT
+    @Path("/status")
+    @Consumes(APPLICATION_JSON)
+    public Uni<Void> setCurrentStatus(@NotNull @Valid CurrentStatus status) {
+        return statusResources.setCurrentStatus(status);
     }
 }

--- a/src/main/java/com/redhat/cloud/notifications/routers/StatusService.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/StatusService.java
@@ -1,0 +1,28 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.db.StatusResources;
+import com.redhat.cloud.notifications.models.CurrentStatus;
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path(API_NOTIFICATIONS_V_1_0 + "/status")
+public class StatusService {
+
+    @Inject
+    StatusResources statusResources;
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    @Tag(name = OApiService.PRIVATE)
+    public Uni<CurrentStatus> getCurrentStatus() {
+        return statusResources.getCurrentStatus();
+    }
+}

--- a/src/main/java/com/redhat/cloud/notifications/routers/filters/MaintenanceModeRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/notifications/routers/filters/MaintenanceModeRequestFilter.java
@@ -1,0 +1,80 @@
+package com.redhat.cloud.notifications.routers.filters;
+
+import com.redhat.cloud.notifications.db.StatusResources;
+import io.quarkus.cache.CacheResult;
+import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+
+import java.util.List;
+
+import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
+import static com.redhat.cloud.notifications.Constants.INTERNAL;
+import static com.redhat.cloud.notifications.models.Status.MAINTENANCE;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
+
+@ApplicationScoped
+public class MaintenanceModeRequestFilter {
+
+    private static final Logger LOGGER = Logger.getLogger(MaintenanceModeRequestFilter.class.getName());
+
+    // This list contains all request paths that should never be affected by the maintenance mode.
+    private static final List<String> NO_MAINTENANCE_REQUEST_PATHS = List.of(
+            INTERNAL,
+            "/health",
+            "/metrics",
+            API_NOTIFICATIONS_V_1_0 + "/status"
+    );
+
+    private static final Response MAINTENANCE_IN_PROGRESS = Response.status(SERVICE_UNAVAILABLE).entity("Maintenance in progress").build();
+
+    @Inject
+    StatusResources statusResources;
+
+    @ServerRequestFilter
+    public Uni<Response> filter(ContainerRequestContext requestContext) {
+        String requestPath = requestContext.getUriInfo().getRequestUri().getPath();
+        LOGGER.tracef("Filtering request to %s", requestPath);
+
+        // First, we check if the request path should be affected by the maintenance mode.
+        for (int i = 0; i < NO_MAINTENANCE_REQUEST_PATHS.size(); i++) {
+            if (requestPath.startsWith(NO_MAINTENANCE_REQUEST_PATHS.get(i))) {
+                LOGGER.trace("Request path shouldn't be affected by the maintenance mode, database check will be skipped");
+                // This filter work is done. The request will be processed normally.
+                return null;
+            }
+        }
+
+        /*
+         * If this point is reached, the current request path can be affected by the maintenance mode.
+         * Let's check if maintenance is on in the database.
+         */
+        return isMaintenance()
+                .onItem().transform(isMaintenance -> {
+                    if (isMaintenance) {
+                        LOGGER.trace("Maintenance mode is enabled in the database, aborting request and returning HTTP status 503");
+                        return MAINTENANCE_IN_PROGRESS;
+                    } else {
+                        // This filter work is done. The request will be processed normally.
+                        return null;
+                    }
+                });
+    }
+
+    @CacheResult(cacheName = "maintenance")
+    public Uni<Boolean> isMaintenance() {
+        /*
+         * We have to memoize (which is the Mutiny word for cache) the Uni result here because quarkus-cache does not
+         * support caching Uni in Quarkus 1.x.
+         * This is already fixed in Quarkus 2.0: see https://github.com/quarkusio/quarkus/pull/16608
+         */
+        return statusResources.getCurrentStatus()
+                .onItem().transform(currentStatus -> currentStatus.status == MAINTENANCE)
+                .memoize().indefinitely(); // TODO Remove memoize after Quarkus is bumped to 2.0
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -108,3 +108,6 @@ quarkus.log.cloudwatch.log-stream-name=notifications-backend
 quarkus.log.cloudwatch.level=INFO
 quarkus.log.cloudwatch.access-key-id=placeholder
 quarkus.log.cloudwatch.access-key-secret=placeholder
+
+# The current status is cached to limit the number of status DB queries
+quarkus.cache.caffeine.maintenance.expire-after-write=PT60s

--- a/src/main/resources/db/migration/V1.20.0__NOTIF-226_maintenance_mode.sql
+++ b/src/main/resources/db/migration/V1.20.0__NOTIF-226_maintenance_mode.sql
@@ -1,0 +1,10 @@
+CREATE TABLE status (
+    value VARCHAR(11) NOT NULL,
+    start_time TIMESTAMP,
+    end_time TIMESTAMP,
+    -- The following PK and CHECK constraints combination guarantees that the table will never contain more than one row.
+    prevent_multiple_rows BOOLEAN PRIMARY KEY DEFAULT TRUE,
+    CONSTRAINT status_table_should_never_contain_multiple_rows CHECK (prevent_multiple_rows)
+) WITH (OIDS=FALSE);
+
+INSERT INTO status (value) VALUES ('UP');

--- a/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
@@ -12,6 +12,7 @@ import com.redhat.cloud.notifications.models.EndpointTarget;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.EventTypeBehavior;
 import com.redhat.cloud.notifications.models.NotificationHistory;
+import com.redhat.cloud.notifications.models.Status;
 import com.redhat.cloud.notifications.models.WebhookProperties;
 import io.smallrye.mutiny.Uni;
 import org.hibernate.reactive.mutiny.Mutiny;
@@ -22,7 +23,9 @@ import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 
-@Path("/internal/db_cleaner")
+import static com.redhat.cloud.notifications.Constants.INTERNAL;
+
+@Path(INTERNAL + "/db_cleaner")
 public class DbCleaner {
 
     private static final String DEFAULT_BUNDLE_NAME = "rhel";
@@ -84,6 +87,11 @@ public class DbCleaner {
                     eventType.setDescription(DEFAULT_EVENT_TYPE_DESCRIPTION);
                     return appResources.createEventType(eventType);
                 })
+                .onItem().transformToUni(ignored ->
+                        session.createQuery("UPDATE CurrentStatus SET status = :status")
+                                .setParameter("status", Status.UP)
+                                .executeUpdate()
+                )
                 .replaceWith(Uni.createFrom().voidItem())
         );
     }

--- a/src/test/java/com/redhat/cloud/notifications/db/DbIsolatedTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/db/DbIsolatedTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.db;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+import static com.redhat.cloud.notifications.Constants.INTERNAL;
 import static io.restassured.RestAssured.given;
 
 /**
@@ -15,7 +16,7 @@ public abstract class DbIsolatedTest {
     @AfterEach
     void cleanDatabase() {
         given()
-                .basePath("/internal")
+                .basePath(INTERNAL)
                 .delete("/db_cleaner")
                 .then()
                 .statusCode(204);

--- a/src/test/java/com/redhat/cloud/notifications/routers/StatusServiceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/routers/StatusServiceTest.java
@@ -1,0 +1,181 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.MockServerClientConfig;
+import com.redhat.cloud.notifications.MockServerConfig;
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.models.CurrentStatus;
+import com.redhat.cloud.notifications.models.Status;
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.Header;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static com.redhat.cloud.notifications.Constants.INTERNAL;
+import static com.redhat.cloud.notifications.TestConstants.API_INTEGRATIONS_V_1_0;
+import static com.redhat.cloud.notifications.TestConstants.API_NOTIFICATIONS_V_1_0;
+import static com.redhat.cloud.notifications.models.Status.MAINTENANCE;
+import static com.redhat.cloud.notifications.models.Status.UP;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class StatusServiceTest extends DbIsolatedTest {
+
+    @MockServerConfig
+    MockServerClientConfig mockServerConfig;
+
+    @Test
+    public void testValidCurrentStatus() {
+        String identityHeaderValue = TestHelpers.encodeIdentityInfo("tenant", "username");
+        Header identityHeader = TestHelpers.createIdentityHeader(identityHeaderValue);
+        mockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
+
+        // The test must not be run with a cached status from another test.
+        clearCachedStatus();
+
+        /*
+         * First, let's check that all APIs are available.
+         * We won't test /health because it's always DOWN and returns 503 during tests.
+         */
+        getMetrics();
+        getBundles();
+        getEndpoints(identityHeader, 200);
+        getEventTypes(identityHeader, 200);
+
+        // Now let's see if the current status is UP.
+        getCurrentStatus(identityHeader, UP.name(), null, null);
+
+        // Let's change that to MAINTENANCE with start and end times.
+        LocalDateTime startTime = LocalDateTime.now();
+        LocalDateTime endTime = startTime.plusHours(1L);
+        putCurrentStatus(MAINTENANCE, startTime, endTime, 204);
+
+        // The cache is cleared again because we don't want to wait for the normal expiration delay.
+        clearCachedStatus();
+
+        // Retrieving the current status should reflect that change.
+        getCurrentStatus(identityHeader, MAINTENANCE.name(), startTime.toString(), endTime.toString());
+
+        // The maintenance is on but /internal and /metrics should still be available.
+        getMetrics();
+        getBundles();
+
+        // On the other hand, /api/integrations and /api/notifications should return 503.
+        getEndpoints(identityHeader, 503);
+        getEventTypes(identityHeader, 503);
+
+        // We don't want other tests to be run with maintenance mode on.
+        clearCachedStatus();
+    }
+
+    @Test
+    public void testInvalidCurrentStatus() {
+        // Null values.
+        putCurrentStatus(MAINTENANCE, null, LocalDateTime.now(), 400);
+        putCurrentStatus(MAINTENANCE, LocalDateTime.now(), null, 400);
+        putCurrentStatus(MAINTENANCE, null, null, 400);
+        // End time before start time.
+        putCurrentStatus(MAINTENANCE, LocalDateTime.now(), LocalDateTime.now().minusHours(1L), 400);
+    }
+
+    @CacheInvalidate(cacheName = "maintenance")
+    void clearCachedStatus() {
+        /*
+         * This would normally happen after a certain duration fixed in application.properties with the
+         * quarkus.cache.caffeine.maintenance.expire-after-write key.
+         */
+    }
+
+    private void getMetrics() {
+        given()
+                .when()
+                .get("/metrics")
+                .then()
+                .statusCode(200);
+    }
+
+    private void getBundles() {
+        given()
+                .basePath(INTERNAL)
+                .when()
+                .get("/bundles")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
+    }
+
+    private void getEndpoints(Header identityHeader, int expectedStatusCode) {
+        given()
+                .basePath(API_INTEGRATIONS_V_1_0)
+                .header(identityHeader)
+                .when()
+                .get("/endpoints")
+                .then()
+                .statusCode(expectedStatusCode);
+    }
+
+    private void getEventTypes(Header identityHeader, int expectedStatusCode) {
+        given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .when()
+                .get("/notifications/eventTypes")
+                .then()
+                .statusCode(expectedStatusCode);
+    }
+
+    private void getCurrentStatus(Header identityHeader, String expectedStatus, String expectedStartTime, String expectedEndTime) {
+        String responseBody = given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .when()
+                .get("/status")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().asString();
+
+        JsonObject jsonCurrentStatus = new JsonObject(responseBody);
+        jsonCurrentStatus.mapTo(CurrentStatus.class);
+        assertEquals(expectedStatus, jsonCurrentStatus.getString("status"));
+        if (expectedStartTime == null) {
+            assertNull(jsonCurrentStatus.getString("start_time"));
+        } else {
+            // Jackson serializes LocalDateTime with a precision slightly smaller than LocalDateTime.toString().
+            assertTrue(expectedStartTime.startsWith(jsonCurrentStatus.getString("start_time")));
+        }
+        if (expectedEndTime == null) {
+            assertNull(jsonCurrentStatus.getString("end_time"));
+        } else {
+            // Jackson serializes LocalDateTime with a precision slightly smaller than LocalDateTime.toString().
+            assertTrue(expectedEndTime.startsWith(jsonCurrentStatus.getString("end_time")));
+        }
+    }
+
+    private void putCurrentStatus(Status status, LocalDateTime startTime, LocalDateTime endTime, int expectedStatusCode) {
+        CurrentStatus currentStatus = new CurrentStatus();
+        currentStatus.setStatus(status);
+        currentStatus.setStartTime(startTime);
+        currentStatus.setEndTime(endTime);
+
+        given()
+                .basePath(INTERNAL)
+                .contentType(JSON)
+                .body(Json.encode(currentStatus))
+                .when()
+                .put("/status")
+                .then()
+                .statusCode(expectedStatusCode);
+    }
+}


### PR DESCRIPTION
⚠️ This does NOT include a maintenance mode for the Kafka messages processing. It only affects REST APIs calls.

Get the current status: `GET /api/notifications/v1.0/status`
Change the current status: `PUT /internal/status`

`GET`/`PUT` will respectively return/accept this data structure:

```
{
    "status": "UP",
    "start_time": "2021-06-11T13:09:31.213141",
    "end_time": "2021-06-11T13:09:31.213141"
}
```

The status can be set to:

- `UP`: all APIs are available
- `MAINTENANCE`: `/internal/*`, `/health/*`, `/metrics*` and `/api/notifications/v1.0/status` are available, all other APIs return 503

**❓ How does maintenance mode work?**

I introduced `MaintenanceModeRequestFilter` which performs two checks before a REST API call is processed:

- First it checks whether the API should be affected by maintenance mode or not.
- Then if the API should be affected, it retrieves the current status from the database. If that status is `MAINTENANCE`, then the API will return 503 with the `Maintenance in progress` message.

**❓ Why persist the status in the database?**

Because in-memory status management won't work if we deploy more than one pod. Maintenance mode has to be enabled on all pods at once.

**❓ Won't the filter execute too many database queries?**

No because the queries result will be cached for a certain amount of time defined in `application.properties` (60 seconds in this PR) . It means that one pod will query the database to retrieve the status at most once per minute. ⚠️ It also means that when we enable the maintenance mode, we should wait for at least one minute before considering the app is in maintenance for real.