### PR TITLE
Hide Maven downloads progress in build logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,12 @@ jobs:
           files: admin-console
       - name: Build admin-console
         if: steps.admin-console-changed.outputs.any_changed == 'true'
-        run: ./mvnw clean verify -Padmin-console -pl :checkstyle,:notifications-admin-console
+        run: ./mvnw clean verify -Padmin-console -pl :checkstyle,:notifications-admin-console --no-transfer-progress
       - name: Push admin-console
         if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: bash .github/scripts/push-admin-console.sh
       - name: Build with Maven
-        run: ./mvnw clean verify
+        run: ./mvnw clean verify --no-transfer-progress
       - uses: actions/upload-artifact@v2
         name: Upload notifications openapi.json
         with:

--- a/docker/Dockerfile.notifications-aggregator.jvm
+++ b/docker/Dockerfile.notifications-aggregator.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-11:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-aggregator
+RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-aggregator --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/docker/Dockerfile.notifications-backend.jvm
+++ b/docker/Dockerfile.notifications-backend.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-11:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-backend
+RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-backend --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/docker/Dockerfile.notifications-camel-demo-log.jvm
+++ b/docker/Dockerfile.notifications-camel-demo-log.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-11:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-camel-sender-demo
+RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-camel-sender-demo --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
Build logs will be much shorter with this in Jenkins and GH.