### PR TITLE
NOTIF-450 Add temp dummy class in common to fix quarkus:dev

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/Dummy.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/Dummy.java
@@ -1,0 +1,5 @@
+package com.redhat.cloud.notifications;
+
+// This class is required because this module is empty, quarkus:dev won't work otherwise.
+public class Dummy {
+}


### PR DESCRIPTION
`quarkus:dev` does not like dependencies on empty modules.