### PR TITLE
NOTIF-336 Work around an ephemeral RBAC timeout issue

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -73,6 +73,8 @@ objects:
           successThreshold: 1
           failureThreshold: 3
         env:
+        - name: ENV_NAME
+          value: ${ENV_NAME}
         - name: MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_INTERVAL_MS
           value: ${MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_INTERVAL_MS}
         - name: MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_RECORDS
@@ -94,9 +96,9 @@ objects:
         - name: PROCESSOR_EMAIL_NO_REPLY
           value: ${PROCESSOR_EMAIL_NO_REPLY}
         - name: RBAC_AUTHENTICATION_MP_REST_READTIMEOUT
-          value: ${RBAC_AUTHENTICATION_MP_REST_READTIMEOUT}
+          value: ${RBAC_AUTHENTICATION_READ_TIMEOUT}
         - name: RBAC_S2S_MP_REST_READTIMEOUT
-          value: ${RBAC_S2S_MP_REST_READTIMEOUT}
+          value: ${RBAC_S2S_READ_TIMEOUT}
         - name: RBAC_SERVICE_TO_SERVICE_APPLICATION
           value: ${RBAC_SERVICE_TO_SERVICE_APP}
         - name: RBAC_SERVICE_TO_SERVICE_SECRET_MAP
@@ -229,10 +231,10 @@ parameters:
 - name: PROCESSOR_EMAIL_NO_REPLY
   description: Email address
   value: no-reply@redhat.com
-- name: RBAC_AUTHENTICATION_MP_REST_READTIMEOUT
+- name: RBAC_AUTHENTICATION_READ_TIMEOUT
   description: Delay in milliseconds before an RBAC authentication query is interrupted
   value: "2000"
-- name: RBAC_S2S_MP_REST_READTIMEOUT
+- name: RBAC_S2S_READ_TIMEOUT
   description: Delay in milliseconds before an RBAC S2S query is interrupted
   value: "120000"
 - name : RBAC_GROUP_USERS_RETENTION_DELAY

--- a/backend/src/main/java/com/redhat/cloud/notifications/ClowderConfigInitializer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/ClowderConfigInitializer.java
@@ -14,6 +14,7 @@ public class ClowderConfigInitializer {
     private static final Logger LOGGER = Logger.getLogger(ClowderConfigInitializer.class);
     private static final String RBAC_AUTHENTICATION_URL_KEY = "rbac-authentication/mp-rest/url";
     private static final String RBAC_S2S_URL_KEY = "rbac-s2s/mp-rest/url";
+    private static final String EPHEMERAL_RBAC_AUTH_TIMEOUT = "10000";
 
     @ConfigProperty(name = "clowder.endpoints.rbac-service")
     Optional<String> rbacClowderEndpoint;
@@ -24,6 +25,15 @@ public class ClowderConfigInitializer {
             LOGGER.infof("Overriding the RBAC URL with the config value from Clowder: %s", rbacUrl);
             System.setProperty(RBAC_AUTHENTICATION_URL_KEY, rbacUrl);
             System.setProperty(RBAC_S2S_URL_KEY, rbacUrl);
+        }
+        increaseRbacAuthTimeoutOnEphemeral();
+    }
+
+    void increaseRbacAuthTimeoutOnEphemeral() {
+        String envName = System.getenv("ENV_NAME");
+        if (envName != null && envName.startsWith("env-ephemeral")) {
+            LOGGER.warnf("Ephemeral environment detected, activating RBAC auth timeout workaround. The new timeout is %sms. Remove this ASAP!", EPHEMERAL_RBAC_AUTH_TIMEOUT);
+            System.setProperty("rbac-authentication/mp-rest/readTimeout", EPHEMERAL_RBAC_AUTH_TIMEOUT);
         }
     }
 }


### PR DESCRIPTION
Tests from `pr_check.sh` are failing because RBAC isn't ready fast enough when the first test is run.