### PR TITLE
Fix issue with datasource labels in grafana dashboard

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
@@ -2541,7 +2541,7 @@ data:
             "allValue": null,
             "current": {
               "selected": true,
-              "text": "crcs02ue1-prometheus",
+              "text": "stage",
               "value": "crcs02ue1-prometheus"
             },
             "description": null,
@@ -2554,12 +2554,12 @@ data:
             "options": [
               {
                 "selected": true,
-                "text": "crcs02ue1-prometheus",
+                "text": "stage",
                 "value": "crcs02ue1-prometheus"
               },
               {
                 "selected": false,
-                "text": "crcp01ue1-prometheus",
+                "text": "prod",
                 "value": "crcp01ue1-prometheus"
               }
             ],
@@ -2602,7 +2602,7 @@ data:
       "timezone": "",
       "title": "Notifications Dashboard",
       "uid": "KQIVyFuMk",
-      "version": 27
+      "version": 28
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Grafana is overwriting the label in the ui and we still have to add the label by hand.