### PR TITLE
Increase expiration delay of cached RBAC data

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -120,8 +120,8 @@ quarkus.log.cloudwatch.access-key-secret=placeholder
 
 # The current status is cached to limit the number of status DB queries
 quarkus.cache.caffeine.maintenance.expire-after-write=PT60s
-quarkus.cache.caffeine.rbac-recipient-users-provider-get-users.expire-after-write=PT60s
-quarkus.cache.caffeine.rbac-recipient-users-provider-get-group-users.expire-after-write=PT60s
+quarkus.cache.caffeine.rbac-recipient-users-provider-get-users.expire-after-write=PT5M
+quarkus.cache.caffeine.rbac-recipient-users-provider-get-group-users.expire-after-write=PT5M
 
 # Period between two event log cleanings. It must be expressed with the ISO-8601 duration format PnDTnHnMn.nS.
 event-log-cleaner.period=PT10M


### PR DESCRIPTION
As suggested by @pilhuhn during the team sync.