### PR TITLE
NOTIF-291 Remove Flyway repair

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
@@ -29,7 +29,6 @@ public class FlywayWorkaround {
     public void runFlywayMigration(@Observes StartupEvent event) {
         LOGGER.warn("Starting Flyway workaround... remove it ASAP!");
         Flyway flyway = Flyway.configure().dataSource("jdbc:" + datasourceUrl, datasourceUsername, datasourcePassword).load();
-        flyway.repair();
         flyway.migrate();
     }
 }


### PR DESCRIPTION
`repair()` was required because the Flyway scripts `V1.22` to `V1.26` were deleted and replaced with `V1.27` while some of them had already been executed on some environments.

CI, stage and prod were already migrated to `V1.27`. I'm leaving this around a bit more to help fixing migration issues in the devs local database.