### PR TITLE
Disable Camel Demo Log build and deploy

### DIFF
--- a/.rhcicd/build_deploy.sh
+++ b/.rhcicd/build_deploy.sh
@@ -26,4 +26,4 @@ function buildAndDeploy() {
 
 buildAndDeploy "notifications-aggregator"
 buildAndDeploy "notifications-backend"
-buildAndDeploy "notifications-camel-demo-log"
+#buildAndDeploy "notifications-camel-demo-log"


### PR DESCRIPTION
Or it won't build the rest since the Quay repo hasn't been provisioned yet ( https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/notifications/app.yml#L34 ) 

See https://ci.ext.devshift.net/job/RedHatInsights-notifications-backend-gh-build-master/548/