### PR TITLE
NOTIF-140 Allow unknown keys in RBAC S2S secrets map

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/recipients/rbac/AuthRequestFilter.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/recipients/rbac/AuthRequestFilter.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.recipients.rbac;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,6 +27,7 @@ class AuthRequestFilter implements ClientRequestFilter {
     // used by dev to by pass the service to service token: Uses user:password format
     static final String RBAC_SERVICE_TO_SERVICE_DEV_EXCEPTIONAL_AUTH_KEY = "rbac.service-to-service.exceptional.auth.info";
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private static class Secret {
         public String secret;
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/recipients/rbac/AuthRequestFilterTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/recipients/rbac/AuthRequestFilterTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 @QuarkusTest
 public class AuthRequestFilterTest {
 
-    private static final String testToken = "{\"approval\":{\"secret\":\"123\"},\"advisor\":{\"secret\":\"456\"},\"notifications\":{\"secret\":\"789\"}}";
+    private static final String testToken = "{\"approval\":{\"secret\":\"123\"},\"advisor\":{\"alt-secret\":\"456\"},\"notifications\":{\"secret\":\"789\"}}";
 
     @BeforeEach
     public void clean() {


### PR DESCRIPTION
We had a failure on stage because of unknown keys in the RBAC S2S secrets map:

```
2021-09-02 13:09:12,494 ERROR [com.red.clo.not.rec.rba.AuthRequestFilter] (vert.x-eventloop-thread-0) Unable to load Rbac service to service secret map, defaulting to empty map: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "alt-secret" (class com.redhat.cloud.notifications.recipients.rbac.AuthRequestFilter$Secret), not marked as ignorable (one known property: "secret"])
 at [Source: (String)"{
  "advisor": {
    "alt-secret": "REMOVED_FROM_SECURITY_REASON"
  },
  "approval": {
    "alt-secret": "REMOVED_FROM_SECURITY_REASON"
  },
  "notifications": {
    "secret": "REMOVED_FROM_SECURITY_REASON"
  }
}
```