### PR TITLE
Feature flag for rbac user query

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/RecipientResolver.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/RecipientResolver.java
@@ -20,12 +20,12 @@ public class RecipientResolver {
     @Inject
     RbacRecipientUsersProvider rbacRecipientUsersProvider;
 
-    @ConfigProperty(name = "processor.email.personalized-email", defaultValue = "false")
-    Boolean personalizedEmail;
+    @ConfigProperty(name = "processor.email.rbac-user-query", defaultValue = "false")
+    Boolean rbacUserQuery;
 
     public Uni<Set<User>> recipientUsers(String accountId, Set<Endpoint> endpoints, Set<String> subscribers) {
 
-        if (!personalizedEmail) {
+        if (!rbacUserQuery) {
             return Uni.createFrom().item(
                     subscribers.stream().map(username -> {
                         User user = new User();

--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/RecipientResolver.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/RecipientResolver.java
@@ -21,7 +21,7 @@ public class RecipientResolver {
     RbacRecipientUsersProvider rbacRecipientUsersProvider;
 
     @ConfigProperty(name = "processor.email.rbac-user-query", defaultValue = "false")
-    Boolean rbacUserQuery;
+    boolean rbacUserQuery;
 
     public Uni<Set<User>> recipientUsers(String accountId, Set<Endpoint> endpoints, Set<String> subscribers) {
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/processors/email/RecipientResolverTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/processors/email/RecipientResolverTest.java
@@ -1,0 +1,81 @@
+package com.redhat.cloud.notifications.processors.email;
+
+import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.recipients.User;
+import com.redhat.cloud.notifications.recipients.rbac.RbacRecipientUsersProvider;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+@QuarkusTest
+public class RecipientResolverTest {
+
+    private static final String ACCOUNT_ID = "acc-1";
+
+    @InjectMock
+    RbacRecipientUsersProvider rbacRecipientUsersProvider;
+
+    @Test
+    public void withPersonalizedEmailOff() {
+        RecipientResolver recipientResolver = new RecipientResolver();
+        recipientResolver.personalizedEmail = false;
+        recipientResolver.rbacRecipientUsersProvider = rbacRecipientUsersProvider;
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setType(EndpointType.EMAIL_SUBSCRIPTION);
+        endpoint.setEnabled(true);
+        endpoint.setAccountId(ACCOUNT_ID);
+        endpoint.setProperties(new EmailSubscriptionProperties());
+
+        User user1 = new User();
+        user1.setUsername("foo");
+        User user2 = new User();
+        user2.setUsername("bar");
+
+        recipientResolver.recipientUsers(
+                ACCOUNT_ID,
+                Set.of(endpoint),
+                Set.of("foo", "bar")
+        )
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .assertCompleted()
+                .assertItem(Set.of(user1, user2));
+    }
+
+    @Test
+    public void withPersonalizedEmailOn() {
+        RecipientResolver recipientResolver = new RecipientResolver();
+        recipientResolver.personalizedEmail = true;
+        recipientResolver.rbacRecipientUsersProvider = rbacRecipientUsersProvider;
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setType(EndpointType.EMAIL_SUBSCRIPTION);
+        endpoint.setEnabled(true);
+        endpoint.setAccountId(ACCOUNT_ID);
+        endpoint.setProperties(new EmailSubscriptionProperties());
+
+        recipientResolver.recipientUsers(
+                ACCOUNT_ID,
+                Set.of(endpoint),
+                Set.of("foo", "bar")
+        )
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create())
+                .assertCompleted();
+
+        Mockito.verify(rbacRecipientUsersProvider, Mockito.times(1)).getUsers(
+                Mockito.eq(ACCOUNT_ID),
+                Mockito.eq(false)
+        );
+
+        Mockito.verifyNoMoreInteractions(rbacRecipientUsersProvider);
+    }
+
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/processors/email/RecipientResolverTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/processors/email/RecipientResolverTest.java
@@ -24,7 +24,7 @@ public class RecipientResolverTest {
     @Test
     public void withPersonalizedEmailOff() {
         RecipientResolver recipientResolver = new RecipientResolver();
-        recipientResolver.personalizedEmail = false;
+        recipientResolver.rbacUserQuery = false;
         recipientResolver.rbacRecipientUsersProvider = rbacRecipientUsersProvider;
 
         Endpoint endpoint = new Endpoint();
@@ -52,7 +52,7 @@ public class RecipientResolverTest {
     @Test
     public void withPersonalizedEmailOn() {
         RecipientResolver recipientResolver = new RecipientResolver();
-        recipientResolver.personalizedEmail = true;
+        recipientResolver.rbacUserQuery = true;
         recipientResolver.rbacRecipientUsersProvider = rbacRecipientUsersProvider;
 
         Endpoint endpoint = new Endpoint();


### PR DESCRIPTION
Adds a feature flag to avoid querying RBAC for the users. 

This does not actually revert back to the state before the personalized emails, what this does instead is avoiding querying for the user data with RBAC (which is the setup that we are missing).

There is still one email sent for each user, but the only data that can be personalized is the username.
Everything else is null, but no one is using it yet. It should be fine™.

