### PR TITLE
Prevent Kafka warning about a notifications config key

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/events/KafkaMessagesCleaner.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/events/KafkaMessagesCleaner.java
@@ -34,7 +34,7 @@ public class KafkaMessagesCleaner {
      * TODO The scheduling is delayed to prevent an unwanted execution during tests. Remove the delay and set the period
      * to `disabled` after the Quarkus 2 bump. See https://quarkus.io/guides/scheduler-reference for more details.
      */
-    @Scheduled(identity = "KafkaMessagesCleaner", delay = 10L, delayUnit = MINUTES, every = "{kafka-messages-cleaner.period}")
+    @Scheduled(identity = "KafkaMessagesCleaner", delay = 10L, delayUnit = MINUTES, every = "{notifications.kafka-messages-cleaner.period}")
     public void clean() {
         testableClean().await().indefinitely();
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -127,4 +127,5 @@ quarkus.cache.caffeine.rbac-recipient-users-provider-get-group-users.expire-afte
 event-log-cleaner.period=PT10M
 
 # Period between two Kafka message IDs cleanings. It must be expressed with the ISO-8601 duration format PnDTnHnMn.nS.
-kafka-messages-cleaner.period=PT10M
+# Kafka doesn't like when a config key starts with "kafka", hence the "notifications." prefix.
+notifications.kafka-messages-cleaner.period=PT10M


### PR DESCRIPTION
This will prevent this warning from Kafka which showed up in Sentry:
```
The configuration 'messages.cleaner.period' was supplied but isn't a known config.
```