### PR TITLE
NOTIF-450 Split the ui-backend and engine DB resources

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/ApplicationResources.java
@@ -105,11 +105,10 @@ public class ApplicationResources {
         });
     }
 
-    // Note: This method uses a stateless session
     public Uni<EventType> getEventType(String bundleName, String applicationName, String eventTypeName) {
         final String query = "FROM EventType WHERE name = :eventTypeName AND application.name = :applicationName AND application.bundle.name = :bundleName";
-        return sessionFactory.withStatelessSession(statelessSession -> {
-            return statelessSession.createQuery(query, EventType.class)
+        return sessionFactory.withSession(session -> {
+            return session.createQuery(query, EventType.class)
                     .setParameter("bundleName", bundleName)
                     .setParameter("applicationName", applicationName)
                     .setParameter("eventTypeName", eventTypeName)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EndpointEmailSubscriptionResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EndpointEmailSubscriptionResources.java
@@ -75,17 +75,4 @@ public class EndpointEmailSubscriptionResources {
                     .getResultList();
         });
     }
-
-    public Uni<List<String>> getEmailSubscribersUserId(String accountNumber, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
-        String query = "SELECT es.id.userId FROM EmailSubscription es WHERE id.accountId = :accountId AND application.bundle.name = :bundleName " +
-                "AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
-        return sessionFactory.withStatelessSession(statelessSession -> {
-            return statelessSession.createQuery(query, String.class)
-                    .setParameter("accountId", accountNumber)
-                    .setParameter("bundleName", bundleName)
-                    .setParameter("applicationName", applicationName)
-                    .setParameter("subscriptionType", subscriptionType)
-                    .getResultList();
-        });
-    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
@@ -23,15 +23,6 @@ public class EventResources {
     @Inject
     Mutiny.SessionFactory sessionFactory;
 
-    // Note: This method uses a stateless session
-    public Uni<Event> create(Event event) {
-        event.prePersist(); // This method must be called manually while using a StatelessSession.
-        return sessionFactory.withStatelessSession(statelessSession -> {
-            return statelessSession.insert(event)
-                    .replaceWith(event);
-        });
-    }
-
     public Uni<List<Event>> getEvents(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<Boolean> invocationResults,
                                       Integer limit, Integer offset, String sortBy) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java
@@ -22,14 +22,6 @@ public class NotificationResources {
     @Inject
     Mutiny.SessionFactory sessionFactory;
 
-    public Uni<NotificationHistory> createNotificationHistory(NotificationHistory history) {
-        history.prePersist(); // This method must be called manually while using a StatelessSession.
-        return sessionFactory.withStatelessSession(statelessSession -> {
-            return statelessSession.insert(history)
-                    .replaceWith(history);
-        });
-    }
-
     public Uni<List<NotificationHistory>> getNotificationHistory(String tenant, UUID endpoint, boolean includeDetails, Query limiter) {
         return sessionFactory.withSession(session -> {
             String query = "SELECT NEW NotificationHistory(nh.id, nh.invocationTime, nh.invocationResult, nh.endpoint, nh.created";
@@ -72,41 +64,6 @@ public class NotificationResources {
                     .setParameter("historyId", historyId)
                     .getSingleResultOrNull()
                     .onItem().ifNotNull().transform(JsonObject::new);
-        });
-    }
-
-    /**
-     * Update a stub history item with data we have received from the Camel sender
-     * @param jo Map containing the returned data
-     * @return Nothing
-     *
-     * @see com.redhat.cloud.notifications.events.FromCamelHistoryFiller for the source of data
-     */
-    public Uni<Void> updateHistoryItem(Map<String, Object> jo) {
-
-        String historyId = (String) jo.get("historyId");
-
-        if (historyId == null || historyId.isBlank()) {
-            return Uni.createFrom().failure(new IllegalArgumentException("History Id is null"));
-        }
-
-        String outcome = (String) jo.get("outcome");
-        boolean result = outcome == null ? false : outcome.startsWith("Success");
-        Map details = (Map) jo.get("details");
-        if (!details.containsKey("outcome")) {
-            details.put("outcome", outcome);
-        }
-        Integer duration = (Integer) jo.get("duration");
-
-        String updateQuery = "UPDATE NotificationHistory SET details = :details, invocationResult = :result, invocationTime= :invocationTime WHERE id = :id";
-        return sessionFactory.withStatelessSession(statelessSession -> {
-            return statelessSession.createQuery(updateQuery)
-                    .setParameter("details", details)
-                    .setParameter("result", result)
-                    .setParameter("id", UUID.fromString(historyId))
-                    .setParameter("invocationTime", (long) duration)
-                    .executeUpdate()
-                    .replaceWith(Uni.createFrom().voidItem());
         });
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepository.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.models.EmailAggregationKey;
@@ -10,8 +10,10 @@ import javax.inject.Inject;
 import java.time.LocalDateTime;
 import java.util.List;
 
+// TODO: Move this class to notifications-engine.
+
 @ApplicationScoped
-public class EmailAggregationResources {
+public class EmailAggregationRepository {
 
     @Inject
     Mutiny.SessionFactory sessionFactory;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
@@ -1,0 +1,31 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.models.EmailSubscriptionType;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+
+// TODO: Move this class to notifications-engine.
+
+@ApplicationScoped
+public class EmailSubscriptionRepository {
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    public Uni<List<String>> getEmailSubscribersUserId(String accountNumber, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
+        String query = "SELECT es.id.userId FROM EmailSubscription es WHERE id.accountId = :accountId AND application.bundle.name = :bundleName " +
+                "AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
+        return sessionFactory.withStatelessSession(statelessSession -> {
+            return statelessSession.createQuery(query, String.class)
+                    .setParameter("accountId", accountNumber)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("applicationName", applicationName)
+                    .setParameter("subscriptionType", subscriptionType)
+                    .getResultList();
+        });
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -1,0 +1,215 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.session.CommonStateSessionFactory;
+import com.redhat.cloud.notifications.models.CamelProperties;
+import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointProperties;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.WebhookProperties;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+// TODO: Move this class to notifications-engine.
+
+@ApplicationScoped
+public class EndpointRepository {
+
+    private static final Logger LOGGER = Logger.getLogger(EndpointRepository.class);
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @Inject
+    CommonStateSessionFactory commonStateSessionFactory;
+
+    public Uni<Endpoint> createEndpoint(Endpoint endpoint, boolean useStatelessSession) {
+        return commonStateSessionFactory.withSession(useStatelessSession, session -> {
+            return session.persist(endpoint)
+                    .onItem().call(session::flush)
+                    .onItem().call(() -> {
+                        // If the endpoint properties are null, they won't be persisted.
+                        if (endpoint.getProperties() != null) {
+                            /*
+                             * As weird as it seems, we need the following line because the Endpoint instance was
+                             * deserialized from JSON and that JSON did not contain any information about the
+                             * @OneToOne relation from EndpointProperties to Endpoint.
+                             */
+                            endpoint.getProperties().setEndpoint(endpoint);
+                            switch (endpoint.getType()) {
+                                case CAMEL:
+                                case WEBHOOK:
+                                case EMAIL_SUBSCRIPTION:
+                                    return session.persist(endpoint.getProperties())
+                                            .onItem().call(session::flush);
+                                default:
+                                    // Do nothing.
+                                    break;
+                            }
+                        }
+                        /*
+                         * If this line is reached, it means the endpoint properties are null or we don't support
+                         * persisting properties for the endpoint type. We still have to return something.
+                         */
+                        return Uni.createFrom().voidItem();
+                    })
+                    .replaceWith(endpoint);
+        });
+    }
+
+    public Uni<List<Endpoint>> getEndpointsPerType(String accountId, Set<EndpointType> type, Boolean activeOnly, Query limiter, boolean useStatelessSession) {
+        return commonStateSessionFactory.withSession(useStatelessSession, session -> {
+            // TODO Modify the parameter to take a vararg of Functions that modify the query
+            // TODO Modify to take account selective joins (JOIN (..) UNION (..)) based on the type, same for getEndpoints
+            String query = "SELECT e FROM Endpoint e WHERE e.type IN (:endpointType)";
+            if (accountId == null) {
+                query += " AND e.accountId IS NULL";
+            } else {
+                query += " AND e.accountId = :accountId";
+            }
+            if (activeOnly != null) {
+                query += " AND enabled = :enabled";
+            }
+
+            if (limiter != null) {
+                query = limiter.getModifiedQuery(query);
+            }
+
+            Mutiny.Query<Endpoint> mutinyQuery = session.createQuery(query, Endpoint.class)
+                    .setParameter("endpointType", type);
+
+            if (accountId != null) {
+                mutinyQuery = mutinyQuery.setParameter("accountId", accountId);
+            }
+            if (activeOnly != null) {
+                mutinyQuery = mutinyQuery.setParameter("enabled", activeOnly);
+            }
+
+            if (limiter != null && limiter.getLimit() != null && limiter.getLimit().getLimit() > 0) {
+                mutinyQuery = mutinyQuery.setMaxResults(limiter.getLimit().getLimit())
+                        .setFirstResult(limiter.getLimit().getOffset());
+            }
+
+            return mutinyQuery.getResultList()
+                    .onItem().call(endpoints -> loadProperties(endpoints, useStatelessSession));
+        });
+    }
+
+    public Uni<Endpoint> getOrCreateEmailSubscriptionEndpoint(String accountId, EmailSubscriptionProperties properties, boolean useStatelessSession) {
+        return commonStateSessionFactory.withSession(useStatelessSession, session -> {
+            return getEndpointsPerType(accountId, Set.of(EndpointType.EMAIL_SUBSCRIPTION), null, null, useStatelessSession)
+                    .onItem().call(endpoints -> loadProperties(endpoints, useStatelessSession))
+                    .onItem().transformToUni(emailEndpoints -> {
+                        Optional<Endpoint> endpointOptional = emailEndpoints
+                                .stream()
+                                .filter(endpoint -> properties.hasSameProperties(endpoint.getProperties(EmailSubscriptionProperties.class)))
+                                .findFirst();
+                        if (endpointOptional.isPresent()) {
+                            return Uni.createFrom().item(endpointOptional.get());
+                        }
+
+                        Endpoint endpoint = new Endpoint();
+                        endpoint.setProperties(properties);
+                        endpoint.setAccountId(accountId);
+                        endpoint.setEnabled(true);
+                        endpoint.setDescription("System email endpoint");
+                        endpoint.setName("Email endpoint");
+                        endpoint.setType(EndpointType.EMAIL_SUBSCRIPTION);
+
+                        return createEndpoint(endpoint, useStatelessSession);
+                    });
+        });
+    }
+
+    // Note: This method uses a stateless session
+    public Uni<List<Endpoint>> getTargetEndpoints(String tenant, EventType eventType) {
+        String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
+                "WHERE e.enabled = TRUE AND b.eventType = :eventType AND (bga.behaviorGroup.accountId = :accountId OR bga.behaviorGroup.accountId IS NULL)";
+
+        return sessionFactory.withStatelessSession(statelessSession -> {
+            return statelessSession.createQuery(query, Endpoint.class)
+                    .setParameter("eventType", eventType)
+                    .setParameter("accountId", tenant)
+                    .getResultList()
+                    .onItem().call(endpoints -> loadProperties(endpoints, true))
+                    .invoke(endpoints -> {
+                        for (Endpoint endpoint : endpoints) {
+                            if (endpoint.getAccountId() == null) {
+                                if (endpoint.getType() == EndpointType.EMAIL_SUBSCRIPTION) {
+                                    endpoint.setAccountId(tenant);
+                                } else {
+                                    LOGGER.warnf("Invalid endpoint configured in default behavior group: %s", endpoint.getId());
+                                }
+                            }
+                        }
+                    });
+        });
+    }
+
+    // Note: This method uses a stateless session
+    public Uni<List<Endpoint>> getTargetEndpointsFromType(String tenant, String bundleName, String applicationName, String eventTypeName, EndpointType endpointType) {
+        String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
+                "WHERE e.enabled = TRUE AND b.eventType.name = :eventTypeName AND (bga.behaviorGroup.accountId = :accountId OR bga.behaviorGroup.accountId IS NULL) " +
+                "AND b.eventType.application.name = :applicationName AND b.eventType.application.bundle.name = :bundleName " +
+                "AND e.type = :endpointType";
+
+        return sessionFactory.withStatelessSession(statelessSession -> {
+            return statelessSession.createQuery(query, Endpoint.class)
+                    .setParameter("applicationName", applicationName)
+                    .setParameter("eventTypeName", eventTypeName)
+                    .setParameter("accountId", tenant)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("endpointType", endpointType)
+                    .getResultList()
+                    .onItem().call(endpoints -> loadProperties(endpoints, true));
+        });
+    }
+
+    private Uni<Void> loadProperties(List<Endpoint> endpoints, boolean useStatelessSession) {
+        if (endpoints.isEmpty()) {
+            return Uni.createFrom().voidItem();
+        }
+
+        // Group endpoints in types and load in batches for each type.
+        Set<Endpoint> endpointSet = new HashSet<>(endpoints);
+
+        return this.loadTypedProperties(WebhookProperties.class, endpointSet, EndpointType.WEBHOOK, useStatelessSession)
+                .chain(() -> loadTypedProperties(CamelProperties.class, endpointSet, EndpointType.CAMEL, useStatelessSession))
+                .chain(() -> loadTypedProperties(EmailSubscriptionProperties.class, endpointSet, EndpointType.EMAIL_SUBSCRIPTION, useStatelessSession));
+    }
+
+    private <T extends EndpointProperties> Uni<Void> loadTypedProperties(Class<T> typedEndpointClass, Set<Endpoint> endpoints, EndpointType type, boolean useStatelessSession) {
+        Map<UUID, Endpoint> endpointsMap = endpoints
+                .stream()
+                .filter(e -> e.getType().equals(type))
+                .collect(Collectors.toMap(Endpoint::getId, Function.identity()));
+
+        if (endpointsMap.size() > 0) {
+            return commonStateSessionFactory.withSession(
+                useStatelessSession,
+                commonStateSession -> commonStateSession.find(typedEndpointClass, endpointsMap.keySet().toArray())
+            ).onItem().invoke(propList -> propList.forEach(props -> {
+                if (props != null) {
+                    Endpoint endpoint = endpointsMap.get(props.getId());
+                    endpoint.setProperties(props);
+                }
+            })).replaceWith(Uni.createFrom().voidItem());
+        }
+
+        return Uni.createFrom().voidItem();
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -1,0 +1,26 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.models.Event;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+// TODO: Move this class to notifications-engine.
+
+@ApplicationScoped
+public class EventRepository {
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    // Note: This method uses a stateless session
+    public Uni<Event> create(Event event) {
+        event.prePersist(); // This method must be called manually while using a StatelessSession.
+        return sessionFactory.withStatelessSession(statelessSession -> {
+            return statelessSession.insert(event)
+                    .replaceWith(event);
+        });
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventTypeRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventTypeRepository.java
@@ -1,0 +1,29 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.models.EventType;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+// TODO: Move this class to notifications-engine.
+
+@ApplicationScoped
+public class EventTypeRepository {
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    // Note: This method uses a stateless session
+    public Uni<EventType> getEventType(String bundleName, String applicationName, String eventTypeName) {
+        final String query = "FROM EventType WHERE name = :eventTypeName AND application.name = :applicationName AND application.bundle.name = :bundleName";
+        return sessionFactory.withStatelessSession(statelessSession -> {
+            return statelessSession.createQuery(query, EventType.class)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("applicationName", applicationName)
+                    .setParameter("eventTypeName", eventTypeName)
+                    .getSingleResult();
+        });
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationHistoryRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationHistoryRepository.java
@@ -1,0 +1,62 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.models.NotificationHistory;
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+
+// TODO: Move this class to notifications-engine.
+
+@ApplicationScoped
+public class NotificationHistoryRepository {
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    public Uni<NotificationHistory> createNotificationHistory(NotificationHistory history) {
+        history.prePersist(); // This method must be called manually while using a StatelessSession.
+        return sessionFactory.withStatelessSession(statelessSession -> {
+            return statelessSession.insert(history)
+                    .replaceWith(history);
+        });
+    }
+
+    /**
+     * Update a stub history item with data we have received from the Camel sender
+     * @param jo Map containing the returned data
+     * @return Nothing
+     *
+     * @see com.redhat.cloud.notifications.events.FromCamelHistoryFiller for the source of data
+     */
+    public Uni<Void> updateHistoryItem(Map<String, Object> jo) {
+
+        String historyId = (String) jo.get("historyId");
+
+        if (historyId == null || historyId.isBlank()) {
+            return Uni.createFrom().failure(new IllegalArgumentException("History Id is null"));
+        }
+
+        String outcome = (String) jo.get("outcome");
+        boolean result = outcome == null ? false : outcome.startsWith("Success");
+        Map details = (Map) jo.get("details");
+        if (!details.containsKey("outcome")) {
+            details.put("outcome", outcome);
+        }
+        Integer duration = (Integer) jo.get("duration");
+
+        String updateQuery = "UPDATE NotificationHistory SET details = :details, invocationResult = :result, invocationTime= :invocationTime WHERE id = :id";
+        return sessionFactory.withStatelessSession(statelessSession -> {
+            return statelessSession.createQuery(updateQuery)
+                    .setParameter("details", details)
+                    .setParameter("result", result)
+                    .setParameter("id", UUID.fromString(historyId))
+                    .setParameter("invocationTime", (long) duration)
+                    .executeUpdate()
+                    .replaceWith(Uni.createFrom().voidItem());
+        });
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -1,7 +1,7 @@
 package com.redhat.cloud.notifications.events;
 
-import com.redhat.cloud.notifications.db.ApplicationResources;
-import com.redhat.cloud.notifications.db.EventResources;
+import com.redhat.cloud.notifications.db.repositories.EventRepository;
+import com.redhat.cloud.notifications.db.repositories.EventTypeRepository;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.utils.ActionParser;
 import io.micrometer.core.instrument.Counter;
@@ -45,10 +45,10 @@ public class EventConsumer {
     ActionParser actionParser;
 
     @Inject
-    ApplicationResources appResources;
+    EventTypeRepository eventTypeRepository;
 
     @Inject
-    EventResources eventResources;
+    EventRepository eventRepository;
 
     @Inject
     KafkaMessageDeduplicator kafkaMessageDeduplicator;
@@ -132,7 +132,7 @@ public class EventConsumer {
                                                      * We need to retrieve an EventType from the DB using the
                                                      * bundle/app/eventType triplet from the parsed Action.
                                                      */
-                                                    return appResources.getEventType(bundleName[0], appName[0], eventTypeName)
+                                                    return eventTypeRepository.getEventType(bundleName[0], appName[0], eventTypeName)
                                                             .onFailure(NoResultException.class).transform(e ->
                                                                     new NoResultException(String.format(EVENT_TYPE_NOT_FOUND_MSG, bundleName[0], appName[0], eventTypeName))
                                                             )
@@ -150,7 +150,7 @@ public class EventConsumer {
                                                                  * message and persist it.
                                                                  */
                                                                 Event event = new Event(eventType, payload, action);
-                                                                return eventResources.create(event);
+                                                                return eventRepository.create(event);
                                                             })
                                                             /*
                                                              * Step 7

--- a/backend/src/main/java/com/redhat/cloud/notifications/events/FromCamelHistoryFiller.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/events/FromCamelHistoryFiller.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.events;
 
-import com.redhat.cloud.notifications.db.NotificationResources;
+import com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.mutiny.Uni;
@@ -30,7 +30,7 @@ public class FromCamelHistoryFiller {
     private static final Logger log = Logger.getLogger(FromCamelHistoryFiller.class);
 
     @Inject
-    NotificationResources notificationResources;
+    NotificationHistoryRepository notificationHistoryRepository;
 
     @Inject
     Mutiny.SessionFactory sessionFactory;
@@ -57,7 +57,7 @@ public class FromCamelHistoryFiller {
                 .onItem()
                 .transformToUni(payload -> {
                     return sessionFactory.withStatelessSession(statelessSession -> {
-                        return notificationResources.updateHistoryItem(payload)
+                        return notificationHistoryRepository.updateHistoryItem(payload)
                                 .onFailure().invoke(t -> log.info("|  Update Fail", t)
                                 );
                     });

--- a/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.processors.email;
 
-import com.redhat.cloud.notifications.db.EndpointResources;
+import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
 import com.redhat.cloud.notifications.models.Event;
@@ -62,7 +62,7 @@ public class EmailSender {
     WebhookTypeProcessor webhookSender;
 
     @Inject
-    EndpointResources endpointResources;
+    EndpointRepository endpointRepository;
 
     @Inject
     EmailTemplateService emailTemplateService;
@@ -91,7 +91,7 @@ public class EmailSender {
 
         Action action = event.getAction();
         // uses canonical EmailSubscription
-        return endpointResources.getOrCreateEmailSubscriptionEndpoint(action.getAccountId(), new EmailSubscriptionProperties(), true)
+        return endpointRepository.getOrCreateEmailSubscriptionEndpoint(action.getAccountId(), new EmailSubscriptionProperties(), true)
                 .onItem().transformToUni(endpoint -> {
                     Notification notification = new Notification(event, endpoint);
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -1,6 +1,8 @@
 package com.redhat.cloud.notifications.db;
 
 import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
+import com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
@@ -48,13 +50,13 @@ public class ResourceHelpers {
     BundleResources bundleResources;
 
     @Inject
-    EmailAggregationResources emailAggregationResources;
+    EmailAggregationRepository emailAggregationRepository;
 
     @Inject
     BehaviorGroupResources behaviorGroupResources;
 
     @Inject
-    NotificationResources notificationResources;
+    NotificationHistoryRepository notificationHistoryRepository;
 
     @Inject
     Mutiny.SessionFactory sessionFactory;
@@ -190,7 +192,7 @@ public class ResourceHelpers {
         history.setEvent(event);
         history.setEndpoint(endpoint);
         history.setEndpointType(endpoint.getType());
-        return notificationResources.createNotificationHistory(history);
+        return notificationHistoryRepository.createNotificationHistory(history);
     }
 
     public Uni<UUID> emailSubscriptionEndpointId(String accountId, EmailSubscriptionProperties properties) {
@@ -242,7 +244,7 @@ public class ResourceHelpers {
 
     public Uni<Boolean> addEmailAggregation(String tenant, String bundle, String application, String policyId, String insightsId) {
         EmailAggregation aggregation = TestHelpers.createEmailAggregation(tenant, bundle, application, policyId, insightsId);
-        return emailAggregationResources.addEmailAggregation(aggregation);
+        return emailAggregationRepository.addEmailAggregation(aggregation);
     }
 
     public Uni<Boolean> addEmailAggregation(String accountId, String bundleName, String applicationName, JsonObject payload) {
@@ -251,6 +253,6 @@ public class ResourceHelpers {
         aggregation.setBundleName(bundleName);
         aggregation.setApplicationName(applicationName);
         aggregation.setPayload(payload);
-        return emailAggregationResources.addEmailAggregation(aggregation);
+        return emailAggregationRepository.addEmailAggregation(aggregation);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepositoryTest.java
@@ -1,6 +1,8 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.models.EmailAggregationKey;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -22,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class EmailAggregationResourcesTest extends DbIsolatedTest {
+public class EmailAggregationRepositoryTest extends DbIsolatedTest {
 
     private static final ZoneId UTC = ZoneId.of("UTC");
     private static final String ACCOUNT_ID = "123456789";
@@ -38,7 +40,7 @@ public class EmailAggregationResourcesTest extends DbIsolatedTest {
     ResourceHelpers resourceHelpers;
 
     @Inject
-    EmailAggregationResources aggregationResources;
+    EmailAggregationRepository emailAggregationRepository;
 
     @Test
     void testAllMethods() {
@@ -52,7 +54,7 @@ public class EmailAggregationResourcesTest extends DbIsolatedTest {
                 .chain(() -> resourceHelpers.addEmailAggregation("other-account", BUNDLE_NAME, APP_NAME, PAYLOAD2))
                 .chain(() -> resourceHelpers.addEmailAggregation(ACCOUNT_ID, "other-bundle", APP_NAME, PAYLOAD2))
                 .chain(() -> resourceHelpers.addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, "other-app", PAYLOAD2))
-                .chain(() -> aggregationResources.getEmailAggregation(key, start, end))
+                .chain(() -> emailAggregationRepository.getEmailAggregation(key, start, end))
                 .invoke(aggregations -> {
                     assertEquals(2, aggregations.size());
                     assertTrue(aggregations.stream().map(EmailAggregation::getAccountId).allMatch(ACCOUNT_ID::equals));
@@ -68,9 +70,9 @@ public class EmailAggregationResourcesTest extends DbIsolatedTest {
                     assertEquals(BUNDLE_NAME, keys.get(0).getBundle());
                     assertEquals(APP_NAME, keys.get(0).getApplication());
                 })
-                .chain(() -> aggregationResources.purgeOldAggregation(key, end))
+                .chain(() -> emailAggregationRepository.purgeOldAggregation(key, end))
                 .invoke(purged -> assertEquals(2, purged))
-                .chain(() -> aggregationResources.getEmailAggregation(key, start, end))
+                .chain(() -> emailAggregationRepository.getEmailAggregation(key, start, end))
                 .invoke(aggregations -> assertEquals(0, aggregations.size()))
                 .chain(aggregations -> getApplicationsWithPendingAggregation(start, end))
                 .invoke(keys -> assertEquals(3, keys.size()))

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -2,8 +2,8 @@ package com.redhat.cloud.notifications.events;
 
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.ApplicationResources;
-import com.redhat.cloud.notifications.db.EventResources;
+import com.redhat.cloud.notifications.db.repositories.EventRepository;
+import com.redhat.cloud.notifications.db.repositories.EventTypeRepository;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.models.Event;
@@ -69,10 +69,10 @@ public class EventConsumerTest {
     EndpointProcessor endpointProcessor;
 
     @InjectMock
-    ApplicationResources appResources;
+    EventTypeRepository eventTypeRepository;
 
     @InjectMock
-    EventResources eventResources;
+    EventRepository eventRepository;
 
     @InjectSpy
     KafkaMessageDeduplicator kafkaMessageDeduplicator;
@@ -278,10 +278,10 @@ public class EventConsumerTest {
 
     private EventType mockGetEventTypeAndCreateEvent() {
         EventType eventType = new EventType();
-        when(appResources.getEventType(eq(BUNDLE), eq(APP), eq(EVENT_TYPE))).thenReturn(
+        when(eventTypeRepository.getEventType(eq(BUNDLE), eq(APP), eq(EVENT_TYPE))).thenReturn(
                 Uni.createFrom().item(eventType)
         );
-        when(eventResources.create(any(Event.class))).thenAnswer(invocation -> {
+        when(eventRepository.create(any(Event.class))).thenAnswer(invocation -> {
             Event event = invocation.getArgument(0);
             return Uni.createFrom().item(event);
         });
@@ -289,7 +289,7 @@ public class EventConsumerTest {
     }
 
     private void mockGetUnknownEventType() {
-        when(appResources.getEventType(eq(BUNDLE), eq(APP), eq(EVENT_TYPE))).thenReturn(
+        when(eventTypeRepository.getEventType(eq(BUNDLE), eq(APP), eq(EVENT_TYPE))).thenReturn(
                 Uni.createFrom().failure(() -> new NoResultException("I am a forced exception!"))
         );
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/FromCamelHistoryFillerTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/FromCamelHistoryFillerTest.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.events;
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.db.NotificationResources;
+import com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
@@ -36,7 +36,7 @@ public class FromCamelHistoryFillerTest {
     InMemoryConnector inMemoryConnector;
 
     @InjectMock
-    NotificationResources notificationResources;
+    NotificationHistoryRepository notificationHistoryRepository;
 
     @Inject
     MicrometerAssertionHelper micrometerAssertionHelper;
@@ -61,7 +61,7 @@ public class FromCamelHistoryFillerTest {
         micrometerAssertionHelper.awaitAndAssertCounterIncrement(MESSAGES_PROCESSED_COUNTER_NAME, 1);
         micrometerAssertionHelper.assertCounterIncrement(MESSAGES_ERROR_COUNTER_NAME, 1);
 
-        verifyNoInteractions(notificationResources);
+        verifyNoInteractions(notificationHistoryRepository);
     }
 
     @Test
@@ -96,8 +96,8 @@ public class FromCamelHistoryFillerTest {
         micrometerAssertionHelper.assertCounterIncrement(MESSAGES_ERROR_COUNTER_NAME, 0);
 
         ArgumentCaptor<Map<String, Object>> decodedPayload = ArgumentCaptor.forClass(Map.class);
-        verify(notificationResources, times(1)).updateHistoryItem(decodedPayload.capture());
-        verifyNoMoreInteractions(notificationResources);
+        verify(notificationHistoryRepository, times(1)).updateHistoryItem(decodedPayload.capture());
+        verifyNoMoreInteractions(notificationHistoryRepository);
 
         assertEquals(expectedHistoryId, decodedPayload.getValue().get("historyId"));
         assertEquals(expectedDuration, decodedPayload.getValue().get("duration"));

--- a/backend/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.processors.email;
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
-import com.redhat.cloud.notifications.db.EmailAggregationResources;
+import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
 import com.redhat.cloud.notifications.models.AggregationCommand;
 import com.redhat.cloud.notifications.models.EmailAggregationKey;
 import com.redhat.cloud.notifications.models.Event;
@@ -49,7 +49,7 @@ class EmailSubscriptionTypeProcessorTest extends DbIsolatedTest {
     EmailTemplateFactory emailTemplateFactory;
 
     @InjectMock
-    EmailAggregationResources emailAggregationResources;
+    EmailAggregationRepository emailAggregationRepository;
 
     @Inject
     MicrometerAssertionHelper micrometerAssertionHelper;
@@ -101,26 +101,26 @@ class EmailSubscriptionTypeProcessorTest extends DbIsolatedTest {
         micrometerAssertionHelper.assertCounterIncrement(AGGREGATION_COMMAND_ERROR_COUNTER_NAME, 0);
 
         // Let's check that EndpointEmailSubscriptionResources#sendEmail was called for each aggregation.
-        verify(emailAggregationResources, times(1)).getEmailAggregation(
+        verify(emailAggregationRepository, times(1)).getEmailAggregation(
                 eq(aggregationCommand1.getAggregationKey()),
                 eq(aggregationCommand1.getStart()),
                 eq(aggregationCommand1.getEnd())
         );
 
-        verify(emailAggregationResources, times(1)).purgeOldAggregation(
+        verify(emailAggregationRepository, times(1)).purgeOldAggregation(
                 eq(aggregationCommand1.getAggregationKey()),
                 eq(aggregationCommand1.getEnd())
         );
-        verify(emailAggregationResources, times(1)).getEmailAggregation(
+        verify(emailAggregationRepository, times(1)).getEmailAggregation(
                 eq(aggregationCommand2.getAggregationKey()),
                 eq(aggregationCommand2.getStart()),
                 eq(aggregationCommand2.getEnd())
         );
-        verify(emailAggregationResources, times(1)).purgeOldAggregation(
+        verify(emailAggregationRepository, times(1)).purgeOldAggregation(
                 eq(aggregationCommand2.getAggregationKey()),
                 eq(aggregationCommand2.getEnd())
         );
-        verifyNoMoreInteractions(emailAggregationResources);
+        verifyNoMoreInteractions(emailAggregationRepository);
 
         micrometerAssertionHelper.clearSavedValues();
     }


### PR DESCRIPTION
This is preparation work for the notifications-backend split. Step 1: DB resources.

I moved the DB methods that will be part of the future `notifications-engine` app to new classes.

I also changed the naming convention for the files responsible for the DB queries: they are now named `*Repository` instead of `*Resources` because that's what they are and also because `*Resource` is a name much more suitable IMO for a file containing REST operations. Opinions on this are welcome, it can be reverted very easily.