### PR TITLE
NOTIF-184 Retry on webhook call failure

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/webhooks/ServerErrorException.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/webhooks/ServerErrorException.java
@@ -1,0 +1,20 @@
+package com.redhat.cloud.notifications.processors.webhooks;
+
+import com.redhat.cloud.notifications.models.NotificationHistory;
+
+/**
+ * This exception is thrown when the response of a webhook call contains a 5xx HTTP status.
+ * Such status can be caused by a temporary remote issue so we should retry the call.
+ */
+public class ServerErrorException extends RuntimeException {
+
+    private final NotificationHistory history;
+
+    public ServerErrorException(NotificationHistory history) {
+        this.history = history;
+    }
+
+    public NotificationHistory getNotificationHistory() {
+        return history;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -11,6 +11,7 @@ import com.redhat.cloud.notifications.processors.webclient.SslVerificationEnable
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.channel.ConnectTimeoutException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
@@ -18,23 +19,33 @@ import io.vertx.ext.web.client.impl.HttpRequestImpl;
 import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.WebClient;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.net.ConnectException;
-import java.net.UnknownHostException;
+import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
-import java.util.logging.Logger;
 
 import static com.redhat.cloud.notifications.models.NotificationHistory.getHistoryStub;
 
 @ApplicationScoped
 public class WebhookTypeProcessor implements EndpointTypeProcessor {
 
-    private final Logger log = Logger.getLogger(this.getClass().getName());
-
+    private static final Logger LOGGER = Logger.getLogger(WebhookTypeProcessor.class);
     private static final String TOKEN_HEADER = "X-Insight-Token";
+
+    @ConfigProperty(name = "processor.webhook.retry.max-attempts", defaultValue = "3")
+    long maxRetryAttempts;
+
+    @ConfigProperty(name = "processor.webhook.retry.back-off.initial-value", defaultValue = "1S")
+    Duration initialRetryBackOff;
+
+    @ConfigProperty(name = "processor.webhook.retry.back-off.max-value", defaultValue = "30S")
+    Duration maxRetryBackOff;
 
     @Inject
     @SslVerificationEnabled
@@ -47,12 +58,13 @@ public class WebhookTypeProcessor implements EndpointTypeProcessor {
     @Inject
     BaseTransformer transformer;
 
+    @Inject
     MeterRegistry registry;
 
-    private final Counter processedCount;
+    private Counter processedCount;
 
-    public WebhookTypeProcessor(MeterRegistry registry) {
-        this.registry = registry;
+    @PostConstruct
+    void postConstruct() {
         processedCount = registry.counter("processor.webhook.processed");
     }
 
@@ -100,23 +112,23 @@ public class WebhookTypeProcessor implements EndpointTypeProcessor {
         return payload.onItem()
                 .transformToUni(json -> req.sendJsonObject(json)
                         .onItem().transform(resp -> {
-                            final long endTime = System.currentTimeMillis();
-                            // Default result is false
-                            NotificationHistory history = getHistoryStub(item, endTime - startTime, UUID.randomUUID());
+                            NotificationHistory history = buildNotificationHistory(item, startTime);
 
-                            if (resp.statusCode() >= 200 && resp.statusCode() <= 300) {
+                            boolean serverError = false;
+                            if (resp.statusCode() >= 200 && resp.statusCode() < 300) {
                                 // Accepted
-                                log.fine("Target endpoint successful: " + resp.statusCode());
+                                LOGGER.debugf("Target endpoint successful: %d", resp.statusCode());
                                 history.setInvocationResult(true);
                             } else if (resp.statusCode() >= 500) {
                                 // Temporary error, allow retry
-                                log.fine("Target endpoint server error: " + resp.statusCode() + " " + resp.statusMessage());
+                                serverError = true;
+                                LOGGER.debugf("Target endpoint server error: %d %s", resp.statusCode(), resp.statusMessage());
                                 history.setInvocationResult(false);
                             } else {
                                 // Disable the target endpoint, it's not working correctly for us (such as 400)
                                 // must be manually re-enabled
                                 // Redirects etc should have been followed by the vertx (test this)
-                                log.fine("Target endpoint error: " + resp.statusCode() + " " + resp.statusMessage() + " " + json);
+                                LOGGER.debugf("Target endpoint error: %d %s %s", resp.statusCode(), resp.statusMessage(), json);
                                 history.setInvocationResult(false);
                             }
 
@@ -132,16 +144,24 @@ public class WebhookTypeProcessor implements EndpointTypeProcessor {
                                 history.setDetails(details.getMap());
                             }
 
+                            if (serverError) {
+                                throw new ServerErrorException(history);
+                            }
                             return history;
-                        }).onFailure().recoverWithItem(t -> {
+                        })
+                        .onFailure(this::shouldRetry)
+                        .retry().withBackOff(initialRetryBackOff, maxRetryBackOff).atMost(maxRetryAttempts)
+                        .onFailure().recoverWithItem(t -> {
 
-                            // TODO Duplicate code with the success part
-                            final long endTime = System.currentTimeMillis();
-                            NotificationHistory history = getHistoryStub(item, endTime - startTime, UUID.randomUUID());
+                            if (t instanceof ServerErrorException) {
+                                return ((ServerErrorException) t).getNotificationHistory();
+                            }
+
+                            NotificationHistory history = buildNotificationHistory(item, startTime);
 
                             HttpRequestImpl<Buffer> reqImpl = (HttpRequestImpl<Buffer>) req.getDelegate();
 
-                            log.fine("Failed: " + t.getMessage());
+                            LOGGER.debugf("Failed: %s", t.getMessage());
 
                             // TODO Duplicate code with the error return code part
                             JsonObject details = new JsonObject();
@@ -149,15 +169,6 @@ public class WebhookTypeProcessor implements EndpointTypeProcessor {
                             details.put("method", reqImpl.method());
                             details.put("error_message", t.getMessage()); // TODO This message isn't always the most descriptive..
                             history.setDetails(details.getMap());
-
-                            if (t instanceof ConnectException) {
-                                // Connection refused for example
-                                ConnectException ce = (ConnectException) t;
-                            } else if (t instanceof UnknownHostException) {
-                                UnknownHostException uhe = (UnknownHostException) t;
-                            }
-
-                            // io.netty.channel.ConnectTimeoutException: connection timed out: webhook.site/46.4.105.116:443
                             return history;
                         })
                 );
@@ -174,4 +185,22 @@ public class WebhookTypeProcessor implements EndpointTypeProcessor {
         return protocol + "://" + reqImpl.host() + ":" + reqImpl.port() + reqImpl.uri();
     }
 
+    private NotificationHistory buildNotificationHistory(Notification item, long startTime) {
+        long invocationTime = System.currentTimeMillis() - startTime;
+        return getHistoryStub(item, invocationTime, UUID.randomUUID());
+    }
+
+    /**
+     * Returns {@code true} if we should retry when the given {@code throwable} is thrown during a webhook call.
+     * <ul>
+     *     <li>{@link ServerErrorException} is thrown when the call was successful but the remote server replied with a 5xx HTTP status.</li>
+     *     <li>{@link IOException} is thrown when the connection between us and the remote server was reset during the call.</li>
+     *     <li>{@link ConnectTimeoutException} is thrown when the remote server did not respond at all to our call.</li>
+     * </ul>
+     */
+    private boolean shouldRetry(Throwable throwable) {
+        return throwable instanceof ServerErrorException ||
+                throwable instanceof IOException ||
+                throwable instanceof ConnectTimeoutException;
+    }
 }


### PR DESCRIPTION
This PR adds retry logic to webhook calls when one of the following happens:
- The remote server returned a 5xx HTTP status, which could be caused by a temporary remote server issue.
- We had a technical communication issue during the call (e.g. `IOException`).

The `WebhookTypeProcessor#shouldRetry` method is meant to contain all exceptions that should cause a retry.

The retry logic is entirely configurable:
| Key | Description | Default |
| - | - | - |
| processor.webhook.retry.max-attempts | Max number of retries for a single webhook call (initial call included) | 3 |
| processor.webhook.retry.back-off.initial-value | Initial delay before the first retry attempt | 1S |
| processor.webhook.retry.back-off.max-value | Max delay before the last retry attempt (delay grows exponentially) | 30S |

Default values are open for discussion. I think `back-off.max-value` could be much higher than that.