### PR TITLE
NOTIF-336 Restore backend PR check

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -2,8 +2,7 @@
 
 set -exv
 
-# TODO Uncomment when the IQE notifications puglin is fixed
-#source ./.rhcicd/pr_check_backend.sh
+source ./.rhcicd/pr_check_backend.sh
 docker build . -f docker/Dockerfile.notifications-aggregator.jvm
 docker build . -f docker/Dockerfile.notifications-camel-demo-log.jvm
 

--- a/.rhcicd/pr_check_backend.sh
+++ b/.rhcicd/pr_check_backend.sh
@@ -4,6 +4,7 @@
 export APP_NAME="notifications"
 export COMPONENT_NAME="notifications-backend"
 export IMAGE="quay.io/cloudservices/notifications-backend"
+export DEPLOY_TIMEOUT="360"
 
 # IQE plugin config
 export IQE_PLUGINS="notifications"


### PR DESCRIPTION
The IQE plugin is fixed.

I had to increase the ephemeral deployment timeout because 300 seconds (default value) is too close from the average deployment time.