### PR TITLE
NOTIF-324 Filter event log by endpoint type and invocation result

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -177,11 +177,11 @@ public class ResourceHelpers {
                 .replaceWith(statsValues);
     }
 
-    public Uni<NotificationHistory> createNotificationHistory(Event event, Endpoint endpoint) {
+    public Uni<NotificationHistory> createNotificationHistory(Event event, Endpoint endpoint, Boolean invocationResult) {
         NotificationHistory history = new NotificationHistory();
         history.setId(UUID.randomUUID());
         history.setInvocationTime(1L);
-        history.setInvocationResult(TRUE);
+        history.setInvocationResult(invocationResult);
         history.setEvent(event);
         history.setEndpoint(endpoint);
         history.setEndpointType(endpoint.getType());


### PR DESCRIPTION
This PR adds the `endpointTypes` and `invocationResults` query params to the existing `/notifications/events` API.