### PR TITLE
Return 400 on unknown endpoint types

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -105,7 +105,12 @@ public class EndpointService {
             Uni<Long> count;
 
             if (targetType != null && targetType.size() > 0) {
-                Set<EndpointType> endpointType = targetType.stream().map(s -> EndpointType.valueOf(s.toUpperCase())).collect(Collectors.toSet());
+                Set<EndpointType> endpointType;
+                try {
+                    endpointType = targetType.stream().map(s -> EndpointType.valueOf(s.toUpperCase())).collect(Collectors.toSet());
+                } catch (IllegalArgumentException e) {
+                    return Uni.createFrom().failure(() -> new BadRequestException("Unknown endpoint type(s)"));
+                }
                 endpoints = resources
                         .getEndpointsPerType(principal.getAccount(), endpointType, activeOnly, query);
                 count = resources.getEndpointsCountPerType(principal.getAccount(), endpointType, activeOnly);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -1121,6 +1121,30 @@ public class EndpointServiceTest extends DbIsolatedTest {
         ).await().indefinitely();
     }
 
+    @Test
+    void testUnknownEndpointTypes() {
+        String identityHeaderValue = TestHelpers.encodeIdentityInfo("test-tenant", "test-user");
+        Header identityHeader = TestHelpers.createIdentityHeader(identityHeaderValue);
+        mockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
+
+        given()
+                .header(identityHeader)
+                .queryParam("type", "foo")
+                .when().get("/endpoints")
+                .then()
+                .statusCode(400)
+                .body(is("Unknown endpoint type(s)"));
+
+        given()
+                .header(identityHeader)
+                .queryParam("type", EndpointType.WEBHOOK.toString())
+                .queryParam("type", "bar")
+                .when().get("/endpoints")
+                .then()
+                .statusCode(400)
+                .body(is("Unknown endpoint type(s)"));
+    }
+
     //    @Test
     void testConnectionCount() {
         String tenant = "count";


### PR DESCRIPTION
This will silence the many `IllegalArgumentException: No enum constant com.redhat.cloud.notifications.models.EndpointType.TYPE` alerts we received on Sentry lately.