### PR TITLE
Enable Hibernate Reactive metrics

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -44,6 +44,7 @@ quarkus.datasource.jdbc=false
 quarkus.datasource.reactive.url=postgresql://127.0.0.1:5432/notifications
 
 quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.notifications.db.naming.SnakeCasePhysicalNamingStrategy
+quarkus.hibernate-orm.metrics.enabled=true
 
 # Uncomment to log Hibernate SQL statements
 #quarkus.hibernate-orm.log.sql=true


### PR DESCRIPTION
We just had what seems to be a connection pool starvation on prod.

I'd like to see if there's anything useful regarding the prod issue in the Hibernate metrics.