### PR TITLE
ADVISOR-1985 distinguish RHEL vs Openshift Advisor

### DIFF
--- a/backend/src/main/resources/templates/Advisor/newRecommendationInstantEmailBody.html
+++ b/backend/src/main/resources/templates/Advisor/newRecommendationInstantEmailBody.html
@@ -1,5 +1,5 @@
 {#include Advisor/insightsEmailBody}
-{#content-title}Advisor instant notification - {action.timestamp.toUtcFormat()}{/content-title}
+{#content-title}Red Hat Enterprise Linux - Advisor Instant Notification - {action.timestamp.toUtcFormat()}{/content-title}
 {#content-body}
 <tr>
     <td class="rh-body rh-multi-column">

--- a/backend/src/main/resources/templates/Advisor/newRecommendationInstantEmailTitle.txt
+++ b/backend/src/main/resources/templates/Advisor/newRecommendationInstantEmailTitle.txt
@@ -1,1 +1,1 @@
-Advisor instant notification - {action.timestamp.toUtcFormat()} - {action.events.size()} new recommendation{#if action.events.size() > 1}s{/if}
+Red Hat Enterprise Linux - Advisor Instant Notification - {action.timestamp.toUtcFormat()} - {action.events.size()} new recommendation{#if action.events.size() > 1}s{/if}

--- a/backend/src/main/resources/templates/Advisor/resolvedRecommendationInstantEmailBody.html
+++ b/backend/src/main/resources/templates/Advisor/resolvedRecommendationInstantEmailBody.html
@@ -1,5 +1,5 @@
 {#include Advisor/insightsEmailBody}
-{#content-title}Advisor instant notification - {action.timestamp.toUtcFormat()}{/content-title}
+{#content-title}Red Hat Enterprise Linux - Advisor Instant Notification - {action.timestamp.toUtcFormat()}{/content-title}
 {#content-body}
 <tr>
     <td class="rh-body rh-multi-column">

--- a/backend/src/main/resources/templates/Advisor/resolvedRecommendationInstantEmailTitle.txt
+++ b/backend/src/main/resources/templates/Advisor/resolvedRecommendationInstantEmailTitle.txt
@@ -1,1 +1,1 @@
-Advisor instant notification - {action.timestamp.toUtcFormat()} - {action.events.size()} resolved recommendation{#if action.events.size() > 1}s{/if}
+Red Hat Enterprise Linux - Advisor Instant Notification - {action.timestamp.toUtcFormat()} - {action.events.size()} resolved recommendation{#if action.events.size() > 1}s{/if}

--- a/backend/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
@@ -52,14 +52,14 @@ public class TestAdvisorTemplate {
                 .data("action", action)
                 .render();
 
-        assertEquals("Advisor instant notification - 03 Oct 2020 15:22 UTC - 4 resolved recommendations", result, "Title contains the number of reports created");
+        assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 4 resolved recommendations\n", result, "Title contains the number of reports created");
 
         // Action with only 1 event
         action.setEvents(List.of(action.getEvents().get(0)));
         result = Advisor.Templates.resolvedRecommendationInstantEmailTitle()
                 .data("action", action)
                 .render();
-        assertEquals("Advisor instant notification - 03 Oct 2020 15:22 UTC - 1 resolved recommendation", result, "Title contains the number of reports created");
+        assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 1 resolved recommendation\n", result, "Title contains the number of reports created");
     }
 
     @Test
@@ -79,14 +79,14 @@ public class TestAdvisorTemplate {
                 .data("action", action)
                 .render();
 
-        assertEquals("Advisor instant notification - 03 Oct 2020 15:22 UTC - 4 new recommendations", result, "Title contains the number of reports created");
+        assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 4 new recommendations\n", result, "Title contains the number of reports created");
 
         // Action with only 1 event
         action.setEvents(List.of(action.getEvents().get(0)));
         result = Advisor.Templates.newRecommendationInstantEmailTitle()
                 .data("action", action)
                 .render();
-        assertEquals("Advisor instant notification - 03 Oct 2020 15:22 UTC - 1 new recommendation", result, "Title contains the number of reports created");
+        assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 1 new recommendation\n", result, "Title contains the number of reports created");
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/ADVISOR-1985
Better distinguish between Red Hat Enterprise Linux Advisor and OpenShift Advisor Instant Notification emails.
This issue showed up on the Advisor Jira board even though it was really a Notifications ticket.  I thought I'd knock it over anyway.