### PR TITLE
Fix daily aggregation date on new aggregator first execution

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EmailAggregationResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EmailAggregationResources.java
@@ -52,4 +52,12 @@ public class EmailAggregationResources {
                 .setParameter("created", lastUsedTime)
                 .executeUpdate();
     }
+
+    // TODO Delete this method when we're done migrating to the new aggregator.
+    public Uni<Integer> updateLastCronJobRun(LocalDateTime lastRun) {
+        String query = "UPDATE cronjob_run SET last_run = :lastRun";
+        return statelessSession.createNativeQuery(query)
+                .setParameter("lastRun", lastRun)
+                .executeUpdate();
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -204,7 +204,8 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
                                     result.size()
                             )
                     );
-                });
+                })
+                .eventually(() -> emailAggregationResources.updateLastCronJobRun(endTime));
     }
 
     private Multi<Tuple2<NotificationHistory, EmailAggregationKey>> processAggregateEmailsByAggregationKey(EmailAggregationKey aggregationKey, LocalDateTime startTime, LocalDateTime endTime, EmailSubscriptionType emailSubscriptionType, boolean delete) {


### PR DESCRIPTION
With this PR, the `cronjob_run.last_run` DB field will be updated each time the old aggregator is done processing aggregations. As a consequence, when the new aggregator will run for the first time on prod, it won't use the following date:

https://github.com/RedHatInsights/notifications-backend/blob/ea5d165851c8a736d58423e02741bb67c90cf52d/backend/src/main/resources/db/migration/V1.28.0__NOTIF-190_cronjob_timestamp.sql#L8

Otherwise, this would be sent on prod (it happened on stage today):

![image](https://user-images.githubusercontent.com/10584698/133995198-fdf974dc-b1d5-45a2-adc9-562e891d6600.png)