### PR TITLE
Remove deprecated conf key and fix Sentry alert

### DIFF
--- a/aggregator/src/main/resources/application.properties
+++ b/aggregator/src/main/resources/application.properties
@@ -26,7 +26,6 @@ quarkus.log.category."com.redhat.cloud.notifications".level=INFO
 %test.quarkus.http.access-log.category=info
 
 # Quarkus since 1.11 redirects non-apps to /q/. We need to prevent this
-quarkus.http.redirect-to-non-application-root-path=false
 quarkus.http.non-application-root-path=/
 
 # Sentry logging. Off by default, enabled on OpenShift


### PR DESCRIPTION
This will no longer appear in Slack each time the aggregator is executed:
```
Unrecognized configuration key "quarkus.http.redirect-to-non-application-root-path" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```