### PR TITLE
Remove quarkus-scheduler dependency

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -61,10 +61,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-scheduler</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-logging-sentry</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
All scheduled tasks have been moved to an OpenShift CronJob. We no longer need that dependency.

Seen on prod:
```
@timestamp:Dec 8, 2021 @ 07:14:25.109 log.level:INFO message:No scheduled business methods found - Simple scheduler will not be started service.environment:prod process.thread.name:main log.logger:io.quarkus.scheduler.runtime.SimpleScheduler @id:36550235969418795718896017338455303230515520878533935108 @message:{"@timestamp":"2021-12-08T13:14:25.109Z", "log.level": "INFO", "message":"No scheduled business methods found - Simple scheduler will not be started", [...]
```