### PR TITLE
NOTIF-150 Prevent duplicate notifications for a single endpoint

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -111,7 +111,7 @@ public class EndpointResources {
     }
 
     public Multi<Endpoint> getTargetEndpoints(String tenant, String bundleName, String applicationName, String eventTypeName) {
-        String query = "SELECT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
+        String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
                 "WHERE e.enabled = TRUE AND b.eventType.name = :eventTypeName AND bga.behaviorGroup.accountId = :accountId " +
                 "AND b.eventType.application.name = :applicationName AND b.eventType.application.bundle.name = :bundleName";
 

--- a/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -144,16 +144,16 @@ public class LifecycleITest extends DbIsolatedTest {
 
         /*
          * Let's change the behavior group actions configuration by adding an action to the second behavior group.
-         * Endpoint 2 is now an action for both behavior groups, so it should be notified twice on each message.
+         * Endpoint 2 is now an action for both behavior groups, but it should not be notified twice on each message because we don't want duplicate notifications.
          */
         addBehaviorGroupActions(identityHeader, behaviorGroupId2, endpointId3, endpointId2);
 
-        // Pushing a new message should trigger four webhook calls.
-        pushMessage(4);
+        // Pushing a new message should trigger three webhook calls.
+        pushMessage(3);
 
         // Let's check the notifications history again.
         checkEndpointHistory(identityHeader, endpointId1, 3, true, 200);
-        checkEndpointHistory(identityHeader, endpointId2, 4, true, 200);
+        checkEndpointHistory(identityHeader, endpointId2, 3, true, 200);
         checkEndpointHistory(identityHeader, endpointId3, 2, false, 400);
 
         /*
@@ -166,7 +166,7 @@ public class LifecycleITest extends DbIsolatedTest {
 
         // The notifications history should be exactly the same than last time.
         checkEndpointHistory(identityHeader, endpointId1, 3, true, 200);
-        checkEndpointHistory(identityHeader, endpointId2, 4, true, 200);
+        checkEndpointHistory(identityHeader, endpointId2, 3, true, 200);
         checkEndpointHistory(identityHeader, endpointId3, 2, false, 400);
 
         /*


### PR DESCRIPTION
With this PR, if:
- `endpoint` is linked with `behavior group A` and `behavior group B`
- `event type` is linked with `behavior group A` and `behavior group B`

when we will process a Kafka message for `event type`, `endpoint` will only be notified once.

Duplicate email notifications are still possible (with different endpoints), that's only the first step towards duplicates prevention.