### PR TITLE
Remove superflous property and adding get all defaults behaviorgroups

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/BehaviorGroupResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/BehaviorGroupResources.java
@@ -60,7 +60,7 @@ public class BehaviorGroupResources {
         });
     }
 
-    public Uni<List<BehaviorGroup>> findDefault() {
+    public Uni<List<BehaviorGroup>> findDefaults() {
         final String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
                 "WHERE b.accountId IS NULL " +
                 "ORDER BY b.created DESC, a.position ASC";

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/BehaviorGroupResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/BehaviorGroupResources.java
@@ -60,6 +60,18 @@ public class BehaviorGroupResources {
         });
     }
 
+    public Uni<List<BehaviorGroup>> findDefault() {
+        final String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+                "WHERE b.accountId IS NULL " +
+                "ORDER BY b.created DESC, a.position ASC";
+
+        return sessionFactory.withSession(session -> {
+            return session.createQuery(query, BehaviorGroup.class)
+                    .getResultList()
+                    .onItem().invoke(behaviorGroups -> behaviorGroups.forEach(BehaviorGroup::filterOutBundle));
+        });
+    }
+
     public Uni<List<BehaviorGroup>> findByBundleId(String accountId, UUID bundleId) {
         return sessionFactory.withSession(session -> {
             return session.createNamedQuery("findByBundleId", BehaviorGroup.class)

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -299,6 +299,15 @@ public class InternalService {
         .onFailure().recoverWithItem(throwable -> Response.status(Response.Status.BAD_REQUEST).entity(new RenderEmailTemplateResponse.Error(throwable.getMessage())).build());
     }
 
+    @GET
+    @Path("/behaviorGroups/default")
+    @Produces(APPLICATION_JSON)
+    public Uni<List<BehaviorGroup>> getDefaultBehaviorGroup() {
+        return sessionFactory.withSession(session -> {
+            return behaviorGroupResources.findDefault();
+        });
+    }
+
     @POST
     @Path("/behaviorGroups/default")
     @Consumes(APPLICATION_JSON)
@@ -350,7 +359,6 @@ public class InternalService {
                         EmailSubscriptionProperties properties = new EmailSubscriptionProperties();
                         properties.setOnlyAdmins(p.isOnlyAdmins());
                         properties.setIgnorePreferences(p.isIgnorePreferences());
-                        properties.setGroupId(p.getGroupId());
                         return properties;
                     })
                     .collect(Collectors.toList())

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/InternalService.java
@@ -302,9 +302,9 @@ public class InternalService {
     @GET
     @Path("/behaviorGroups/default")
     @Produces(APPLICATION_JSON)
-    public Uni<List<BehaviorGroup>> getDefaultBehaviorGroup() {
+    public Uni<List<BehaviorGroup>> getDefaultBehaviorGroups() {
         return sessionFactory.withSession(session -> {
-            return behaviorGroupResources.findDefault();
+            return behaviorGroupResources.findDefaults();
         });
     }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/internal/RequestDefaultBehaviorGroupPropertyList.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/internal/RequestDefaultBehaviorGroupPropertyList.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
-import java.util.UUID;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RequestDefaultBehaviorGroupPropertyList {
@@ -14,8 +13,6 @@ public class RequestDefaultBehaviorGroupPropertyList {
 
     @NotNull
     private boolean ignorePreferences;
-
-    private UUID groupId;
 
     public boolean isOnlyAdmins() {
         return onlyAdmins;
@@ -33,14 +30,6 @@ public class RequestDefaultBehaviorGroupPropertyList {
         this.ignorePreferences = ignorePreferences;
     }
 
-    public UUID getGroupId() {
-        return groupId;
-    }
-
-    public void setGroupId(UUID groupId) {
-        this.groupId = groupId;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -52,11 +41,11 @@ public class RequestDefaultBehaviorGroupPropertyList {
         }
 
         RequestDefaultBehaviorGroupPropertyList that = (RequestDefaultBehaviorGroupPropertyList) o;
-        return onlyAdmins == that.onlyAdmins && ignorePreferences == that.ignorePreferences && Objects.equals(groupId, that.groupId);
+        return onlyAdmins == that.onlyAdmins && ignorePreferences == that.ignorePreferences;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(onlyAdmins, ignorePreferences, groupId);
+        return Objects.hash(onlyAdmins, ignorePreferences);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -13,7 +13,6 @@ import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
-import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
@@ -26,6 +25,7 @@ import com.redhat.cloud.notifications.recipients.User;
 import com.redhat.cloud.notifications.recipients.rbac.RbacRecipientUsersProvider;
 import com.redhat.cloud.notifications.routers.models.RequestEmailSubscriptionProperties;
 import com.redhat.cloud.notifications.routers.models.SettingsValues;
+import com.redhat.cloud.notifications.routers.models.internal.RequestDefaultBehaviorGroupPropertyList;
 import com.redhat.cloud.notifications.templates.Blank;
 import com.redhat.cloud.notifications.templates.EmailTemplateFactory;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -128,7 +128,7 @@ public class LifecycleITest extends DbIsolatedTest {
         final String username = "user";
         setupEmailMock(accountId, username);
 
-        EmailSubscriptionProperties defaultBehaviorGroupProperties = new EmailSubscriptionProperties();
+        RequestDefaultBehaviorGroupPropertyList defaultBehaviorGroupProperties = new RequestDefaultBehaviorGroupPropertyList();
         defaultBehaviorGroupProperties.setOnlyAdmins(true);
 
         // All events are stored in the canonical email endpoint
@@ -514,7 +514,7 @@ public class LifecycleITest extends DbIsolatedTest {
                 .contentType(TEXT);
     }
 
-    private void addDefaultBehaviorGroupActions(String defaultBehaviorGroupId, int expectedHttpStatusCode, EmailSubscriptionProperties... properties) {
+    private void addDefaultBehaviorGroupActions(String defaultBehaviorGroupId, int expectedHttpStatusCode, RequestDefaultBehaviorGroupPropertyList... properties) {
         given()
                 .basePath(API_INTERNAL)
                 .contentType(JSON)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
@@ -260,7 +260,7 @@ public class InternalServiceTest extends DbIsolatedTest {
 
     @Test
     void testDefaultBehaviorGroupCRUD() {
-        // We need to persist a bundle, an app and two event types for this test.
+        // We need to persist a bundle.
         String bundleId = createBundle("dbg-bundle-name", "Bundle", OK).get();
 
         // Creates 2 behavior groups
@@ -652,8 +652,8 @@ public class InternalServiceTest extends DbIsolatedTest {
                 .basePath(API_INTERNAL)
                 .contentType(JSON)
                 .body(Json.encode(behaviorGroup))
-                .pathParam("behavior_group_id", behaviorGroupId)
-                .put("/behaviorGroups/default/{behavior_group_id}")
+                .pathParam("id", behaviorGroupId)
+                .put("/behaviorGroups/default/{id}")
                 .then()
                 .statusCode(200)
                 .extract().as(Boolean.class);
@@ -664,8 +664,8 @@ public class InternalServiceTest extends DbIsolatedTest {
     private static void deleteDefaultBehaviorGroup(String behaviorGroupId, boolean expectedResult) {
         Boolean result = given()
                 .basePath(API_INTERNAL)
-                .pathParam("behavior_group_id", behaviorGroupId)
-                .delete("/behaviorGroups/default/{behavior_group_id}")
+                .pathParam("id", behaviorGroupId)
+                .delete("/behaviorGroups/default/{id}")
                 .then()
                 .statusCode(200)
                 .extract().as(Boolean.class);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
@@ -4,18 +4,25 @@ import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response.Status.Family;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static io.restassured.http.ContentType.TEXT;
@@ -249,6 +256,49 @@ public class InternalServiceTest extends DbIsolatedTest {
 
         // The app should also contain one event type now.
         getEventTypes(appId, OK, 1);
+    }
+
+    @Test
+    void testDefaultBehaviorGroupCRUD() {
+        // We need to persist a bundle, an app and two event types for this test.
+        String bundleId = createBundle("dbg-bundle-name", "Bundle", OK).get();
+
+        // Creates 2 behavior groups
+        String dbgId1 = createDefaultBehaviorGroup("DefaultBehaviorGroup1", bundleId);
+        String dbgId2 = createDefaultBehaviorGroup("DefaultBehaviorGroup2", bundleId);
+
+        assertEquals(
+                Set.of(
+                        Pair.of(dbgId1, "DefaultBehaviorGroup1"),
+                        Pair.of(dbgId2, "DefaultBehaviorGroup2")
+                ),
+                getDefaultBehaviorGroups().stream().map(bg -> Pair.of(bg.getId().toString(), bg.getDisplayName())).collect(Collectors.toSet())
+        );
+
+        // Update displayName of behavior group 1
+        updateDefaultBehaviorGroup(dbgId1, "Group1", bundleId, true);
+        assertEquals(
+                Set.of(
+                        Pair.of(dbgId1, "Group1"),
+                        Pair.of(dbgId2, "DefaultBehaviorGroup2")
+                ),
+                getDefaultBehaviorGroups().stream().map(bg -> Pair.of(bg.getId().toString(), bg.getDisplayName())).collect(Collectors.toSet())
+        );
+
+        // Delete behaviors
+        deleteDefaultBehaviorGroup(dbgId1, true);
+        assertEquals(
+                Set.of(dbgId2),
+                getDefaultBehaviorGroups().stream().map(BehaviorGroup::getId).map(UUID::toString).collect(Collectors.toSet())
+        );
+        deleteDefaultBehaviorGroup(dbgId2, true);
+        assertEquals(
+                Set.of(),
+                getDefaultBehaviorGroups().stream().map(BehaviorGroup::getId).map(UUID::toString).collect(Collectors.toSet())
+        );
+
+        // Deleting again yields false
+        deleteDefaultBehaviorGroup(dbgId1, false);
     }
 
     private static Bundle buildBundle(String name, String displayName) {
@@ -569,5 +619,78 @@ public class InternalServiceTest extends DbIsolatedTest {
                 .extract().body().as(Boolean.class);
 
         assertEquals(expectedResult, result);
+    }
+
+    private static BehaviorGroup buildDefaultBehaviorGroup(String displayName, String bundleId) {
+        BehaviorGroup bg = new BehaviorGroup();
+        bg.setDisplayName(displayName);
+        bg.setBundleId(UUID.fromString(bundleId));
+        return bg;
+    }
+
+    private static String createDefaultBehaviorGroup(String displayName, String bundleId) {
+        BehaviorGroup behaviorGroup = buildDefaultBehaviorGroup(displayName, bundleId);
+
+        return given()
+                .basePath(API_INTERNAL)
+                .contentType(JSON)
+                .body(Json.encode(behaviorGroup))
+                .post("/behaviorGroups/default")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract()
+                .body()
+                .jsonPath()
+                .getString("id");
+    }
+
+    private static void updateDefaultBehaviorGroup(String behaviorGroupId, String displayName, String bundleId, boolean expectedResult) {
+        BehaviorGroup behaviorGroup = buildDefaultBehaviorGroup(displayName, bundleId);
+
+        Boolean result = given()
+                .basePath(API_INTERNAL)
+                .contentType(JSON)
+                .body(Json.encode(behaviorGroup))
+                .pathParam("behavior_group_id", behaviorGroupId)
+                .put("/behaviorGroups/default/{behavior_group_id}")
+                .then()
+                .statusCode(200)
+                .extract().as(Boolean.class);
+
+        assertEquals(expectedResult, result);
+    }
+
+    private static void deleteDefaultBehaviorGroup(String behaviorGroupId, boolean expectedResult) {
+        Boolean result = given()
+                .basePath(API_INTERNAL)
+                .pathParam("behavior_group_id", behaviorGroupId)
+                .delete("/behaviorGroups/default/{behavior_group_id}")
+                .then()
+                .statusCode(200)
+                .extract().as(Boolean.class);
+
+        assertEquals(expectedResult, result);
+    }
+
+    private static List<BehaviorGroup> getDefaultBehaviorGroups() {
+        List<?> behaviorGroups = given()
+                .basePath(API_INTERNAL)
+                .get("/behaviorGroups/default")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract()
+                .body().as(List.class);
+
+        return behaviorGroups.stream().map(rawBg -> {
+            Map<String, Object> mbg = (Map<String, Object>) rawBg;
+            BehaviorGroup bg = new BehaviorGroup();
+            bg.setId(UUID.fromString(mbg.get("id").toString()));
+            bg.setDisplayName(mbg.get("display_name").toString());
+            bg.setBundleId(UUID.fromString(mbg.get("bundle_id").toString()));
+
+            return bg;
+        }).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
 - It doesn't make sense to specify a groupId in the default email action
   as is not linked to any account
 - Adds endpoint to query all the default behavior groups
 - Adding tests