### PR TITLE
Fix tests instabilities

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -548,7 +548,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
         mockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
 
         // Create 50 test-ones with sanely sortable name & enabled & disabled & type
-        sessionFactory.withSession(session -> helpers.createTestEndpoints(tenant, 50)
+        sessionFactory.withSession(session -> helpers.createTestEndpoints(tenant, 50))
                 .call(stats -> runOnWorkerThread(() -> {
                     int disableCount = stats[1];
                     int webhookCount = stats[2];
@@ -601,7 +601,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
                     assertEquals("Endpoint 1", endpoints[endpoints.length - 1].getName());
                     assertEquals("Endpoint 10", endpoints[endpoints.length - 2].getName());
                     assertEquals("Endpoint 27", endpoints[0].getName());
-                }).get())
+                }).get()
         ).await().indefinitely();
     }
 


### PR DESCRIPTION
The build has been a bit instable since the Quarkus 2 PR was merged.

If my intuition is right, most (if not all) of the failures were caused by the fact that a RestAssured call declared within the boundaries of a reactive session in test code will use the session from the test code. Sometimes the RestAssured call will be processed from the same event loop thread than the one used in the test code and the test will pass. Sometimes it will processed from a different event loop thread and the test will fail.

The tests stability after this PR will confirm or deny that asumption.