### PR TITLE
Silence Hibernate statistics in logs

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -45,6 +45,7 @@ quarkus.datasource.reactive.url=postgresql://127.0.0.1:5432/notifications
 
 quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.notifications.db.naming.SnakeCasePhysicalNamingStrategy
 quarkus.hibernate-orm.metrics.enabled=true
+quarkus.log.category."org.hibernate.engine.internal.StatisticalLoggingSessionEventListener".level=WARN
 
 # Uncomment to log Hibernate SQL statements
 #quarkus.hibernate-orm.log.sql=true


### PR DESCRIPTION
Related to #651.

With `quarkus.hibernate-orm.metrics.enabled=true`, Hibernate logs tons of statistics which are way too noisy for prod. We only need the Hibernate metrics available at `/metrics`.

```
2021-09-28T08:15:18.8092201Z 2021-09-28 08:15:18,798 INFO  [info] (vert.x-eventloop-thread-0) 127.0.0.1 - -noauth- 28/Sep/2021:08:15:18 +0000 "GET /internal/bundles/69efff0f-841d-4c1e-aa94-b05d37162618 HTTP/1.1" 200 133 "-" "Apache-HttpClient/4.5.13 (Java/11.0.11)"
2021-09-28T08:15:18.8131884Z 2021-09-28 08:15:18,799 INFO  [org.hib.eng.int.StatisticalLoggingSessionEventListener] (vert.x-eventloop-thread-0) Session Metrics {
2021-09-28T08:15:18.8138734Z     0 nanoseconds spent acquiring 0 JDBC connections;
2021-09-28T08:15:18.8144242Z     0 nanoseconds spent releasing 0 JDBC connections;
2021-09-28T08:15:18.8196623Z     0 nanoseconds spent preparing 0 JDBC statements;
2021-09-28T08:15:18.8202343Z     0 nanoseconds spent executing 0 JDBC statements;
2021-09-28T08:15:18.8207699Z     0 nanoseconds spent executing 0 JDBC batches;
2021-09-28T08:15:18.8214785Z     0 nanoseconds spent performing 0 L2C puts;
2021-09-28T08:15:18.8221186Z     0 nanoseconds spent performing 0 L2C hits;
2021-09-28T08:15:18.8226240Z     0 nanoseconds spent performing 0 L2C misses;
2021-09-28T08:15:18.8234996Z     0 nanoseconds spent executing 0 flushes (flushing a total of 0 entities and 0 collections);
2021-09-28T08:15:18.8245294Z     0 nanoseconds spent executing 0 partial-flushes (flushing a total of 0 entities and 0 collections)
2021-09-28T08:15:18.8248269Z }
```