### PR TITLE
Fix build time injection warning

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
+++ b/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
@@ -19,7 +19,7 @@ public class NotificationsApp {
     private static final Pattern pattern = Pattern.compile(FILTER_REGEX);
 
     @ConfigProperty(name = "quarkus.http.access-log.category")
-    private String loggerName;
+    String loggerName;
 
     private static final Logger LOG = Logger.getLogger(NotificationsApp.class);
 


### PR DESCRIPTION
Fixes:

```
[INFO] [io.quarkus.arc.processor.BeanProcessor] Found unrecommended usage of private members (use package-private instead) in application beans:
        - @Inject field com.redhat.cloud.notifications.NotificationsApp#loggerName
```