### PR TITLE
Include Kafka records consumed rate in health check

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -77,6 +77,10 @@ objects:
         env:
         - name: ENV_NAME
           value: ${ENV_NAME}
+        - name: KAFKA_CONSUMED_RATE_CHECKER_ENABLED
+          value: ${KAFKA_CONSUMED_RATE_CHECKER_ENABLED}
+        - name: KAFKA_CONSUMED_RATE_CHECKER_MAX_FAILURES
+          value: ${KAFKA_CONSUMED_RATE_CHECKER_MAX_FAILURES}
         - name: MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_INTERVAL_MS
           value: ${MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_INTERVAL_MS}
         - name: MP_MESSAGING_INCOMING_INGRESS_MAX_POLL_RECORDS
@@ -242,6 +246,12 @@ parameters:
   value: quay.io/cloudservices/notifications-backend
 - name: IMAGE_TAG
   value: latest
+- name: KAFKA_CONSUMED_RATE_CHECKER_ENABLED
+  description: Is the Kafka records consumed rate included in the global health check?
+  value: "false"
+- name: KAFKA_CONSUMED_RATE_CHECKER_MAX_FAILURES
+  description: Kafka records consumed rate failures required before the app is marked as DOWN in the global health check
+  value: "5"
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 500Mi

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -79,6 +79,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-reactive-pg-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler</artifactId>
+        </dependency>
 
         <!-- Flyway specific dependencies -->
         <dependency>

--- a/backend/src/main/java/com/redhat/cloud/notifications/health/KafkaConsumedRateChecker.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/health/KafkaConsumedRateChecker.java
@@ -1,0 +1,55 @@
+package com.redhat.cloud.notifications.health;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.scheduler.Scheduled;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class KafkaConsumedRateChecker {
+
+    private static final Logger LOGGER = Logger.getLogger(KafkaConsumedRateChecker.class);
+    private static final String INGRESS_TOPIC = "platform.notifications.ingress";
+
+    @ConfigProperty(name = "kafka-consumed-rate-checker.enabled", defaultValue = "false")
+    boolean enabled;
+
+    @ConfigProperty(name = "kafka-consumed-rate-checker.max-failures", defaultValue = "5")
+    int maxFailures;
+
+    @Inject
+    MeterRegistry meterRegistry;
+
+    private Gauge consumedRateGauge;
+    private int currentFailures;
+
+    @PostConstruct
+    void postConstruct() {
+        consumedRateGauge = meterRegistry.find("kafka.consumer.fetch.manager.records.consumed.rate")
+                .tag("client.id", "kafka-consumer-ingress")
+                .gauge();
+    }
+
+    @Scheduled(every = "${kafka-consumed-rate-checker.period:1m}", delayed = "${kafka-consumed-rate-checker.initial-delay:5m}")
+    public void periodicCheck() {
+        if (enabled) {
+            if (consumedRateGauge.value() == 0d) {
+                currentFailures++;
+                LOGGER.debugf("Kafka records consumed rate check failed for topic '%s'", INGRESS_TOPIC);
+            } else if (currentFailures > 0) {
+                currentFailures = 0;
+                LOGGER.debugf("Kafka records consumed rate check succeeded for topic '%s' after %d failures",
+                        INGRESS_TOPIC, currentFailures);
+            }
+        }
+    }
+
+    public boolean isDown() {
+        return enabled && currentFailures >= maxFailures;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -118,3 +118,5 @@ quarkus.log.cloudwatch.access-key-secret=placeholder
 quarkus.cache.caffeine.maintenance.expire-after-write=PT60s
 quarkus.cache.caffeine.rbac-recipient-users-provider-get-users.expire-after-write=PT10M
 quarkus.cache.caffeine.rbac-recipient-users-provider-get-group-users.expire-after-write=PT10M
+
+quarkus.log.category."com.redhat.cloud.notifications.health.KafkaConsumedRateChecker".level=DEBUG


### PR DESCRIPTION
This adds a new check (disabled by default) to the existing health checks.

After a 5 minutes initial delay (configurable), every 1 minute (configurable) the `kafka.consumer.fetch.manager.records.consumed.rate` Micrometer gauge value will be tested.

A gauge value equal to zero will be recorded as a minor failure. If the number of _consecutive_ minor failures exceeds the maximum number allowed (configurable), then the app will be marked as `DOWN` the next time OpenShift calls `/health`.

If the gauge value is greater than zero when it is tested, the minor failures counter will be reseted.