### PR TITLE
Bump mockserver-client-java to 5.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <checkstyle-plugin.version>3.1.2</checkstyle-plugin.version>
         <checkstyle.version>8.43</checkstyle.version>
         <testcontainers.version>1.15.3</testcontainers.version>
-        <mockserver-client-java.version>5.5.4</mockserver-client-java.version> <!-- not the newest, but matches what is in org.testcontainers:mockserver -->
+        <mockserver-client-java.version>5.11.2</mockserver-client-java.version> <!-- Keep the version synced with TestLifecycleManager -->
         <version.cloud-commons>0.1.1</version.cloud-commons>
         <openapi-parser.version>4.0.4</openapi-parser.version>
         <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>

--- a/src/test/java/com/redhat/cloud/notifications/MockServerClientConfig.java
+++ b/src/test/java/com/redhat/cloud/notifications/MockServerClientConfig.java
@@ -28,8 +28,8 @@ public class MockServerClientConfig {
         }
     }
 
-    public MockServerClientConfig(MockServerClient mockServerClient) {
-        this.mockServerClient = mockServerClient;
+    public MockServerClientConfig(String containerIpAddress, Integer serverPort) {
+        mockServerClient = new MockServerClient(containerIpAddress, serverPort);
     }
 
     public void addMockRbacAccess(String xRhIdentity, RbacAccess access) {

--- a/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -27,6 +27,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 import org.mockserver.model.HttpRequest;
+import org.mockserver.model.RequestDefinition;
 
 import javax.enterprise.inject.Any;
 import javax.inject.Inject;
@@ -405,7 +406,7 @@ public class LifecycleITest extends DbIsolatedTest {
         if (expectedWebhookCalls > 0) {
             if (!requestsCounter.await(30, TimeUnit.SECONDS)) {
                 fail("HttpServer never received the requests");
-                HttpRequest[] httpRequests = mockServerConfig.getMockServerClient().retrieveRecordedRequests(expectedRequestPattern);
+                RequestDefinition[] httpRequests = mockServerConfig.getMockServerClient().retrieveRecordedRequests(expectedRequestPattern);
                 assertEquals(2, httpRequests.length);
                 // Verify calls were correct, sort first?
             }


### PR DESCRIPTION
While adding mockserver to policies-engine, I realized we're not actually stuck with `mockserver-client-java:5.5.4`.