### PR TITLE
Reverting changes on the aggregator code

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -68,7 +68,7 @@ public class EmailAggregator {
                                     subscribers.onItem().transformToUni(users ->
                                             /*
                                              * The actual recipients list may differ from the candidates depending on the endpoint properties and the action settings.
-                                             * The target endpoints properties and the action settings will determine whether or not each candidate will actually receive an email.
+                                             * The target endpoints properties will determine whether or not each candidate will actually receive an email.
                                              */
                                             recipientResolver.recipientUsers(
                                                     aggregationKey.getAccountId(),

--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -11,9 +11,7 @@ import com.redhat.cloud.notifications.processors.email.aggregators.AbstractEmail
 import com.redhat.cloud.notifications.processors.email.aggregators.EmailPayloadAggregatorFactory;
 import com.redhat.cloud.notifications.recipients.RecipientResolver;
 import com.redhat.cloud.notifications.recipients.User;
-import com.redhat.cloud.notifications.recipients.request.ActionRecipientSettings;
 import com.redhat.cloud.notifications.recipients.request.EndpointRecipientSettings;
-import com.redhat.cloud.notifications.utils.ActionParser;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
@@ -24,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @ApplicationScoped
 public class EmailAggregator {
@@ -41,8 +38,8 @@ public class EmailAggregator {
     @Inject
     EndpointEmailSubscriptionResources subscriptionResources;
 
-    @Inject
-    ActionParser actionParser;
+    // This is manually used from the JSON payload instead of converting it to an Action and using getEventType()
+    private static final String EVENT_TYPE_KEY = "event_type";
 
     private Uni<Set<String>> getEmailSubscribers(EmailAggregationKey aggregationKey, EmailSubscriptionType emailSubscriptionType) {
         return subscriptionResources
@@ -60,42 +57,38 @@ public class EmailAggregator {
                 .onItem().transformToMulti(Multi.createFrom()::iterable)
                 // For each aggregation...
                 .onItem().transformToUniAndConcatenate(aggregation -> {
-                    // We need to parse the action to determine the target endpoints.
-                    return actionParser.fromJsonString(aggregation.getPayload().encode())
-                            .onItem().transformToUni(action -> {
-                                // Let's retrieve these targets.
-                                return endpointResources.getTargetEndpointsFromType(aggregationKey.getAccountId(), aggregationKey.getBundle(), aggregationKey.getApplication(), action.getEventType(), EndpointType.EMAIL_SUBSCRIPTION)
-                                        .onItem().transform(Set::copyOf)
-                                        // Now we want to determine who will actually receive the aggregation email.
-                                        .onItem().transformToUni(endpoints ->
-                                                // All users who subscribed to the current application and subscription type combination are recipients candidates.
-                                                subscribers.onItem().transformToUni(users ->
-                                                        /*
-                                                         * The actual recipients list may differ from the candidates depending on the endpoint properties and the action settings.
-                                                         * The target endpoints properties and the action settings will determine whether or not each candidate will actually receive an email.
-                                                         */
-                                                        recipientResolver.recipientUsers(
-                                                                aggregationKey.getAccountId(),
-                                                                Stream.concat(
-                                                                        endpoints
-                                                                                .stream()
-                                                                                .map(EndpointRecipientSettings::new),
-                                                                        ActionRecipientSettings.fromAction(action).stream()
-                                                                ).collect(Collectors.toSet()),
-                                                                users
-                                                        )
-                                                )
-                                        )
-                                        /*
-                                         * We now have the final recipients list.
-                                         * Let's populate with synchronized side-effects (invoke) the Map that will be returned by the method.
-                                         */
-                                        .onItem().invoke(users -> {
-                                            users.forEach(user -> {
-                                                // It's aggregation time!
-                                                fillUsers(aggregationKey, user, aggregated, aggregation);
-                                            });
-                                        });
+                    // We need its event type to determine the target endpoints.
+                    String eventType = getEventType(aggregation);
+                    // Let's retrieve these targets.
+                    return endpointResources.getTargetEndpointsFromType(aggregationKey.getAccountId(), aggregationKey.getBundle(), aggregationKey.getApplication(), eventType, EndpointType.EMAIL_SUBSCRIPTION)
+                            .onItem().transform(Set::copyOf)
+                            // Now we want to determine who will actually receive the aggregation email.
+                            .onItem().transformToUni(endpoints ->
+                                    // All users who subscribed to the current application and subscription type combination are recipients candidates.
+                                    subscribers.onItem().transformToUni(users ->
+                                            /*
+                                             * The actual recipients list may differ from the candidates depending on the endpoint properties and the action settings.
+                                             * The target endpoints properties and the action settings will determine whether or not each candidate will actually receive an email.
+                                             */
+                                            recipientResolver.recipientUsers(
+                                                    aggregationKey.getAccountId(),
+                                                    endpoints
+                                                        .stream()
+                                                        .map(EndpointRecipientSettings::new)
+                                                        .collect(Collectors.toSet()),
+                                                    users
+                                            )
+                                    )
+                            )
+                            /*
+                             * We now have the final recipients list.
+                             * Let's populate with synchronized side-effects (invoke) the Map that will be returned by the method.
+                             */
+                            .onItem().invoke(users -> {
+                                users.forEach(user -> {
+                                    // It's aggregation time!
+                                    fillUsers(aggregationKey, user, aggregated, aggregation);
+                                });
                             });
                 })
                 // We need to wait for everything to be done before proceeding to the final step.
@@ -123,6 +116,10 @@ public class EmailAggregator {
     private void fillUsers(EmailAggregationKey aggregationKey, User user, Map<User, AbstractEmailPayloadAggregator> aggregated, EmailAggregation emailAggregation) {
         AbstractEmailPayloadAggregator aggregator = aggregated.computeIfAbsent(user, ignored -> EmailPayloadAggregatorFactory.by(aggregationKey));
         aggregator.aggregate(emailAggregation);
+    }
+
+    private String getEventType(EmailAggregation aggregation) {
+        return aggregation.getPayload().getString(EVENT_TYPE_KEY);
     }
 
 }


### PR DESCRIPTION
 - Do not parse using the action parser.
   Aggregation does not follow the same encoding rules

Reverts changes on `EmailAggregator` from https://github.com/RedHatInsights/notifications-backend/pull/595

`Hide whitespace` makes it easier to review