### PR TITLE
NOTIF-336 Fix clowdapp.yaml apiVersion

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: notifications-backend


### PR DESCRIPTION
```
01:16:26 W1104 00:16:26.224755   28410 shim_kubectl.go:55] Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource
```