### PR TITLE
NOTIF-236 Lay some groundwork for email duplicates prevention

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -5,7 +5,6 @@ import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.WebhookProperties;
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import org.hibernate.reactive.mutiny.Mutiny;
 
@@ -110,7 +109,7 @@ public class EndpointResources {
         return mutinyQuery.getSingleResult();
     }
 
-    public Multi<Endpoint> getTargetEndpoints(String tenant, String bundleName, String applicationName, String eventTypeName) {
+    public Uni<List<Endpoint>> getTargetEndpoints(String tenant, String bundleName, String applicationName, String eventTypeName) {
         String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
                 "WHERE e.enabled = TRUE AND b.eventType.name = :eventTypeName AND bga.behaviorGroup.accountId = :accountId " +
                 "AND b.eventType.application.name = :applicationName AND b.eventType.application.bundle.name = :bundleName";
@@ -121,8 +120,7 @@ public class EndpointResources {
                 .setParameter("accountId", tenant)
                 .setParameter("bundleName", bundleName)
                 .getResultList()
-                .onItem().call(endpoints -> loadProperties(endpoints, true))
-                .onItem().transformToMulti(Multi.createFrom()::iterable);
+                .onItem().call(endpoints -> loadProperties(endpoints, true));
     }
 
     public Uni<List<Endpoint>> getEndpoints(String tenant, Query limiter) {

--- a/src/main/java/com/redhat/cloud/notifications/processors/EndpointTypeProcessor.java
+++ b/src/main/java/com/redhat/cloud/notifications/processors/EndpointTypeProcessor.java
@@ -1,9 +1,12 @@
 package com.redhat.cloud.notifications.processors;
 
-import com.redhat.cloud.notifications.models.Notification;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.NotificationHistory;
-import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.Multi;
+
+import java.util.List;
 
 public interface EndpointTypeProcessor {
-    Uni<NotificationHistory> process(Notification notification);
+    Multi<NotificationHistory> process(Action action, List<Endpoint> endpoints);
 }

--- a/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
@@ -10,13 +10,12 @@ import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.HttpType;
-import com.redhat.cloud.notifications.models.Notification;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.WebhookProperties;
 import com.redhat.cloud.notifications.processors.webhooks.WebhookTypeProcessor;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.Multi;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
@@ -114,10 +113,9 @@ public class WebhookTest extends DbIsolatedTest {
         ep.setEnabled(true);
         ep.setProperties(properties);
 
-        Notification notif = new Notification(webhookActionMessage, ep);
         try {
-            Uni<NotificationHistory> process = webhookTypeProcessor.process(notif);
-            NotificationHistory history = process.await().indefinitely();
+            Multi<NotificationHistory> process = webhookTypeProcessor.process(webhookActionMessage, List.of(ep));
+            NotificationHistory history = process.collect().asList().await().indefinitely().get(0);
             assertTrue(history.isInvocationResult());
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
This ticket will be divided into two PRs (reviews will be easier). This one changes the way actions are processed:

| Before | After |
| - | - |
| Each target endpoint is processed separately by the relevant processor. There is no way to detect multiple `EMAIL_SUBSCRIPTION` endpoints and prevent email duplicates. | Each processor receives all the endpoints it has to notify at once for a single action. Email duplicates prevention becomes possible. |

Next step: email duplicates prevention implementation.