### PR TITLE
Making Prometheus push gateway optional

### DIFF
--- a/.rhcicd/clowdapp-aggregator.yaml
+++ b/.rhcicd/clowdapp-aggregator.yaml
@@ -80,7 +80,7 @@ parameters:
   required: true
 - name: PROMETHEUS_PUSHGATEWAY
   description: Prometheus Pushgateway URL
-  required: true
+  required: false
 - name: IMAGE
   description: Image URL
   value: quay.io/cloudservices/notifications-aggregator


### PR DESCRIPTION
- Ephemeral environment doesn't have a Prometheus Push Gateway (yet?)
- I haven't checked that the code would work without it