### PR TITLE
Delay scheduled DB jobs after the Flyway migration

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EventLogCleaner.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EventLogCleaner.java
@@ -12,6 +12,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 @ApplicationScoped
 public class EventLogCleaner {
 
@@ -27,7 +29,7 @@ public class EventLogCleaner {
      * The event log entries are stored in the database until their retention time is reached.
      * This scheduled job deletes from the database the expired event log entries.
      */
-    @Scheduled(identity = "EventLogCleaner", every = "${event-log-cleaner.period}")
+    @Scheduled(identity = "EventLogCleaner", every = "${event-log-cleaner.period}", delay = 5L, delayUnit = MINUTES)
     public void clean() {
         testableClean().await().indefinitely();
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/events/KafkaMessagesCleaner.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/events/KafkaMessagesCleaner.java
@@ -12,6 +12,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 // TODO Replace this with an OpenShift cronjob.
 @ApplicationScoped
 public class KafkaMessagesCleaner {
@@ -28,7 +30,7 @@ public class KafkaMessagesCleaner {
      * The Kafka messages identifiers are stored in the database until their retention time is reached.
      * This scheduled job deletes from the database the expired Kafka messages identifiers.
      */
-    @Scheduled(identity = "KafkaMessagesCleaner", every = "${notifications.kafka-messages-cleaner.period}")
+    @Scheduled(identity = "KafkaMessagesCleaner", every = "${notifications.kafka-messages-cleaner.period}", delay = 5L, delayUnit = MINUTES)
     public void clean() {
         testableClean().await().indefinitely();
     }


### PR DESCRIPTION
The delay was removed with the Quarkus 2 bump, but now the scheduled jobs are executed before the Flyway migrations are done. This could lead to migration issues someday, so this PR restores a 5 minutes delay.