### PR TITLE
NOTIF-190 Add sleep to test if this fixes the exception in OpenShift

### DIFF
--- a/aggregator/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
@@ -35,6 +35,13 @@ public class NotificationsApp implements QuarkusApplication {
         LOG.info(readGitProperties());
 
         dailyEmailAggregationJob.processDailyEmail(Instant.now());
+
+        try {
+            Thread.sleep(30000);
+        } catch (InterruptedException e) {
+            LOG.warn("Interruption after sending the messages!");
+        }
+
         return 0;
     }
 

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
@@ -36,12 +36,6 @@ public class NotificationsApp implements QuarkusApplication {
 
         dailyEmailAggregationJob.processDailyEmail(Instant.now());
 
-        try {
-            Thread.sleep(30000);
-        } catch (InterruptedException e) {
-            LOG.warn("Interruption after sending the messages!");
-        }
-
         return 0;
     }
 


### PR DESCRIPTION
In OpenShift ci we are getting this exception in every cronjob run:

2021-08-06 14:45:41,165 ERROR [io.sma.rea.mes.kafka] (vert.x-eventloop-thread-0) SRMSG18206: Unable to write to Kafka from channel aggregation (topic: ...): org.apache.kafka.common.KafkaException: Producer closed while send in progress

Locally this doesn't happen with the same code, but when I add a System.exit(1) after sending the first AggregationCommand in the kafka topic, I get the same exception.

The Thread of the run() method is faster than the kafka connection thingy somehow.

This PR is just to see if this solves the issue on ci. If anyone has got a better idea of how to fix this issue... :-)