### PR TITLE
Fix CodeQL analysis failure because of Dependabot

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches-ignore: [dependabot/**]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]


### PR DESCRIPTION
The following error happens randomly during a CodeQL analysis after a @dependabot push:
```
Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.
```
Example: see the checks from https://github.com/RedHatInsights/notifications-backend/commit/602c34d37ff44e0f9b8d838a2c6b5c2c3f711b98.

This PR should fix the issue.