### PR TITLE
NOTIF-291 Repair CI and stage Flyway schema history

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
@@ -29,6 +29,7 @@ public class FlywayWorkaround {
     public void runFlywayMigration(@Observes StartupEvent event) {
         LOGGER.warn("Starting Flyway workaround... remove it ASAP!");
         Flyway flyway = Flyway.configure().dataSource("jdbc:" + datasourceUrl, datasourceUsername, datasourcePassword).load();
+        flyway.repair();
         flyway.migrate();
     }
 }


### PR DESCRIPTION
https://github.com/RedHatInsights/notifications-backend/pull/536 removed some Flyway scripts that had already been executed on CI and stage (not prod).

This PR repairs the Flyway schema history and in particular fixes that kind of error:
```
Detected applied migration not resolved locally: 1.23.0. If you removed this migration intentionally, run repair to mark the migration as deleted.
```