### PR TITLE
Increase backend PR check timeout

### DIFF
--- a/.rhcicd/pr_check_backend.sh
+++ b/.rhcicd/pr_check_backend.sh
@@ -4,7 +4,7 @@
 export APP_NAME="notifications"
 export COMPONENT_NAME="notifications-backend"
 export IMAGE="quay.io/cloudservices/notifications-backend"
-export DEPLOY_TIMEOUT="360"
+export DEPLOY_TIMEOUT="420"
 
 # IQE plugin config
 export IQE_PLUGINS="notifications"


### PR DESCRIPTION
The current 360 seconds timeout can lead to PR check failures if some dependencies are slower than usual.

Let's see how it goes with 420 seconds.