### PR TITLE
Fix test race condition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
             <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
This fixes a test race condition:

1. The test produces a Kafka message in the `ingress` channel and waits for a webhook call.
2. The message is processed and the webhook call is done.
3. Then in an unpredictable order, an history entry is persisted and the test tries to retrieve that entry. Sometimes, the retrieval happens before the entry was persisted.

cc @josejulio 