### PR TITLE
NOTIF-273 Prepare tests for the Quarkus 2 bump

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -6,6 +6,7 @@ import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.BasicAuthentication;
 import com.redhat.cloud.notifications.models.CamelProperties;
@@ -67,6 +68,9 @@ public class EndpointServiceTest extends DbIsolatedTest {
 
     @Inject
     ResourceHelpers helpers;
+
+    @Inject
+    EndpointEmailSubscriptionResources subscriptionResources;
 
     @Test
     void testEndpointAdding() {
@@ -531,7 +535,8 @@ public class EndpointServiceTest extends DbIsolatedTest {
         mockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
 
         // Create 50 test-ones with sanely sortable name & enabled & disabled & type
-        int[] stats = helpers.createTestEndpoints(tenant, 50);
+        int[] stats = helpers.createTestEndpoints(tenant, 50)
+                .await().indefinitely();
         int disableCount = stats[1];
         int webhookCount = stats[2];
 
@@ -811,7 +816,8 @@ public class EndpointServiceTest extends DbIsolatedTest {
         Header identityHeader = TestHelpers.createIdentityHeader(identityHeaderValue);
         mockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
 
-        helpers.createTestAppAndEventTypes();
+        helpers.createTestAppAndEventTypes()
+                .await().indefinitely();
 
         // invalid bundle/application combination gives a 404
         given()
@@ -881,10 +887,14 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .then().statusCode(200)
                 .contentType(JSON);
 
-        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY)
+                .await().indefinitely());
 
         // Enable instant on rhel.policies
         given()
@@ -893,10 +903,14 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/rhel/policies/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY)
+                .await().indefinitely());
 
         // Enable daily on rhel.policies
         given()
@@ -905,10 +919,14 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/rhel/policies/daily")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY)
+                .await().indefinitely());
 
         // Enable instant on TEST_BUNDLE_NAME.TEST_APP_NAME
         given()
@@ -917,10 +935,14 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/" + ResourceHelpers.TEST_BUNDLE_NAME + "/" + ResourceHelpers.TEST_APP_NAME + "/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNotNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY)
+                .await().indefinitely());
+        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY)
+                .await().indefinitely());
 
         // Disable daily on rhel.policies
         given()
@@ -929,10 +951,14 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .delete("/endpoints/email/subscription/rhel/policies/daily")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNotNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY)
+                .await().indefinitely());
+        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY)
+                .await().indefinitely());
 
         // Disable instant on rhel.policies
         given()
@@ -941,10 +967,14 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .delete("/endpoints/email/subscription/rhel/policies/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY));
-        assertNotNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT));
-        assertNull(helpers.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY));
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", EmailSubscriptionType.DAILY)
+                .await().indefinitely());
+        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.INSTANT)
+                .await().indefinitely());
+        assertNull(subscriptionResources.getEmailSubscription(tenant, username, ResourceHelpers.TEST_BUNDLE_NAME, ResourceHelpers.TEST_APP_NAME, EmailSubscriptionType.DAILY)
+                .await().indefinitely());
     }
 
     //    @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
@@ -74,27 +74,39 @@ public class EventServiceTest extends DbIsolatedTest {
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, "user", FULL_ACCESS);
         Header otherIdentityHeader = mockRbac(OTHER_ACCOUNT_ID, "other-username", FULL_ACCESS);
 
-        Bundle bundle1 = resourceHelpers.createBundle("bundle-1", "Bundle 1");
-        Bundle bundle2 = resourceHelpers.createBundle("bundle-2", "Bundle 2");
+        Bundle bundle1 = resourceHelpers.createBundle("bundle-1", "Bundle 1")
+                .await().indefinitely();
+        Bundle bundle2 = resourceHelpers.createBundle("bundle-2", "Bundle 2")
+                .await().indefinitely();
 
-        Application app1 = resourceHelpers.createApplication(bundle1.getId(), "app-1", "Application 1");
-        Application app2 = resourceHelpers.createApplication(bundle2.getId(), "app-2", "Application 2");
+        Application app1 = resourceHelpers.createApplication(bundle1.getId(), "app-1", "Application 1")
+                .await().indefinitely();
+        Application app2 = resourceHelpers.createApplication(bundle2.getId(), "app-2", "Application 2")
+                .await().indefinitely();
 
-        EventType eventType1 = resourceHelpers.createEventType(app1.getId(), "event-type-1", "Event type 1", "Event type 1");
-        EventType eventType2 = resourceHelpers.createEventType(app2.getId(), "event-type-2", "Event type 2", "Event type 2");
+        EventType eventType1 = resourceHelpers.createEventType(app1.getId(), "event-type-1", "Event type 1", "Event type 1")
+                .await().indefinitely();
+        EventType eventType2 = resourceHelpers.createEventType(app2.getId(), "event-type-2", "Event type 2", "Event type 2")
+                .await().indefinitely();
 
         Event event1 = createEvent(DEFAULT_ACCOUNT_ID, eventType1, NOW.minusDays(5L));
         Event event2 = createEvent(DEFAULT_ACCOUNT_ID, eventType2, NOW);
         Event event3 = createEvent(DEFAULT_ACCOUNT_ID, eventType2, NOW.minusDays(2L));
         Event event4 = createEvent(OTHER_ACCOUNT_ID, eventType2, NOW.minusDays(10L));
 
-        Endpoint endpoint1 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, WEBHOOK);
-        Endpoint endpoint2 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, EMAIL_SUBSCRIPTION);
+        Endpoint endpoint1 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, WEBHOOK)
+                .await().indefinitely();
+        Endpoint endpoint2 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, EMAIL_SUBSCRIPTION)
+                .await().indefinitely();
 
-        NotificationHistory history1 = resourceHelpers.createNotificationHistory(event1, endpoint1);
-        NotificationHistory history2 = resourceHelpers.createNotificationHistory(event1, endpoint2);
-        NotificationHistory history3 = resourceHelpers.createNotificationHistory(event2, endpoint1);
-        NotificationHistory history4 = resourceHelpers.createNotificationHistory(event3, endpoint2);
+        NotificationHistory history1 = resourceHelpers.createNotificationHistory(event1, endpoint1)
+                .await().indefinitely();
+        NotificationHistory history2 = resourceHelpers.createNotificationHistory(event1, endpoint2)
+                .await().indefinitely();
+        NotificationHistory history3 = resourceHelpers.createNotificationHistory(event2, endpoint1)
+                .await().indefinitely();
+        NotificationHistory history4 = resourceHelpers.createNotificationHistory(event3, endpoint2)
+                .await().indefinitely();
 
         /*
          * Test #1

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -6,6 +6,8 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.ApplicationResources;
+import com.redhat.cloud.notifications.db.BehaviorGroupResources;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.Application;
@@ -57,6 +59,12 @@ public class NotificationServiceTest extends DbIsolatedTest {
     @Inject
     ResourceHelpers helpers;
 
+    @Inject
+    ApplicationResources applicationResources;
+
+    @Inject
+    BehaviorGroupResources behaviorGroupResources;
+
     @BeforeEach
     void beforeEach() {
         RestAssured.basePath = TestConstants.API_NOTIFICATIONS_V_1_0;
@@ -71,7 +79,8 @@ public class NotificationServiceTest extends DbIsolatedTest {
 
     @Test
     void testEventTypeFetching() {
-        helpers.createTestAppAndEventTypes();
+        helpers.createTestAppAndEventTypes()
+                .await().indefinitely();
         Header identityHeader = initRbacMock(TENANT, USERNAME, RbacAccess.FULL_ACCESS);
 
         Response response = given()
@@ -95,10 +104,12 @@ public class NotificationServiceTest extends DbIsolatedTest {
 
     @Test
     void testEventTypeFetchingByApplication() {
-        helpers.createTestAppAndEventTypes();
+        helpers.createTestAppAndEventTypes()
+                .await().indefinitely();
         Header identityHeader = initRbacMock(TENANT, USERNAME, RbacAccess.FULL_ACCESS);
 
-        List<Application> applications = helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
+        List<Application> applications = applicationResources.getApplications(ResourceHelpers.TEST_BUNDLE_NAME)
+                .await().indefinitely();
         UUID myOtherTesterApplicationId = applications.stream().filter(a -> a.getName().equals(ResourceHelpers.TEST_APP_NAME_2)).findFirst().get().getId();
 
         Response response = given()
@@ -123,10 +134,12 @@ public class NotificationServiceTest extends DbIsolatedTest {
 
     @Test
     void testEventTypeFetchingByBundle() {
-        helpers.createTestAppAndEventTypes();
+        helpers.createTestAppAndEventTypes()
+                .await().indefinitely();
         Header identityHeader = initRbacMock(TENANT, USERNAME, RbacAccess.FULL_ACCESS);
 
-        List<Application> applications = helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
+        List<Application> applications = applicationResources.getApplications(ResourceHelpers.TEST_BUNDLE_NAME)
+                .await().indefinitely();
         UUID myBundleId = applications.stream().filter(a -> a.getName().equals(helpers.TEST_APP_NAME_2)).findFirst().get().getBundleId();
 
         Response response = given()
@@ -151,10 +164,12 @@ public class NotificationServiceTest extends DbIsolatedTest {
 
     @Test
     void testEventTypeFetchingByBundleAndApplicationId() {
-        helpers.createTestAppAndEventTypes();
+        helpers.createTestAppAndEventTypes()
+                .await().indefinitely();
         Header identityHeader = initRbacMock(TENANT, USERNAME, RbacAccess.FULL_ACCESS);
 
-        List<Application> applications = helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME);
+        List<Application> applications = applicationResources.getApplications(ResourceHelpers.TEST_BUNDLE_NAME)
+                .await().indefinitely();
         UUID myOtherTesterApplicationId = applications.stream().filter(a -> a.getName().equals(helpers.TEST_APP_NAME_2)).findFirst().get().getId();
         UUID myBundleId = applications.stream().filter(a -> a.getName().equals(helpers.TEST_APP_NAME_2)).findFirst().get().getBundleId();
 
@@ -182,22 +197,34 @@ public class NotificationServiceTest extends DbIsolatedTest {
 
     @Test
     void testGetEventTypesAffectedByEndpoint() {
-        UUID bundleId = helpers.createTestAppAndEventTypes();
+        UUID bundleId = helpers.createTestAppAndEventTypes()
+                .await().indefinitely();
         String tenant = "testGetEventTypesAffectedByEndpoint";
         Header identityHeader = initRbacMock(tenant, "user", RbacAccess.FULL_ACCESS);
 
-        UUID behaviorGroupId1 = helpers.createBehaviorGroup(tenant, "behavior-group-1", bundleId).getId();
-        UUID behaviorGroupId2 = helpers.createBehaviorGroup(tenant, "behavior-group-2", bundleId).getId();
-        UUID applicationId = helpers.getApplications(ResourceHelpers.TEST_BUNDLE_NAME).stream().filter(a -> a.getName().equals(ResourceHelpers.TEST_APP_NAME_2)).findFirst().get().getId();
-        UUID ep1 = helpers.createWebhookEndpoint(tenant);
-        UUID ep2 = helpers.createWebhookEndpoint(tenant);
-        List<EventType> eventTypesFromApp1 = helpers.getEventTypesForApplication(applicationId);
+        UUID behaviorGroupId1 = helpers.createBehaviorGroup(tenant, "behavior-group-1", bundleId)
+                .onItem().transform(BehaviorGroup::getId)
+                .await().indefinitely();
+        UUID behaviorGroupId2 = helpers.createBehaviorGroup(tenant, "behavior-group-2", bundleId)
+                .onItem().transform(BehaviorGroup::getId)
+                .await().indefinitely();
+        UUID applicationId = applicationResources.getApplications(ResourceHelpers.TEST_BUNDLE_NAME)
+                .await().indefinitely()
+                .stream().filter(a -> a.getName().equals(ResourceHelpers.TEST_APP_NAME_2)).findFirst().get().getId();
+        UUID ep1 = helpers.createWebhookEndpoint(tenant)
+                .await().indefinitely();
+        UUID ep2 = helpers.createWebhookEndpoint(tenant)
+                .await().indefinitely();
+        List<EventType> eventTypesFromApp1 = applicationResources.getEventTypes(applicationId)
+                .await().indefinitely();
         EventType ev0 = eventTypesFromApp1.get(0);
         EventType ev1 = eventTypesFromApp1.get(1);
 
         // ep1 assigned to ev0; ep2 not assigned.
-        helpers.updateEventTypeBehaviors(tenant, ev0.getId(), Set.of(behaviorGroupId1));
-        helpers.updateBehaviorGroupActions(tenant, behaviorGroupId1, List.of(ep1));
+        behaviorGroupResources.updateEventTypeBehaviors(tenant, ev0.getId(), Set.of(behaviorGroupId1))
+                .await().indefinitely();
+        behaviorGroupResources.updateBehaviorGroupActions(tenant, behaviorGroupId1, List.of(ep1))
+                .await().indefinitely();
         String responseBody = given()
                 .header(identityHeader)
                 .pathParam("endpointId", ep1.toString())
@@ -227,8 +254,10 @@ public class NotificationServiceTest extends DbIsolatedTest {
         assertEquals(0, behaviorGroups.size());
 
         // ep1 assigned to event ev0; ep2 assigned to event ev1
-        helpers.updateEventTypeBehaviors(tenant, ev1.getId(), Set.of(behaviorGroupId2));
-        helpers.updateBehaviorGroupActions(tenant, behaviorGroupId2, List.of(ep2));
+        behaviorGroupResources.updateEventTypeBehaviors(tenant, ev1.getId(), Set.of(behaviorGroupId2))
+                .await().indefinitely();
+        behaviorGroupResources.updateBehaviorGroupActions(tenant, behaviorGroupId2, List.of(ep2))
+                .await().indefinitely();
         responseBody = given()
                 .header(identityHeader)
                 .pathParam("endpointId", ep1.toString())


### PR DESCRIPTION
This is phase 1 of the preparation work, there will be more. As a consequence, some parts of this PR may look unfinished but that's perfectly normal.

Quarkus 2 requires all tests involving Hibernate Reactive to be written in a reactive way. In other words, `.await().indefinitely()` has to be removed completely from tests (it won't happen before the bump).