### PR TITLE
Add a default limit to the endpoints /history API

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
+import static com.redhat.cloud.notifications.db.NotificationResources.MAX_NOTIFICATION_HISTORY_RESULTS;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
@@ -246,7 +247,7 @@ public class EndpointService {
         @Parameter(
                     name = "limit",
                     in = ParameterIn.QUERY,
-                    description = "Number of items per page, if not specified or 0 is used, returns all elements",
+                    description = "Number of items per page, if not specified or 0 is used, returns a maximum of " + MAX_NOTIFICATION_HISTORY_RESULTS + " elements.",
                     schema = @Schema(type = SchemaType.INTEGER)
             ),
         @Parameter(


### PR DESCRIPTION
This should prevent an `OutOfMemoryError` when the `/history` API is called without a reasonnable limit for an endpoint that would have a huge number of history entries in the database.

The default limit will be enforced to 500 if:
- the request has no limit
- the request has a limit higher than 500 (in that case, the `offset` parameter from the query will be ignored as well)
