### PR TITLE
NOTIF-336 Remove the ephemeral RBAC timeout workaround

### DIFF
--- a/.rhcicd/clowdapp-aggregator.yaml
+++ b/.rhcicd/clowdapp-aggregator.yaml
@@ -85,8 +85,6 @@ parameters:
 - name: MEMORY_REQUEST
   description: Memory request on ephemeral
   value: 250Mi
-- name: MIN_REPLICAS
-  value: "1"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
   value: INFO

--- a/backend/src/main/java/com/redhat/cloud/notifications/ClowderConfigInitializer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/ClowderConfigInitializer.java
@@ -14,7 +14,6 @@ public class ClowderConfigInitializer {
     private static final Logger LOGGER = Logger.getLogger(ClowderConfigInitializer.class);
     private static final String RBAC_AUTHENTICATION_URL_KEY = "rbac-authentication/mp-rest/url";
     private static final String RBAC_S2S_URL_KEY = "rbac-s2s/mp-rest/url";
-    private static final String EPHEMERAL_RBAC_AUTH_TIMEOUT = "10000";
 
     @ConfigProperty(name = "clowder.endpoints.rbac-service")
     Optional<String> rbacClowderEndpoint;
@@ -25,15 +24,6 @@ public class ClowderConfigInitializer {
             LOGGER.infof("Overriding the RBAC URL with the config value from Clowder: %s", rbacUrl);
             System.setProperty(RBAC_AUTHENTICATION_URL_KEY, rbacUrl);
             System.setProperty(RBAC_S2S_URL_KEY, rbacUrl);
-        }
-        increaseRbacAuthTimeoutOnEphemeral();
-    }
-
-    void increaseRbacAuthTimeoutOnEphemeral() {
-        String envName = System.getenv("ENV_NAME");
-        if (envName != null && envName.startsWith("env-ephemeral")) {
-            LOGGER.warnf("Ephemeral environment detected, activating RBAC auth timeout workaround. The new timeout is %sms. Remove this ASAP!", EPHEMERAL_RBAC_AUTH_TIMEOUT);
-            System.setProperty("rbac-authentication/mp-rest/readTimeout", EPHEMERAL_RBAC_AUTH_TIMEOUT);
         }
     }
 }


### PR DESCRIPTION
The timeout value is now managed from app-interface.