### PR TITLE
NOTIF-450 Decouple the templates rendering from notifications-ui-backend

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/templates/BadRequestExceptionMapper.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/templates/BadRequestExceptionMapper.java
@@ -1,0 +1,20 @@
+package com.redhat.cloud.notifications.templates;
+
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response;
+
+// This mapper is required to forward the HTTP 400 error message.
+public class BadRequestExceptionMapper implements ResponseExceptionMapper<BadRequestException> {
+
+    @Override
+    public BadRequestException toThrowable(Response response) {
+        String errorMessage = response.readEntity(String.class);
+        if (errorMessage != null && !errorMessage.isEmpty()) {
+            return new BadRequestException(errorMessage);
+        } else {
+            return new BadRequestException();
+        }
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineClient.java
@@ -1,0 +1,29 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateRequest;
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path(API_INTERNAL + "/template-engine")
+@RegisterRestClient(configKey = "template-engine")
+@RegisterProvider(BadRequestExceptionMapper.class)
+public interface TemplateEngineClient {
+
+    @PUT
+    @Path("/render")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    Uni<Response> render(@NotNull @Valid RenderEmailTemplateRequest renderEmailTemplateRequest);
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineResource.java
@@ -1,0 +1,71 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.recipients.User;
+import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateRequest;
+import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateResponse;
+import com.redhat.cloud.notifications.utils.ActionParser;
+import io.smallrye.mutiny.Uni;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+// TODO: Move this class to notifications-engine.
+
+@Path(API_INTERNAL + "/template-engine")
+public class TemplateEngineResource {
+
+    @Inject
+    ActionParser actionParser;
+
+    @Inject
+    EmailTemplateService emailTemplateService;
+
+    @PUT
+    @Path("/render")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public Uni<Response> render(@NotNull @Valid RenderEmailTemplateRequest renderEmailTemplateRequest) {
+        User user = createInternalUser();
+
+        String payload = renderEmailTemplateRequest.getPayload();
+        return actionParser.fromJsonString(payload)
+                .onItem().transformToUni(action -> Uni.combine().all().unis(
+                                emailTemplateService
+                                        .compileTemplate(renderEmailTemplateRequest.getSubjectTemplate(), "subject")
+                                        .onItem().transformToUni(templateInstance -> emailTemplateService.renderTemplate(
+                                                user,
+                                                action,
+                                                templateInstance
+                                        )),
+                                emailTemplateService
+                                        .compileTemplate(renderEmailTemplateRequest.getBodyTemplate(), "body")
+                                        .onItem().transformToUni(templateInstance -> emailTemplateService.renderTemplate(
+                                                user,
+                                                action,
+                                                templateInstance
+                                        ))
+                        ).asTuple()
+                ).onItem().transform(titleAndBody -> Response.ok(new RenderEmailTemplateResponse.Success(titleAndBody.getItem1(), titleAndBody.getItem2())).build())
+                .onFailure().recoverWithItem(throwable -> Response.status(Response.Status.BAD_REQUEST).entity(new RenderEmailTemplateResponse.Error(throwable.getMessage())).build());
+    }
+
+    private User createInternalUser() {
+        User user = new User();
+        user.setUsername("jdoe");
+        user.setEmail("jdoe@jdoe.com");
+        user.setFirstName("John");
+        user.setLastName("Doe");
+        user.setActive(true);
+        user.setAdmin(false);
+        return user;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -120,3 +120,5 @@ quarkus.cache.caffeine.rbac-recipient-users-provider-get-users.expire-after-writ
 quarkus.cache.caffeine.rbac-recipient-users-provider-get-group-users.expire-after-write=PT10M
 
 quarkus.log.category."com.redhat.cloud.notifications.health.KafkaConsumedTotalChecker".level=DEBUG
+
+template-engine/mp-rest/url=${clowder.endpoints.notifications-backend-service:http://localhost:${quarkus.http.port}}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateRequest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.json.JsonArray;
@@ -299,6 +300,27 @@ public class InternalServiceTest extends DbIsolatedTest {
 
         // Deleting again yields false
         deleteDefaultBehaviorGroup(dbgId1, false);
+    }
+
+    @Test
+    void testInvalidEmailTemplateRendering() {
+        RenderEmailTemplateRequest request = new RenderEmailTemplateRequest();
+        request.setPayload("I am invalid!");
+        request.setSubjectTemplate(""); // Not important, won't be used.
+        request.setBodyTemplate(""); // Not important, won't be used.
+
+        String responseBody = given()
+                .basePath(API_INTERNAL)
+                .contentType(JSON)
+                .body(Json.encode(request))
+                .when()
+                .post("/templates/email/render")
+                .then()
+                .contentType(JSON)
+                .statusCode(400)
+                .extract().asString();
+
+        assertEquals("Action parsing failed for payload: I am invalid!", new JsonObject(responseBody).getString("message"));
     }
 
     private static Bundle buildBundle(String name, String displayName) {


### PR DESCRIPTION
This is preparation work for the notifications-backend split. Step 2: templates rendering.

To avoid having to share all templates-related classes and files (HTML) between `notifications-ui-backend` and `notifications-engine`, the engine will be solely responsible for rendering templates.

When `notifications-ui-backend` receives a REST request from the admin UI to render a template, that request will be forwarded to a `notifications-engine` REST endpoint (`TemplateEngineResource`) that will perform the rendering and return the result.