### PR TITLE
Fix tests instability

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -25,7 +25,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKN
 public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
 
     // Keep the version synced with pom.xml.
-    private static final DockerImageName MOCK_SERVER_DOCKER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.11.2");
+    private static final DockerImageName MOCK_SERVER_DOCKER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.5.4");
 
     PostgreSQLContainer<?> postgreSQLContainer;
     MockServerContainer mockEngineServer;

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -42,7 +42,7 @@ public class EventConsumerTest {
     InMemoryConnector inMemoryConnector;
 
     @InjectMock
-    EndpointProcessor destinations;
+    EndpointProcessor endpointProcessor;
 
     @Inject
     CounterAssertionHelper counterAssertionHelper;
@@ -64,7 +64,7 @@ public class EventConsumerTest {
         inMemoryConnector.source("ingress").send(serializedAction);
         counterAssertionHelper.assertIncrement(REJECTED_COUNTER_NAME, 0);
         counterAssertionHelper.assertIncrement(PROCESSING_ERROR_COUNTER_NAME, 0);
-        verify(destinations, times(1)).process(eq(action));
+        verify(endpointProcessor, times(1)).process(eq(action));
     }
 
     @Test
@@ -72,20 +72,20 @@ public class EventConsumerTest {
         inMemoryConnector.source("ingress").send("I am not a valid serialized action!");
         counterAssertionHelper.assertIncrement(REJECTED_COUNTER_NAME, 1);
         counterAssertionHelper.assertIncrement(PROCESSING_ERROR_COUNTER_NAME, 0);
-        verify(destinations, never()).process(any(Action.class));
+        verify(endpointProcessor, never()).process(any(Action.class));
     }
 
     @Test
     void testProcessingError() throws IOException {
         Action action = buildValidAction();
         String serializedAction = serializeAction(action);
-        when(destinations.process(eq(action))).thenReturn(
+        when(endpointProcessor.process(eq(action))).thenReturn(
                 Uni.createFrom().failure(() -> new RuntimeException("I am a forced exception!"))
         );
         inMemoryConnector.source("ingress").send(serializedAction);
         counterAssertionHelper.assertIncrement(REJECTED_COUNTER_NAME, 0);
         counterAssertionHelper.assertIncrement(PROCESSING_ERROR_COUNTER_NAME, 1);
-        verify(destinations, times(1)).process(eq(action));
+        verify(endpointProcessor, times(1)).process(eq(action));
     }
 
     private static Action buildValidAction() {

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -27,7 +27,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 import org.mockserver.model.HttpRequest;
-import org.mockserver.model.RequestDefinition;
 
 import javax.enterprise.inject.Any;
 import javax.inject.Inject;
@@ -406,7 +405,7 @@ public class LifecycleITest extends DbIsolatedTest {
         if (expectedWebhookCalls > 0) {
             if (!requestsCounter.await(30, TimeUnit.SECONDS)) {
                 fail("HttpServer never received the requests");
-                RequestDefinition[] httpRequests = mockServerConfig.getMockServerClient().retrieveRecordedRequests(expectedRequestPattern);
+                HttpRequest[] httpRequests = mockServerConfig.getMockServerClient().retrieveRecordedRequests(expectedRequestPattern);
                 assertEquals(2, httpRequests.length);
                 // Verify calls were correct, sort first?
             }

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,12 @@
         <checkstyle.version>8.44</checkstyle.version>
 
         <testcontainers.version>1.15.3</testcontainers.version>
-        <mockserver-client-java.version>5.11.2</mockserver-client-java.version> <!-- Keep the version synced with TestLifecycleManager -->
         <version.cloud-commons>0.1.1</version.cloud-commons>
         <openapi-parser.version>4.0.4</openapi-parser.version>
+
+        <!-- Keep the version synced with TestLifecycleManager -->
+        <!-- Be careful with bumps, version 5.11.2 caused tests instability so we had to rollback to 5.5.4 -->
+        <mockserver-client-java.version>5.5.4</mockserver-client-java.version>
 
         <insights-notification-schemas-java.version>0.3</insights-notification-schemas-java.version>
         <clowder-quarkus-config-source.version>0.1.4</clowder-quarkus-config-source.version>


### PR DESCRIPTION
`mockserver:5.11.2` is causing the tests instability.

I tried to fix the issue without success so let's rollback to `5.5.4` for now.