### PR TITLE
NOTIF-273 Add missing configuration value

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -125,3 +125,6 @@ quarkus.cache.caffeine.rbac-recipient-users-provider-get-group-users.expire-afte
 
 # Period between two event log cleanings. It must be expressed with the ISO-8601 duration format PnDTnHnMn.nS.
 event-log-cleaner.period=PT10M
+
+# Period between two Kafka message IDs cleanings. It must be expressed with the ISO-8601 duration format PnDTnHnMn.nS.
+kafka-messages-cleaner.period=PT10M


### PR DESCRIPTION
`backend` fails to start because of that missing conf value.