### PR TITLE
NOTIF-336 Fix clowdapp.yaml deployment name

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -34,7 +34,7 @@ objects:
     testing:
       iqePlugin: notifications
     deployments:
-    - name: notifications-backend
+    - name: service
       minReplicas: ${{MIN_REPLICAS}}
       web: true
       podSpec:


### PR DESCRIPTION
This is the preferred deployment naming which is already used in most migrated Clowdapps.