### PR TITLE
Refactor resources usage in tests

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/TestConstants.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestConstants.java
@@ -7,4 +7,5 @@ public class TestConstants {
     public static final String API_NOTIFICATIONS_V_1_0 = "/api/notifications/v1.0";
     public static final String API_NOTIFICATIONS_V_1 = "/api/notifications/v1";
     public static final String API_INTEGRATIONS_V_1 = "/api/integrations/v1";
+    public static final String DEFAULT_ACCOUNT_ID = "default-account-id";
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
@@ -74,7 +74,6 @@ public class DbCleaner {
                     app.setBundleId(bundle.getId());
                     app.setName(DEFAULT_APP_NAME);
                     app.setDisplayName(DEFAULT_APP_DISPLAY_NAME);
-                    app.setBundleId(bundle.getId());
                     return appResources.createApp(app);
                 })
                 .onItem().transformToUni(app -> {

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -5,20 +5,29 @@ import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.models.EmailAggregationKey;
 import com.redhat.cloud.notifications.models.EmailSubscription;
 import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.WebhookProperties;
+import io.vertx.core.json.JsonObject;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
+import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
+import static java.lang.Boolean.FALSE;
 
 @ApplicationScoped
 public class ResourceHelpers {
@@ -46,50 +55,104 @@ public class ResourceHelpers {
     @Inject
     BehaviorGroupResources behaviorGroupResources;
 
-    public List<Application> getApplications(String bundleName) {
-        return appResources.getApplications(bundleName).await().indefinitely();
+    public Bundle createBundle() {
+        return createBundle("name", "displayName");
     }
 
-    public EmailSubscription getSubscription(String accountNumber, String username, String bundle, String application, EmailSubscriptionType type) {
-        return subscriptionResources.getEmailSubscription(accountNumber, username, bundle, application, type).await().indefinitely();
+    public Bundle createBundle(String name, String displayName) {
+        Bundle bundle = new Bundle(name, displayName);
+        return bundleResources.createBundle(bundle)
+                .await().indefinitely();
+    }
+
+    public UUID getBundleId(String bundleName) {
+        return bundleResources.getBundle(bundleName)
+                .await().indefinitely()
+                .getId();
+    }
+
+    public Application createApplication(UUID bundleId) {
+        return createApplication(bundleId, "name", "displayName");
+    }
+
+    public Application createApplication(UUID bundleId, String name, String displayName) {
+        Application app = new Application();
+        app.setBundleId(bundleId);
+        app.setName(name);
+        app.setDisplayName(displayName);
+        return appResources.createApp(app)
+                .await().indefinitely();
+    }
+
+    public List<Application> getApplications(String bundleName) {
+        return appResources.getApplications(bundleName)
+                .await().indefinitely();
+    }
+
+    public UUID createEventType(String bundleName, String applicationName, String eventTypeName) {
+        Application app = appResources.getApplication(bundleName, applicationName).await().indefinitely();
+        return createEventType(app.getId(), eventTypeName, eventTypeName, "new event type");
+    }
+
+    public UUID createEventType(UUID applicationId, String name, String displayName, String description) {
+        EventType eventType = new EventType();
+        eventType.setName(name);
+        eventType.setDisplayName(displayName);
+        eventType.setDescription(description);
+        eventType.setApplicationId(applicationId);
+        return appResources.createEventType(eventType)
+                .await().indefinitely()
+                .getId();
     }
 
     public UUID createTestAppAndEventTypes() {
-        Bundle bundle = new Bundle(TEST_BUNDLE_NAME, "...");
-        Bundle b = bundleResources.createBundle(bundle).await().indefinitely();
+        Bundle bundle = createBundle(TEST_BUNDLE_NAME, "...");
 
-        Application app = new Application();
-        app.setBundleId(b.getId());
-        app.setName(TEST_APP_NAME);
-        app.setDisplayName("...");
-        app.setBundleId(b.getId());
-        Application added = appResources.createApp(app).await().indefinitely();
-
+        Application app = createApplication(bundle.getId(), TEST_APP_NAME, "...");
         for (int i = 0; i < 100; i++) {
-            EventType eventType = new EventType();
-            eventType.setApplicationId(added.getId());
-            eventType.setName(String.format(TEST_EVENT_TYPE_FORMAT, i));
-            eventType.setDisplayName("... -> " + i);
-            eventType.setDescription("Desc .. --> " + i);
-            appResources.createEventType(eventType).await().indefinitely();
+            String name = String.format(TEST_EVENT_TYPE_FORMAT, i);
+            String displayName = "... -> " + i;
+            String description = "Desc .. --> " + i;
+            createEventType(app.getId(), name, displayName, description);
         }
 
-        Application app2 = new Application();
-        app2.setBundleId(b.getId());
-        app2.setName(TEST_APP_NAME_2);
-        app2.setDisplayName("...");
-        app2.setBundleId(b.getId());
-        Application added2 = appResources.createApp(app2).await().indefinitely();
-
+        Application app2 = createApplication(bundle.getId(), TEST_APP_NAME_2, "...");
         for (int i = 0; i < 100; i++) {
-            EventType eventType = new EventType();
-            eventType.setApplicationId(added2.getId());
-            eventType.setName(String.format(TEST_EVENT_TYPE_FORMAT, i));
-            eventType.setDisplayName("... -> " + i);
-            appResources.createEventType(eventType).await().indefinitely();
+            String name = String.format(TEST_EVENT_TYPE_FORMAT, i);
+            String displayName = "... -> " + i;
+            createEventType(app2.getId(), name, displayName, null);
         }
 
-        return b.getId();
+        return bundle.getId();
+    }
+
+    public List<EventType> getEventTypesForApplication(UUID applicationId) {
+        return appResources.getEventTypes(applicationId)
+                .await().indefinitely();
+    }
+
+    public Endpoint createEndpoint(String accountId, EndpointType type) {
+        return createEndpoint(accountId, type, "name", "description", null, FALSE);
+    }
+
+    public UUID createWebhookEndpoint(String accountId) {
+        WebhookProperties properties = new WebhookProperties();
+        properties.setMethod(HttpType.POST);
+        properties.setUrl("https://localhost");
+        String name = "Endpoint " + UUID.randomUUID();
+        return createEndpoint(accountId, WEBHOOK, name, "Automatically generated", properties, Boolean.TRUE).getId();
+    }
+
+    public Endpoint createEndpoint(String accountId, EndpointType type, String name, String description, EndpointProperties properties, Boolean enabled) {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setAccountId(accountId);
+        endpoint.setType(type);
+        endpoint.setName(name);
+        endpoint.setDescription(description);
+        endpoint.setProperties(properties);
+        endpoint.setEnabled(enabled);
+        return endpointResources.createEndpoint(endpoint)
+                .await().indefinitely();
     }
 
     public int[] createTestEndpoints(String tenant, int count) {
@@ -102,7 +165,7 @@ public class ResourceHelpers {
             properties.setUrl("https://localhost");
 
             Endpoint ep = new Endpoint();
-            ep.setType(EndpointType.WEBHOOK);
+            ep.setType(WEBHOOK);
             ep.setName(String.format("Endpoint %d", count - i));
             ep.setDescription("Automatically generated");
             boolean enabled = (i % (count / 5)) != 0;
@@ -116,75 +179,108 @@ public class ResourceHelpers {
             }
 
             ep.setAccountId(tenant);
-            endpointResources.createEndpoint(ep).await().indefinitely();
+            endpointResources.createEndpoint(ep)
+                    .await().indefinitely();
         }
         return statsValues;
     }
 
-    public UUID createWebhookEndpoint(String tenant) {
-        WebhookProperties properties = new WebhookProperties();
-        properties.setMethod(HttpType.POST);
-        properties.setUrl("https://localhost");
-        Endpoint ep = new Endpoint();
-        ep.setType(EndpointType.WEBHOOK);
-        ep.setName(String.format("Endpoint %s", UUID.randomUUID().toString()));
-        ep.setDescription("Automatically generated");
-        ep.setEnabled(true);
-        ep.setAccountId(tenant);
-        ep.setProperties(properties);
-        return endpointResources.createEndpoint(ep).await().indefinitely().getId();
+    public UUID emailSubscriptionEndpointId(String accountId, EmailSubscriptionProperties properties) {
+        return endpointResources.getOrCreateEmailSubscriptionEndpoint(accountId, properties)
+                .await().indefinitely().getId();
     }
 
-    public UUID getBundleId(String bundleName) {
-        return bundleResources.getBundle(bundleName).await().indefinitely().getId();
+    public BehaviorGroup createBehaviorGroup(String accountId, String displayName, UUID bundleId) {
+        BehaviorGroup behaviorGroup = new BehaviorGroup();
+        behaviorGroup.setDisplayName(displayName);
+        behaviorGroup.setBundleId(bundleId);
+        return behaviorGroupResources.create(accountId, behaviorGroup)
+                .await().indefinitely();
     }
 
-    public UUID createEventType(String bundleName, String applicationName, String eventTypeName) {
-        Application app = appResources.getApplication(bundleName, applicationName).await().indefinitely();
-
-        EventType eventType = new EventType();
-        eventType.setDescription("new event type");
-        eventType.setName(eventTypeName);
-        eventType.setDisplayName(eventTypeName);
-        eventType.setBehaviors(Set.of());
-        eventType.setApplication(app);
-        eventType.setApplicationId(app.getId());
-        return appResources.createEventType(eventType).await().indefinitely().getId();
+    public List<BehaviorGroup> findBehaviorGroupsByBundleId(String accountId, UUID bundleId) {
+        return behaviorGroupResources.findByBundleId(accountId, bundleId)
+                .await().indefinitely();
     }
 
-    public void createSubscription(String tenant, String username, String bundle, String application, EmailSubscriptionType type) {
-        subscriptionResources.subscribe(tenant, username, bundle, application, type).await().indefinitely();
+    public List<EventType> findEventTypesByBehaviorGroupId(UUID behaviorGroupId) {
+        return behaviorGroupResources.findEventTypesByBehaviorGroupId(DEFAULT_ACCOUNT_ID, behaviorGroupId)
+                .await().indefinitely();
     }
 
-    public void removeSubscription(String tenant, String username, String bundle, String application, EmailSubscriptionType type) {
-        subscriptionResources.unsubscribe(tenant, username, bundle, application, type).await().indefinitely();
+    public List<BehaviorGroup> findBehaviorGroupsByEventTypeId(UUID eventTypeId) {
+        return behaviorGroupResources.findBehaviorGroupsByEventTypeId(DEFAULT_ACCOUNT_ID, eventTypeId, new Query())
+                .await().indefinitely();
+    }
+
+    public List<BehaviorGroup> findBehaviorGroupsByEndpointId(UUID endpointId) {
+        return behaviorGroupResources.findBehaviorGroupsByEndpointId(DEFAULT_ACCOUNT_ID, endpointId)
+                .await().indefinitely();
+    }
+
+    public Boolean updateBehaviorGroup(BehaviorGroup behaviorGroup) {
+        return behaviorGroupResources.update(DEFAULT_ACCOUNT_ID, behaviorGroup)
+                .await().indefinitely();
+    }
+
+    public Response.Status updateBehaviorGroupActions(String accountId, UUID behaviorGroupId, List<UUID> endpointIds) {
+        return behaviorGroupResources.updateBehaviorGroupActions(accountId, behaviorGroupId, endpointIds)
+                .await().indefinitely();
+    }
+
+    public Boolean updateEventTypeBehaviors(String accountId, UUID eventTypeId, Set<UUID> behaviorGroupIds) {
+        return behaviorGroupResources.updateEventTypeBehaviors(accountId, eventTypeId, behaviorGroupIds)
+                .await().indefinitely();
+    }
+
+    public Boolean deleteBehaviorGroup(UUID behaviorGroupId) {
+        return behaviorGroupResources.delete(DEFAULT_ACCOUNT_ID, behaviorGroupId)
+                .await().indefinitely();
+    }
+
+    public void subscribe(String tenant, String username, String bundle, String application, EmailSubscriptionType type) {
+        subscriptionResources.subscribe(tenant, username, bundle, application, type)
+                .await().indefinitely();
+    }
+
+    public void unsubscribe(String tenant, String username, String bundle, String application, EmailSubscriptionType type) {
+        subscriptionResources.unsubscribe(tenant, username, bundle, application, type)
+                .await().indefinitely();
+    }
+
+    public EmailSubscription getEmailSubscription(String accountNumber, String username, String bundle, String application, EmailSubscriptionType type) {
+        return subscriptionResources.getEmailSubscription(accountNumber, username, bundle, application, type)
+                .await().indefinitely();
     }
 
     public void addEmailAggregation(String tenant, String bundle, String application, String policyId, String insightsId) {
         EmailAggregation aggregation = TestHelpers.createEmailAggregation(tenant, bundle, application, policyId, insightsId);
-        emailAggregationResources.addEmailAggregation(aggregation).await().indefinitely();
+        emailAggregationResources.addEmailAggregation(aggregation)
+                .await().indefinitely();
     }
 
-    public List<EventType> getEventTypesForApplication(UUID applicationId) {
-        return appResources.getEventTypes(applicationId).await().indefinitely();
+    public Boolean addEmailAggregation(String accountId, String bundleName, String applicationName, JsonObject payload) {
+        EmailAggregation aggregation = new EmailAggregation();
+        aggregation.setAccountId(accountId);
+        aggregation.setBundleName(bundleName);
+        aggregation.setApplicationName(applicationName);
+        aggregation.setPayload(payload);
+        return emailAggregationResources.addEmailAggregation(aggregation)
+                .await().indefinitely();
     }
 
-    public UUID createBehaviorGroup(String accountId, String name, UUID bundleId) {
-        BehaviorGroup behaviorGroup = new BehaviorGroup();
-        behaviorGroup.setDisplayName("Behavior group");
-        behaviorGroup.setBundleId(bundleId);
-        return behaviorGroupResources.create(accountId, behaviorGroup).await().indefinitely().getId();
+    public List<EmailAggregation> getEmailAggregation(EmailAggregationKey key, LocalDateTime start, LocalDateTime end) {
+        return emailAggregationResources.getEmailAggregation(key, start, end)
+                .await().indefinitely();
     }
 
-    public void updateEventTypeBehaviors(String accountId, UUID eventTypeId, Set<UUID> behaviorGroupIds) {
-        behaviorGroupResources.updateEventTypeBehaviors(accountId, eventTypeId, behaviorGroupIds).await().indefinitely();
+    public List<EmailAggregationKey> getApplicationsWithPendingAggregation(LocalDateTime start, LocalDateTime end) {
+        return emailAggregationResources.getApplicationsWithPendingAggregation(start, end)
+                .await().indefinitely();
     }
 
-    public void updateBehaviorGroupActions(String accountId, UUID behaviorGroupId, List<UUID> endpointIds) {
-        behaviorGroupResources.updateBehaviorGroupActions(accountId, behaviorGroupId, endpointIds).await().indefinitely();
-    }
-
-    public UUID emailSubscriptionEndpointId(String accountId, EmailSubscriptionProperties properties) {
-        return endpointResources.getOrCreateEmailSubscriptionEndpoint(accountId, properties).await().indefinitely().getId();
+    public Integer purgeOldAggregation(EmailAggregationKey key, LocalDateTime lastUsedTime) {
+        return emailAggregationResources.purgeOldAggregation(key, lastUsedTime)
+                .await().indefinitely();
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
@@ -110,7 +110,7 @@ public class EmailTest extends DbIsolatedTest {
         String application = "policies";
 
         for (String username : usernames) {
-            helpers.createSubscription(tenant, username, bundle, application, EmailSubscriptionType.INSTANT);
+            helpers.subscribe(tenant, username, bundle, application, EmailSubscriptionType.INSTANT);
         }
 
         final List<String> bodyRequests = new ArrayList<>();
@@ -192,7 +192,7 @@ public class EmailTest extends DbIsolatedTest {
         String application = "policies";
 
         for (String username : usernames) {
-            helpers.createSubscription(tenant, username, bundle, application, EmailSubscriptionType.INSTANT);
+            helpers.subscribe(tenant, username, bundle, application, EmailSubscriptionType.INSTANT);
         }
 
         final List<String> bodyRequests = new ArrayList<>();
@@ -278,22 +278,22 @@ public class EmailTest extends DbIsolatedTest {
         for (String accountId : accountIds) {
             UUID endpointId = helpers.emailSubscriptionEndpointId(accountId, new EmailSubscriptionProperties());
             UUID bundleId = helpers.getBundleId(bundle);
-            UUID behaviorGroupId = helpers.createBehaviorGroup(accountId, "test-behavior-group", bundleId);
+            UUID behaviorGroupId = helpers.createBehaviorGroup(accountId, "test-behavior-group", bundleId).getId();
 
             helpers.updateEventTypeBehaviors(accountId, eventTypeId, Set.of(behaviorGroupId));
             helpers.updateBehaviorGroupActions(accountId, behaviorGroupId, List.of(endpointId));
         }
 
         for (String username : tenant1Usernames) {
-            helpers.createSubscription(tenant1, username, bundle, application, EmailSubscriptionType.DAILY);
+            helpers.subscribe(tenant1, username, bundle, application, EmailSubscriptionType.DAILY);
         }
 
         for (String username : tenant2Usernames) {
-            helpers.createSubscription(tenant2, username, bundle, application, EmailSubscriptionType.DAILY);
+            helpers.subscribe(tenant2, username, bundle, application, EmailSubscriptionType.DAILY);
         }
 
         for (String username : noSubscribedUsersTenantTestUser) {
-            helpers.removeSubscription(noSubscribedUsersTenant, username, bundle, application, EmailSubscriptionType.DAILY);
+            helpers.unsubscribe(noSubscribedUsersTenant, username, bundle, application, EmailSubscriptionType.DAILY);
         }
 
         final Instant nowPlus5HoursInstant = Instant.now().plus(Duration.ofHours(5));
@@ -428,11 +428,11 @@ public class EmailTest extends DbIsolatedTest {
             }
 
             bodyRequests.clear();
-            helpers.createSubscription(noSubscribedUsersTenant, noSubscribedUsersTenantTestUser[0], bundle, application, EmailSubscriptionType.DAILY);
+            helpers.subscribe(noSubscribedUsersTenant, noSubscribedUsersTenantTestUser[0], bundle, application, EmailSubscriptionType.DAILY);
             emailProcessor.processDailyEmail(nowPlus5Hours);
             // 0 emails; previous aggregations were deleted in this step, even if no one was subscribed by that time
             assertEquals(0, bodyRequests.size());
-            helpers.removeSubscription(noSubscribedUsersTenant, noSubscribedUsersTenantTestUser[0], bundle, application, EmailSubscriptionType.DAILY);
+            helpers.unsubscribe(noSubscribedUsersTenant, noSubscribedUsersTenantTestUser[0], bundle, application, EmailSubscriptionType.DAILY);
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -811,7 +811,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
         Header identityHeader = TestHelpers.createIdentityHeader(identityHeaderValue);
         mockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
 
-        this.helpers.createTestAppAndEventTypes();
+        helpers.createTestAppAndEventTypes();
 
         // invalid bundle/application combination gives a 404
         given()
@@ -881,10 +881,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .then().statusCode(200)
                 .contentType(JSON);
 
-        assertNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
+        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
 
         // Enable instant on rhel.policies
         given()
@@ -893,10 +893,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/rhel/policies/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
+        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
 
         // Enable daily on rhel.policies
         given()
@@ -905,10 +905,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/rhel/policies/daily")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
+        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
+        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
 
         // Enable instant on TEST_BUNDLE_NAME.TEST_APP_NAME
         given()
@@ -917,10 +917,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/" + ResourceHelpers.TEST_BUNDLE_NAME + "/" + ResourceHelpers.TEST_APP_NAME + "/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNotNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
+        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
+        assertNotNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
 
         // Disable daily on rhel.policies
         given()
@@ -929,10 +929,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .delete("/endpoints/email/subscription/rhel/policies/daily")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNotNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
+        assertNotNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
 
         // Disable instant on rhel.policies
         given()
@@ -941,10 +941,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .delete("/endpoints/email/subscription/rhel/policies/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNotNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(this.helpers.getSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
+        assertNotNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
+        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
     }
 
     //    @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -98,7 +98,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
         helpers.createTestAppAndEventTypes();
         Header identityHeader = initRbacMock(TENANT, USERNAME, RbacAccess.FULL_ACCESS);
 
-        List<Application> applications = this.helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
+        List<Application> applications = helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
         UUID myOtherTesterApplicationId = applications.stream().filter(a -> a.getName().equals(ResourceHelpers.TEST_APP_NAME_2)).findFirst().get().getId();
 
         Response response = given()
@@ -126,8 +126,8 @@ public class NotificationServiceTest extends DbIsolatedTest {
         helpers.createTestAppAndEventTypes();
         Header identityHeader = initRbacMock(TENANT, USERNAME, RbacAccess.FULL_ACCESS);
 
-        List<Application> applications = this.helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
-        UUID myBundleId = applications.stream().filter(a -> a.getName().equals(this.helpers.TEST_APP_NAME_2)).findFirst().get().getBundleId();
+        List<Application> applications = helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
+        UUID myBundleId = applications.stream().filter(a -> a.getName().equals(helpers.TEST_APP_NAME_2)).findFirst().get().getBundleId();
 
         Response response = given()
                 .when()
@@ -154,9 +154,9 @@ public class NotificationServiceTest extends DbIsolatedTest {
         helpers.createTestAppAndEventTypes();
         Header identityHeader = initRbacMock(TENANT, USERNAME, RbacAccess.FULL_ACCESS);
 
-        List<Application> applications = this.helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
-        UUID myOtherTesterApplicationId = applications.stream().filter(a -> a.getName().equals(this.helpers.TEST_APP_NAME_2)).findFirst().get().getId();
-        UUID myBundleId = applications.stream().filter(a -> a.getName().equals(this.helpers.TEST_APP_NAME_2)).findFirst().get().getBundleId();
+        List<Application> applications = helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
+        UUID myOtherTesterApplicationId = applications.stream().filter(a -> a.getName().equals(helpers.TEST_APP_NAME_2)).findFirst().get().getId();
+        UUID myBundleId = applications.stream().filter(a -> a.getName().equals(helpers.TEST_APP_NAME_2)).findFirst().get().getBundleId();
 
         Response response = given()
                 .when()
@@ -186,12 +186,12 @@ public class NotificationServiceTest extends DbIsolatedTest {
         String tenant = "testGetEventTypesAffectedByEndpoint";
         Header identityHeader = initRbacMock(tenant, "user", RbacAccess.FULL_ACCESS);
 
-        UUID behaviorGroupId1 = helpers.createBehaviorGroup(tenant, "behavior-group-1", bundleId);
-        UUID behaviorGroupId2 = helpers.createBehaviorGroup(tenant, "behavior-group-2", bundleId);
-        UUID applicationId = this.helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME).stream().filter(a -> a.getName().equals(ResourceHelpers.TEST_APP_NAME_2)).findFirst().get().getId();
-        UUID ep1 = this.helpers.createWebhookEndpoint(tenant);
-        UUID ep2 = this.helpers.createWebhookEndpoint(tenant);
-        List<EventType> eventTypesFromApp1 = this.helpers.getEventTypesForApplication(applicationId);
+        UUID behaviorGroupId1 = helpers.createBehaviorGroup(tenant, "behavior-group-1", bundleId).getId();
+        UUID behaviorGroupId2 = helpers.createBehaviorGroup(tenant, "behavior-group-2", bundleId).getId();
+        UUID applicationId = helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME).stream().filter(a -> a.getName().equals(ResourceHelpers.TEST_APP_NAME_2)).findFirst().get().getId();
+        UUID ep1 = helpers.createWebhookEndpoint(tenant);
+        UUID ep2 = helpers.createWebhookEndpoint(tenant);
+        List<EventType> eventTypesFromApp1 = helpers.getEventTypesForApplication(applicationId);
         EventType ev0 = eventTypesFromApp1.get(0);
         EventType ev1 = eventTypesFromApp1.get(1);
 


### PR DESCRIPTION
This PR moves resources-related test code around to reduce code duplication and ease tests maintenance.

It will also help me with NOTIF-273 and NOTIF-291.

- 100% test code, no impact on prod
- 0% tests coverage change, it is exactly like it was before this PR
- 100% boring to review, I'll merge it by the end of the day (without approval) unless someone likes boring reviews 😄 