### PR TITLE
NOTIF-152 Add recipient users

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/PoliciesEmailPayloadAggregator.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/PoliciesEmailPayloadAggregator.java
@@ -37,7 +37,6 @@ class PoliciesEmailPayloadAggregator extends AbstractEmailPayloadAggregator {
     }
 
     void processEmailAggregation(EmailAggregation notification) {
-
         JsonObject notificationJson = notification.getPayload();
 
         JsonObject policies = context.getJsonObject(POLICIES_KEY);

--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/PoliciesEmailPayloadAggregator.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/PoliciesEmailPayloadAggregator.java
@@ -37,6 +37,7 @@ class PoliciesEmailPayloadAggregator extends AbstractEmailPayloadAggregator {
     }
 
     void processEmailAggregation(EmailAggregation notification) {
+
         JsonObject notificationJson = notification.getPayload();
 
         JsonObject policies = context.getJsonObject(POLICIES_KEY);

--- a/backend/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
@@ -3,7 +3,6 @@ package com.redhat.cloud.notifications.recipients;
 import com.redhat.cloud.notifications.recipients.rbac.RbacRecipientUsersProvider;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -14,8 +13,6 @@ import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class RecipientResolver {
-
-    private static final Logger LOGGER = Logger.getLogger(RecipientResolver.class);
 
     @Inject
     RbacRecipientUsersProvider rbacRecipientUsersProvider;
@@ -34,17 +31,31 @@ public class RecipientResolver {
             usersUni = rbacRecipientUsersProvider.getGroupUsers(accountId, request.isOnlyAdmins(), request.getGroupId());
         }
 
-        return usersUni.onItem().transform(users -> {
-            if (request.isIgnoreUserPreferences()) {
-                return Set.copyOf(users);
-            }
+        return usersUni
+                .onItem().transform(Set::copyOf)
+                .onItem().transform(users -> {
+                    // This step requires a specific set of users and all others needs to be ignored (for this step)
+                    if (request.getUsers().size() > 0) {
+                        return filterUsers(users, request.getUsers());
+                    }
 
-            return users.stream()
-                    .filter(user -> subscribers
+                    return users;
+                }).onItem().transform(users -> {
+                    if (request.isIgnoreUserPreferences()) {
+                        return Set.copyOf(users);
+                    }
+
+                    return filterUsers(users, subscribers);
+                });
+    }
+
+    private Set<User> filterUsers(Set<User> users, Set<String> target) {
+        return users.stream()
+                .filter(
+                    user -> target
                             .stream()
-                            .anyMatch(subscriber -> subscriber.equalsIgnoreCase(user.getUsername()))
-                    )
-                    .collect(Collectors.toSet());
-        });
+                            .anyMatch(requested -> requested.equalsIgnoreCase(user.getUsername()))
+                )
+                .collect(Collectors.toSet());
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/recipients/RecipientSettings.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/recipients/RecipientSettings.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.recipients;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 public abstract class RecipientSettings {
@@ -10,6 +11,8 @@ public abstract class RecipientSettings {
     public abstract boolean isIgnoreUserPreferences();
 
     public abstract UUID getGroupId();
+
+    public abstract Set<String> getUsers();
 
     @Override
     public boolean equals(Object o) {
@@ -23,12 +26,12 @@ public abstract class RecipientSettings {
 
         RecipientSettings that = (RecipientSettings) o;
         return this.isOnlyAdmins() == that.isOnlyAdmins() && this.isIgnoreUserPreferences() == that.isIgnoreUserPreferences() &&
-                Objects.equals(this.getGroupId(), that.getGroupId());
+                Objects.equals(this.getGroupId(), that.getGroupId()) && Objects.equals(this.getUsers(), that.getUsers());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isOnlyAdmins(), isIgnoreUserPreferences(), getGroupId());
+        return Objects.hash(isOnlyAdmins(), isIgnoreUserPreferences(), getGroupId(), getUsers());
     }
 
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/recipients/request/ActionRecipientSettings.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/recipients/request/ActionRecipientSettings.java
@@ -14,7 +14,7 @@ public class ActionRecipientSettings extends RecipientSettings {
     private final Recipient recipient;
     private final Set<String> users;
 
-    ActionRecipientSettings(Recipient recipient) {
+    public ActionRecipientSettings(Recipient recipient) {
         this.recipient = recipient;
         this.users = Set.copyOf(this.recipient.getUsers());
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/recipients/request/ActionRecipientSettings.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/recipients/request/ActionRecipientSettings.java
@@ -5,15 +5,18 @@ import com.redhat.cloud.notifications.ingress.Recipient;
 import com.redhat.cloud.notifications.recipients.RecipientSettings;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class ActionRecipientSettings extends RecipientSettings {
 
     private final Recipient recipient;
+    private final Set<String> users;
 
     ActionRecipientSettings(Recipient recipient) {
         this.recipient = recipient;
+        this.users = Set.copyOf(this.recipient.getUsers());
     }
 
     @Override
@@ -29,6 +32,11 @@ public class ActionRecipientSettings extends RecipientSettings {
     @Override
     public UUID getGroupId() {
         return null;
+    }
+
+    @Override
+    public Set<String> getUsers() {
+        return users;
     }
 
     public static List<ActionRecipientSettings> fromAction(Action action) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/recipients/request/EndpointRecipientSettings.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/recipients/request/EndpointRecipientSettings.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.recipients.RecipientSettings;
 
+import java.util.Set;
 import java.util.UUID;
 
 public class EndpointRecipientSettings extends RecipientSettings {
@@ -27,5 +28,10 @@ public class EndpointRecipientSettings extends RecipientSettings {
     @Override
     public UUID getGroupId() {
         return endpoint.getProperties(EmailSubscriptionProperties.class).getGroupId();
+    }
+
+    @Override
+    public Set<String> getUsers() {
+        return Set.of();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <!-- Be careful with bumps, version 5.11.2 caused tests instability so we had to rollback to 5.5.4 -->
         <mockserver-client-java.version>5.5.4</mockserver-client-java.version>
 
-        <insights-notification-schemas-java.version>0.4</insights-notification-schemas-java.version>
+        <insights-notification-schemas-java.version>0.5</insights-notification-schemas-java.version>
         <clowder-quarkus-config-source.version>0.5.0</clowder-quarkus-config-source.version>
 
         <cloudwatch.version>4.0.1</cloudwatch.version>


### PR DESCRIPTION
Allows notification message to specify a list of users.

This allows an applications to specify users they want to send a specific notification. This list of users is added to whatever the notification administrator already set and does not overwrite the setting.