### PR TITLE
NOTIF-320 Use static endpoint type in the event log

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
@@ -38,7 +38,7 @@ public class EventResources {
                 .onItem().transformToUni(eventIds -> {
                     String hql = "SELECT DISTINCT e FROM Event e " +
                             "JOIN FETCH e.eventType et JOIN FETCH et.application a JOIN FETCH a.bundle b " +
-                            "LEFT JOIN FETCH e.historyEntries he LEFT JOIN FETCH he.endpoint " +
+                            "LEFT JOIN FETCH e.historyEntries he " +
                             "WHERE e.accountId = :accountId AND e.id IN (:eventIds)";
 
                     if (orderByCondition.isPresent()) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -74,7 +74,7 @@ public class Endpoint extends CreationUpdateTimestamped {
     @JsonIgnore
     private Set<BehaviorGroupAction> behaviorGroupActions;
 
-    @OneToMany(mappedBy = "endpoint", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "endpoint")
     @JsonIgnore
     private Set<NotificationHistory> notificationHistories;
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
@@ -64,7 +64,7 @@ public class EventService {
                                             List<EventLogEntryAction> actions = event.getHistoryEntries().stream().map(historyEntry -> {
                                                 EventLogEntryAction action = new EventLogEntryAction();
                                                 action.setId(historyEntry.getId());
-                                                action.setEndpointType(historyEntry.getEndpoint().getType());
+                                                action.setEndpointType(historyEntry.getEndpointType());
                                                 action.setInvocationResult(historyEntry.isInvocationResult());
                                                 return action;
                                             }).collect(Collectors.toList());

--- a/backend/src/main/resources/db/migration/V1.30.0__NOTIF-320_event_log_static_endpoint_type.sql
+++ b/backend/src/main/resources/db/migration/V1.30.0__NOTIF-320_event_log_static_endpoint_type.sql
@@ -1,0 +1,17 @@
+-- This script recreates a constraint to drop the ON DELETE and ON UPDATE clauses.
+-- This is done using the NOT VALID option and the VALIDATE CONSTRAINT operation to speed up the schema migration.
+-- See https://www.postgresql.org/docs/13/sql-altertable.html for more details about NOT VALID.
+
+ALTER TABLE notification_history
+    ADD COLUMN endpoint_type INTEGER;
+
+UPDATE notification_history nh SET endpoint_type = (SELECT e.endpoint_type FROM endpoints e WHERE e.id = nh.endpoint_id);
+
+ALTER TABLE notification_history
+    ALTER COLUMN endpoint_type SET NOT NULL,
+    ALTER COLUMN endpoint_id DROP NOT NULL,
+    DROP CONSTRAINT notification_history_endpoint_id_fkey,
+    ADD CONSTRAINT fk_notification_history_endpoint_id FOREIGN KEY (endpoint_id) REFERENCES endpoints (id) ON DELETE SET NULL NOT VALID;
+
+ALTER TABLE notification_history
+    VALIDATE CONSTRAINT fk_notification_history_endpoint_id;

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -185,6 +185,7 @@ public class ResourceHelpers {
         history.setInvocationResult(TRUE);
         history.setEvent(event);
         history.setEndpoint(endpoint);
+        history.setEndpointType(endpoint.getType());
         return notificationResources.createNotificationHistory(history);
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.EndpointResources;
 import com.redhat.cloud.notifications.db.ModelInstancesHolder;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.Event;
@@ -59,6 +60,9 @@ public class EventServiceTest extends DbIsolatedTest {
     @Inject
     ResourceHelpers resourceHelpers;
 
+    @Inject
+    EndpointResources endpointResources;
+
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
 
@@ -108,6 +112,8 @@ public class EventServiceTest extends DbIsolatedTest {
                 .invoke(model.notificationHistories::add)
                 .chain(() -> resourceHelpers.createNotificationHistory(model.events.get(2), model.endpoints.get(1)))
                 .invoke(model.notificationHistories::add)
+                .chain(() -> endpointResources.deleteEndpoint(DEFAULT_ACCOUNT_ID, model.endpoints.get(0).getId()))
+                .chain(() -> endpointResources.deleteEndpoint(DEFAULT_ACCOUNT_ID, model.endpoints.get(1).getId()))
                 .chain(runOnWorkerThread(() -> {
 
                     /*
@@ -417,7 +423,7 @@ public class EventServiceTest extends DbIsolatedTest {
                 Optional<NotificationHistory> historyEntry = Arrays.stream(historyEntries)
                         .filter(entry -> entry.getId().equals(eventLogEntryAction.getId())).findAny();
                 assertTrue(historyEntry.isPresent());
-                assertEquals(historyEntry.get().getEndpoint().getType(), eventLogEntryAction.getEndpointType());
+                assertEquals(historyEntry.get().getEndpointType(), eventLogEntryAction.getEndpointType());
                 assertEquals(historyEntry.get().isInvocationResult(), eventLogEntryAction.getInvocationResult());
             }
         }


### PR DESCRIPTION
This PR duplicates the `Endpoint#type` field into `NotificationHistory#endpointType` to make sure the data shown in the event log will not be altered by an endpoint deletion.

Deleting an `Endpoint` no longer causes a cascade delete of `NotificationHistory`.