### PR TITLE
NOTIF-242 Prevent from creating/updating Email_Subscription endpoints

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -103,13 +103,13 @@ public class EndpointResources {
     }
 
     public Uni<Endpoint> getOrCreateEmailSubscriptionEndpoint(String accountId, EmailSubscriptionProperties properties) {
-        return getEndpointsPerType(accountId, EndpointType.EMAIL_SUBSCRIPTION, true, null)
+        return getEndpointsPerType(accountId, EndpointType.EMAIL_SUBSCRIPTION, null, null)
                 .onItem().call(this::loadProperties)
                 .onItem().transformToUni(emailEndpoints -> {
                     Optional<Endpoint> endpointOptional = emailEndpoints
                             .stream()
-                            // Todo: This should be changed once we store the properties - (properties = null right now)
-                            // .filter(endpoint -> endpoint.getProperties().equals(properties))
+                            // Todo: This should be changed once we store the properties - (properties are null right now)
+                            // .filter(endpoint -> properties.hasSameProperties((EmailSubscriptionProperties) endpoint.getProperties()))
                             .findFirst();
                     if (endpointOptional.isPresent()) {
                         return Uni.createFrom().item(endpointOptional.get());

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -94,6 +94,14 @@ public class EndpointResources {
                 .onItem().call(this::loadProperties);
     }
 
+    public Uni<EndpointType> getEndpointTypeById(String accountId, UUID endpointId) {
+        String query = "Select e.type from Endpoint e WHERE e.accountId = :accountId AND e.id = :endpointId";
+        return session.createQuery(query, EndpointType.class)
+                .setParameter("accountId", accountId)
+                .setParameter("endpointId", endpointId)
+                .getSingleResultOrNull();
+    }
+
     public Uni<Endpoint> getOrCreateEmailSubscriptionEndpoint(String accountId, EmailSubscriptionProperties properties) {
         return getEndpointsPerType(accountId, EndpointType.EMAIL_SUBSCRIPTION, true, null)
                 .onItem().call(this::loadProperties)

--- a/backend/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -63,6 +63,7 @@ public class BehaviorGroup extends CreationUpdateTimestamped {
     @JsonIgnore
     private String accountId;
 
+    @NotNull
     @NotBlank
     @Schema(name = "display_name")
     private String displayName;

--- a/backend/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionProperties.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionProperties.java
@@ -1,4 +1,22 @@
 package com.redhat.cloud.notifications.models;
 
 public class EmailSubscriptionProperties extends EndpointProperties {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof EndpointProperties)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionProperties.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionProperties.java
@@ -8,7 +8,7 @@ public class EmailSubscriptionProperties extends EndpointProperties {
             return true;
         }
 
-        if (!(o instanceof EndpointProperties)) {
+        if (!(o instanceof EmailSubscriptionProperties)) {
             return false;
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionProperties.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionProperties.java
@@ -2,21 +2,7 @@ package com.redhat.cloud.notifications.models;
 
 public class EmailSubscriptionProperties extends EndpointProperties {
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (!(o instanceof EmailSubscriptionProperties)) {
-            return false;
-        }
-
+    public boolean hasSameProperties(EmailSubscriptionProperties otherProps) {
         return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return 0;
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EmailEndpointMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EmailEndpointMigrationService.java
@@ -1,0 +1,150 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.redhat.cloud.notifications.models.BehaviorGroupAction;
+import com.redhat.cloud.notifications.models.BehaviorGroupActionId;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logging.Logger;
+
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static com.redhat.cloud.notifications.Constants.INTERNAL;
+
+// Todo: Delete after migration
+@Path(INTERNAL + "/email_endpoint/migrate")
+public class EmailEndpointMigrationService {
+
+    public static final String CONFIRMATION_TOKEN = "ready-set-go";
+
+    private static final Logger LOGGER = Logger.getLogger(EmailEndpointMigrationService.class.getName());
+
+    @Inject
+    Mutiny.Session session;
+
+    @GET
+    public Uni<MigrationReport> migrateEmailEndpoint(@QueryParam("confirmation-token") String confirmationToken) {
+        // For every account we can only have a single Endpoint.type = EmailSubscription (as of today).
+        // Fetch every account and ensure this
+        long start = System.currentTimeMillis();
+        if (!CONFIRMATION_TOKEN.equals(confirmationToken)) {
+            throw new BadRequestException("You forgot to confirm the migration!");
+        }
+        MigrationReport report = new MigrationReport();
+
+        return session.withTransaction(transaction -> {
+            LOGGER.debugf("[NOTIF-240] Starting");
+            return session.createQuery("SELECT DISTINCT accountId from Endpoint WHERE type = :endpointType", String.class)
+                    .setParameter("endpointType", EndpointType.EMAIL_SUBSCRIPTION)
+                    .getResultList()
+                    .onItem().invoke(accounts -> LOGGER.debugf("[NOTIF-240] Collapsing Email endpoints"))
+                    .onItem().transformToMulti(Multi.createFrom()::iterable)
+                    .invoke(s -> report.updatedAccounts.incrementAndGet())
+                    .onItem().transformToUniAndConcatenate(accountId -> session.createQuery("FROM Endpoint WHERE type = :endpointType AND accountId = :accountId", Endpoint.class)
+                            .setParameter("endpointType", EndpointType.EMAIL_SUBSCRIPTION)
+                            .setParameter("accountId", accountId)
+                            .getResultList()
+                            .onItem().transformToUni(endpoints -> {
+                                if (endpoints.size() > 1) {
+                                    Endpoint defaultEmailEndpoint = endpoints.remove(0);
+                                    LOGGER.debugf("[NOTIF-240] Account [%s] has [%d] EmailEndpoints. Using [%s] as the default", accountId, endpoints.size() + 1, defaultEmailEndpoint.getId());
+                                    Set<UUID> endpointIds = endpoints.stream().map(Endpoint::getId).collect(Collectors.toSet());
+
+                                    return session.createQuery("FROM BehaviorGroupAction bga WHERE bga.id.endpointId IN (:endpointIds)", BehaviorGroupAction.class)
+                                            .setParameter("endpointIds", endpointIds)
+                                            .getResultList()
+                                            .onItem().transformToMulti(Multi.createFrom()::iterable)
+                                            .invoke(behaviorGroupAction -> {
+                                                LOGGER.debugf(
+                                                        "[NOTIF-240] Updating BehaviorGroup [%s] to use default EmailEndpoint [%s]",
+                                                        behaviorGroupAction.getId().behaviorGroupId,
+                                                        defaultEmailEndpoint.getId()
+                                                );
+                                            })
+                                            .onItem().transformToUniAndConcatenate(behaviorGroupAction -> session.remove(behaviorGroupAction)
+                                                    .onItem().transformToUni(_unused -> {
+                                                        BehaviorGroupActionId bgaId = new BehaviorGroupActionId();
+                                                        bgaId.endpointId = defaultEmailEndpoint.getId();
+                                                        bgaId.behaviorGroupId = behaviorGroupAction.getId().behaviorGroupId;
+
+                                                        return session.find(BehaviorGroupAction.class, bgaId)
+                                                                .onItem().transformToUni(bgaFound -> {
+                                                                    if (bgaFound == null) {
+                                                                        BehaviorGroupAction replacement = new BehaviorGroupAction(
+                                                                                behaviorGroupAction.getBehaviorGroup(),
+                                                                                defaultEmailEndpoint
+                                                                        );
+                                                                        replacement.setPosition(behaviorGroupAction.getPosition());
+                                                                        return session.persist(replacement)
+                                                                                .invoke(_unused2 -> report.updatedBehaviorGroupActions.incrementAndGet());
+                                                                    }
+
+                                                                    return Uni.createFrom().voidItem();
+                                                                });
+                                                    })).collect().asList()
+                                            .invoke(_unused -> {
+                                                report.deletedEndpoints.addAndGet(endpoints.size());
+                                                LOGGER.debugf(
+                                                        "[NOTIF-240 Deleting [%d] endpoints from account: [%s]",
+                                                        endpoints.size(),
+                                                        accountId
+                                                );
+                                            })
+                                            .onItem().transformToUni(_unused -> {
+                                                endpoints.forEach(endpoint -> {
+                                                    endpoint.setBehaviorGroupActions(Set.of());
+                                                });
+
+                                                return session.removeAll(endpoints.toArray());
+                                            });
+                                }
+
+                                LOGGER.debugf("[NOTIF-240] Account [%s] only has one EmailEndpoint - skipping", accountId);
+                                return Uni.createFrom().voidItem();
+                            })).collect().asList();
+        })
+        .onItem().invoke(_unused -> {
+            report.durationInMs.set(System.currentTimeMillis() - start);
+            LOGGER.debugf("[NOTIF-240] End");
+        })
+        .onItem().transform(_unused -> report);
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    static class MigrationReport {
+        private final AtomicLong durationInMs = new AtomicLong();
+        private final AtomicLong deletedEndpoints = new AtomicLong();
+        private final AtomicLong updatedBehaviorGroupActions = new AtomicLong();
+        private final AtomicLong updatedAccounts = new AtomicLong();
+
+
+        public AtomicLong getDurationInMs() {
+            return durationInMs;
+        }
+
+        public AtomicLong getDeletedEndpoints() {
+            return deletedEndpoints;
+        }
+
+        public AtomicLong getUpdatedBehaviorGroupActions() {
+            return updatedBehaviorGroupActions;
+        }
+
+        public AtomicLong getUpdatedAccounts() {
+            return updatedAccounts;
+        }
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -152,9 +152,9 @@ public class EndpointService {
     @APIResponse(responseCode = "204", description = "The integration has been deleted", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        return resources.getEndpoint(principal.getAccount(), id)
-                .onItem().transformToUni(endpoint -> {
-                    checkSystemEndpoint(endpoint.getType());
+        return resources.getEndpointTypeById(principal.getAccount(), id)
+                .onItem().transformToUni(endpointType -> {
+                    checkSystemEndpoint(endpointType);
                     return resources.deleteEndpoint(principal.getAccount(), id);
                 })
                 // onFailure() ?
@@ -168,9 +168,9 @@ public class EndpointService {
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        return resources.getEndpoint(principal.getAccount(), id)
-                .onItem().transformToUni(endpoint -> {
-                    checkSystemEndpoint(endpoint.getType());
+        return resources.getEndpointTypeById(principal.getAccount(), id)
+                .onItem().transformToUni(endpointType -> {
+                    checkSystemEndpoint(endpointType);
                     return resources.enableEndpoint(principal.getAccount(), id);
                 })
                 .onItem().transform(ignored -> Response.ok().build());
@@ -182,9 +182,9 @@ public class EndpointService {
     @APIResponse(responseCode = "204", description = "The integration has been disabled", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        return resources.getEndpoint(principal.getAccount(), id)
-                .onItem().transformToUni(endpoint -> {
-                    checkSystemEndpoint(endpoint.getType());
+        return resources.getEndpointTypeById(principal.getAccount(), id)
+                .onItem().transformToUni(endpointType -> {
+                    checkSystemEndpoint(endpointType);
                     return resources.disableEndpoint(principal.getAccount(), id);
                 })
                 .onItem().transform(ignored -> Response.noContent().build());

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -8,6 +8,7 @@ import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.EndpointResources;
 import com.redhat.cloud.notifications.db.NotificationResources;
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
@@ -44,6 +45,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -53,6 +55,10 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 // Email endpoints are not added at this point
 // TODO Needs documentation annotations
 public class EndpointService {
+
+    private static final List<EndpointType> systemEndpointType = List.of(
+            EndpointType.EMAIL_SUBSCRIPTION
+    );
 
     @Inject
     EndpointResources resources;
@@ -109,6 +115,8 @@ public class EndpointService {
     @Produces(APPLICATION_JSON)
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public Uni<Endpoint> createEndpoint(@Context SecurityContext sec, @NotNull @Valid Endpoint endpoint) {
+        checkSystemEndpoint(endpoint.getType());
+
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         endpoint.setAccountId(principal.getAccount());
 
@@ -117,6 +125,38 @@ public class EndpointService {
         }
 
         return resources.createEndpoint(endpoint);
+    }
+
+    @POST
+    @Path("/system/email_subscription")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
+    public Uni<Endpoint> getOrCreateEmailSubscriptionEndpoint(@Context SecurityContext sec, @NotNull @Valid EmailSubscriptionProperties properties) {
+        RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
+        return resources
+                .getEndpointsPerType(principal.getAccount(), EndpointType.EMAIL_SUBSCRIPTION, true, null)
+                .onItem().call(emailEndpoints -> resources.loadProperties(emailEndpoints))
+                .onItem().transformToUni(emailEndpoints -> {
+                    Optional<Endpoint> endpointOptional = emailEndpoints
+                            .stream()
+                            // Todo: This should be changed once we store the properties - (properties = null right now)
+                            // .filter(endpoint -> endpoint.getProperties().equals(properties))
+                            .findFirst();
+                    if (endpointOptional.isPresent()) {
+                        return Uni.createFrom().item(endpointOptional.get());
+                    }
+
+                    Endpoint endpoint = new Endpoint();
+                    endpoint.setProperties(properties);
+                    endpoint.setAccountId(principal.getAccount());
+                    endpoint.setEnabled(true);
+                    endpoint.setDescription("System email endpoint");
+                    endpoint.setName("Email endpoint");
+                    endpoint.setType(EndpointType.EMAIL_SUBSCRIPTION);
+
+                    return resources.createEndpoint(endpoint);
+                });
     }
 
     @GET
@@ -135,7 +175,11 @@ public class EndpointService {
     @APIResponse(responseCode = "204", description = "The integration has been deleted", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        return resources.deleteEndpoint(principal.getAccount(), id)
+        return resources.getEndpoint(principal.getAccount(), id)
+                .onItem().transformToUni(endpoint -> {
+                    checkSystemEndpoint(endpoint.getType());
+                    return resources.deleteEndpoint(principal.getAccount(), id);
+                })
                 // onFailure() ?
                 .onItem().transform(ignored -> Response.noContent().build());
     }
@@ -147,7 +191,11 @@ public class EndpointService {
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        return resources.enableEndpoint(principal.getAccount(), id)
+        return resources.getEndpoint(principal.getAccount(), id)
+                .onItem().transformToUni(endpoint -> {
+                    checkSystemEndpoint(endpoint.getType());
+                    return resources.enableEndpoint(principal.getAccount(), id);
+                })
                 .onItem().transform(ignored -> Response.ok().build());
     }
 
@@ -157,7 +205,11 @@ public class EndpointService {
     @APIResponse(responseCode = "204", description = "The integration has been disabled", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        return resources.disableEndpoint(principal.getAccount(), id)
+        return resources.getEndpoint(principal.getAccount(), id)
+                .onItem().transformToUni(endpoint -> {
+                    checkSystemEndpoint(endpoint.getType());
+                    return resources.disableEndpoint(principal.getAccount(), id);
+                })
                 .onItem().transform(ignored -> Response.noContent().build());
     }
 
@@ -168,10 +220,18 @@ public class EndpointService {
     @RolesAllowed(RbacIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Uni<Response> updateEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id, @NotNull @Valid Endpoint endpoint) {
+        // This prevents from updating an endpoint from whatever EndpointType to a system EndpointType
+        checkSystemEndpoint(endpoint.getType());
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         endpoint.setAccountId(principal.getAccount());
         endpoint.setId(id);
-        return resources.updateEndpoint(endpoint)
+
+        return resources.getEndpoint(principal.getAccount(), id)
+                .onItem().transformToUni(tmpEndpoint -> {
+                    // This prevents from updating an endpoint from system EndpointType to a whatever EndpointType
+                    checkSystemEndpoint(tmpEndpoint.getType());
+                    return resources.updateEndpoint(endpoint);
+                })
                 .onItem().transform(ignored -> Response.ok().build());
     }
 
@@ -276,6 +336,15 @@ public class EndpointService {
                         applicationName,
                         type
                 ));
+    }
+
+    private static void checkSystemEndpoint(EndpointType endpointType) {
+        if (systemEndpointType.contains(endpointType)) {
+            throw new BadRequestException(String.format(
+                    "Is not possible to create or alter endpoint with type %s, check API for alternatives",
+                    endpointType
+            ));
+        }
     }
 
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -203,10 +203,10 @@ public class EndpointService {
         endpoint.setAccountId(principal.getAccount());
         endpoint.setId(id);
 
-        return resources.getEndpoint(principal.getAccount(), id)
-                .onItem().transformToUni(tmpEndpoint -> {
+        return resources.getEndpointTypeById(principal.getAccount(), id)
+                .onItem().transformToUni(endpointType -> {
                     // This prevents from updating an endpoint from system EndpointType to a whatever EndpointType
-                    checkSystemEndpoint(tmpEndpoint.getType());
+                    checkSystemEndpoint(endpointType);
                     return resources.updateEndpoint(endpoint);
                 })
                 .onItem().transform(ignored -> Response.ok().build());

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -45,7 +45,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -134,29 +134,7 @@ public class EndpointService {
     @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
     public Uni<Endpoint> getOrCreateEmailSubscriptionEndpoint(@Context SecurityContext sec, @NotNull @Valid EmailSubscriptionProperties properties) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        return resources
-                .getEndpointsPerType(principal.getAccount(), EndpointType.EMAIL_SUBSCRIPTION, true, null)
-                .onItem().call(emailEndpoints -> resources.loadProperties(emailEndpoints))
-                .onItem().transformToUni(emailEndpoints -> {
-                    Optional<Endpoint> endpointOptional = emailEndpoints
-                            .stream()
-                            // Todo: This should be changed once we store the properties - (properties = null right now)
-                            // .filter(endpoint -> endpoint.getProperties().equals(properties))
-                            .findFirst();
-                    if (endpointOptional.isPresent()) {
-                        return Uni.createFrom().item(endpointOptional.get());
-                    }
-
-                    Endpoint endpoint = new Endpoint();
-                    endpoint.setProperties(properties);
-                    endpoint.setAccountId(principal.getAccount());
-                    endpoint.setEnabled(true);
-                    endpoint.setDescription("System email endpoint");
-                    endpoint.setName("Email endpoint");
-                    endpoint.setType(EndpointType.EMAIL_SUBSCRIPTION);
-
-                    return resources.createEndpoint(endpoint);
-                });
+        return resources.getOrCreateEmailSubscriptionEndpoint(principal.getAccount(), properties);
     }
 
     @GET

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -168,11 +168,4 @@ public class InternalService {
     public Uni<Void> setCurrentStatus(@NotNull @Valid CurrentStatus status) {
         return statusResources.setCurrentStatus(status);
     }
-
-    @POST
-    @Path("/migrate/email_endpoint")
-    public Uni<Void> migrateEmailEndpoint() {
-        // Todo: implement this
-        return Uni.createFrom().voidItem();
-    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -168,4 +168,11 @@ public class InternalService {
     public Uni<Void> setCurrentStatus(@NotNull @Valid CurrentStatus status) {
         return statusResources.setCurrentStatus(status);
     }
+
+    @POST
+    @Path("/migrate/email_endpoint")
+    public Uni<Void> migrateEmailEndpoint() {
+        // Todo: implement this
+        return Uni.createFrom().voidItem();
+    }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -54,7 +54,7 @@ quarkus.http.access-log.enabled=true
 quarkus.http.access-log.category=access_log
 quarkus.http.access-log.pattern=combined
 quarkus.log.category."com.redhat.cloud.notifications".level=INFO
-quarkus.log.category."com.redhat.cloud.notifications.routers.BehaviorGroupMigrationService".level=DEBUG
+quarkus.log.category."com.redhat.cloud.notifications.routers.EmailEndpointMigrationService".level=DEBUG
 
 %test.quarkus.http.access-log.category=info
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/TestEmailEndpointMigrationService.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/TestEmailEndpointMigrationService.java
@@ -1,0 +1,165 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.models.BehaviorGroup;
+import com.redhat.cloud.notifications.models.BehaviorGroupAction;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.ValidatableResponse;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class TestEmailEndpointMigrationService {
+
+    private static final String ACCOUNT1 = "account-1";
+    private static final String ACCOUNT2 = "account-2";
+    private static final String ACCOUNT3 = "account-3";
+    private static final String ACCOUNT4 = "account-4";
+    private static final String ACCOUNT5 = "account-5";
+
+    @Inject
+    Mutiny.Session session;
+
+    @Test
+    void testMigration() {
+
+        // setup
+        Bundle bundle1 = createBundle("migration-test-bundle");
+
+        createBehaviorGroupActions(
+                createBehaviorGroup(ACCOUNT5, bundle1, "b-1"),
+                createEndpoint(ACCOUNT5, EndpointType.WEBHOOK, "w-1")
+        );
+
+        for (String account : Arrays.asList(ACCOUNT1, ACCOUNT2, ACCOUNT3, ACCOUNT4)) {
+            createBehaviorGroupActions(
+                    createBehaviorGroup(account, bundle1, "b-1"),
+                    createEndpoint(account, EndpointType.EMAIL_SUBSCRIPTION, "e-1"),
+                    createEndpoint(account, EndpointType.WEBHOOK, "w-1")
+            );
+
+            createBehaviorGroupActions(
+                    createBehaviorGroup(account, bundle1, "b-2"),
+                    createEndpoint(account, EndpointType.EMAIL_SUBSCRIPTION, "e-2"),
+                    createEndpoint(account, EndpointType.WEBHOOK, "w-2")
+            );
+
+            createBehaviorGroupActions(
+                    createBehaviorGroup(account, bundle1, "b-3"),
+                    createEndpoint(account, EndpointType.EMAIL_SUBSCRIPTION, "e-3"),
+                    createEndpoint(account, EndpointType.WEBHOOK, "w-3"),
+                    createEndpoint(account, EndpointType.EMAIL_SUBSCRIPTION, "e-4")
+            );
+
+            createBehaviorGroupActions(
+                    createBehaviorGroup(account, bundle1, "b-4"),
+                    createEndpoint(account, EndpointType.WEBHOOK, "w-4")
+            );
+
+            createBehaviorGroupActions(
+                    createBehaviorGroup(account, bundle1, "b-5")
+            );
+
+            createEndpoint(account, EndpointType.EMAIL_SUBSCRIPTION, "e-4");
+        }
+
+        EmailEndpointMigrationService.MigrationReport report = migrate().extract().as(EmailEndpointMigrationService.MigrationReport.class);
+        assertEquals(16, report.getDeletedEndpoints().get());
+
+        // Repeated behavior -> endpoint links are deleted
+        assertEquals(8, report.getUpdatedBehaviorGroupActions().get());
+        assertEquals(4, report.getUpdatedAccounts().get());
+
+        assertEquals(1, getEmailEndpoints(ACCOUNT1).size());
+        assertEquals(1, getEmailEndpoints(ACCOUNT2).size());
+        assertEquals(1, getEmailEndpoints(ACCOUNT3).size());
+        assertEquals(1, getEmailEndpoints(ACCOUNT4).size());
+        assertEquals(0, getEmailEndpoints(ACCOUNT5).size());
+
+        assertEquals(7, getActions(ACCOUNT1).size());
+        assertEquals(7, getActions(ACCOUNT2).size());
+        assertEquals(7, getActions(ACCOUNT3).size());
+        assertEquals(7, getActions(ACCOUNT4).size());
+        assertEquals(1, getActions(ACCOUNT5).size());
+
+    }
+
+    private Bundle createBundle(String name) {
+        Bundle bundle = new Bundle();
+        bundle.setName(name);
+        bundle.setDisplayName("Migration bundle");
+        session.persist(bundle)
+                .call(session::flush)
+                .await().indefinitely();
+        return bundle;
+    }
+
+    private Endpoint createEndpoint(String accountId, EndpointType type, String name) {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setAccountId(accountId);
+        endpoint.setType(type);
+        endpoint.setName(name);
+        endpoint.setDescription("Migration endpoint");
+        session.persist(endpoint)
+                .call(session::flush)
+                .await().indefinitely();
+        return endpoint;
+    }
+
+    private BehaviorGroup createBehaviorGroup(String accountId, Bundle bundle, String name) {
+        BehaviorGroup behaviorGroup = new BehaviorGroup();
+        behaviorGroup.setAccountId(accountId);
+        behaviorGroup.setBundle(bundle);
+        behaviorGroup.setBundleId(bundle.getId());
+        behaviorGroup.setDisplayName(name);
+        session.persist(behaviorGroup)
+                .call(session::flush)
+                .await().indefinitely();
+        return behaviorGroup;
+    }
+
+    private List<BehaviorGroupAction> createBehaviorGroupActions(BehaviorGroup behaviorGroup, Endpoint...endpoints) {
+        return Arrays.stream(endpoints).map(endpoint -> {
+            BehaviorGroupAction action = new BehaviorGroupAction(behaviorGroup, endpoint);
+            session.persist(action)
+                    .call(session::flush)
+                    .await().indefinitely();
+            return action;
+        }).collect(Collectors.toList());
+    }
+
+    private List<Endpoint> getEmailEndpoints(String account) {
+        return session.createQuery("FROM Endpoint e WHERE e.type = :endpointType AND e.accountId = :accountId", Endpoint.class)
+                .setParameter("endpointType", EndpointType.EMAIL_SUBSCRIPTION)
+                .setParameter("accountId", account)
+                .getResultList().await().indefinitely();
+    }
+
+    private List<BehaviorGroupAction> getActions(String account) {
+        return session.createQuery("FROM BehaviorGroupAction a WHERE a.behaviorGroup.accountId = :accountId", BehaviorGroupAction.class)
+                .setParameter("accountId", account)
+                .getResultList().await().indefinitely();
+    }
+
+    private ValidatableResponse migrate() {
+        return given()
+                .queryParam("confirmation-token", EmailEndpointMigrationService.CONFIRMATION_TOKEN)
+                .when()
+                .get("/internal/email_endpoint/migrate")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/TestEmailEndpointMigrationService.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/TestEmailEndpointMigrationService.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.BehaviorGroupAction;
 import com.redhat.cloud.notifications.models.Bundle;
@@ -22,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class TestEmailEndpointMigrationService {
+public class TestEmailEndpointMigrationService extends DbIsolatedTest {
 
     private static final String ACCOUNT1 = "account-1";
     private static final String ACCOUNT2 = "account-2";


### PR DESCRIPTION
This prevents the creation of multiple Endpoint with type `EmailSubscription` and adds an API to get the `Endpoint` (with `EmailSubscription` type) represented by the `EmailSubscriptionProperties`. 
Currently the properties is an empty object, but going soon this will change to be able to configure it. 

This PR also has a migration function that is in charge of collapsing the multiple `EmailSubscription Endpoint's` into a single one (per account) and update the `BehaviorGroupAction` (The link between a `BehaviorGroup` and an `Endpoint`) to use the account's default - Removing any duplicate in the process so that each behavior group can at max one `EmailSubscription Endpoint`.

To merge with https://github.com/RedHatInsights/notifications-frontend/pull/141