### PR TITLE
NOTIF-273 Fix RestAssured body serialization with Quarkus 2

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/recipients/rbac/AuthRequestFilter.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/recipients/rbac/AuthRequestFilter.java
@@ -16,7 +16,7 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.logging.Logger;
 
-class AuthRequestFilter implements ClientRequestFilter {
+public class AuthRequestFilter implements ClientRequestFilter {
 
     static final String RBAC_SERVICE_TO_SERVICE_APPLICATION_KEY = "rbac.service-to-service.application";
     static final String RBAC_SERVICE_TO_SERVICE_APPLICATION_DEFAULT = "notifications";

--- a/backend/src/test/java/com/redhat/cloud/notifications/Json.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/Json.java
@@ -1,0 +1,43 @@
+package com.redhat.cloud.notifications;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.redhat.cloud.notifications.models.filter.ApiResponseFilter;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
+/*
+ * Before Quarkus 2, we used io.vertx.core.json.Json to (de)serialize RestAssured requests bodies. Since Quarkus 2, the
+ * underlying ObjectMapper instance which is provided by QuarkusJacksonJsonCodec is no longer customizable. That's why
+ * we need this class now.
+ */
+public class Json {
+
+    private static ObjectMapper OBJECT_MAPPER = init();
+
+    private static ObjectMapper init() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setFilterProvider(new SimpleFilterProvider().addFilter(ApiResponseFilter.NAME, new ApiResponseFilter()));
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return objectMapper;
+    }
+
+    public static String encode(Object value) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Jackson serialization failed", e);
+        }
+    }
+
+    public static <T> T decodeValue(String jsonValue, Class<T> decodedClass) {
+        try {
+            return OBJECT_MAPPER.readValue(jsonValue, decodedClass);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Jackson deserialization failed", e);
+        }
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -1,13 +1,7 @@
 package com.redhat.cloud.notifications;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.FilterProvider;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.redhat.cloud.notifications.models.filter.ApiResponseFilter;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
-import io.vertx.core.json.jackson.DatabindCodec;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -20,7 +14,6 @@ import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.AGGREGATION_CHANNEL;
 
 public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
@@ -35,7 +28,6 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
     @Override
     public Map<String, String> start() {
         System.out.println("++++  TestLifecycleManager start +++");
-        configureObjectMapper();
         Map<String, String> properties = new HashMap<>();
         try {
             setupPostgres(properties);
@@ -53,14 +45,6 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
 
         System.out.println(" -- Running with properties: " + properties);
         return properties;
-    }
-
-    private void configureObjectMapper() {
-        FilterProvider filterProvider = new SimpleFilterProvider().addFilter(ApiResponseFilter.NAME, new ApiResponseFilter());
-        ObjectMapper mapper = DatabindCodec.mapper();
-        mapper.setFilterProvider(filterProvider);
-        mapper.registerModule(new JavaTimeModule());
-        mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     @Override

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.events;
 
 import com.redhat.cloud.notifications.CounterAssertionHelper;
+import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestHelpers;
@@ -22,7 +23,6 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.Header;
 import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.processors.email;
 
+import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.EmailAggregationResources;
 import com.redhat.cloud.notifications.models.AggregationCommand;
@@ -15,7 +16,6 @@ import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
-import io.vertx.core.json.Json;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/AuthenticationTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/AuthenticationTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.http.ContentType.JSON;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
@@ -67,8 +66,7 @@ public class AuthenticationTest {
                 .header(identityHeader)
                 .when().get("/endpoints")
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
 
         clearRbacCache();
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.routers;
 
+import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
@@ -23,7 +24,6 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -440,7 +440,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .contentType(JSON)
                 .when()
-                .body(Json.encode(responsePointSingle))
+                .body(responsePointSingle.encode())
                 .put(String.format("/endpoints/%s", responsePointSingle.getString("id")))
                 .then()
                 .statusCode(200)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
@@ -317,8 +317,7 @@ public class EventServiceTest extends DbIsolatedTest {
                 .header(noAccessIdentityHeader)
                 .when().get(PATH)
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
     }
 
     @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.routers;
 
+import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.models.Application;
@@ -7,7 +8,6 @@ import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
@@ -21,6 +21,7 @@ import static io.restassured.http.ContentType.JSON;
 import static io.restassured.http.ContentType.TEXT;
 import static javax.ws.rs.core.Response.Status.Family.familyOf;
 import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -320,7 +321,7 @@ public class InternalServiceTest extends DbIsolatedTest {
                 .put("/internal/bundles/{bundleId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(familyOf(expectedStatusCode) == Family.SUCCESSFUL ? is(TEXT.toString()) : any(String.class));
+                .contentType(familyOf(expectedStatusCode) == Family.SUCCESSFUL ? containsString(TEXT.toString()) : any(String.class));
 
         if (familyOf(expectedStatusCode) == Family.SUCCESSFUL) {
             getBundle(bundleId, bundle.getName(), bundle.getDisplayName(), OK);
@@ -435,7 +436,7 @@ public class InternalServiceTest extends DbIsolatedTest {
                 .put("/internal/applications/{appId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(familyOf(expectedStatusCode) == Family.SUCCESSFUL ? is(TEXT.toString()) : any(String.class));
+                .contentType(familyOf(expectedStatusCode) == Family.SUCCESSFUL ? containsString(TEXT.toString()) : any(String.class));
 
         if (familyOf(expectedStatusCode) == Family.SUCCESSFUL) {
             getApp(appId, app.getName(), app.getDisplayName(), OK);
@@ -528,7 +529,7 @@ public class InternalServiceTest extends DbIsolatedTest {
                 .put("/internal/eventTypes/{eventTypeId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(familyOf(expectedStatusCode) == Family.SUCCESSFUL ? is(TEXT.toString()) : any(String.class));
+                .contentType(familyOf(expectedStatusCode) == Family.SUCCESSFUL ? containsString(TEXT.toString()) : any(String.class));
 
         if (familyOf(expectedStatusCode) == Family.SUCCESSFUL) {
             String responseBody = given()

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.routers;
 
+import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerClientConfig.RbacAccess;
 import com.redhat.cloud.notifications.MockServerConfig;
@@ -19,7 +20,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +35,6 @@ import java.util.UUID;
 import static com.redhat.cloud.notifications.TestThreadHelper.runOnWorkerThread;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static io.restassured.http.ContentType.TEXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -358,8 +357,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .get("/notifications/eventTypes")
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
 
         given()
                 .header(noAccessIdentityHeader)
@@ -367,8 +365,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .get("/notifications/eventTypes/affectedByRemovalOfBehaviorGroup/{behaviorGroupId}")
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
 
         given()
                 .header(noAccessIdentityHeader)
@@ -376,8 +373,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .get("/notifications/behaviorGroups/affectedByRemovalOfEndpoint/{endpointId}")
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
 
         given()
                 .header(readAccessIdentityHeader)
@@ -387,8 +383,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .put("/notifications/eventTypes/{eventTypeId}/behaviorGroups")
                 .then()
-                .statusCode(403)
-                .contentType(TEXT);
+                .statusCode(403);
 
         given()
                 .header(noAccessIdentityHeader)
@@ -396,8 +391,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .get("/notifications/eventTypes/{eventTypeId}/behaviorGroups")
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
 
         given()
                 .header(readAccessIdentityHeader)
@@ -407,8 +401,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .post("/notifications/behaviorGroups")
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
 
         given()
                 .header(readAccessIdentityHeader)
@@ -419,8 +412,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .put("/notifications/behaviorGroups/{id}")
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
 
         given()
                 .header(readAccessIdentityHeader)
@@ -428,8 +420,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .delete("/notifications/behaviorGroups/{id}")
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
 
         given()
                 .header(readAccessIdentityHeader)
@@ -439,8 +430,7 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .put("/notifications/behaviorGroups/{behaviorGroupId}/actions")
                 .then()
-                .statusCode(403)
-                .contentType(TEXT);
+                .statusCode(403);
 
         given()
                 .header(noAccessIdentityHeader)
@@ -448,7 +438,6 @@ public class NotificationServiceTest extends DbIsolatedTest {
                 .when()
                 .get("/notifications/bundles/{bundleId}/behaviorGroups")
                 .then()
-                .statusCode(403)
-                .contentType(JSON);
+                .statusCode(403);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/StatusServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/StatusServiceTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.routers;
 
+import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestHelpers;
@@ -11,7 +12,6 @@ import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.Header;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
@@ -147,7 +147,7 @@ public class StatusServiceTest extends DbIsolatedTest {
                 .extract().asString();
 
         JsonObject jsonCurrentStatus = new JsonObject(responseBody);
-        jsonCurrentStatus.mapTo(CurrentStatus.class);
+        Json.decodeValue(responseBody, CurrentStatus.class);
         assertEquals(expectedStatus, jsonCurrentStatus.getString("status"));
         if (expectedStartTime == null) {
             assertNull(jsonCurrentStatus.getString("start_time"));

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigServiceTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.routers;
 
+import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
@@ -23,7 +24,6 @@ import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.json.Json;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Here's another prep work PR for Quarkus 2.

With Quarkus 1, we currently serialize the RestAssured request bodies with an `ObjectMapper` instance provided by Vert.x. That instance is customized in our test code because we use Jackson filters and `LocalDate(Time)`.

With Quarkus 2, the instance that was provided by Vert.x has been replaced by another one from Quarkus which is not customizable from tests. I created a Quarkus PR that made it customizable but it was refused, so we can no longer use the old way of serializing bodies.

This PR also contains a few unrelated changes that are all required for the Quarkus 2 bump.