### PR TITLE
NOTIF-314 Prevent in memory events pagination

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
@@ -58,7 +58,7 @@ public class EventService {
         }
         return getAccountId(securityContext)
                 .onItem().transformToUni(accountId ->
-                        eventResources.get(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, limit, offset, sortBy)
+                        eventResources.getEvents(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, limit, offset, sortBy)
                                 .onItem().transform(events ->
                                         events.stream().map(event -> {
                                             List<EventLogEntryAction> actions = event.getHistoryEntries().stream().map(historyEntry -> {


### PR DESCRIPTION
This fixes the following warning:
```
HHH000104: firstResult/maxResults specified with collection fetch; applying in memory!
```
The warning cause as well as the solution implemented in this PR are explained here: https://vladmihalcea.com/fix-hibernate-hhh000104-entity-fetch-pagination-warning-message/