### PR TITLE
NOTIF-309 Deduplicate incoming ingress Kafka messages

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/events/KafkaMessageDeduplicator.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/events/KafkaMessageDeduplicator.java
@@ -1,0 +1,131 @@
+package com.redhat.cloud.notifications.events;
+
+import com.redhat.cloud.notifications.models.KafkaMessage;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.reactive.messaging.kafka.KafkaMessageMetadata;
+import org.apache.kafka.common.header.Header;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.UUID;
+
+import static java.lang.Boolean.FALSE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@ApplicationScoped
+public class KafkaMessageDeduplicator {
+
+    public static final String MESSAGE_ID_HEADER = "rh-message-id";
+    public static final String MESSAGE_ID_VALID_COUNTER_NAME = "kafka-message-id.valid";
+    public static final String MESSAGE_ID_INVALID_COUNTER_NAME = "kafka-message-id.invalid";
+    public static final String MESSAGE_ID_MISSING_COUNTER_NAME = "kafka-message-id.missing";
+
+    private static final Logger LOGGER = Logger.getLogger(KafkaMessageDeduplicator.class);
+    private static final String ACCEPTED_UUID_VERSION = "4";
+
+    @Inject
+    Mutiny.StatelessSession statelessSession;
+
+    @Inject
+    MeterRegistry meterRegistry;
+
+    private Counter validMessageIdCounter;
+    private Counter invalidMessageIdCounter;
+    private Counter missingMessageIdCounter;
+
+    @PostConstruct
+    void initCounters() {
+        validMessageIdCounter = meterRegistry.counter(MESSAGE_ID_VALID_COUNTER_NAME);
+        invalidMessageIdCounter = meterRegistry.counter(MESSAGE_ID_INVALID_COUNTER_NAME);
+        missingMessageIdCounter = meterRegistry.counter(MESSAGE_ID_MISSING_COUNTER_NAME);
+    }
+
+    /**
+     * Extracts the message ID from a Kafka message header value. If multiple header values are available, the first one
+     * will be used and the other ones will be ignored. An invalid header value will be counted and logged, but won't
+     * interrupt the message processing: the deduplication will be disabled for the message.
+     */
+    public UUID findMessageId(String bundleName, String applicationName, Message<String> message) {
+        boolean found = false;
+        Optional<KafkaMessageMetadata> metadata = message.getMetadata(KafkaMessageMetadata.class);
+        if (metadata.isPresent()) {
+            Iterator<Header> headers = metadata.get().getHeaders().headers(MESSAGE_ID_HEADER).iterator();
+            if (headers.hasNext()) {
+                found = true;
+                Header header = headers.next();
+                if (header.value() == null) {
+                    invalidMessageIdCounter.increment();
+                    LOGGER.warnf("Application %s/%s sent an invalid Kafka header [%s=null]. They must change their " +
+                                    "integration and send a non-null value.", bundleName, applicationName, MESSAGE_ID_HEADER);
+                } else {
+                    String headerValue = new String(header.value(), UTF_8);
+                    try {
+                        UUID messageId = UUID.fromString(headerValue);
+                        // If the UUID version is 4, then its 15th character has to be "4".
+                        if (!headerValue.substring(14, 15).equals(ACCEPTED_UUID_VERSION)) {
+                            throw new IllegalArgumentException("Wrong UUID version received");
+                        }
+                        validMessageIdCounter.increment();
+                        LOGGER.tracef("Application %s/%s sent a valid Kafka header [%s=%s]",
+                                bundleName, applicationName, MESSAGE_ID_HEADER, headerValue);
+                        return messageId;
+                    } catch (IllegalArgumentException e) {
+                        invalidMessageIdCounter.increment();
+                        LOGGER.warnf("Application %s/%s sent an invalid Kafka header [%s=%s]. They must change their " +
+                                "integration and send a valid UUID (version 4).", bundleName, applicationName, MESSAGE_ID_HEADER, headerValue);
+                    }
+                }
+            }
+            if (headers.hasNext()) {
+                LOGGER.warnf("Application %s/%s sent multiple Kafka headers [%s]. They must change their " +
+                                "integration and send only one value.", bundleName, applicationName, MESSAGE_ID_HEADER);
+            }
+        }
+        if (!found) {
+            missingMessageIdCounter.increment();
+            LOGGER.tracef("Application %s/%s did not send any Kafka header [%s]",
+                    bundleName, applicationName, MESSAGE_ID_HEADER);
+        }
+        // This will be returned if the message ID is either invalid or not found.
+        return null;
+    }
+
+    /**
+     * Verifies that another Kafka consumer didn't already process the given message and then failed to commit its
+     * offset. Such failure can happen when a consumer is kicked out of its consumer group because it didn't poll new
+     * messages fast enough. We experienced that already on production.
+     */
+    public Uni<Boolean> isDuplicate(UUID messageId) {
+        if (messageId == null) {
+            /*
+             * For now, messages without an ID are always considered new. This is necessary to give the onboarded apps
+             * time to change their integration and start sending the new header. The message ID may become mandatory later.
+             */
+            return Uni.createFrom().item(FALSE);
+        } else {
+            String hql = "SELECT TRUE FROM KafkaMessage WHERE id = :messageId";
+            return statelessSession.createQuery(hql, Boolean.class)
+                    .setParameter("messageId", messageId)
+                    .getSingleResultOrNull()
+                    .onItem().ifNull().continueWith(FALSE);
+        }
+    }
+
+    public Uni<Void> registerMessageId(UUID messageId) {
+        if (messageId == null) {
+            return Uni.createFrom().voidItem();
+        } else {
+            KafkaMessage kafkaMessage = new KafkaMessage(messageId);
+            kafkaMessage.prePersist(); // This method must be called manually while using a StatelessSession.
+            return statelessSession.insert(kafkaMessage);
+        }
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/events/KafkaMessagesCleaner.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/events/KafkaMessagesCleaner.java
@@ -1,0 +1,56 @@
+package com.redhat.cloud.notifications.events;
+
+import io.quarkus.scheduler.Scheduled;
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+// TODO Replace this with an OpenShift cronjob.
+@ApplicationScoped
+public class KafkaMessagesCleaner {
+
+    public static final String KAFKA_MESSAGES_CLEANER_DELETE_AFTER_CONF_KEY = "kafka-messages-cleaner.delete-after";
+
+    private static final Logger LOGGER = Logger.getLogger(KafkaMessagesCleaner.class);
+    private static final Duration DEFAULT_DELETE_DELAY = Duration.ofDays(1L);
+
+    @Inject
+    Mutiny.StatelessSession statelessSession;
+
+    /**
+     * The Kafka messages identifiers are stored in the database until their retention time is reached.
+     * This scheduled job deletes from the database the expired Kafka messages identifiers.
+     */
+    /*
+     * TODO The scheduling is delayed to prevent an unwanted execution during tests. Remove the delay and set the period
+     * to `disabled` after the Quarkus 2 bump. See https://quarkus.io/guides/scheduler-reference for more details.
+     */
+    @Scheduled(identity = "KafkaMessagesCleaner", delay = 10L, delayUnit = MINUTES, every = "{kafka-messages-cleaner.period}")
+    public void clean() {
+        testableClean().await().indefinitely();
+    }
+
+    Uni<Integer> testableClean() {
+        Duration deleteDelay = ConfigProvider.getConfig().getOptionalValue(KAFKA_MESSAGES_CLEANER_DELETE_AFTER_CONF_KEY, Duration.class)
+                .orElse(DEFAULT_DELETE_DELAY);
+        LocalDateTime deleteBefore = now().minus(deleteDelay);
+        LOGGER.infof("Kafka messages purge starting. Entries older than %s will be deleted.", deleteBefore.toString());
+        return statelessSession.createQuery("DELETE FROM KafkaMessage WHERE created < :deleteBefore")
+                .setParameter("deleteBefore", deleteBefore)
+                .executeUpdate()
+                .invoke(deleted -> LOGGER.infof("Kafka messages purge ended. %d entries were deleted from the database.", deleted));
+    }
+
+    public static LocalDateTime now() {
+        return LocalDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/models/KafkaMessage.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/KafkaMessage.java
@@ -1,0 +1,39 @@
+package com.redhat.cloud.notifications.models;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "kafka_message")
+public class KafkaMessage extends CreationTimestamped {
+
+    @Id
+    private UUID id;
+
+    public KafkaMessage() {
+    }
+
+    public KafkaMessage(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof KafkaMessage) {
+            KafkaMessage other = (KafkaMessage) o;
+            return Objects.equals(id, other.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/backend/src/main/resources/db/migration/V1.29.0__message_deduplicator.sql
+++ b/backend/src/main/resources/db/migration/V1.29.0__message_deduplicator.sql
@@ -1,0 +1,5 @@
+CREATE TABLE kafka_message (
+    id UUID NOT NULL,
+    created TIMESTAMP NOT NULL,
+    CONSTRAINT pk_kafka_message PRIMARY KEY (id)
+);

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/KafkaMessagesCleanerTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/KafkaMessagesCleanerTest.java
@@ -1,0 +1,86 @@
+package com.redhat.cloud.notifications.events;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.models.KafkaMessage;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.db.EventLogCleaner.now;
+import static com.redhat.cloud.notifications.events.KafkaMessagesCleaner.KAFKA_MESSAGES_CLEANER_DELETE_AFTER_CONF_KEY;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class KafkaMessagesCleanerTest {
+
+    /*
+     * The KafkaMessage#created field is automatically set because of the @PrePersist annotation in CreationTimestamped
+     * when a KafkaMessage is persisted using a stateful session. @PrePersist does not work with a stateless session. We
+     * need to set KafkaMessage#created manually to a past date in the tests below, that's why these tests are run using
+     * a stateless session.
+     */
+    @Inject
+    Mutiny.StatelessSession statelessSession;
+
+    @Inject
+    KafkaMessagesCleaner kafkaMessagesCleaner;
+
+    @BeforeEach
+    void beforeEach() {
+        statelessSession.createQuery("DELETE FROM KafkaMessage")
+                .executeUpdate()
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .await()
+                .assertCompleted();
+    }
+
+    @Test
+    void testWithDefaultConfiguration() {
+        createKafkaMessage(now().minus(Duration.ofHours(13L)))
+                .chain(() -> createKafkaMessage(now().minus(Duration.ofDays(2L))))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .await()
+                .assertCompleted();
+        assertCount(2L);
+        kafkaMessagesCleaner.clean();
+        assertCount(1L);
+    }
+
+    @Test
+    void testWithCustomConfiguration() {
+        System.setProperty(KAFKA_MESSAGES_CLEANER_DELETE_AFTER_CONF_KEY, "12h");
+        createKafkaMessage(now().minus(Duration.ofHours(13L)))
+                .chain(() -> createKafkaMessage(now().minus(Duration.ofDays(2L))))
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .await()
+                .assertCompleted();
+        assertCount(2L);
+        kafkaMessagesCleaner.clean();
+        assertCount(0L);
+        System.clearProperty(KAFKA_MESSAGES_CLEANER_DELETE_AFTER_CONF_KEY);
+    }
+
+    private Uni<Void> createKafkaMessage(LocalDateTime created) {
+        KafkaMessage kafkaMessage = new KafkaMessage(UUID.randomUUID());
+        kafkaMessage.setCreated(created);
+        return statelessSession.insert(kafkaMessage);
+    }
+
+    private void assertCount(long expectedCount) {
+        statelessSession.createQuery("SELECT COUNT(*) FROM KafkaMessage", Long.class)
+                .getSingleResult()
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .await()
+                .assertItem(expectedCount)
+                .assertCompleted();
+    }
+}


### PR DESCRIPTION
By default, Kafka guarantees that each message will be consumed/processed _at least once_. This PR introduces Kafka messages deduplication in order to consume each message _exactly once_. The underlying goal is to protect us against Kafka failures like the one we had recently on prod when our consumer failed to commit its offset because it was kicked out of the consumer group. We never confirmed it but it most probably led to duplicate notifications being sent during the incident.

This PR is based on two things:
- A new optional (for now) `rh-message-id` Kafka header which can be sent by the onboarded apps with their message. It is then used as a unique identifier for the message.
- A new `kafka_message` DB table where all valid messages IDs are stored for a limited period of time (default: 1 day, configurable) and then purged.

ℹ️ This is a non-breaking PR that should allow a smooth migration for the onboarded apps. We may decide on a date when the new header will become mandatory, or not. I added a several new counters to allow us to monitor the migration progress. It should help us know when all apps are done migrating.

⚠️ The app behavior should be _exactly identical_ before and after this PR for an onboarded app that _doesn't_ send the new header. If you suspect a behavior change during the review, please add a comment about it.

When a message is received, if its ID is already known (found in the database), then the message is ignored. If the ID is missing (not sent by the onboarded app) or invalid, then the message is considered unknown and processed normally. Invalid IDs are reported at `WARN` level in the logs and will show up in Sentry, allowing us to inform the onboarded app of an integration issue.

⚠️ Version 4 of UUID is mandatory. Any other version received will be rejected.