### PR TITLE
Fix RBAC mock settings collision in tests

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
@@ -493,7 +493,7 @@ public class EventServiceTest extends DbIsolatedTest {
 
     @Test
     void shouldBeAllowedToGetEventLogs() {
-        Header noAccessIdentityHeader = mockRbac("tenant", "user", NOTIFICATIONS_READ_ACCESS_ONLY);
+        Header noAccessIdentityHeader = mockRbac("tenant", "user-read-access", NOTIFICATIONS_READ_ACCESS_ONLY);
         given()
                 .header(noAccessIdentityHeader)
                 .when().get(PATH)


### PR DESCRIPTION
This failure appeared in the GitHub build after #771 was merged:
```
2021-12-02T13:06:19.8068789Z 1 expectation failed.
2021-12-02T13:06:19.8069614Z Expected status code <200> but was <403>.
2021-12-02T13:06:19.8070222Z 
2021-12-02T13:06:19.8072779Z 	at com.redhat.cloud.notifications.events.LifecycleITest.createBehaviorGroup(LifecycleITest.java:290)
2021-12-02T13:06:19.8075898Z 	at com.redhat.cloud.notifications.events.LifecycleITest.test(LifecycleITest.java:109)
```
It doesn't happen on my machine so I'm not sure yet but this PR should fix it.