### PR TITLE
NOTIF-291 Add EventService

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.db;
 
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
-import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
 import io.smallrye.mutiny.Uni;
 import org.hibernate.reactive.mutiny.Mutiny;
@@ -162,12 +161,5 @@ public class ApplicationResources {
         }
 
         return mutinyQuery.getResultList();
-    }
-
-    // Note: This method uses a stateless session
-    public Uni<Event> createEvent(Event event) {
-        event.prePersist(); // This method must be called manually while using a StatelessSession.
-        return statelessSession.insert(event)
-                .replaceWith(event);
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
@@ -1,0 +1,119 @@
+package com.redhat.cloud.notifications.db;
+
+import com.redhat.cloud.notifications.models.Event;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+
+import static com.redhat.cloud.notifications.routers.EventService.SORT_BY_PATTERN;
+
+@ApplicationScoped
+public class EventResources {
+
+    @Inject
+    Mutiny.Session session;
+
+    @Inject
+    Mutiny.StatelessSession statelessSession;
+
+    // Note: This method uses a stateless session
+    public Uni<Event> create(Event event) {
+        event.prePersist(); // This method must be called manually while using a StatelessSession.
+        return statelessSession.insert(event)
+                .replaceWith(event);
+    }
+
+    public Uni<List<Event>> get(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeName,
+                                LocalDate startDate, LocalDate endDate, Integer limit, Integer offset, String sortBy) {
+        String hql = "SELECT DISTINCT e FROM Event e " +
+                "JOIN FETCH e.eventType et JOIN FETCH et.application a JOIN FETCH a.bundle b " +
+                "LEFT JOIN FETCH e.historyEntries he LEFT JOIN FETCH he.endpoint " +
+                "WHERE e.accountId = :accountId";
+
+        if (bundleIds != null && !bundleIds.isEmpty()) {
+            hql += " AND b.id IN (:bundleIds)";
+        }
+
+        if (appIds != null && !appIds.isEmpty()) {
+            hql += " AND a.id IN (:appIds)";
+        }
+
+        if (eventTypeName != null) {
+            hql += " AND et.name = :eventTypeName";
+        }
+
+        if (startDate != null && endDate != null) {
+            hql += " AND DATE(e.created) BETWEEN :startDate AND :endDate";
+        } else if (startDate != null) {
+            hql += " AND DATE(e.created) >= :startDate";
+        } else if (endDate != null) {
+            hql += " AND DATE(e.created) <= :endDate";
+        }
+
+        if (sortBy == null) {
+            hql += " ORDER BY e.created DESC";
+        } else {
+            Matcher sortByMatcher = SORT_BY_PATTERN.matcher(sortBy);
+            if (sortByMatcher.matches()) {
+                String sortField = getSortField(sortByMatcher.group(1));
+                String sortDirection = sortByMatcher.group(2);
+                hql += " ORDER BY " + sortField + " " + sortDirection + ", e.created DESC";
+            }
+        }
+
+        Mutiny.Query<Event> query = session.createQuery(hql, Event.class)
+                .setParameter("accountId", accountId);
+
+        if (bundleIds != null && !bundleIds.isEmpty()) {
+            query.setParameter("bundleIds", bundleIds);
+        }
+
+        if (appIds != null && !appIds.isEmpty()) {
+            query.setParameter("appIds", appIds);
+        }
+
+        if (eventTypeName != null) {
+            query.setParameter("eventTypeName", eventTypeName);
+        }
+
+        if (startDate != null && endDate != null) {
+            query.setParameter("startDate", startDate)
+                    .setParameter("endDate", endDate);
+        } else if (startDate != null) {
+            query.setParameter("startDate", startDate);
+        } else if (endDate != null) {
+            query.setParameter("endDate", endDate);
+        }
+
+        if (limit != null) {
+            query.setMaxResults(limit);
+        }
+        if (offset != null) {
+            query.setFirstResult(offset);
+        }
+
+        return query.getResultList();
+    }
+
+    private static String getSortField(String field) {
+        switch (field) {
+            case "bundle":
+                return "b.displayName";
+            case "application":
+                return "a.displayName";
+            case "event":
+                return "et.displayName";
+            case "created":
+                return "e.created";
+            default:
+                throw new IllegalArgumentException("Unknown sort field: " + field);
+        }
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
@@ -83,12 +83,10 @@ public class EventResources {
             query.setParameter("eventTypeName", eventTypeName);
         }
 
-        if (startDate != null && endDate != null) {
-            query.setParameter("startDate", startDate)
-                    .setParameter("endDate", endDate);
-        } else if (startDate != null) {
+        if (startDate != null) {
             query.setParameter("startDate", startDate);
-        } else if (endDate != null) {
+        }
+        if (endDate != null) {
             query.setParameter("endDate", endDate);
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.events;
 
 import com.redhat.cloud.notifications.db.ApplicationResources;
+import com.redhat.cloud.notifications.db.EventResources;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.utils.ActionParser;
 import io.micrometer.core.instrument.Counter;
@@ -37,6 +38,9 @@ public class EventConsumer {
     @Inject
     ApplicationResources appResources;
 
+    @Inject
+    EventResources eventResources;
+
     private Counter rejectedCount;
     private Counter processingErrorCount;
 
@@ -68,7 +72,7 @@ public class EventConsumer {
                 .onItem().transformToUni(action -> appResources.getEventType(action.getBundle(), action.getApplication(), action.getEventType())
                         .onItem().transformToUni(eventType -> {
                             Event event = new Event(eventType, payload, action);
-                            return appResources.createEvent(event);
+                            return eventResources.create(event);
                         })
                 )
                 // If an exception was thrown during steps 1 or 2, the payload is considered rejected.

--- a/backend/src/main/java/com/redhat/cloud/notifications/models/Event.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/Event.java
@@ -1,8 +1,5 @@
 package com.redhat.cloud.notifications.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.ingress.Action;
 
 import javax.persistence.Entity;
@@ -10,36 +7,36 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
-import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.CascadeType.REMOVE;
 
 @Entity
 @Table(name = "event")
-@JsonNaming(SnakeCaseStrategy.class)
 public class Event extends CreationTimestamped {
 
     @Id
     @GeneratedValue
-    @JsonProperty(access = READ_ONLY)
     private UUID id;
 
     @NotNull
     @Size(max = 50)
-    @JsonIgnore
     private String accountId;
 
     // TODO [Event log phase 2] Make this field @NotNull (in the SQL schema as well) and the @ManyToOne relationship not optional.
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne
     @JoinColumn(name = "event_type_id")
     private EventType eventType;
+
+    @OneToMany(mappedBy = "event", cascade = REMOVE)
+    Set<NotificationHistory> historyEntries;
 
     private String payload;
 
@@ -77,6 +74,14 @@ public class Event extends CreationTimestamped {
 
     public void setEventType(EventType eventType) {
         this.eventType = eventType;
+    }
+
+    public Set<NotificationHistory> getHistoryEntries() {
+        return historyEntries;
+    }
+
+    public void setHistoryEntries(Set<NotificationHistory> historyEntries) {
+        this.historyEntries = historyEntries;
     }
 
     public String getPayload() {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
@@ -48,7 +48,7 @@ public class EventService {
     @RolesAllowed(RBAC_READ_NOTIFICATIONS)
     @Operation(summary = "Retrieve the event log entries.")
     public Uni<Page<EventLogEntry>> getEvents(@Context SecurityContext securityContext, @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
-                                              @RestQuery String eventTypeName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
+                                              @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
                                               @RestQuery @DefaultValue("10") int limit, @RestQuery @DefaultValue("0") int offset, @RestQuery String sortBy) {
         if (limit < 1 || limit > 200) {
             throw new BadRequestException("Invalid 'limit' query parameter, its value must be between 1 and 200");
@@ -58,7 +58,7 @@ public class EventService {
         }
         return getAccountId(securityContext)
                 .onItem().transformToUni(accountId ->
-                        eventResources.get(accountId, bundleIds, appIds, eventTypeName, startDate, endDate, limit, offset, sortBy)
+                        eventResources.get(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, limit, offset, sortBy)
                                 .onItem().transform(events ->
                                         events.stream().map(event -> {
                                             List<EventLogEntryAction> actions = event.getHistoryEntries().stream().map(historyEntry -> {
@@ -80,7 +80,7 @@ public class EventService {
                                         }).collect(Collectors.toList())
                                 )
                                 .onItem().transformToUni(entries ->
-                                        eventResources.count(accountId, bundleIds, appIds, eventTypeName, startDate, endDate)
+                                        eventResources.count(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate)
                                                 .onItem().transform(count -> {
                                                     Meta meta = new Meta();
                                                     meta.setCount(count);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
@@ -1,9 +1,11 @@
 package com.redhat.cloud.notifications.routers;
 
-import com.redhat.cloud.notifications.Constants;
 import com.redhat.cloud.notifications.db.EventResources;
 import com.redhat.cloud.notifications.routers.models.EventLogEntry;
 import com.redhat.cloud.notifications.routers.models.EventLogEntryAction;
+import com.redhat.cloud.notifications.routers.models.Meta;
+import com.redhat.cloud.notifications.routers.models.Page;
+import com.redhat.cloud.notifications.routers.models.PageLinksBuilder;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.resteasy.reactive.RestQuery;
@@ -11,6 +13,7 @@ import org.jboss.resteasy.reactive.RestQuery;
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -18,19 +21,23 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
 import static com.redhat.cloud.notifications.auth.rbac.RbacIdentityProvider.RBAC_READ_NOTIFICATIONS;
+import static com.redhat.cloud.notifications.routers.EventService.PATH;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getAccountId;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-@Path(Constants.API_NOTIFICATIONS_V_1_0 + "/event")
+@Path(PATH)
 public class EventService {
 
+    public static final String PATH = API_NOTIFICATIONS_V_1_0 + "/event";
     public static final Pattern SORT_BY_PATTERN = Pattern.compile("^([a-z0-9_-]+):(asc|desc)$", CASE_INSENSITIVE);
 
     @Inject
@@ -40,35 +47,53 @@ public class EventService {
     @Produces(APPLICATION_JSON)
     @RolesAllowed(RBAC_READ_NOTIFICATIONS)
     @Operation(summary = "Retrieve the event log entries.")
-    public Uni<List<EventLogEntry>> getEvents(@Context SecurityContext securityContext, @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
+    public Uni<Page<EventLogEntry>> getEvents(@Context SecurityContext securityContext, @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
                                               @RestQuery String eventTypeName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
-                                              @RestQuery Integer limit, @RestQuery Integer offset, @RestQuery String sortBy) {
+                                              @RestQuery @DefaultValue("10") int limit, @RestQuery @DefaultValue("0") int offset, @RestQuery String sortBy) {
+        if (limit < 1 || limit > 200) {
+            throw new BadRequestException("Invalid 'limit' query parameter, its value must be between 1 and 200");
+        }
         if (sortBy != null && !SORT_BY_PATTERN.matcher(sortBy).matches()) {
-            throw new BadRequestException("Invalid sort_by query parameter");
+            throw new BadRequestException("Invalid 'sortBy' query parameter");
         }
         return getAccountId(securityContext)
                 .onItem().transformToUni(accountId ->
                         eventResources.get(accountId, bundleIds, appIds, eventTypeName, startDate, endDate, limit, offset, sortBy)
-                )
-                .onItem().transform(events ->
-                        events.stream().map(event -> {
-                            List<EventLogEntryAction> actions = event.getHistoryEntries().stream().map(historyEntry -> {
-                                EventLogEntryAction action = new EventLogEntryAction();
-                                action.setId(historyEntry.getId());
-                                action.setEndpointType(historyEntry.getEndpoint().getType());
-                                action.setInvocationResult(historyEntry.isInvocationResult());
-                                return action;
-                            }).collect(Collectors.toList());
+                                .onItem().transform(events ->
+                                        events.stream().map(event -> {
+                                            List<EventLogEntryAction> actions = event.getHistoryEntries().stream().map(historyEntry -> {
+                                                EventLogEntryAction action = new EventLogEntryAction();
+                                                action.setId(historyEntry.getId());
+                                                action.setEndpointType(historyEntry.getEndpoint().getType());
+                                                action.setInvocationResult(historyEntry.isInvocationResult());
+                                                return action;
+                                            }).collect(Collectors.toList());
 
-                            EventLogEntry entry = new EventLogEntry();
-                            entry.setId(event.getId());
-                            entry.setCreated(event.getCreated());
-                            entry.setBundle(event.getEventType().getApplication().getBundle().getDisplayName());
-                            entry.setApplication(event.getEventType().getApplication().getDisplayName());
-                            entry.setEventType(event.getEventType().getDisplayName());
-                            entry.setActions(actions);
-                            return entry;
-                        }).collect(Collectors.toList())
+                                            EventLogEntry entry = new EventLogEntry();
+                                            entry.setId(event.getId());
+                                            entry.setCreated(event.getCreated());
+                                            entry.setBundle(event.getEventType().getApplication().getBundle().getDisplayName());
+                                            entry.setApplication(event.getEventType().getApplication().getDisplayName());
+                                            entry.setEventType(event.getEventType().getDisplayName());
+                                            entry.setActions(actions);
+                                            return entry;
+                                        }).collect(Collectors.toList())
+                                )
+                                .onItem().transformToUni(entries ->
+                                        eventResources.count(accountId, bundleIds, appIds, eventTypeName, startDate, endDate)
+                                                .onItem().transform(count -> {
+                                                    Meta meta = new Meta();
+                                                    meta.setCount(count);
+
+                                                    Map<String, String> links = PageLinksBuilder.build(PATH, count, limit, offset);
+
+                                                    Page<EventLogEntry> page = new Page<>();
+                                                    page.setData(entries);
+                                                    page.setMeta(meta);
+                                                    page.setLinks(links);
+                                                    return page;
+                                                })
+                                )
                 );
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
@@ -1,0 +1,74 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.Constants;
+import com.redhat.cloud.notifications.db.EventResources;
+import com.redhat.cloud.notifications.routers.models.EventLogEntry;
+import com.redhat.cloud.notifications.routers.models.EventLogEntryAction;
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.jboss.resteasy.reactive.RestQuery;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.redhat.cloud.notifications.auth.rbac.RbacIdentityProvider.RBAC_READ_NOTIFICATIONS;
+import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getAccountId;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path(Constants.API_NOTIFICATIONS_V_1_0 + "/event")
+public class EventService {
+
+    public static final Pattern SORT_BY_PATTERN = Pattern.compile("^([a-z0-9_-]+):(asc|desc)$", CASE_INSENSITIVE);
+
+    @Inject
+    EventResources eventResources;
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    @RolesAllowed(RBAC_READ_NOTIFICATIONS)
+    @Operation(summary = "Retrieve the event log entries.")
+    public Uni<List<EventLogEntry>> getEvents(@Context SecurityContext securityContext, @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
+                                              @RestQuery String eventTypeName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
+                                              @RestQuery Integer limit, @RestQuery Integer offset, @RestQuery String sortBy) {
+        if (sortBy != null && !SORT_BY_PATTERN.matcher(sortBy).matches()) {
+            throw new BadRequestException("Invalid sort_by query parameter");
+        }
+        return getAccountId(securityContext)
+                .onItem().transformToUni(accountId ->
+                        eventResources.get(accountId, bundleIds, appIds, eventTypeName, startDate, endDate, limit, offset, sortBy)
+                )
+                .onItem().transform(events ->
+                        events.stream().map(event -> {
+                            List<EventLogEntryAction> actions = event.getHistoryEntries().stream().map(historyEntry -> {
+                                EventLogEntryAction action = new EventLogEntryAction();
+                                action.setId(historyEntry.getId());
+                                action.setEndpointType(historyEntry.getEndpoint().getType());
+                                action.setInvocationResult(historyEntry.isInvocationResult());
+                                return action;
+                            }).collect(Collectors.toList());
+
+                            EventLogEntry entry = new EventLogEntry();
+                            entry.setId(event.getId());
+                            entry.setCreated(event.getCreated());
+                            entry.setBundle(event.getEventType().getApplication().getBundle().getDisplayName());
+                            entry.setApplication(event.getEventType().getApplication().getDisplayName());
+                            entry.setEventType(event.getEventType().getDisplayName());
+                            entry.setActions(actions);
+                            return entry;
+                        }).collect(Collectors.toList())
+                );
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/SecurityContextUtil.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/SecurityContextUtil.java
@@ -1,0 +1,16 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.auth.rhid.RhIdPrincipal;
+import io.smallrye.mutiny.Uni;
+
+import javax.ws.rs.core.SecurityContext;
+
+public class SecurityContextUtil {
+
+    public static Uni<String> getAccountId(SecurityContext securityContext) {
+        return Uni.createFrom().item(() -> {
+            RhIdPrincipal principal = (RhIdPrincipal) securityContext.getUserPrincipal();
+            return principal.getAccount();
+        });
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EventLogEntry.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EventLogEntry.java
@@ -1,0 +1,85 @@
+package com.redhat.cloud.notifications.routers.models;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public class EventLogEntry {
+
+    @NotNull
+    private UUID id;
+
+    @NotNull
+    @JsonFormat(shape = STRING)
+    private LocalDateTime created;
+
+    @NotNull
+    private String bundle;
+
+    @NotNull
+    private String application;
+
+    @NotNull
+    @Schema(name = "event_type")
+    private String eventType;
+
+    @NotNull
+    private List<EventLogEntryAction> actions;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(LocalDateTime created) {
+        this.created = created;
+    }
+
+    public String getBundle() {
+        return bundle;
+    }
+
+    public void setBundle(String bundle) {
+        this.bundle = bundle;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public void setApplication(String application) {
+        this.application = application;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public List<EventLogEntryAction> getActions() {
+        return actions;
+    }
+
+    public void setActions(List<EventLogEntryAction> actions) {
+        this.actions = actions;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EventLogEntryAction.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EventLogEntryAction.java
@@ -1,0 +1,50 @@
+package com.redhat.cloud.notifications.routers.models;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.redhat.cloud.notifications.models.EndpointType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public class EventLogEntryAction {
+
+    @NotNull
+    private UUID id;
+
+    @NotNull
+    @Schema(name = "endpoint_type")
+    private EndpointType endpointType;
+
+    @NotNull
+    @Schema(name = "invocation_result")
+    private Boolean invocationResult;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public EndpointType getEndpointType() {
+        return endpointType;
+    }
+
+    public void setEndpointType(EndpointType endpointType) {
+        this.endpointType = endpointType;
+    }
+
+    public Boolean getInvocationResult() {
+        return invocationResult;
+    }
+
+    public void setInvocationResult(Boolean invocationResult) {
+        this.invocationResult = invocationResult;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/PageLinksBuilder.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/PageLinksBuilder.java
@@ -1,0 +1,39 @@
+package com.redhat.cloud.notifications.routers.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PageLinksBuilder {
+
+    public static Map<String, String> build(String apiPath, long count, long limit, long currentOffset) {
+        Map<String, String> links = new HashMap<>();
+
+        String baseLink = apiPath + "?limit=" + limit + "&offset=";
+
+        // first
+        links.put("first", baseLink + "0");
+
+        // last
+        long lastOffset;
+        if (limit >= count) {
+            lastOffset = 0;
+        } else {
+            lastOffset = count - (limit == 1 ? 1 : count % limit);
+        }
+        links.put("last", baseLink + lastOffset);
+
+        // prev
+        if (currentOffset > 0) {
+            long prevOffset = currentOffset - limit;
+            links.put("prev", baseLink + prevOffset);
+        }
+
+        // next
+        if (currentOffset < lastOffset) {
+            long nextOffset = currentOffset + limit;
+            links.put("next", baseLink + nextOffset);
+        }
+
+        return links;
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -12,8 +12,10 @@ import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.HttpType;
+import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.WebhookProperties;
 import io.vertx.core.json.JsonObject;
 
@@ -28,6 +30,7 @@ import java.util.UUID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
 import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 
 @ApplicationScoped
 public class ResourceHelpers {
@@ -54,6 +57,9 @@ public class ResourceHelpers {
 
     @Inject
     BehaviorGroupResources behaviorGroupResources;
+
+    @Inject
+    NotificationResources notificationResources;
 
     public Bundle createBundle() {
         return createBundle("name", "displayName");
@@ -91,18 +97,17 @@ public class ResourceHelpers {
 
     public UUID createEventType(String bundleName, String applicationName, String eventTypeName) {
         Application app = appResources.getApplication(bundleName, applicationName).await().indefinitely();
-        return createEventType(app.getId(), eventTypeName, eventTypeName, "new event type");
+        return createEventType(app.getId(), eventTypeName, eventTypeName, "new event type").getId();
     }
 
-    public UUID createEventType(UUID applicationId, String name, String displayName, String description) {
+    public EventType createEventType(UUID applicationId, String name, String displayName, String description) {
         EventType eventType = new EventType();
         eventType.setName(name);
         eventType.setDisplayName(displayName);
         eventType.setDescription(description);
         eventType.setApplicationId(applicationId);
         return appResources.createEventType(eventType)
-                .await().indefinitely()
-                .getId();
+                .await().indefinitely();
     }
 
     public UUID createTestAppAndEventTypes() {
@@ -140,7 +145,7 @@ public class ResourceHelpers {
         properties.setMethod(HttpType.POST);
         properties.setUrl("https://localhost");
         String name = "Endpoint " + UUID.randomUUID();
-        return createEndpoint(accountId, WEBHOOK, name, "Automatically generated", properties, Boolean.TRUE).getId();
+        return createEndpoint(accountId, WEBHOOK, name, "Automatically generated", properties, TRUE).getId();
     }
 
     public Endpoint createEndpoint(String accountId, EndpointType type, String name, String description, EndpointProperties properties, Boolean enabled) {
@@ -183,6 +188,18 @@ public class ResourceHelpers {
                     .await().indefinitely();
         }
         return statsValues;
+    }
+
+    public NotificationHistory createNotificationHistory(Event event, Endpoint endpoint) {
+        NotificationHistory history = new NotificationHistory();
+        history.setId(UUID.randomUUID());
+        history.setAccountId(DEFAULT_ACCOUNT_ID);
+        history.setInvocationTime(1L);
+        history.setInvocationResult(TRUE);
+        history.setEvent(event);
+        history.setEndpoint(endpoint);
+        return notificationResources.createNotificationHistory(history)
+                .await().indefinitely();
     }
 
     public UUID emailSubscriptionEndpointId(String accountId, EmailSubscriptionProperties properties) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.events;
 import com.redhat.cloud.notifications.CounterAssertionHelper;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.ApplicationResources;
+import com.redhat.cloud.notifications.db.EventResources;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.models.Event;
@@ -57,6 +58,9 @@ public class EventConsumerTest {
 
     @InjectMock
     ApplicationResources appResources;
+
+    @InjectMock
+    EventResources eventResources;
 
     @Inject
     CounterAssertionHelper counterAssertionHelper;
@@ -118,7 +122,7 @@ public class EventConsumerTest {
         when(appResources.getEventType(eq(BUNDLE), eq(APP), eq(EVENT_TYPE))).thenReturn(
                 Uni.createFrom().item(eventType)
         );
-        when(appResources.createEvent(any(Event.class))).thenAnswer(invocation -> {
+        when(eventResources.create(any(Event.class))).thenAnswer(invocation -> {
             Event event = invocation.getArgument(0);
             return Uni.createFrom().item(event);
         });

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
@@ -206,7 +206,7 @@ public class EventServiceTest extends DbIsolatedTest {
          * Account: DEFAULT_ACCOUNT_ID
          * Request: Existing event type
          */
-        page = getEventLogPage(defaultIdentityHeader, null, null, eventType1.getName().substring(2), null, null, null, null, null);
+        page = getEventLogPage(defaultIdentityHeader, null, null, eventType1.getDisplayName().substring(2).toUpperCase(), null, null, null, null, null);
         assertEquals(1, page.getMeta().getCount());
         assertEquals(1, page.getData().size());
         assertSameEvent(page.getData().get(0), event1, history1, history2);
@@ -251,7 +251,7 @@ public class EventServiceTest extends DbIsolatedTest {
          * Account: DEFAULT_ACCOUNT_ID
          * Request: Let's try all request params at once!
          */
-        page = getEventLogPage(defaultIdentityHeader, Set.of(bundle2.getId()), Set.of(app2.getId()), eventType2.getName(), NOW.minusDays(3L), NOW.minusDays(1L), 10, 0, "created:desc");
+        page = getEventLogPage(defaultIdentityHeader, Set.of(bundle2.getId()), Set.of(app2.getId()), eventType2.getDisplayName(), NOW.minusDays(3L), NOW.minusDays(1L), 10, 0, "created:desc");
         assertEquals(1, page.getMeta().getCount());
         assertEquals(1, page.getData().size());
         assertSameEvent(page.getData().get(0), event3, history4);
@@ -358,7 +358,7 @@ public class EventServiceTest extends DbIsolatedTest {
         return TestHelpers.createIdentityHeader(identityHeaderValue);
     }
 
-    private static Page<EventLogEntry> getEventLogPage(Header identityHeader, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeName,
+    private static Page<EventLogEntry> getEventLogPage(Header identityHeader, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                                        LocalDateTime startDate, LocalDateTime endDate, Integer limit, Integer offset, String sortBy) {
         RequestSpecification request = given()
                 .basePath(API_NOTIFICATIONS_V_1_0)
@@ -369,8 +369,8 @@ public class EventServiceTest extends DbIsolatedTest {
         if (appIds != null) {
             request.param("appIds", appIds);
         }
-        if (eventTypeName != null) {
-            request.param("eventTypeName", eventTypeName);
+        if (eventTypeDisplayName != null) {
+            request.param("eventTypeDisplayName", eventTypeDisplayName);
         }
         if (startDate != null) {
             request.param("startDate", startDate.toLocalDate().toString());

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
@@ -1,0 +1,361 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.MockServerClientConfig;
+import com.redhat.cloud.notifications.MockServerConfig;
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.Event;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.NotificationHistory;
+import com.redhat.cloud.notifications.routers.models.EventLogEntry;
+import com.redhat.cloud.notifications.routers.models.EventLogEntryAction;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.Header;
+import io.restassured.specification.RequestSpecification;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
+import static com.redhat.cloud.notifications.MockServerClientConfig.RbacAccess;
+import static com.redhat.cloud.notifications.MockServerClientConfig.RbacAccess.FULL_ACCESS;
+import static com.redhat.cloud.notifications.MockServerClientConfig.RbacAccess.NO_ACCESS;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
+import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPTION;
+import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.time.ZoneOffset.UTC;
+import static java.util.UUID.randomUUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class EventServiceTest extends DbIsolatedTest {
+
+    private static final String OTHER_ACCOUNT_ID = "other-account-id";
+    private static final LocalDateTime NOW = LocalDateTime.now(UTC);
+
+    @Inject
+    Mutiny.StatelessSession statelessSession;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @MockServerConfig
+    MockServerClientConfig mockServerConfig;
+
+    @Test
+    void testAllQueryParams() {
+        /*
+         * This method is very long, but splitting it into several smaller ones would mean we have to recreate lots of
+         * database records for each test. To avoid doing that, the data is only persisted once and many tests are run
+         * from the same data.
+         */
+
+        Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, "user", FULL_ACCESS);
+        Header otherIdentityHeader = mockRbac(OTHER_ACCOUNT_ID, "other-username", FULL_ACCESS);
+
+        Bundle bundle1 = resourceHelpers.createBundle("bundle-1", "Bundle 1");
+        Bundle bundle2 = resourceHelpers.createBundle("bundle-2", "Bundle 2");
+
+        Application app1 = resourceHelpers.createApplication(bundle1.getId(), "app-1", "Application 1");
+        Application app2 = resourceHelpers.createApplication(bundle2.getId(), "app-2", "Application 2");
+
+        EventType eventType1 = resourceHelpers.createEventType(app1.getId(), "event-type-1", "Event type 1", "Event type 1");
+        EventType eventType2 = resourceHelpers.createEventType(app2.getId(), "event-type-2", "Event type 2", "Event type 2");
+
+        Event event1 = createEvent(DEFAULT_ACCOUNT_ID, eventType1, NOW.minusDays(5L));
+        Event event2 = createEvent(DEFAULT_ACCOUNT_ID, eventType2, NOW);
+        Event event3 = createEvent(DEFAULT_ACCOUNT_ID, eventType2, NOW.minusDays(2L));
+        Event event4 = createEvent(OTHER_ACCOUNT_ID, eventType2, NOW.minusDays(10L));
+
+        Endpoint endpoint1 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, WEBHOOK);
+        Endpoint endpoint2 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, EMAIL_SUBSCRIPTION);
+
+        NotificationHistory history1 = resourceHelpers.createNotificationHistory(event1, endpoint1);
+        NotificationHistory history2 = resourceHelpers.createNotificationHistory(event1, endpoint2);
+        NotificationHistory history3 = resourceHelpers.createNotificationHistory(event2, endpoint1);
+        NotificationHistory history4 = resourceHelpers.createNotificationHistory(event3, endpoint2);
+
+        /*
+         * Test #1
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: No filter
+         * Expected response: All event log entries from DEFAULT_ACCOUNT_ID should be returned
+         */
+        List<EventLogEntry> eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, null, null, null, null, null, null, null);
+        assertEquals(3, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event2, history3);
+        assertSameEvent(eventLogEntries.get(1), event3, history4);
+        assertSameEvent(eventLogEntries.get(2), event1, history1, history2);
+
+        /*
+         * Test #2
+         * Account: OTHER_ACCOUNT_ID
+         * Request: No filter
+         * Expected response: All event log entries from OTHER_ACCOUNT_ID should be returned
+         */
+        eventLogEntries = getEventLogEntries(otherIdentityHeader, null, null, null, null, null, null, null, null);
+        assertEquals(1, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event4);
+
+        /*
+         * Test #3
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: Unknown bundle
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, Set.of(randomUUID()), null, null, null, null, null, null, null);
+        assertTrue(eventLogEntries.isEmpty());
+
+        /*
+         * Test #4
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: One existing bundle
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, Set.of(bundle1.getId()), null, null, null, null, null, null, null);
+        assertEquals(1, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event1, history1, history2);
+
+        /*
+         * Test #5
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: Multiple existing bundles, sort by ascending bundle names
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, Set.of(bundle1.getId(), bundle2.getId()), null, null, null, null, null, null, "bundle:asc");
+        assertEquals(3, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event1, history1, history2);
+        assertSameEvent(eventLogEntries.get(1), event2, history3);
+        assertSameEvent(eventLogEntries.get(2), event3, history4);
+
+        /*
+         * Test #6
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: Unknown application
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, Set.of(randomUUID()), null, null, null, null, null, null);
+        assertTrue(eventLogEntries.isEmpty());
+
+        /*
+         * Test #7
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: One existing application
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, Set.of(app2.getId()), null, null, null, null, null, null);
+        assertEquals(2, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event2, history3);
+        assertSameEvent(eventLogEntries.get(1), event3, history4);
+
+        /*
+         * Test #8
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: Multiple existing applications, sort by ascending application names
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, Set.of(app1.getId(), app2.getId()), null, null, null, null, null, "application:asc");
+        assertEquals(3, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event1, history1, history2);
+        assertSameEvent(eventLogEntries.get(1), event2, history3);
+        assertSameEvent(eventLogEntries.get(2), event3, history4);
+
+        /*
+         * Test #9
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: Unknown event type
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, null, "unknown", null, null, null, null, null);
+        assertTrue(eventLogEntries.isEmpty());
+
+        /*
+         * Test #10
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: Existing event type
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, null, eventType1.getName(), null, null, null, null, null);
+        assertEquals(1, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event1, history1, history2);
+
+        /*
+         * Test #11
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: Start date three days in the past
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, null, null, NOW.minusDays(3L), null, null, null, null);
+        assertEquals(2, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event2, history3);
+        assertSameEvent(eventLogEntries.get(1), event3, history4);
+
+        /*
+         * Test #12
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: End date three days in the past
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, null, null, null, NOW.minusDays(3L), null, null, null);
+        assertEquals(1, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event1, history1, history2);
+
+        /*
+         * Test #13
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: Both start and end date are set
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, null, null, NOW.minusDays(3L), NOW.minusDays(1L), null, null, null);
+        assertEquals(1, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event3, history4);
+
+        /*
+         * Test #14
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: Let's try all request params at once!
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, Set.of(bundle2.getId()), Set.of(app2.getId()), eventType2.getName(), NOW.minusDays(3L), NOW.minusDays(1L), 10, 0, "created:desc");
+        assertEquals(1, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event3, history4);
+
+        /*
+         * Test #15
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: No filter, limit without offset
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, null, null, null, null, 2, null, null);
+        assertEquals(2, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event2, history3);
+        assertSameEvent(eventLogEntries.get(1), event3, history4);
+
+        /*
+         * Test #16
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: No filter, limit with offset
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, null, null, null, null, 1, 2, null);
+        assertEquals(1, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event1, history1, history2);
+
+        /*
+         * Test #17
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: No filter, sort by ascending event names
+         */
+        eventLogEntries = getEventLogEntries(defaultIdentityHeader, null, null, null, null, null, null, null, "event:asc");
+        assertEquals(3, eventLogEntries.size());
+        assertSameEvent(eventLogEntries.get(0), event1, history1, history2);
+        assertSameEvent(eventLogEntries.get(1), event2, history3);
+        assertSameEvent(eventLogEntries.get(2), event3, history4);
+    }
+
+    @Test
+    void testInsufficientPrivileges() {
+        Header noAccessIdentityHeader = mockRbac("tenant", "noAccess", NO_ACCESS);
+        given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(noAccessIdentityHeader)
+                .when().get("/event")
+                .then()
+                .statusCode(403)
+                .contentType(JSON);
+    }
+
+    @Test
+    void testInvalidSortBy() {
+        Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, "user", FULL_ACCESS);
+        given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader)
+                .param("sortBy", "I am not valid!")
+                .when().get("/event")
+                .then()
+                .statusCode(400)
+                .contentType(JSON);
+    }
+
+    private Event createEvent(String accountId, EventType eventType, LocalDateTime created) {
+        Event event = new Event();
+        event.setAccountId(accountId);
+        event.setEventType(eventType);
+        event.setCreated(created);
+        statelessSession.insert(event)
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .await()
+                .assertCompleted();
+        return event;
+    }
+
+    private Header mockRbac(String tenant, String username, RbacAccess access) {
+        String identityHeaderValue = TestHelpers.encodeIdentityInfo(tenant, username);
+        mockServerConfig.addMockRbacAccess(identityHeaderValue, access);
+        return TestHelpers.createIdentityHeader(identityHeaderValue);
+    }
+
+    private static List<EventLogEntry> getEventLogEntries(Header identityHeader, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeName,
+                                                          LocalDateTime startDate, LocalDateTime endDate, Integer limit, Integer offset, String sortBy) {
+        RequestSpecification request = given()
+                .basePath(API_NOTIFICATIONS_V_1_0)
+                .header(identityHeader);
+        if (bundleIds != null) {
+            request.param("bundleIds", bundleIds);
+        }
+        if (appIds != null) {
+            request.param("appIds", appIds);
+        }
+        if (eventTypeName != null) {
+            request.param("eventTypeName", eventTypeName);
+        }
+        if (startDate != null) {
+            request.param("startDate", startDate.toLocalDate().toString());
+        }
+        if (endDate != null) {
+            request.param("endDate", endDate.toLocalDate().toString());
+        }
+        if (limit != null) {
+            request.param("limit", limit);
+        }
+        if (offset != null) {
+            request.param("offset", offset);
+        }
+        if (sortBy != null) {
+            request.param("sortBy", sortBy);
+        }
+        return request
+                .when().get("/event")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().body().jsonPath().getList(".", EventLogEntry.class);
+    }
+
+    private static void assertSameEvent(EventLogEntry eventLogEntry, Event event, NotificationHistory... historyEntries) {
+        assertEquals(event.getId(), eventLogEntry.getId());
+        // Jackson's serialization gets rid of nanoseconds so an equals between the LocalDateTime objects won't work.
+        assertEquals(event.getCreated().toEpochSecond(UTC), eventLogEntry.getCreated().toEpochSecond(UTC));
+        assertEquals(event.getEventType().getApplication().getBundle().getDisplayName(), eventLogEntry.getBundle());
+        assertEquals(event.getEventType().getApplication().getDisplayName(), eventLogEntry.getApplication());
+        assertEquals(event.getEventType().getDisplayName(), eventLogEntry.getEventType());
+        if (historyEntries == null) {
+            assertTrue(eventLogEntry.getActions().isEmpty());
+        } else {
+            assertEquals(historyEntries.length, eventLogEntry.getActions().size());
+            for (EventLogEntryAction eventLogEntryAction : eventLogEntry.getActions()) {
+                Optional<NotificationHistory> historyEntry = Arrays.stream(historyEntries)
+                        .filter(entry -> entry.getId().equals(eventLogEntryAction.getId())).findAny();
+                assertTrue(historyEntry.isPresent());
+                assertEquals(historyEntry.get().getEndpoint().getType(), eventLogEntryAction.getEndpointType());
+                assertEquals(historyEntry.get().isInvocationResult(), eventLogEntryAction.getInvocationResult());
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/models/PageLinksBuilderTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/models/PageLinksBuilderTest.java
@@ -1,0 +1,56 @@
+package com.redhat.cloud.notifications.routers.models;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class PageLinksBuilderTest {
+
+    @Test
+    void testLimitHigherThanCount() {
+        Map<String, String> links = PageLinksBuilder.build("test", 10, 15, 0);
+        assertEquals("test?limit=15&offset=0", links.get("first"));
+        assertEquals("test?limit=15&offset=0", links.get("last"));
+        assertFalse(links.containsKey("prev"));
+        assertFalse(links.containsKey("next"));
+    }
+
+    @Test
+    void testLimitEqualsCount() {
+        Map<String, String> links = PageLinksBuilder.build("test", 10, 10, 0);
+        assertEquals("test?limit=10&offset=0", links.get("first"));
+        assertEquals("test?limit=10&offset=0", links.get("last"));
+        assertFalse(links.containsKey("prev"));
+        assertFalse(links.containsKey("next"));
+    }
+
+    @Test
+    void testLimitSmallerThanCountFirstPage() {
+        Map<String, String> links = PageLinksBuilder.build("test", 10, 7, 0);
+        assertEquals("test?limit=7&offset=0", links.get("first"));
+        assertEquals("test?limit=7&offset=7", links.get("last"));
+        assertEquals("test?limit=7&offset=7", links.get("next"));
+        assertFalse(links.containsKey("prev"));
+    }
+
+    @Test
+    void testLimitSmallerThanCountMiddlePage() {
+        Map<String, String> links = PageLinksBuilder.build("test", 10, 3, 6);
+        assertEquals("test?limit=3&offset=0", links.get("first"));
+        assertEquals("test?limit=3&offset=9", links.get("last"));
+        assertEquals("test?limit=3&offset=3", links.get("prev"));
+        assertEquals("test?limit=3&offset=9", links.get("next"));
+    }
+
+    @Test
+    void testLimitSmallerThanCountLastPage() {
+        Map<String, String> links = PageLinksBuilder.build("test", 10, 3, 9);
+        assertEquals("test?limit=3&offset=0", links.get("first"));
+        assertEquals("test?limit=3&offset=9", links.get("last"));
+        assertEquals("test?limit=3&offset=6", links.get("prev"));
+        assertFalse(links.containsKey("next"));
+    }
+}


### PR DESCRIPTION
This PR introduces the main REST API for the event log.

We will probably need two more (much smaller) REST APIs to retrieve:
- the properties of an endpoint displayed in the event log
- the details of an event

If this is confirmed, the missing APIs will be added in a separate PR.