### PR TITLE
NOTIF-336 Disable PR check

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -2,7 +2,8 @@
 
 set -exv
 
-source ./.rhcicd/pr_check_backend.sh
+# TODO Uncomment when the IQE notifications puglin is fixed
+#source ./.rhcicd/pr_check_backend.sh
 docker build . -f docker/Dockerfile.notifications-aggregator.jvm
 docker build . -f docker/Dockerfile.notifications-camel-demo-log.jvm
 


### PR DESCRIPTION
The IQE notifications plugin is currently broken which causes a PR check failure.