### PR TITLE
Use RBAC URL from Clowder

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -52,10 +52,6 @@ objects:
           value: ${CLOWDER_FILE}
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
-        - name: RBAC_AUTHENTICATION_MP_REST_URL
-          value: ${RBAC_SCHEME}://${RBAC_HOST}:${RBAC_PORT}
-        - name: RBAC_S2S_MP_REST_URL
-          value: ${RBAC_SCHEME}://${RBAC_HOST}:${RBAC_PORT}
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -144,18 +140,6 @@ parameters:
 - name: CLOWDER_FILE
   value: /cdapp/cdappconfig.json
   description: default path for cdappconfig file
-- name: RBAC_HOST
-  displayName: Rbac Service Host
-  description: Host to use for the RBAC service URL.
-  value: "rbac-service"
-- name: RBAC_PORT
-  displayName: Rbac Service Port
-  description: Port to use for the RBAC service URL.
-  value: "8000"
-- name: RBAC_SCHEME
-  displayName: Rbac Service Scheme
-  description: Scheme to use for the RBAC service URL. Can be either http or https
-  value: http
 - name: CRONJOB_ENABLED
   displayName: Enable the cron job
   value: "false"

--- a/backend/src/main/java/com/redhat/cloud/notifications/ClowderConfigInitializer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/ClowderConfigInitializer.java
@@ -1,0 +1,29 @@
+package com.redhat.cloud.notifications;
+
+import io.quarkus.runtime.StartupEvent;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import java.util.Optional;
+
+@ApplicationScoped
+public class ClowderConfigInitializer {
+
+    private static final Logger LOGGER = Logger.getLogger(ClowderConfigInitializer.class);
+    private static final String RBAC_AUTHENTICATION_URL_KEY = "rbac-authentication/mp-rest/url";
+    private static final String RBAC_S2S_URL_KEY = "rbac-s2s/mp-rest/url";
+
+    @ConfigProperty(name = "clowder.endpoints.rbac-service")
+    Optional<String> rbacClowderEndpoint;
+
+    void init(@Observes StartupEvent event) {
+        if (rbacClowderEndpoint.isPresent()) {
+            String rbacUrl = "http://" + rbacClowderEndpoint.get();
+            LOGGER.infof("Overriding the RBAC URL with the config value from Clowder: %s", rbacUrl);
+            System.setProperty(RBAC_AUTHENTICATION_URL_KEY, rbacUrl);
+            System.setProperty(RBAC_S2S_URL_KEY, rbacUrl);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <mockserver-client-java.version>5.5.4</mockserver-client-java.version>
 
         <insights-notification-schemas-java.version>0.3</insights-notification-schemas-java.version>
-        <clowder-quarkus-config-source.version>0.2.0</clowder-quarkus-config-source.version>
+        <clowder-quarkus-config-source.version>0.2.2</clowder-quarkus-config-source.version>
 
         <cloudwatch.version>3.0.0</cloudwatch.version>
 


### PR DESCRIPTION
The build will fail because `clowder-quarkus-config-source:0.2.2` isn't available yet.