### PR TITLE
NOTIF-236 Prevent duplicate email notifications

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -127,11 +127,20 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
 
     @Override
     public Multi<NotificationHistory> process(Action action, List<Endpoint> endpoints) {
-        return Multi.createFrom().iterable(endpoints)
-                .onItem().transformToUniAndConcatenate(endpoint -> {
-                    Notification notification = new Notification(action, endpoint);
-                    return process(notification);
-                });
+        if (endpoints == null || endpoints.isEmpty()) {
+            return Multi.createFrom().empty();
+        } else {
+            /*
+             * Since EmailSubscriptionProperties is currently empty, if we process all endpoints from the given list,
+             * each one of them will be used to send (and possibly aggregate) the exact same email data. This means
+             * users will receive duplicate emails for a single event. This can happen when two behavior groups are
+             * linked with the same event type and each behavior group contains an EMAIL_SUBSCRIPTION action. We need
+             * to prevent duplicate emails which is why only the first endpoint from the given list will be used.
+             * TODO: Review this logic if fields are added to EmailSubscriptionProperties.
+             */
+            Notification notification = new Notification(action, endpoints.get(0));
+            return process(notification).toMulti();
+        }
     }
 
     private Uni<NotificationHistory> process(Notification item) {


### PR DESCRIPTION
The second part is shorter than what I had in mind initially.

This code is kind of temporary. It will change if we add fields to `EmailSubscriptionProperties` and we certainly will in the future.