### PR TITLE
Render emails on admin UI 

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -202,10 +202,10 @@ public class InternalService {
     @Produces(APPLICATION_JSON)
     @APIResponses(value = {
             @APIResponse(responseCode = "200", content = {
-                    @Content(schema = @Schema(implementation = RenderEmailTemplateResponse.class))
+                    @Content(schema = @Schema(title = "RenderEmailTemplateResponseSuccess", implementation = RenderEmailTemplateResponse.Success.class))
             }),
             @APIResponse(responseCode = "400", content = {
-                    @Content(schema = @Schema(implementation = RenderEmailTemplateResponse.Error.class))
+                    @Content(schema = @Schema(title = "RenderEmailTemplateResponseError", implementation = RenderEmailTemplateResponse.Error.class))
             })
     })
     public Uni<Response> renderEmailTemplate(@NotNull @Valid RenderEmailTemplateRequest renderEmailTemplateRequest) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -14,7 +14,6 @@ import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateResponse
 import com.redhat.cloud.notifications.templates.EmailTemplateService;
 import com.redhat.cloud.notifications.utils.ActionParser;
 import io.smallrye.mutiny.Uni;
-import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateRequest.java
@@ -1,0 +1,40 @@
+package com.redhat.cloud.notifications.routers.models;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+public class RenderEmailTemplateRequest {
+
+    @NotNull
+    private String titleTemplate;
+
+    @NotNull
+    private String bodyTemplate;
+
+    @NotEmpty
+    private String payload;
+
+    public String getTitleTemplate() {
+        return titleTemplate;
+    }
+
+    public void setTitleTemplate(String titleTemplate) {
+        this.titleTemplate = titleTemplate;
+    }
+
+    public String getBodyTemplate() {
+        return bodyTemplate;
+    }
+
+    public void setBodyTemplate(String bodyTemplate) {
+        this.bodyTemplate = bodyTemplate;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateRequest.java
@@ -1,8 +1,12 @@
 package com.redhat.cloud.notifications.routers.models;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RenderEmailTemplateRequest {
 
     @NotNull
@@ -11,6 +15,7 @@ public class RenderEmailTemplateRequest {
     @NotNull
     private String bodyTemplate;
 
+    @NotNull
     @NotEmpty
     private String payload;
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateRequest.java
@@ -6,7 +6,7 @@ import javax.validation.constraints.NotNull;
 public class RenderEmailTemplateRequest {
 
     @NotNull
-    private String titleTemplate;
+    private String subjectTemplate;
 
     @NotNull
     private String bodyTemplate;
@@ -14,12 +14,12 @@ public class RenderEmailTemplateRequest {
     @NotEmpty
     private String payload;
 
-    public String getTitleTemplate() {
-        return titleTemplate;
+    public String getSubjectTemplate() {
+        return subjectTemplate;
     }
 
-    public void setTitleTemplate(String titleTemplate) {
-        this.titleTemplate = titleTemplate;
+    public void setSubjectTemplate(String subjectTemplate) {
+        this.subjectTemplate = subjectTemplate;
     }
 
     public String getBodyTemplate() {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateResponse.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateResponse.java
@@ -2,19 +2,37 @@ package com.redhat.cloud.notifications.routers.models;
 
 public class RenderEmailTemplateResponse {
 
-    private final String title;
-    private final String body;
+    public static class Error {
+        private final String message;
 
-    public RenderEmailTemplateResponse(String title, String body) {
-        this.title = title;
-        this.body = body;
+        public Error(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
     }
 
-    public String getTitle() {
-        return title;
+    public static class Success {
+        private final String subject;
+        private final String body;
+
+        public Success(String subject, String body) {
+            this.subject = subject;
+            this.body = body;
+        }
+
+        public String getSubject() {
+            return subject;
+        }
+
+        public String getBody() {
+            return body;
+        }
     }
 
-    public String getBody() {
-        return body;
+    private RenderEmailTemplateResponse() {
+
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateResponse.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RenderEmailTemplateResponse.java
@@ -1,0 +1,20 @@
+package com.redhat.cloud.notifications.routers.models;
+
+public class RenderEmailTemplateResponse {
+
+    private final String title;
+    private final String body;
+
+    public RenderEmailTemplateResponse(String title, String body) {
+        this.title = title;
+        this.body = body;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getBody() {
+        return body;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateService.java
@@ -9,7 +9,6 @@ import io.smallrye.mutiny.Uni;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.logging.Level;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped

--- a/backend/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateService.java
@@ -10,7 +10,7 @@ import io.smallrye.mutiny.Uni;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class EmailTemplateService {
@@ -31,12 +31,12 @@ public class EmailTemplateService {
                 .data("user", user)
                 .createUni()
                 .onFailure().invoke(templateEx -> {
-                    logger.log(Level.WARNING, templateEx, () -> String.format(
+                    logger.warnf(templateEx,
                             "Unable to render template for bundle: [%s] application: [%s], eventType: [%s].",
                             action.getBundle(),
                             action.getApplication(),
                             action.getEventType()
-                    ));
+                    );
                 });
     }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateService.java
@@ -6,10 +6,10 @@ import io.quarkus.qute.Engine;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import io.smallrye.mutiny.Uni;
+import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class EmailTemplateService {

--- a/backend/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateService.java
@@ -1,0 +1,43 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.recipients.User;
+import io.quarkus.qute.Engine;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.smallrye.mutiny.Uni;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class EmailTemplateService {
+
+    @Inject
+    Engine engine;
+
+    private final Logger logger = Logger.getLogger(this.getClass().getName());
+
+    public Uni<TemplateInstance> compileTemplate(String template, String name) {
+        return Uni.createFrom().item(engine.parse(template, null, name))
+                .onItem().transform(Template::instance);
+    }
+
+    public Uni<String> renderTemplate(User user, Action action, TemplateInstance templateInstance) {
+        return templateInstance
+                .data("action", action)
+                .data("user", user)
+                .createUni()
+                .onFailure().invoke(templateEx -> {
+                    logger.log(Level.WARNING, templateEx, () -> String.format(
+                            "Unable to render template for bundle: [%s] application: [%s], eventType: [%s].",
+                            action.getBundle(),
+                            action.getApplication(),
+                            action.getEventType()
+                    ));
+                });
+    }
+
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/utils/ActionParser.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/utils/ActionParser.java
@@ -1,0 +1,27 @@
+package com.redhat.cloud.notifications.utils;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.JsonDecoder;
+import org.apache.avro.specific.SpecificDatumReader;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+
+@ApplicationScoped
+public class ActionParser {
+
+    public Action fromJsonString(String actionJson) {
+        Action action = new Action();
+        try {
+            // Which ones can I reuse?
+            JsonDecoder jsonDecoder = DecoderFactory.get().jsonDecoder(Action.getClassSchema(), actionJson);
+            DatumReader<Action> reader = new SpecificDatumReader<>(Action.class);
+            reader.read(action, jsonDecoder);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Action parsing from json failed", e);
+        }
+        return action;
+    }
+}

--- a/backend/src/main/webapp/src/Routes.tsx
+++ b/backend/src/main/webapp/src/Routes.tsx
@@ -3,6 +3,7 @@ import { Redirect, Route, Switch } from 'react-router';
 
 import { AggregationPage } from './pages/AggregationPage';
 import { ApplicationPage } from './pages/ApplicationPage';
+import { RenderEmailPage } from './pages/RenderEmailPage';
 
 interface Path {
     readonly path: string;
@@ -11,7 +12,8 @@ interface Path {
 
 export const linkTo = {
     application: (applicationId: string) => `/application/${applicationId}`,
-    aggregation: () => '/aggregation'
+    aggregation: () => '/aggregation',
+    email: () => '/email'
 };
 
 const pathRoutes: Path[] = [
@@ -22,6 +24,10 @@ const pathRoutes: Path[] = [
     {
         path: linkTo.application(':applicationId'),
         component: ApplicationPage
+    },
+    {
+        path: linkTo.email(),
+        component: RenderEmailPage
     }
 ];
 

--- a/backend/src/main/webapp/src/app/Navigation.tsx
+++ b/backend/src/main/webapp/src/app/Navigation.tsx
@@ -42,6 +42,9 @@ export const Navigation: React.FunctionComponent<NavigationProps> = props => {
                     )) }
                 </NavGroup>
                 <NavItemSeparator />
+                <EnhancedNavItem to={ linkTo.email() }>
+                    Email templates
+                </EnhancedNavItem>
                 <EnhancedNavItem to={ linkTo.aggregation() }>
                     Aggregation
                 </EnhancedNavItem>

--- a/backend/src/main/webapp/src/generated/OpenapiInternal.ts
+++ b/backend/src/main/webapp/src/generated/OpenapiInternal.ts
@@ -141,11 +141,6 @@ export namespace Schemas {
     weak?: boolean | undefined | null;
   };
 
-  export const Error = zodSchemaError();
-  export type Error = {
-    message?: string | undefined | null;
-  };
-
   export const EventType = zodSchemaEventType();
   export type EventType = {
     application?: Application | undefined | null;
@@ -347,15 +342,8 @@ export namespace Schemas {
     zodSchemaRenderEmailTemplateRequest();
   export type RenderEmailTemplateRequest = {
     bodyTemplate: string;
-    payload?: string | undefined | null;
+    payload: string;
     subjectTemplate: string;
-  };
-
-  export const RenderEmailTemplateResponse =
-    zodSchemaRenderEmailTemplateResponse();
-  export type RenderEmailTemplateResponse = {
-    body?: string | undefined | null;
-    subject?: string | undefined | null;
   };
 
   export const Response = zodSchemaResponse();
@@ -574,14 +562,6 @@ export namespace Schemas {
       .nonstrict();
   }
 
-  function zodSchemaError() {
-      return z
-      .object({
-          message: z.string().optional().nullable()
-      })
-      .nonstrict();
-  }
-
   function zodSchemaEventType() {
       return z
       .object({
@@ -792,17 +772,8 @@ export namespace Schemas {
       return z
       .object({
           bodyTemplate: z.string(),
-          payload: z.string().optional().nullable(),
+          payload: z.string(),
           subjectTemplate: z.string()
-      })
-      .nonstrict();
-  }
-
-  function zodSchemaRenderEmailTemplateResponse() {
-      return z
-      .object({
-          body: z.string().optional().nullable(),
-          subject: z.string().optional().nullable()
       })
       .nonstrict();
   }
@@ -1315,17 +1286,31 @@ export namespace Operations {
   }
   // POST /templates/email/render
   export namespace InternalServiceRenderEmailTemplate {
+    const Response200 = z
+    .object({
+        body: z.string().optional().nullable(),
+        subject: z.string().optional().nullable()
+    })
+    .nonstrict();
+    type Response200 = {
+      body?: string | undefined | null;
+      subject?: string | undefined | null;
+    };
+    const Response400 = z
+    .object({
+        message: z.string().optional().nullable()
+    })
+    .nonstrict();
+    type Response400 = {
+      message?: string | undefined | null;
+    };
     export interface Params {
       body: Schemas.RenderEmailTemplateRequest;
     }
 
     export type Payload =
-      | ValidatedResponse<
-          'RenderEmailTemplateResponse',
-          200,
-          Schemas.RenderEmailTemplateResponse
-        >
-      | ValidatedResponse<'Error', 400, Schemas.Error>
+      | ValidatedResponse<'unknown', 200, Response200>
+      | ValidatedResponse<'unknown', 400, Response400>
       | ValidatedResponse<'unknown', undefined, unknown>;
     export type ActionCreator = Action<Payload, ActionValidatableConfig>;
     export const actionCreator = (params: Params): ActionCreator => {
@@ -1336,12 +1321,8 @@ export namespace Operations {
         .data(params.body)
         .config({
             rules: [
-                new ValidateRule(
-                    Schemas.RenderEmailTemplateResponse,
-                    'RenderEmailTemplateResponse',
-                    200
-                ),
-                new ValidateRule(Schemas.Error, 'Error', 400)
+                new ValidateRule(Response200, 'unknown', 200),
+                new ValidateRule(Response400, 'unknown', 400)
             ]
         })
         .build();

--- a/backend/src/main/webapp/src/generated/OpenapiInternal.ts
+++ b/backend/src/main/webapp/src/generated/OpenapiInternal.ts
@@ -141,6 +141,11 @@ export namespace Schemas {
     weak?: boolean | undefined | null;
   };
 
+  export const Error = zodSchemaError();
+  export type Error = {
+    message?: string | undefined | null;
+  };
+
   export const EventType = zodSchemaEventType();
   export type EventType = {
     application?: Application | undefined | null;
@@ -336,6 +341,21 @@ export namespace Schemas {
     lastName?: string | undefined | null;
     orgAdmin?: boolean | undefined | null;
     username?: string | undefined | null;
+  };
+
+  export const RenderEmailTemplateRequest =
+    zodSchemaRenderEmailTemplateRequest();
+  export type RenderEmailTemplateRequest = {
+    bodyTemplate: string;
+    payload?: string | undefined | null;
+    subjectTemplate: string;
+  };
+
+  export const RenderEmailTemplateResponse =
+    zodSchemaRenderEmailTemplateResponse();
+  export type RenderEmailTemplateResponse = {
+    body?: string | undefined | null;
+    subject?: string | undefined | null;
   };
 
   export const Response = zodSchemaResponse();
@@ -554,6 +574,14 @@ export namespace Schemas {
       .nonstrict();
   }
 
+  function zodSchemaError() {
+      return z
+      .object({
+          message: z.string().optional().nullable()
+      })
+      .nonstrict();
+  }
+
   function zodSchemaEventType() {
       return z
       .object({
@@ -756,6 +784,25 @@ export namespace Schemas {
           lastName: z.string().optional().nullable(),
           orgAdmin: z.boolean().optional().nullable(),
           username: z.string().optional().nullable()
+      })
+      .nonstrict();
+  }
+
+  function zodSchemaRenderEmailTemplateRequest() {
+      return z
+      .object({
+          bodyTemplate: z.string(),
+          payload: z.string().optional().nullable(),
+          subjectTemplate: z.string()
+      })
+      .nonstrict();
+  }
+
+  function zodSchemaRenderEmailTemplateResponse() {
+      return z
+      .object({
+          body: z.string().optional().nullable(),
+          subject: z.string().optional().nullable()
       })
       .nonstrict();
   }
@@ -1262,6 +1309,40 @@ export namespace Operations {
         .data(params.body)
         .config({
             rules: [ new ValidateRule(Response200, 'unknown', 200) ]
+        })
+        .build();
+    };
+  }
+  // POST /templates/email/render
+  export namespace InternalServiceRenderEmailTemplate {
+    export interface Params {
+      body: Schemas.RenderEmailTemplateRequest;
+    }
+
+    export type Payload =
+      | ValidatedResponse<
+          'RenderEmailTemplateResponse',
+          200,
+          Schemas.RenderEmailTemplateResponse
+        >
+      | ValidatedResponse<'Error', 400, Schemas.Error>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/templates/email/render';
+        const query = {} as Record<string, any>;
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(
+                    Schemas.RenderEmailTemplateResponse,
+                    'RenderEmailTemplateResponse',
+                    200
+                ),
+                new ValidateRule(Schemas.Error, 'Error', 400)
+            ]
         })
         .build();
     };

--- a/backend/src/main/webapp/src/pages/RenderEmailPage.tsx
+++ b/backend/src/main/webapp/src/pages/RenderEmailPage.tsx
@@ -52,15 +52,15 @@ const defaultPayload = JSON.stringify({
     events: [
         {
             metadata: {},
-            payload: '{"my_id":"3df53241-3e09-481b-a322-4892caaaaadc","my_name":"Good name"}'
+            payload: '{"my_id":"3df53241-3e09-481b-a322-4892caaaaadc","my_name":"Red color"}'
         },
         {
             metadata: {},
-            payload: '{"my_id":"6c5e8451-a40a-4bb7-ab9a-0cb10a4c577d","my_name":"Bad name"}'
+            payload: '{"my_id":"6c5e8451-a40a-4bb7-ab9a-0cb10a4c577d","my_name":"Green color"}'
         },
         {
             metadata: {},
-            payload: '{"my_id":"b4c6378a-c1fb-4d3e-8e9b-7e5bdfc09dd3","my_name":"Ugly name"}'
+            payload: '{"my_id":"b4c6378a-c1fb-4d3e-8e9b-7e5bdfc09dd3","my_name":"Blue color"}'
         }
     ]
 }, null, 2);

--- a/backend/src/main/webapp/src/pages/RenderEmailPage.tsx
+++ b/backend/src/main/webapp/src/pages/RenderEmailPage.tsx
@@ -21,7 +21,7 @@ Important email to {user.firstName} from MyCoolApp!
 
 const defaultBodyTemplate = `
 <div>Hello {user.firstName} {user.lastName},</div>
-<div>We have some important news to you, MyApp has a notification for you</div>
+<div>We have some important news for you, MyApp has a notification for you</div>
 <div>As a reminder, current user: {user.username}: is active? {user.isActive}; is admin? {user.isAdmin}</div>
 <div>
     System with name <strong>{action.context.display_name}</strong> (<strong>{action.context.inventory_id}</strong>) 

--- a/backend/src/main/webapp/src/pages/RenderEmailPage.tsx
+++ b/backend/src/main/webapp/src/pages/RenderEmailPage.tsx
@@ -1,0 +1,220 @@
+import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import {
+    HelperText,
+    HelperTextItem,
+    PageSection,
+    Spinner,
+    Split,
+    SplitItem,
+    Stack,
+    StackItem,
+    Title
+} from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/';
+import * as React from 'react';
+
+import { useRenderEmailRequest } from '../services/RenderEmailRequest';
+
+const defaultSubjectTemplate = `
+Important email to {user.firstName} from MyCoolApp!
+`.trimLeft();
+
+const defaultBodyTemplate = `
+<div>Hello {user.firstName} {user.lastName},</div>
+<div>We have some important news to you, MyApp has a notification for you</div>
+<div>As a reminder, current user: {user.username}: is active? {user.isActive}; is admin? {user.isAdmin}</div>
+<div>
+    System with name <strong>{action.context.display_name}</strong> (<strong>{action.context.inventory_id}</strong>) 
+    did a check in at {action.context.system_check_in.toUtcFormat()}. 
+    It was about {action.context.system_check_in.toTimeAgo()}
+</div>
+<div>This is a loop:</div>
+{#if action.events.size() > 0}
+<ul>
+    {#each action.events}
+        <li>
+            <a href="http://google.com?q={it.payload.my_id}" target="_blank">{it.payload.my_name}</a>
+        </li>
+    {/each}
+</ul>
+<div>Have a nice day!</div>
+{/if}
+`.trimLeft();
+
+const defaultPayload = JSON.stringify({
+    bundle: 'rhel',
+    application: 'policies',
+    event_type: 'policy-triggered',
+    timestamp: '2021-08-05T16:21:14.243',
+    account_id: '5758117',
+    // eslint-disable-next-line max-len
+    context: '{"inventory_id":"80f7e57d-a16a-4189-82af-1d68a747c8b3","system_check_in":"2021-08-05T16:21:12.953036","display_name":"cool display name"}',
+    events: [
+        {
+            metadata: {},
+            payload: '{"my_id":"3df53241-3e09-481b-a322-4892caaaaadc","my_name":"Good name"}'
+        },
+        {
+            metadata: {},
+            payload: '{"my_id":"6c5e8451-a40a-4bb7-ab9a-0cb10a4c577d","my_name":"Bad name"}'
+        },
+        {
+            metadata: {},
+            payload: '{"my_id":"b4c6378a-c1fb-4d3e-8e9b-7e5bdfc09dd3","my_name":"Ugly name"}'
+        }
+    ]
+}, null, 2);
+
+type RenderedTemplateProps = {
+    isLoading: true;
+} | {
+   isLoading: false;
+   succeeded: true;
+   subject: string;
+   body: string;
+} | {
+    isLoading: false;
+    succeeded: false;
+    error: string;
+};
+
+const RenderedTemplate: React.FunctionComponent<RenderedTemplateProps> = props => {
+    if (props.isLoading) {
+        return <Spinner />;
+    }
+
+    if (props.succeeded) {
+        return (
+            <>
+                <StackItem>
+                    <span><strong>Subject:</strong> { props.subject }</span>
+                </StackItem>
+                <StackItem>
+                    <strong>Body:</strong>
+                </StackItem>
+                <StackItem>
+                    <iframe width="100%" srcDoc={ props.body } />
+                </StackItem>
+            </>
+        );
+    }
+
+    return (
+        <StackItem>
+            <HelperText>
+                <HelperTextItem variant="error">{ props.error }</HelperTextItem>
+            </HelperText>
+        </StackItem>
+    );
+};
+
+export const RenderEmailPage: React.FunctionComponent = () => {
+    const emailTemplate = useRenderEmailRequest();
+    const [ subjectTemplate, setSubjectTemplate ] = React.useState<string | undefined>(defaultSubjectTemplate);
+    const [ bodyTemplate, setBodyTemplate ] = React.useState<string | undefined>(defaultBodyTemplate);
+    const [ payload, setPayload ] = React.useState<string | undefined>(defaultPayload);
+
+    React.useEffect(() => {
+        const mutate = emailTemplate.mutate;
+        mutate({
+            subject: subjectTemplate ?? '',
+            body: bodyTemplate ?? '',
+            payload: payload ?? ''
+        });
+        // We only want to activate this once
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [ ]);
+
+    let renderedProps: RenderedTemplateProps;
+
+    console.log(emailTemplate);
+
+    if (emailTemplate.loading) {
+        renderedProps = {
+            isLoading: true
+        };
+    } else if (emailTemplate.payload?.status === 200) {
+        renderedProps = {
+            isLoading: false,
+            succeeded: true,
+            subject: emailTemplate.payload.value.subject ?? '',
+            body: emailTemplate.payload.value.body ?? ''
+        };
+    } else if (emailTemplate.payload?.status === 400) {
+        renderedProps = {
+            isLoading: false,
+            succeeded: false,
+            error: emailTemplate.payload.value.message ?? 'Unknown error'
+        };
+    } else {
+        renderedProps = {
+            isLoading: false,
+            succeeded: false,
+            error: 'Unknown error'
+        };
+    }
+
+    const onRender = React.useCallback(() => {
+        const mutate = emailTemplate.mutate;
+        mutate({
+            subject: subjectTemplate ?? '',
+            body: bodyTemplate ?? '',
+            payload: payload ?? ''
+        });
+    }, [ emailTemplate.mutate, subjectTemplate, bodyTemplate, payload ]);
+
+    return (
+        <>
+            <PageSection>
+                <Split>
+                    <SplitItem isFilled>
+                        <Title headingLevel="h1" >Email templates</Title>
+                    </SplitItem>
+                    <SplitItem>
+                        <Button onClick={ onRender }>Render</Button>
+                    </SplitItem>
+                </Split>
+            </PageSection>
+            <PageSection>
+                <Stack>
+                    <StackItem>
+                        <Title headingLevel="h2">Result</Title>
+                    </StackItem>
+                    <RenderedTemplate { ...renderedProps }  />
+                </Stack>
+            </PageSection>
+            <PageSection>
+                <Title headingLevel="h2">Subject template</Title>
+                <CodeEditor
+                    isLineNumbersVisible
+                    isMinimapVisible={ false }
+                    code={ defaultSubjectTemplate }
+                    height="50px"
+                    onChange={ setSubjectTemplate }
+                />
+            </PageSection>
+            <PageSection>
+                <Title headingLevel="h2">Body template</Title>
+                <CodeEditor
+                    isLineNumbersVisible
+                    isMinimapVisible={ false }
+                    code={ defaultBodyTemplate }
+                    height="300px"
+                    onChange={ setBodyTemplate }
+                />
+            </PageSection>
+            <PageSection>
+                <Title headingLevel="h2">Payload</Title>
+                <CodeEditor
+                    isLineNumbersVisible
+                    isMinimapVisible={ false }
+                    code={ defaultPayload }
+                    height="300px"
+                    isLanguageLabelVisible
+                    language={ Language.json }
+                    onChange={ setPayload }
+                />
+            </PageSection>
+        </>
+    );
+};

--- a/backend/src/main/webapp/src/services/RenderEmailRequest.ts
+++ b/backend/src/main/webapp/src/services/RenderEmailRequest.ts
@@ -1,0 +1,21 @@
+import { useMutation } from 'react-fetching-library';
+
+import { Operations } from '../generated/OpenapiInternal';
+
+export type RenderEmailRequest = {
+    subject: string;
+    body: string;
+    payload: string;
+}
+
+const actionCreator = (params: RenderEmailRequest) => Operations.InternalServiceRenderEmailTemplate.actionCreator({
+    body: {
+        subjectTemplate: params.subject,
+        bodyTemplate: params.body,
+        payload: params.payload
+    }
+});
+
+export const useRenderEmailRequest = () => {
+    return useMutation(actionCreator);
+};


### PR DESCRIPTION
This could help devs into trying an email template without actually having to put the code in the repository and trigger an event.
The idea is to write the templates (subject, body) and the payloads to render on the page.
There is sample data to get started.

![Screenshot_2021-08-16_11-14-49](https://user-images.githubusercontent.com/3845764/129595503-679fee9e-1148-4c3a-8b8c-1d7d8f0246b4.png)

![Screenshot_2021-08-16_11-16-25](https://user-images.githubusercontent.com/3845764/129595685-0f40ed8c-00e5-4ad2-bbae-d2739c9d2283.png)

