### PR TITLE
NOTIF-427 Return the payload on demand in the /events response

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
@@ -56,7 +56,7 @@ public class EventService {
                                               @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
                                               @RestQuery Set<EndpointType> endpointTypes, @RestQuery Set<Boolean> invocationResults,
                                               @RestQuery @DefaultValue("10") int limit, @RestQuery @DefaultValue("0") int offset, @RestQuery String sortBy,
-                                              @RestQuery boolean includeDetails) {
+                                              @RestQuery boolean includeDetails, @RestQuery boolean includePayload) {
         if (limit < 1 || limit > 200) {
             throw new BadRequestException("Invalid 'limit' query parameter, its value must be between 1 and 200");
         }
@@ -88,6 +88,9 @@ public class EventService {
                                                 entry.setApplication(event.getEventType().getApplication().getDisplayName());
                                                 entry.setEventType(event.getEventType().getDisplayName());
                                                 entry.setActions(actions);
+                                                if (includePayload) {
+                                                    entry.setPayload(event.getPayload());
+                                                }
                                                 return entry;
                                             }).collect(Collectors.toList())
                                     )

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EventLogEntry.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EventLogEntry.java
@@ -30,6 +30,8 @@ public class EventLogEntry {
     @NotNull
     private String eventType;
 
+    private String payload;
+
     @NotNull
     private List<EventLogEntryAction> actions;
 
@@ -71,6 +73,14 @@ public class EventLogEntry {
 
     public void setEventType(String eventType) {
         this.eventType = eventType;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
     }
 
     public List<EventLogEntryAction> getActions() {


### PR DESCRIPTION
FYI we are loading the payload from the database even when it is not returned in the response, which is bad for performances.

I'll change that in another PR.