### PR TITLE
NOTIF-150 Enable Kafka ingress channel

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,9 +13,6 @@ mp.messaging.incoming.ingress.topic=platform.notifications.ingress
 mp.messaging.incoming.ingress.group.id=integrations
 mp.messaging.incoming.ingress.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.ingress.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-%prod.mp.messaging.incoming.ingress.enabled=false # TODO [BG Phase 2.3] Remove this line
-
-%prod.quarkus.health.extensions.enabled=false # TODO [BG Phase 2.3] Remove this line
 
 # Output queue to Camel (notifications-sender)
 mp.messaging.outgoing.toCamel.connector=smallrye-kafka


### PR DESCRIPTION
Based on #312.

The Docker image resulting from this PR build should be deployed on prod:
- After the data migration is done.
- Before the maintenance mode is disabled.