### PR TITLE
Other attempt to have the internal UI relative

### DIFF
--- a/backend/src/main/webapp/package.json
+++ b/backend/src/main/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internal",
-  "homepage": "/",
+  "homepage": "/internal/",
   "version": "0.1.0",
   "private": true,
   "proxy": "https://localhost:8085/internal",

--- a/backend/src/main/webapp/package.json
+++ b/backend/src/main/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internal",
-  "homepage": "/internal/",
+  "homepage": ".",
   "version": "0.1.0",
   "private": true,
   "proxy": "https://localhost:8085/internal",

--- a/backend/src/main/webapp/public/index.html
+++ b/backend/src/main/webapp/public/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" class="pf-m-redhat-font">
   <head>
+    <base href="%PUBLIC_URL%/">
     <meta charset="utf-8" />
-    <link rel="icon" href="favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
@@ -13,7 +14,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
Tested locally opening build assets in the browser.

Previous attempt didn't work, because react adds the scripts to `index.html` at build time using the `PUBLIC_URL` as a base.
Changing the PUBLIC_URL to `.` yields base as `./` instead.


```
<script src="./static/js/main.0af8c67b.chunk.js">
```