### PR TITLE
Revert "Log the Flyway JDBC URL (#733)"

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
@@ -28,7 +28,6 @@ public class FlywayWorkaround {
 
     public void runFlywayMigration(@Observes StartupEvent event) {
         LOGGER.warn("Starting Flyway workaround... remove it ASAP!");
-        LOGGER.debugf("Connecting to jdbc:%s", datasourceUrl);
         Flyway flyway = Flyway.configure().dataSource("jdbc:" + datasourceUrl, datasourceUsername, datasourcePassword).load();
         flyway.migrate();
     }


### PR DESCRIPTION
https://github.com/RedHatInsights/notifications-backend/pull/733 served its purpose. The issue on ephemeral is fixed and we no longer need that log entry.