### PR TITLE
Update method to check if subscription is supported

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -215,7 +215,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
                         .onItem().transformToMulti(unused -> Multi.createFrom().empty()) :
                 Multi.createFrom().empty();
 
-        if (!emailTemplate.isSupported(null, emailSubscriptionType)) {
+        if (!emailTemplate.isEmailSubscriptionSupported(emailSubscriptionType)) {
             return doDelete;
         }
 


### PR DESCRIPTION
After reviewing #576 I noticed that we could use `isEmailSubscriptionSupported` in this check.