### PR TITLE
Updating Clowdapp

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -36,7 +36,9 @@ objects:
     deployments:
     - name: service
       minReplicas: ${{MIN_REPLICAS}}
-      web: true
+      webServices:
+        public:
+          enabled: true
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         resources:


### PR DESCRIPTION
`web` is deprecated and [will go away](https://docs.google.com/document/d/1m_MgEhZjb-z-bE8RbTrii559e9Sb3yS7P3gYsqAwveI/edit#).

We'll need to do the same for:

- https://github.com/RedHatInsights/notifications-gw/blob/main/.rhcicd/clowdapp.yaml
- https://github.com/RedHatInsights/policies-ui-backend/blob/master/.rhcicd/clowdapp.yaml#L27
- https://github.com/RedHatInsights/policies-engine/blob/master/.rhcicd/clowdapp.yaml#L47

But testing here before...