### PR TITLE
Make unprocessed Kafka messages max age configurable

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -83,6 +83,8 @@ objects:
           value: ${MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_INTERVAL_MS}
         - name: MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_RECORDS
           value: ${MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_RECORDS}
+        - name: MP_MESSAGING_INCOMING_INGRESS_THROTTLED_UNPROCESSED_RECORD_MAX_AGE_MS
+          value: ${MP_MESSAGING_INCOMING_INGRESS_THROTTLED_UNPROCESSED_RECORD_MAX_AGE_MS}
         - name: NOTIFICATIONS_EPHEMERAL_DATA
           valueFrom:
             configMapKeyRef:
@@ -260,6 +262,9 @@ parameters:
 - name: MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_RECORDS
   description: Maximum number of records returned in a single call to poll()
   value: "500"
+- name: MP_MESSAGING_INCOMING_INGRESS_THROTTLED_UNPROCESSED_RECORD_MAX_AGE_MS
+  description: Max age in milliseconds that an unprocessed message can be before the connector is marked as unhealthy
+  value: "60000"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
   value: INFO


### PR DESCRIPTION
This will be used from app-interface to prevent the issue we had on prod last night:
```
SRMSG18231: The record 5170910 from topic-partition 'platform.notifications.ingress-1' has waited for 61 seconds to be acknowledged. This waiting time is greater than the configured threshold (60000 ms). At the moment 1 messages from this partition are awaiting acknowledgement. The last committed offset for this partition was 5170909. This error is due to a potential issue in the application which does not acknowledged the records in a timely fashion. The connector cannot commit as a record processing has not completed.
```

See https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/3.1/kafka/kafka.html for more details.