### PR TITLE
Replace quarkus-vertx-web with reactive-routes

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
I missed that detail in the [migration guide for 2.3](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.3#reactive-routes).