### PR TITLE
Fix integrations OpenAPI casing issue

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RequestEmailSubscriptionProperties.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RequestEmailSubscriptionProperties.java
@@ -2,12 +2,14 @@ package com.redhat.cloud.notifications.routers.models;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import javax.validation.constraints.NotNull;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RequestEmailSubscriptionProperties {
     @NotNull
+    @Schema(name = "only_admins")
     private boolean onlyAdmins;
 
     public boolean isOnlyAdmins() {


### PR DESCRIPTION
Fixes

```
ERROR in /notifications-frontend/src/services/Integrations/GetDefaultSystemEndpoint.ts
./src/services/Integrations/GetDefaultSystemEndpoint.ts 10:16-62
[tsl] ERROR in /notifications-frontend/src/services/Integrations/GetDefaultSystemEndpoint.ts(10,17)
      TS2322: Type '{ only_admins: boolean; }' is not assignable to type 'RequestEmailSubscriptionProperties'.
  Object literal may only specify known properties, but 'only_admins' does not exist in type 'RequestEmailSubscriptionProperties'. Did you mean to write 'onlyAdmins'?
```