### PR TITLE
DRFT-344 Add Daily email template for Drift

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/DriftEmailPayloadAggregator.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/DriftEmailPayloadAggregator.java
@@ -1,7 +1,6 @@
 package com.redhat.cloud.notifications.processors.email.aggregators;
 
 import com.redhat.cloud.notifications.models.EmailAggregation;
-import com.redhat.cloud.notifications.models.EmailAggregationKey;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -29,14 +28,6 @@ public class DriftEmailPayloadAggregator extends AbstractEmailPayloadAggregator 
 
     private final Set<String> uniqueHosts = new HashSet<>();
     private final Map<String, HashSet<String>> uniqueHostPerBaseline = new HashMap<>();
-
-    static AbstractEmailPayloadAggregator by(EmailAggregationKey aggregationKey) {
-        if (aggregationKey.getBundle().equals("rhel") && aggregationKey.getApplication().equals("drift")) {
-            return new DriftEmailPayloadAggregator();
-        }
-
-        return null;
-    }
 
     public DriftEmailPayloadAggregator() {
         context.put(DRIFT_KEY, new JsonObject());

--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/DriftEmailPayloadAggregator.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/DriftEmailPayloadAggregator.java
@@ -1,0 +1,88 @@
+package com.redhat.cloud.notifications.processors.email.aggregators;
+
+import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.models.EmailAggregationKey;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class DriftEmailPayloadAggregator extends AbstractEmailPayloadAggregator {
+
+    private static final String DRIFT_KEY = "drift";
+    private static final String HOST_KEY = "hosts";
+    private static final String UNIQUE_SYSTEM_COUNT = "unique_system_count";
+    private static final String CONTEXT_KEY = "context";
+    private static final String EVENTS_KEY = "events";
+    private static final String PAYLOAD_KEY = "payload";
+
+    // Drift Payload
+    private static final String BASELINE_ID = "baseline_id";
+    private static final String BASELINE_NAME = "baseline_name";
+
+    private static final String DISPLAY_NAME = "display_name";
+    private static final String INVENTORY_ID = "inventory_id";
+    private static final String TAGS = "tags";
+
+    private final Set<String> uniqueHosts = new HashSet<>();
+    private final Map<String, HashSet<String>> uniqueHostPerBaseline = new HashMap<>();
+
+    static AbstractEmailPayloadAggregator by(EmailAggregationKey aggregationKey) {
+        if (aggregationKey.getBundle().equals("rhel") && aggregationKey.getApplication().equals("drift")) {
+            return new DriftEmailPayloadAggregator();
+        }
+
+        return null;
+    }
+
+    public DriftEmailPayloadAggregator() {
+        context.put(DRIFT_KEY, new JsonObject());
+    }
+
+    void processEmailAggregation(EmailAggregation notification) {
+        JsonObject notificationJson = notification.getPayload();
+
+        JsonObject drift = context.getJsonObject(DRIFT_KEY);
+        JsonObject context = notificationJson.getJsonObject(CONTEXT_KEY);
+
+        JsonObject host = new JsonObject();
+        this.copyStringField(host, context, DISPLAY_NAME);
+        this.copyStringField(host, context, INVENTORY_ID);
+        host.put(TAGS, context.getJsonArray(TAGS));
+
+        notificationJson.getJsonArray(EVENTS_KEY).stream().forEach(eventObject -> {
+            JsonObject event = (JsonObject) eventObject;
+            JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
+            String baselineId = payload.getString(BASELINE_ID);
+
+            if (!drift.containsKey(baselineId)) {
+                JsonObject newBaseline = new JsonObject();
+                this.copyStringField(newBaseline, payload, BASELINE_ID);
+                this.copyStringField(newBaseline, payload, BASELINE_NAME);
+
+                newBaseline.put(HOST_KEY, new JsonArray());
+
+                drift.put(baselineId, newBaseline);
+                uniqueHostPerBaseline.put(baselineId, new HashSet<>());
+            }
+
+            JsonObject baseline = drift.getJsonObject(baselineId);
+            String insightsId = host.getString(INVENTORY_ID);
+            baseline.getJsonArray(HOST_KEY).add(host);
+            uniqueHostPerBaseline.get(baselineId).add(insightsId);
+            baseline.put(UNIQUE_SYSTEM_COUNT, this.uniqueHostPerBaseline.get(baselineId).size());
+        });
+
+        String insightsId = host.getString(INVENTORY_ID);
+        uniqueHosts.add(insightsId);
+        this.context.put(UNIQUE_SYSTEM_COUNT, this.uniqueHosts.size());
+    }
+
+    public Integer getUniqueHostCount() {
+        return this.uniqueHosts.size();
+    }
+
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
@@ -12,6 +12,9 @@ public class EmailPayloadAggregatorFactory {
         if (aggregationKey.getBundle().equals("rhel") && aggregationKey.getApplication().equals("policies")) {
             return new PoliciesEmailPayloadAggregator();
         }
+        if (aggregationKey.getBundle().equals("rhel") && aggregationKey.getApplication().equals("drift")) {
+            return new DriftEmailPayloadAggregator();
+        }
 
         return null;
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/templates/Drift.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/templates/Drift.java
@@ -13,10 +13,7 @@ public class Drift implements EmailTemplate {
             return Templates.newBaselineDriftInstantEmailTitle();
         }
 
-        throw new UnsupportedOperationException(String.format(
-                "No email title template for Drift event_type: %s and EmailSubscription: %s found.",
-                eventType, type
-        ));
+        return Templates.dailyEmailTitle();
     }
 
     @Override
@@ -25,20 +22,17 @@ public class Drift implements EmailTemplate {
             return Templates.newBaselineDriftInstantEmailBody();
         }
 
-        throw new UnsupportedOperationException(String.format(
-                "No email body template for Drift event_type: %s and EmailSubscription: %s found.",
-                eventType, type
-        ));
+        return Templates.dailyEmailBody();
     }
 
     @Override
     public boolean isSupported(String eventType, EmailSubscriptionType type) {
-        return eventType.equals("drift-baseline-detected") && type == EmailSubscriptionType.INSTANT;
+        return true;
     }
 
     @Override
     public boolean isEmailSubscriptionSupported(EmailSubscriptionType type) {
-        return type == EmailSubscriptionType.INSTANT;
+        return true;
     }
 
     @CheckedTemplate
@@ -47,6 +41,10 @@ public class Drift implements EmailTemplate {
         public static native TemplateInstance newBaselineDriftInstantEmailTitle();
 
         public static native TemplateInstance newBaselineDriftInstantEmailBody();
+
+        public static native TemplateInstance dailyEmailTitle();
+
+        public static native TemplateInstance dailyEmailBody();
 
     }
 

--- a/backend/src/main/resources/templates/Drift/dailyEmailBody.html
+++ b/backend/src/main/resources/templates/Drift/dailyEmailBody.html
@@ -1,3 +1,7 @@
+
+
+
+
 {#include Drift/insightsEmailBody}
 {#content-title}Daily Drift Summary - {action.context.start_time.toStringFormat()}{/content-title}
 {#content-body}
@@ -12,15 +16,17 @@
             <thead>
             <tr>
                 <th>Baseline</th>
-                <th>Systems</th>
+                <th>System</th>
             </tr>
             </thead>
             <tbody>
             {#for key in action.context.drift.keySet()}
+                {#for host in action.context.drift.get(key).hosts}
             <tr>
-                <td><a href="https://cloud.redhat.com/insights/drift/?baseline_ids={action.context.drift.get(key).baseline_id}&reference_id={action.context.drift.get(key).baseline_id}&system_ids={action.context.inventory_id}" target="_blank">{action.context.drift.get(key).baseline_name}</a></td>
-                <td>{action.context.drift.get(key).unique_system_count}</td>
+                <td><a href="https://cloud.redhat.com/insights/drift/?baseline_ids={action.context.drift.get(key).baseline_id}&reference_id={action.context.drift.get(key).baseline_id}&system_ids={host.inventory_id}" target="_blank">{action.context.drift.get(key).baseline_name}</a></td>
+                <td>{host.display_name}</td>
             </tr>
+            {/for}
             {/for}
             </tbody>
         </table>

--- a/backend/src/main/resources/templates/Drift/dailyEmailBody.html
+++ b/backend/src/main/resources/templates/Drift/dailyEmailBody.html
@@ -1,0 +1,45 @@
+{#include Drift/insightsEmailBody}
+{#content-title}Daily Drift Summary - {action.context.start_time.toStringFormat()}{/content-title}
+{#content-body}
+<tr>
+    <td class="rh-content__block">
+        <p>Daily drift summary for <b>{action.context.start_time.toStringFormat()}</b> from Red Hat Insights. <b>{action.context.drift.size()} {#if action.context.drift.size() == 1}baseline{#else}baselines{/if}</b> drifted on <b>{action.context.unique_system_count} {#if action.context.unique_system_count == 1}system{#else}unique systems{/if}</b>.</p>
+    </td>
+</tr>
+<tr>
+    <td class="rh-content__block">
+        <table class="rh-data-table rh-m-bordered">
+            <thead>
+            <tr>
+                <th>Baseline</th>
+                <th>Systems</th>
+            </tr>
+            </thead>
+            <tbody>
+            {#for key in action.context.drift.keySet()}
+            <tr>
+                <td><a href="https://cloud.redhat.com/insights/drift/?baseline_ids={action.context.drift.get(key).baseline_id}&reference_id={action.context.drift.get(key).baseline_id}&system_ids={action.context.inventory_id}" target="_blank">{action.context.drift.get(key).baseline_name}</a></td>
+                <td>{action.context.drift.get(key).unique_system_count}</td>
+            </tr>
+            {/for}
+            </tbody>
+        </table>
+    </td>
+</tr>
+<tr>
+    <td class="rh-content__block">
+        <table align="center">
+            <tr>
+                <td class="rh-cta-link" align="center">
+                    <a target="_blank" href="https://cloud.redhat.com/insights/drift">
+                                <span>
+                                  Open Drift in Insights
+                                </span>
+                    </a>
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+{/content-body}
+{/include}

--- a/backend/src/main/resources/templates/Drift/dailyEmailTitle.txt
+++ b/backend/src/main/resources/templates/Drift/dailyEmailTitle.txt
@@ -1,0 +1,1 @@
+{action.context.start_time.toStringFormat()} - {action.context.drift.size()} {#if action.context.drift.size() == 1}baseline{#else}baselines{/if} drifted on {action.context.unique_system_count} {#if action.context.unique_system_count == 1}system{#else}unique systems{/if}

--- a/backend/src/test/java/com/redhat/cloud/notifications/DriftTestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/DriftTestHelpers.java
@@ -1,0 +1,54 @@
+package com.redhat.cloud.notifications;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.transformers.BaseTransformer;
+import io.vertx.core.json.JsonObject;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class DriftTestHelpers {
+
+    public static BaseTransformer baseTransformer = new BaseTransformer();
+
+    public static EmailAggregation createEmailAggregation(String tenant, String bundle, String application, String baselineId, String inventory_id) {
+        EmailAggregation aggregation = new EmailAggregation();
+        aggregation.setBundleName(bundle);
+        aggregation.setApplicationName(application);
+        aggregation.setAccountId(tenant);
+
+        Action emailActionMessage = new Action();
+        emailActionMessage.setBundle(bundle);
+        emailActionMessage.setApplication(application);
+        emailActionMessage.setTimestamp(LocalDateTime.now());
+        emailActionMessage.setEventType("testEmailSubscriptionInstant");
+
+        emailActionMessage.setContext(Map.of(
+                "inventory_id", inventory_id,
+                "system_check_in", "2021-07-13T15:22:42.199046",
+                "display_name", "Drift test machine",
+                "tags", List.of()
+        ));
+        emailActionMessage.setEvents(List.of(
+                Event
+                        .newBuilder()
+                        .setMetadataBuilder(Metadata.newBuilder())
+                        .setPayload(Map.of(
+                            "baseline_id", baselineId,
+                            "baseline_name", "drift_baseline_test"
+                        ))
+                        .build()
+        ));
+
+        emailActionMessage.setAccountId(tenant);
+
+        JsonObject payload = baseTransformer.transform(emailActionMessage).await().indefinitely();
+        aggregation.setPayload(payload);
+
+        return aggregation;
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/processors/email/DriftEmailPayloadAggregatorTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/processors/email/DriftEmailPayloadAggregatorTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+import java.util.Map;
+
 class DriftEmailPayloadAggregatorTest {
 
     private DriftEmailPayloadAggregator aggregator;
@@ -32,11 +35,18 @@ class DriftEmailPayloadAggregatorTest {
 
     @Test
     void validatePayload() {
+
+        LocalDateTime startTime = LocalDateTime.of(2021, 4, 22, 13, 15, 33);
+        LocalDateTime endTime = LocalDateTime.of(2021, 4, 22, 14, 15, 33);
+
         aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-01"));
         aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-02"));
         aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_02", "host-01"));
         aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_02", "host-03"));
-        System.out.println(JsonObject.mapFrom(aggregator.getContext()).toString());
+        Map<String, Object> drift = aggregator.getContext();
+        drift.put("start_time", startTime.toString());
+        drift.put("end_time", endTime.toString());
+        System.out.println(JsonObject.mapFrom(drift).toString());
         Assertions.assertEquals(1, 1);
     }
     /*private Integer getUniqueHostForPolicy(PoliciesEmailPayloadAggregator aggregator, String policy) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/processors/email/DriftEmailPayloadAggregatorTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/processors/email/DriftEmailPayloadAggregatorTest.java
@@ -1,0 +1,46 @@
+package com.redhat.cloud.notifications.processors.email;
+
+import com.redhat.cloud.notifications.DriftTestHelpers;
+import com.redhat.cloud.notifications.processors.email.aggregators.DriftEmailPayloadAggregator;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DriftEmailPayloadAggregatorTest {
+
+    private DriftEmailPayloadAggregator aggregator;
+
+    @BeforeEach
+    void setUp() {
+        aggregator = new DriftEmailPayloadAggregator();
+    }
+
+    @Test
+    void emptyAggregatorHasNoAccountId() {
+        Assertions.assertNull(aggregator.getAccountId(), "Empty aggregator has no accountId");
+    }
+
+    @Test
+    void shouldHaveOneSingleHost() {
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-01"));
+        Assertions.assertEquals("tenant", aggregator.getAccountId());
+
+        // 1 host
+        Assertions.assertEquals(1, aggregator.getUniqueHostCount());
+    }
+
+    @Test
+    void validatePayload() {
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-01"));
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-02"));
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_02", "host-01"));
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_02", "host-03"));
+        System.out.println(JsonObject.mapFrom(aggregator.getContext()).toString());
+        Assertions.assertEquals(1, 1);
+    }
+    /*private Integer getUniqueHostForPolicy(PoliciesEmailPayloadAggregator aggregator, String policy) {
+        Map<String, Map> policies = (Map<String, Map>) aggregator.getContext().get("policies");
+        return (Integer) policies.get(policy).get("unique_system_count");
+    }*/
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/processors/email/DriftEmailPayloadAggregatorTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/processors/email/DriftEmailPayloadAggregatorTest.java
@@ -49,8 +49,4 @@ class DriftEmailPayloadAggregatorTest {
         System.out.println(JsonObject.mapFrom(drift).toString());
         Assertions.assertEquals(1, 1);
     }
-    /*private Integer getUniqueHostForPolicy(PoliciesEmailPayloadAggregator aggregator, String policy) {
-        Map<String, Map> policies = (Map<String, Map>) aggregator.getContext().get("policies");
-        return (Integer) policies.get(policy).get("unique_system_count");
-    }*/
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/templates/TestDriftTemplate.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/templates/TestDriftTemplate.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 @QuarkusTest
 public class TestDriftTemplate {
     private DriftEmailPayloadAggregator aggregator;
@@ -55,8 +57,8 @@ public class TestDriftTemplate {
     @Test
     public void testDailyEmailBodyOneBaselineAndMultipleSystem() {
 
-        LocalDateTime startTime = LocalDateTime.of(2021, 4, 22, 13, 15, 33);
-        LocalDateTime endTime = LocalDateTime.of(2021, 4, 22, 14, 15, 33);
+        LocalDateTime startTime = LocalDateTime.of(2021, 7, 14, 13, 15, 33);
+        LocalDateTime endTime = LocalDateTime.of(2021, 7, 14, 14, 15, 33);
 
         aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-01"));
         aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-02"));
@@ -67,6 +69,7 @@ public class TestDriftTemplate {
         String result = Drift.Templates.dailyEmailBody()
                 .data("action", Map.of("context", drift))
                 .render();
-        System.out.println(result);
+        assertTrue(result.contains("<b>1 baseline</b> drifted on <b>3 unique systems</b>"));
+        //System.out.println(result);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/templates/TestDriftTemplate.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/templates/TestDriftTemplate.java
@@ -1,0 +1,72 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.DriftTestHelpers;
+import com.redhat.cloud.notifications.processors.email.aggregators.DriftEmailPayloadAggregator;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@QuarkusTest
+public class TestDriftTemplate {
+    private DriftEmailPayloadAggregator aggregator;
+
+    @BeforeEach
+    void setUp() {
+        aggregator = new DriftEmailPayloadAggregator();
+    }
+
+    @Test
+    public void testDailyEmailBodyOneBaselineAndOneSystem() {
+
+        LocalDateTime startTime = LocalDateTime.of(2021, 4, 22, 13, 15, 33);
+        LocalDateTime endTime = LocalDateTime.of(2021, 4, 22, 14, 15, 33);
+
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-01"));
+        Map<String, Object> drift = aggregator.getContext();
+        drift.put("start_time", startTime.toString());
+        drift.put("end_time", endTime.toString());
+        String result = Drift.Templates.dailyEmailBody()
+                .data("action", Map.of("context", drift))
+                .render();
+        //System.out.println(result);
+    }
+
+    @Test
+    public void testDailyEmailBodyMultipleBaselineAndOneSystem() {
+
+        LocalDateTime startTime = LocalDateTime.of(2021, 4, 22, 13, 15, 33);
+        LocalDateTime endTime = LocalDateTime.of(2021, 4, 22, 14, 15, 33);
+
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-01"));
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_02", "host-01"));
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_03", "host-01"));
+        Map<String, Object> drift = aggregator.getContext();
+        drift.put("start_time", startTime.toString());
+        drift.put("end_time", endTime.toString());
+        String result = Drift.Templates.dailyEmailBody()
+                .data("action", Map.of("context", drift))
+                .render();
+        //System.out.println(result);
+    }
+
+    @Test
+    public void testDailyEmailBodyOneBaselineAndMultipleSystem() {
+
+        LocalDateTime startTime = LocalDateTime.of(2021, 4, 22, 13, 15, 33);
+        LocalDateTime endTime = LocalDateTime.of(2021, 4, 22, 14, 15, 33);
+
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-01"));
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-02"));
+        aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "host-03"));
+        Map<String, Object> drift = aggregator.getContext();
+        drift.put("start_time", startTime.toString());
+        drift.put("end_time", endTime.toString());
+        String result = Drift.Templates.dailyEmailBody()
+                .data("action", Map.of("context", drift))
+                .render();
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
Run:

`./mvnw install --projects :notifications-backend -Dtest=DriftEmailPayloadAggregatorTest -Dskip.yarn`

You may see a result like this is the logs:

```
{
  "drift": {
    "baseline_01": {
      "baseline_id": "baseline_01",
      "baseline_name": "drift_baseline_test",
      "hosts": [
        {
          "display_name": "Drift test machine",
          "inventory_id": "host-01",
          "tags": []
        },
        {
          "display_name": "Drift test machine",
          "inventory_id": "host-02",
          "tags": []
        }
      ],
      "unique_system_count": 2
    },
    "baseline_02": {
      "baseline_id": "baseline_02",
      "baseline_name": "drift_baseline_test",
      "hosts": [
        {
          "display_name": "Drift test machine",
          "inventory_id": "host-01",
          "tags": []
        },
        {
          "display_name": "Drift test machine",
          "inventory_id": "host-03",
          "tags": []
        }
      ],
      "unique_system_count": 2
    }
  },
  "unique_system_count": 3,
  "start_time": null,
  "end_time": null
}
```

To test HTML template use the following command:

`./mvnw install --projects :notifications-backend -Dtest=TestDriftTemplate -Dskip.yarn`

Uncomment the `System.out.println` from `TestDriftTemplate.java` to check the HTML it self.



