### PR TITLE
Remove sort and limit from the notification details API

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -285,25 +285,11 @@ public class EndpointService {
     @Path("/{id}/history/{history_id}/details")
     @Produces(APPLICATION_JSON)
     @RolesAllowed(RbacIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
-    @Parameters({
-        @Parameter(
-                    name = "limit",
-                    in = ParameterIn.QUERY,
-                    description = "Number of items per page, if not specified or 0 is used, returns all elements",
-                    schema = @Schema(type = SchemaType.INTEGER)
-            ),
-        @Parameter(
-                    name = "pageNumber",
-                    in = ParameterIn.QUERY,
-                    description = "Page number. Starts at first page (0), if not specified starts at first page.",
-                    schema = @Schema(type = SchemaType.INTEGER)
-            )
-    })
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    public Uni<Response> getDetailedEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID endpointId, @PathParam("history_id") UUID historyId, @BeanParam Query query) {
+    public Uni<Response> getDetailedEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID endpointId, @PathParam("history_id") UUID historyId) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         return sessionFactory.withSession(session -> {
-            return notifResources.getNotificationDetails(principal.getAccount(), query, endpointId, historyId)
+            return notifResources.getNotificationDetails(principal.getAccount(), endpointId, historyId)
                     // Maybe 404 should only be returned if history_id matches nothing? Otherwise 204
                     .onItem().ifNull().failWith(new NotFoundException())
                     .onItem().transform(json -> {


### PR DESCRIPTION
The query will never return more than one DB record. There's no point sorting or limiting the data.