### PR TITLE
Increase RBAC S2S calls read timeout

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -54,7 +54,9 @@ objects:
           value: ${CLOWDER_ENABLED}
         - name: RBAC_URL
           value: ${RBAC_SCHEME}://${RBAC_HOST}:${RBAC_PORT}
-        - name: RBAC_MP_REST_URL
+        - name: RBAC_AUTHENTICATION_MP_REST_URL
+          value: ${RBAC_SCHEME}://${RBAC_HOST}:${RBAC_PORT}
+        - name: RBAC_S2S_MP_REST_URL
           value: ${RBAC_SCHEME}://${RBAC_HOST}:${RBAC_PORT}
         resources:
           limits:

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
@@ -14,7 +14,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
 @Path("/api/rbac/v1")
-@RegisterRestClient(configKey = "rbac")
+@RegisterRestClient(configKey = "rbac-authentication")
 @RegisterProvider(RbacRestClientRequestFilter.class)
 @RegisterProvider(RbacClientResponseFilter.class)
 public interface RbacServer {

--- a/backend/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacServiceToService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacServiceToService.java
@@ -15,7 +15,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.UUID;
 
 @Path("/api/rbac/v1")
-@RegisterRestClient(configKey = "rbac")
+@RegisterRestClient(configKey = "rbac-s2s")
 @RegisterProvider(AuthRequestFilter.class)
 public interface RbacServiceToService {
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -65,12 +65,20 @@ quarkus.log.category."com.redhat.cloud.notifications".level=INFO
 
 %test.quarkus.http.access-log.category=info
 
-# RBAC server
 rbac.enabled=true
-#rbac/mp-rest/url=http://ci.foo.redhat.com:1337
-rbac/mp-rest/url=https://ci.cloud.redhat.com
-rbac/mp-rest/connectTimeout=2000
-rbac/mp-rest/readTimeout=2000
+
+# RBAC configuration used during user authentication. It is used when a public REST API is called.
+#rbac-authentication/mp-rest/url=http://ci.foo.redhat.com:1337
+rbac-authentication/mp-rest/url=https://ci.cloud.redhat.com
+rbac-authentication/mp-rest/connectTimeout=2000
+rbac-authentication/mp-rest/readTimeout=2000
+
+# RBAC configuration used to retrieve email recipients. It is used when an email notification is sent.
+#rbac-s2s/mp-rest/url=http://ci.foo.redhat.com:1337
+rbac-s2s/mp-rest/url=https://ci.cloud.redhat.com
+rbac-s2s/mp-rest/connectTimeout=2000
+rbac-s2s/mp-rest/readTimeout=120000
+
 # Duration rbac entries are kept in cache
 quarkus.cache.caffeine.rbac-cache.expire-after-write=PT120s
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -111,6 +111,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
 
         configurator = new MockServerClientConfig(mockEngineServer.getContainerIpAddress(), mockEngineServer.getServerPort());
 
-        props.put("rbac/mp-rest/url", mockServerUrl);
+        props.put("rbac-authentication/mp-rest/url", mockServerUrl);
+        props.put("rbac-s2s/mp-rest/url", mockServerUrl);
     }
 }


### PR DESCRIPTION
This PR is meant to fix:
```
io.vertx.core.http.impl.NoStackTraceTimeoutException: The timeout period of 2000ms has been exceeded while executing GET /api/rbac/v1/principals/?admin_only=false&offset=0&limit=1000 for server rbac******HIDDEN******
```
It was thrown on prod right after we deployed Quarkus 2.

The `rbac_get_users_page_seconds_max` metric shows durations over 30 seconds (max 45 seconds) multiple times on a daily basis.

We have to increase the rest-client timeout if we don't want lots of RBAC queries to be interrupted by the same exception.