### PR TITLE
NOTIF-373 Introduce EphemeralDataInitializer

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -79,6 +79,12 @@ objects:
           value: ${MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_INTERVAL_MS}
         - name: MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_RECORDS
           value: ${MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_RECORDS}
+        - name: NOTIFICATIONS_EPHEMERAL_DATA
+          valueFrom:
+            configMapKeyRef:
+              name: notifications-ephemeral-data
+              key: ephemeral_data.json
+              optional: true
         - name: PROCESSOR_EMAIL_BOP_APITOKEN
           valueFrom:
             secretKeyRef:

--- a/README.adoc
+++ b/README.adoc
@@ -9,3 +9,97 @@ which is invoked when running maven.
 
 This project uses the Clowder Config Source from https://github.com/RedHatInsights/clowder-quarkus-config-source.
 To configure this source to use a different file than `/cdappconfig/cdappconfig.json` you can use the property `clowder.file=/path/to/file.json`.
+
+## Deploying the backend with data on ephemeral
+
+If you deploy `notifications-backend` on ephemeral, the database may not contain all the data you need for your tests.
+It is possible to load data on ephemeral when the backend pod starts, but this is restricted to three kinds of database
+records: `Bundle`, `Application` and `EventType`.
+
+There are two ways of loading that data, as explained below. Both can be used at the same time as long as the `name`
+field is globally unique for each type of database record. If there is no `name` conflict, the data from both sources
+will be inserted into the database.
+
+### Loading data using a ConfigMap
+
+The `notifications-backend` ClowdApp template contains an environment variable definition that can be used to load data:
+
+```yaml
+env:
+- name: NOTIFICATIONS_EPHEMERAL_DATA
+  valueFrom:
+    configMapKeyRef:
+      name: notifications-ephemeral-data
+      key: ephemeral_data.json
+      optional: true
+```
+
+If a `ConfigMap` named `notifications-ephemeral-data` is created by any of the pods present in the ephemeral namespace,
+the backend pod will consume that `ConfigMap` as an environment variable and put the value of the `ephemeral_data.json`
+key into the `NOTIFICATIONS_EPHEMERAL_DATA` environment variable.
+
+[TIP]
+The `ConfigMap` is optional, it is not a requirement for the `notifications-backend` pod deployment.
+
+Here is an example of the `ConfigMap` you could add to your application ClowdApp template:
+
+```yaml
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: notifications-ephemeral-data
+  data:
+    ephemeral_data.json: |
+      {
+        "bundles": [
+          {
+            "name": "my-bundle",
+            "display_name": "My Bundle",
+            "applications": [
+              {
+                "name": "my-app",
+                "display_name": "My Application",
+                "event_types": [
+                  {
+                    "name": "my-event-type",
+                    "display_name": "My Event Type",
+                    "description": "This is my event type"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+```
+
+### Loading data using the persistent `ephemeral_data.json` file
+
+You can also load data on ephemeral by creating a pull request that modifies the https://github.com/RedHatInsights/notifications-backend/tree/master/backend/src/main/resources/ephemeral/ephemeral_data.json[ephemeral_data.json] file which is hosted in this repository.
+This file may contain ephemeral data from other applications so please be careful not to delete or edit data that would belong to another team.
+
+Here is an example of the data structure allowed in `ephemeral_data.json`:
+
+```json
+{
+  "bundles": [
+    {
+      "name": "my-bundle",
+      "display_name": "My Bundle",
+      "applications": [
+        {
+          "name": "my-app",
+          "display_name": "My Application",
+          "event_types": [
+            {
+              "name": "my-event-type",
+              "display_name": "My Event Type",
+              "description": "This is my event type"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```

--- a/backend/src/main/java/com/redhat/cloud/notifications/clowder/ClowderConfigInitializer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/clowder/ClowderConfigInitializer.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications;
+package com.redhat.cloud.notifications.clowder;
 
 import io.quarkus.runtime.StartupEvent;
 import org.eclipse.microprofile.config.inject.ConfigProperty;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayEndEvent.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayEndEvent.java
@@ -1,0 +1,7 @@
+package com.redhat.cloud.notifications.db;
+
+/**
+ * This event is fired when the {@link FlywayWorkaround} DB migration is complete.
+ */
+public class FlywayEndEvent {
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java
@@ -6,7 +6,9 @@ import org.flywaydb.core.Flyway;
 import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
+import javax.inject.Inject;
 
 /**
  * This is a temporary workaround for a quarkus-flyway / quarkus-hibernate-reactive incompatibility.
@@ -26,9 +28,13 @@ public class FlywayWorkaround {
     @ConfigProperty(name = "quarkus.datasource.password")
     String datasourcePassword;
 
+    @Inject
+    Event<FlywayEndEvent> endEvent;
+
     public void runFlywayMigration(@Observes StartupEvent event) {
         LOGGER.warn("Starting Flyway workaround... remove it ASAP!");
         Flyway flyway = Flyway.configure().dataSource("jdbc:" + datasourceUrl, datasourceUsername, datasourcePassword).load();
         flyway.migrate();
+        endEvent.fire(new FlywayEndEvent());
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/Application.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/Application.java
@@ -1,0 +1,14 @@
+package com.redhat.cloud.notifications.ephemeral;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.Set;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public class Application {
+    public String name;
+    public String displayName;
+    public Set<EventType> eventTypes;
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/Bundle.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/Bundle.java
@@ -1,0 +1,14 @@
+package com.redhat.cloud.notifications.ephemeral;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.Set;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public class Bundle {
+    public String name;
+    public String displayName;
+    public Set<Application> applications;
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/EphemeralData.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/EphemeralData.java
@@ -1,0 +1,12 @@
+package com.redhat.cloud.notifications.ephemeral;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.Set;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public class EphemeralData {
+    public Set<Bundle> bundles;
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/EphemeralDataInitializer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/EphemeralDataInitializer.java
@@ -1,0 +1,126 @@
+package com.redhat.cloud.notifications.ephemeral;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.notifications.db.FlywayEndEvent;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.EventType;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@ApplicationScoped
+public class EphemeralDataInitializer {
+
+    public static final String EPHEMERAL_DATA_KEY = "NOTIFICATIONS_EPHEMERAL_DATA";
+
+    private static final Logger LOGGER = Logger.getLogger(EphemeralDataInitializer.class);
+    private static final String ENV_NAME_KEY = "ENV_NAME";
+    private static final String ENV_EPHEMERAL_PREFIX = "env-ephemeral";
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    /**
+     * This method will always be invoked after the Flyway DB migration is complete.
+     */
+    // TODO When FlywayWorkaround is removed, replace FlywayEndEvent with StartupEvent.
+    void init(@Observes FlywayEndEvent event) {
+        String envName = System.getenv(ENV_NAME_KEY);
+        if (envName != null && envName.startsWith(ENV_EPHEMERAL_PREFIX)) {
+            loadFromFile();
+            loadFromEnvVar();
+        }
+    }
+
+    private void loadFromFile() {
+        try {
+            URL ephemeralFileUrl = getClass().getClassLoader().getResource("/ephemeral/ephemeral_data.json");
+            if (ephemeralFileUrl != null) {
+                Path ephemeralFilePath = Path.of(ephemeralFileUrl.toURI());
+                if (Files.exists(ephemeralFilePath)) {
+                    String rawData = Files.readString(ephemeralFilePath);
+                    if (!rawData.isBlank()) {
+                        LOGGER.info("Loading ephemeral data from file");
+                        EphemeralData data = objectMapper.readValue(rawData, EphemeralData.class);
+                        persist(data);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("Ephemeral data loading from file failed", e);
+        }
+    }
+
+    private void loadFromEnvVar() {
+        String rawData = System.getenv(EPHEMERAL_DATA_KEY);
+        if (rawData != null && !rawData.isBlank()) {
+            LOGGER.info("Loading ephemeral data from environment variable");
+            try {
+                EphemeralData data = objectMapper.readValue(rawData, EphemeralData.class);
+                persist(data);
+            } catch (Exception e) {
+                LOGGER.error("Ephemeral data loading from environment variable failed", e);
+            }
+        }
+    }
+
+    private void persist(EphemeralData data) {
+        if (data.bundles != null) {
+            sessionFactory.withStatelessTransaction((session, transaction) -> {
+                return Multi.createFrom().iterable(data.bundles)
+                        .onItem().transformToUniAndConcatenate(b -> {
+                            Bundle bundle = new Bundle();
+                            bundle.setName(b.name);
+                            bundle.setDisplayName(b.displayName);
+                            bundle.prePersist();
+                            return session.insert(bundle)
+                                    .call(() -> {
+                                        if (b.applications == null) {
+                                            return Uni.createFrom().voidItem();
+                                        } else {
+                                            return Multi.createFrom().iterable(b.applications)
+                                                    .onItem().transformToUniAndConcatenate(a -> {
+                                                        Application application = new Application();
+                                                        application.setName(a.name);
+                                                        application.setDisplayName(a.displayName);
+                                                        application.setBundle(bundle);
+                                                        application.prePersist();
+                                                        return session.insert(application)
+                                                                .call(() -> {
+                                                                    if (a.eventTypes == null) {
+                                                                        return Uni.createFrom().voidItem();
+                                                                    } else {
+                                                                        return Multi.createFrom().iterable(a.eventTypes)
+                                                                                .onItem().transformToUniAndConcatenate(et -> {
+                                                                                    EventType eventType = new EventType();
+                                                                                    eventType.setName(et.name);
+                                                                                    eventType.setDisplayName(et.displayName);
+                                                                                    eventType.setDescription(et.description);
+                                                                                    eventType.setApplication(application);
+                                                                                    return session.insert(eventType);
+                                                                                })
+                                                                                .onItem().ignoreAsUni();
+                                                                    }
+                                                                });
+                                                    })
+                                                    .onItem().ignoreAsUni();
+                                        }
+                                    });
+                        })
+                        .onItem().ignoreAsUni();
+            }).await().indefinitely();
+        }
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/EventType.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/EventType.java
@@ -1,0 +1,12 @@
+package com.redhat.cloud.notifications.ephemeral;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public class EventType {
+    public String name;
+    public String displayName;
+    public String description;
+}

--- a/backend/src/main/resources/ephemeral/ephemeral_data.sample.json
+++ b/backend/src/main/resources/ephemeral/ephemeral_data.sample.json
@@ -1,0 +1,21 @@
+{
+  "bundles": [
+    {
+      "name": "my-bundle",
+      "display_name": "My Bundle",
+      "applications": [
+        {
+          "name": "my-app",
+          "display_name": "My Application",
+          "event_types": [
+            {
+              "name": "my-event-type",
+              "display_name": "My Event Type",
+              "description": "This is my event type"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces data initialization on ephemeral environments.

▶️ **Which data?**

The init will persist any provided `Bundle`, `Application` or `EventType`.

We can't initialize any other kind of data because it would require an `accountId` which can only be found when a REST API is called from the UI (or the python helpers) or when we receive a Kafka message.

▶️ **When?**

The init will only happen if the `ENV_NAME` environment variable contains a value that starts with `env-ephemeral`.

It is guaranteed to happen _after_ the Flyway DB migration is done. For now, we're migrating the DB with [FlywayWorkaround](https://github.com/RedHatInsights/notifications-backend/blob/master/backend/src/main/java/com/redhat/cloud/notifications/db/FlywayWorkaround.java) which observes `StartupEvent`, so I introduced `FlywayEndEvent` to enforce an order and make sure `FlywayWorkaround` runs first. `FlywayWorkaround` will be removed in the future and this won't break the enforced execution order because the Flyway execution from the `quarkus-flyway` extension happens before the beans observing `StartupEvent` are invoked.

▶️ **How?**

There are two ways to init data on ephemeral:
- Persistent: commit a change to the `src/main/resources/ephemeral/ephemeral_data.json` file.
- Temporary: put the data in the `NOTIFICATIONS_EPHEMERAL_DATA` environment variable.

Both can be used at the same time.

Since the `src/main/resources/ephemeral/ephemeral_data.json` file is currently empty, a data example is provided in  `src/main/resources/ephemeral/ephemeral_data.sample.json`.

Here's an example of data passed to the app with the environment variable:
```
NOTIFICATIONS_EPHEMERAL_DATA="{\"bundles\":[{\"name\":\"my-bundle\",\"display_name\":\"My Bundle\",\"applications\":[{\"name\":\"my-app\",\"display_name\":\"My Application\",\"event_types\":[{\"name\":\"my-event-type\",\"display_name\":\"My Event Type\",\"description\":\"This is my event type\"}]}]}]}"
```

▶️ **Why use JSON for the input data?**

Because it will be easier to use for developers who are not familiar with the programming languages we use in notifications.