### PR TITLE
NOTIF-291 Fix OutOfMemoryError during notifications history migration

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventLogMigrationServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventLogMigrationServiceTest.java
@@ -12,6 +12,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.Header;
 import io.vertx.core.json.JsonArray;
 import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
@@ -20,6 +22,7 @@ import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.API_INTEGRATIONS_V_1_0;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
+import static com.redhat.cloud.notifications.routers.EventLogMigrationService.BATCH_SIZE_KEY;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,6 +40,16 @@ public class EventLogMigrationServiceTest extends DbIsolatedTest {
 
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty(BATCH_SIZE_KEY, "2");
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty(BATCH_SIZE_KEY);
+    }
 
     @Test
     void test() {


### PR DESCRIPTION
CI database contains 265241 records in `notification_history`. The migration failed because it tried to load all these records into an `ArrayList` which caused an `OutOfMemoryError`.

The new code migrates 1000 records at a time and repeats itself until there's nothing more to migrate.