### PR TITLE
NOTIF-429 Expose subtypes

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EndpointResources.java
@@ -9,7 +9,6 @@ import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.EndpointType;
-import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.WebhookProperties;
 import io.smallrye.mutiny.Uni;
 import org.hibernate.reactive.mutiny.Mutiny;
@@ -161,39 +160,6 @@ public class EndpointResources {
                 activeOnly,
                 useStatelessSession
         );
-    }
-
-    // Note: This method uses a stateless session
-    public Uni<List<Endpoint>> getTargetEndpoints(String tenant, EventType eventType) {
-        String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
-                "WHERE e.enabled = TRUE AND b.eventType = :eventType AND bga.behaviorGroup.accountId = :accountId";
-
-        return sessionFactory.withStatelessSession(statelessSession -> {
-            return statelessSession.createQuery(query, Endpoint.class)
-                    .setParameter("eventType", eventType)
-                    .setParameter("accountId", tenant)
-                    .getResultList()
-                    .onItem().call(endpoints -> loadProperties(endpoints, true));
-        });
-    }
-
-    // Note: This method uses a stateless session
-    public Uni<List<Endpoint>> getTargetEndpointsFromType(String tenant, String bundleName, String applicationName, String eventTypeName, EndpointType endpointType) {
-        String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
-                "WHERE e.enabled = TRUE AND b.eventType.name = :eventTypeName AND bga.behaviorGroup.accountId = :accountId " +
-                "AND b.eventType.application.name = :applicationName AND b.eventType.application.bundle.name = :bundleName " +
-                "AND e.compositeType.type = :endpointType";
-
-        return sessionFactory.withStatelessSession(statelessSession -> {
-            return statelessSession.createQuery(query, Endpoint.class)
-                    .setParameter("applicationName", applicationName)
-                    .setParameter("eventTypeName", eventTypeName)
-                    .setParameter("accountId", tenant)
-                    .setParameter("bundleName", bundleName)
-                    .setParameter("endpointType", endpointType)
-                    .getResultList()
-                    .onItem().call(endpoints -> loadProperties(endpoints, true));
-        });
     }
 
     public Uni<List<Endpoint>> getEndpoints(String tenant, Query limiter) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -124,6 +124,15 @@ public class Query {
         return query;
     }
 
+    public String getSortQuery() {
+        Sort sort = getSort();
+        String query = "";
+        if (sort != null) {
+            query = modifyWithSort(query, sort);
+        }
+        return query;
+    }
+
     public static Function<String, String> modifyToCountQuery() {
         return s -> "SELECT COUNT(*) FROM (" +
                 s +

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -124,15 +124,6 @@ public class Query {
         return query;
     }
 
-    public String getSortQuery() {
-        Sort sort = getSort();
-        String query = "";
-        if (sort != null) {
-            query = modifyWithSort(query, sort);
-        }
-        return query;
-    }
-
     public static Function<String, String> modifyToCountQuery() {
         return s -> "SELECT COUNT(*) FROM (" +
                 s +

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -8,6 +8,7 @@ import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.EndpointResources;
 import com.redhat.cloud.notifications.db.NotificationResources;
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.models.Endpoint;
@@ -97,7 +98,11 @@ public class EndpointService {
                 schema = @Schema(type = SchemaType.INTEGER)
             )
     })
-    public Uni<EndpointPage> getEndpoints(@Context SecurityContext sec, @BeanParam Query query, @QueryParam("type") List<String> targetType, @QueryParam("active") Boolean activeOnly) {
+    public Uni<EndpointPage> getEndpoints(
+            @Context SecurityContext sec,
+            @BeanParam Query query,
+            @QueryParam("type") List<String> targetType,
+            @QueryParam("active") Boolean activeOnly) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
 
         return sessionFactory.withSession(session -> {
@@ -105,15 +110,22 @@ public class EndpointService {
             Uni<Long> count;
 
             if (targetType != null && targetType.size() > 0) {
-                Set<EndpointType> endpointType;
+                Set<CompositeEndpointType> compositeType;
                 try {
-                    endpointType = targetType.stream().map(s -> EndpointType.valueOf(s.toUpperCase())).collect(Collectors.toSet());
+                    compositeType = targetType.stream().map(s -> {
+                        String[] pieces = s.split(":", 2);
+                        if (pieces.length == 1) {
+                            return new CompositeEndpointType(EndpointType.valueOf(s.toUpperCase()));
+                        } else {
+                            return new CompositeEndpointType(EndpointType.valueOf(pieces[0].toUpperCase()), pieces[1]);
+                        }
+                    }).collect(Collectors.toSet());
                 } catch (IllegalArgumentException e) {
                     return Uni.createFrom().failure(() -> new BadRequestException("Unknown endpoint type(s)"));
                 }
                 endpoints = resources
-                        .getEndpointsPerType(principal.getAccount(), endpointType, activeOnly, query, false);
-                count = resources.getEndpointsCountPerType(principal.getAccount(), endpointType, activeOnly);
+                        .getEndpointsPerCompositeType(principal.getAccount(), compositeType, activeOnly, query, false);
+                count = resources.getEndpointsCountPerCompositeType(principal.getAccount(), compositeType, activeOnly, false);
             } else {
                 endpoints = resources.getEndpoints(principal.getAccount(), query);
                 count = resources.getEndpointsCount(principal.getAccount());

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointService.java
@@ -114,14 +114,18 @@ public class EndpointService {
                 try {
                     compositeType = targetType.stream().map(s -> {
                         String[] pieces = s.split(":", 2);
-                        if (pieces.length == 1) {
-                            return new CompositeEndpointType(EndpointType.valueOf(s.toUpperCase()));
-                        } else {
-                            return new CompositeEndpointType(EndpointType.valueOf(pieces[0].toUpperCase()), pieces[1]);
+                        try {
+                            if (pieces.length == 1) {
+                                return new CompositeEndpointType(EndpointType.valueOf(s.toUpperCase()));
+                            } else {
+                                return new CompositeEndpointType(EndpointType.valueOf(pieces[0].toUpperCase()), pieces[1]);
+                            }
+                        } catch (IllegalArgumentException e) {
+                            throw new BadRequestException("Unknown endpoint type: [" + s + "]", e);
                         }
                     }).collect(Collectors.toSet());
-                } catch (IllegalArgumentException e) {
-                    return Uni.createFrom().failure(() -> new BadRequestException("Unknown endpoint type(s)"));
+                } catch (BadRequestException badRequestException) {
+                    return Uni.createFrom().failure(() -> badRequestException);
                 }
                 endpoints = resources
                         .getEndpointsPerCompositeType(principal.getAccount(), compositeType, activeOnly, query, false);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventService.java
@@ -74,6 +74,7 @@ public class EventService {
                                                     action.setId(historyEntry.getId());
                                                     action.setEndpointId(historyEntry.getEndpointId());
                                                     action.setEndpointType(historyEntry.getEndpointType());
+                                                    action.setEndpointSubType(historyEntry.getEndpointSubType());
                                                     action.setInvocationResult(historyEntry.isInvocationResult());
                                                     if (includeDetails) {
                                                         action.setDetails(historyEntry.getDetails());

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EventLogEntryAction.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EventLogEntryAction.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.routers.models;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.models.EndpointType;
 
@@ -20,9 +21,12 @@ public class EventLogEntryAction {
     @NotNull
     private EndpointType endpointType;
 
+    private String endpointSubType;
+
     @NotNull
     private Boolean invocationResult;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private UUID endpointId;
 
     @Nullable
@@ -42,6 +46,14 @@ public class EventLogEntryAction {
 
     public void setEndpointType(EndpointType endpointType) {
         this.endpointType = endpointType;
+    }
+
+    public String getEndpointSubType() {
+        return endpointSubType;
+    }
+
+    public void setEndpointSubType(String endpointSubType) {
+        this.endpointSubType = endpointSubType;
     }
 
     public Boolean getInvocationResult() {

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/EndpointResourcesTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/EndpointResourcesTest.java
@@ -1,0 +1,75 @@
+package com.redhat.cloud.notifications.db;
+
+import com.redhat.cloud.notifications.models.CompositeEndpointType;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class EndpointResourcesTest {
+
+    @Test
+    public void queryBuilderTest() {
+        Mutiny.Query<Endpoint> query = mock(Mutiny.Query.class);
+
+        // types with subtype and without it
+        EndpointResources.queryBuilderEndpointsPerType(
+                null,
+                Set.of(
+                        new CompositeEndpointType(EndpointType.WEBHOOK),
+                        new CompositeEndpointType(EndpointType.CAMEL, "splunk")
+                ),
+                null
+        ).build((hql, endpointClass) -> {
+            assertEquals("SELECT e FROM Endpoint e WHERE e.accountId IS NULL AND (e.compositeType.type IN (:endpointType) OR e.compositeType IN (:compositeTypes))", hql);
+            return query;
+        });
+
+        verify(query, times(2)).setParameter((String) any(), any());
+        verifyNoMoreInteractions(query);
+        clearInvocations(query);
+
+        // without sub-types
+        EndpointResources.queryBuilderEndpointsPerType(
+                null,
+                Set.of(
+                        new CompositeEndpointType(EndpointType.WEBHOOK)
+                ),
+                null
+        ).build((hql, endpointClass) -> {
+            assertEquals("SELECT e FROM Endpoint e WHERE e.accountId IS NULL AND (e.compositeType.type IN (:endpointType))", hql);
+            return query;
+        });
+
+        verify(query, times(1)).setParameter((String) any(), any());
+        verifyNoMoreInteractions(query);
+        clearInvocations(query);
+
+        // with sub-types
+        EndpointResources.queryBuilderEndpointsPerType(
+                null,
+                Set.of(
+                        new CompositeEndpointType(EndpointType.CAMEL, "splunk")
+                ),
+                null
+        ).build((hql, endpointClass) -> {
+            assertEquals("SELECT e FROM Endpoint e WHERE e.accountId IS NULL AND (e.compositeType IN (:compositeTypes))", hql);
+            return query;
+        });
+
+        verify(query, times(1)).setParameter((String) any(), any());
+        verifyNoMoreInteractions(query);
+        clearInvocations(query);
+    }
+
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/builder/QueryBuilderTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/builder/QueryBuilderTest.java
@@ -197,7 +197,4 @@ public class QueryBuilderTest {
                         .buildRawQuery()
         );
     }
-
-
-
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -115,15 +115,18 @@ public class CamelTypeProcessorTest {
         JsonObject notifMetadata = payload.getJsonObject(NOTIF_METADATA_KEY);
         assertEquals(properties1.getDisableSslVerification().toString(), notifMetadata.getString("trustAll"));
         assertEquals(properties1.getUrl(), notifMetadata.getString("url"));
+        assertEquals(endpoint1.getSubType(), notifMetadata.getString("type"));
+        // Todo: NOTIF-429 backward compatibility change - Remove soon.
         assertEquals(properties1.getSubType(), notifMetadata.getString("type"));
+
         assertEquals(new MapConverter().convertToDatabaseColumn(properties1.getExtras()), notifMetadata.getString("extras"));
         assertEquals(properties1.getSecretToken(), notifMetadata.getString(TOKEN_HEADER));
         checkBasicAuthentication(notifMetadata, properties1.getBasicAuthentication());
 
         // Finally, we need to check the Kafka message metadata.
         UUID historyId = result.get(0).getId();
-        checkKafkaMetadata(message, historyId, properties1.getSubType());
-        checkCloudEventMetadata(message, historyId, endpoint1.getAccountId(), properties1.getSubType());
+        checkKafkaMetadata(message, historyId, endpoint1.getSubType());
+        checkCloudEventMetadata(message, historyId, endpoint1.getAccountId(), endpoint1.getSubType());
         checkTracingMetadata(message);
     }
 
@@ -160,12 +163,14 @@ public class CamelTypeProcessorTest {
         properties.setDisableSslVerification(TRUE);
         properties.setSecretToken("top-secret");
         properties.setBasicAuthentication(basicAuth);
-        properties.setSubType("sub-type");
         properties.setExtras(Map.of("foo", "bar"));
+        // Todo: NOTIF-429 backward compatibility change - Remove soon.
+        properties.setSubType("sub-type");
 
         Endpoint endpoint = new Endpoint();
         endpoint.setAccountId(accountId);
         endpoint.setType(CAMEL);
+        endpoint.setSubType("sub-type");
         endpoint.setProperties(properties);
         return endpoint;
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -1135,7 +1135,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .when().get("/endpoints")
                 .then()
                 .statusCode(400)
-                .body(is("Unknown endpoint type(s)"));
+                .body(is("Unknown endpoint type: [foo]"));
 
         given()
                 .header(identityHeader)
@@ -1144,7 +1144,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .when().get("/endpoints")
                 .then()
                 .statusCode(400)
-                .body(is("Unknown endpoint type(s)"));
+                .body(is("Unknown endpoint type: [bar]"));
     }
 
     //    @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointServiceTest.java
@@ -308,7 +308,6 @@ public class EndpointServiceTest extends DbIsolatedTest {
         CamelProperties cAttr = new CamelProperties();
         cAttr.setDisableSslVerification(false);
         cAttr.setUrl(String.format("https://%s", mockServerConfig.getRunningAddress()));
-        cAttr.setSubType("ansible");
         cAttr.setBasicAuthentication(new BasicAuthentication("testuser", "secret"));
         Map<String, String> extras = new HashMap<>();
         extras.put("template", "11");
@@ -316,6 +315,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
 
         Endpoint ep = new Endpoint();
         ep.setType(EndpointType.CAMEL);
+        ep.setSubType("ansible");
         ep.setName("Push the camel through the needle's ear");
         ep.setDescription("How many humps has a camel?");
         ep.setEnabled(true);
@@ -342,6 +342,8 @@ public class EndpointServiceTest extends DbIsolatedTest {
             JsonObject properties = responsePoint.getJsonObject("properties");
             assertNotNull(properties);
             assertTrue(endpoint.getBoolean("enabled"));
+            assertEquals("ansible", endpoint.getString("sub_type"));
+            // Todo: NOTIF-429 backward compatibility change - Remove soon.
             assertEquals("ansible", properties.getString("sub_type"));
             JsonObject extrasObject = properties.getJsonObject("extras");
             assertNotNull(extrasObject);
@@ -521,10 +523,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
         camelProperties.setSecretToken("my-super-secret-token");
         camelProperties.setUrl(String.format("https://%s", mockServerConfig.getRunningAddress()));
         camelProperties.setExtras(new HashMap<>());
-        camelProperties.setSubType("demo");
 
         Endpoint camelEp = new Endpoint();
         camelEp.setType(EndpointType.CAMEL);
+        camelEp.setSubType("demo");
         camelEp.setName("endpoint to find");
         camelEp.setDescription("needle in the haystack");
         camelEp.setEnabled(true);

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthentication.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthentication.java
@@ -1,9 +1,12 @@
 package com.redhat.cloud.notifications.models;
 
+import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
 public class BasicAuthentication {
+    @NotNull
     private String username;
+    @NotNull
     private String password;
 
     public BasicAuthentication() { }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
@@ -8,6 +8,7 @@ import com.redhat.cloud.notifications.db.converters.MapConverter;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.Map;
@@ -31,7 +32,8 @@ public class CamelProperties extends EndpointProperties {
     @Convert(converter = BasicAuthenticationConverter.class)
     private BasicAuthentication basicAuthentication;
 
-    // Subtype for camel
+    // Todo: NOTIF-429 backward compatibility change - Remove soon.
+    @Transient
     private String subType;
 
     @Convert(converter = MapConverter.class)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
@@ -34,6 +34,7 @@ public class CamelProperties extends EndpointProperties {
 
     // Todo: NOTIF-429 backward compatibility change - Remove soon.
     @Transient
+    @Deprecated(forRemoval = true)
     private String subType;
 
     @Convert(converter = MapConverter.class)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CompositeEndpointType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CompositeEndpointType.java
@@ -1,0 +1,71 @@
+package com.redhat.cloud.notifications.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.redhat.cloud.notifications.db.converters.EndpointTypeConverter;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Embeddable;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+@Embeddable
+public class CompositeEndpointType {
+    @NotNull
+    @Column(name = "endpoint_type")
+    @Convert(converter = EndpointTypeConverter.class)
+    private EndpointType type;
+
+    @Column(name = "endpoint_sub_type")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String subType;
+
+    public CompositeEndpointType() {
+
+    }
+
+    public CompositeEndpointType(EndpointType type) {
+        this.type = type;
+    }
+
+    public CompositeEndpointType(EndpointType type, String subType) {
+        this.type = type;
+        this.subType = subType;
+    }
+
+    public EndpointType getType() {
+        return type;
+    }
+
+    public void setType(EndpointType type) {
+        this.type = type;
+    }
+
+    public String getSubType() {
+        return subType;
+    }
+
+    public void setSubType(String subType) {
+        this.subType = subType;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CompositeEndpointType that = (CompositeEndpointType) o;
+        return type == that.type && Objects.equals(subType, that.subType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, subType);
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
@@ -9,9 +9,9 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(enumeration = { "webhook", "email_subscription", "default", "camel" })
 public enum EndpointType {
     @JsonProperty("webhook")
-    WEBHOOK, // 0
+    WEBHOOK(false), // 0
     @JsonProperty("email_subscription")
-    EMAIL_SUBSCRIPTION, // 1
+    EMAIL_SUBSCRIPTION(false), // 1
     /**
      * This enum member is no longer used.
      * <p>
@@ -20,7 +20,14 @@ public enum EndpointType {
      */
     @JsonProperty("default")
     @Deprecated
-    DEFAULT, // 2
+    DEFAULT(false), // 2
     @JsonProperty("camel")
-    CAMEL // 3
+    CAMEL(true); // 3
+
+    final boolean requiresSubType;
+
+    EndpointType(boolean requiresSubType) {
+        this.requiresSubType = requiresSubType;
+    }
+
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -59,6 +59,13 @@ public class NotificationHistory extends CreationTimestamped {
     @JsonIgnore
     private EndpointType endpointType;
 
+    /*
+     * This is a duplicate of the Endpoint#subType field. We need it to guarantee that the endpoint type will remain
+     * available for the event log even if the endpoint is deleted by an org admin.
+     */
+    @JsonIgnore
+    private String endpointSubType;
+
     @Convert(converter = NotificationHistoryDetailsConverter.class)
     private Map<String, Object> details;
 
@@ -137,6 +144,14 @@ public class NotificationHistory extends CreationTimestamped {
         this.endpointType = endpointType;
     }
 
+    public String getEndpointSubType() {
+        return endpointSubType;
+    }
+
+    public void setEndpointSubType(String endpointSubType) {
+        this.endpointSubType = endpointSubType;
+    }
+
     public Map<String, Object> getDetails() {
         return details;
     }
@@ -167,6 +182,7 @@ public class NotificationHistory extends CreationTimestamped {
         history.setInvocationTime(invocationTime);
         history.setEndpoint(endpoint);
         history.setEndpointType(endpoint.getType());
+        history.setEndpointSubType(endpoint.getSubType());
         history.setEvent(event);
         history.setInvocationResult(false);
         history.setId(historyId);

--- a/database/src/main/resources/db/migration/V1.37.0__add_subtype_to_endpoint.sql
+++ b/database/src/main/resources/db/migration/V1.37.0__add_subtype_to_endpoint.sql
@@ -1,0 +1,17 @@
+-- Moves the sub_type to the endpoints table and removes it from the camel_properties
+
+-- Adds subtype property for endpoints
+
+ALTER TABLE endpoints ADD COLUMN endpoint_sub_type VARCHAR(20);
+ALTER TABLE notification_history ADD COLUMN endpoint_sub_type VARCHAR(20);
+
+CREATE INDEX ix_endpoints_type_sub_type ON endpoints (endpoint_type, endpoint_sub_type);
+
+-- Migrate camel sub_types
+UPDATE endpoints as e SET endpoint_sub_type = (SELECT sub_type FROM camel_properties WHERE id = e.id);
+
+-- Populate notification_history endpoint_sub_type
+UPDATE notification_history as n SET endpoint_sub_type = (SELECT endpoint_sub_type FROM endpoints WHERE id = n.endpoint_id);
+
+-- Drop column
+ALTER TABLE camel_properties DROP COLUMN sub_type;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -93,7 +93,7 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
         }
 
         BasicAuthentication basicAuthentication = properties.getBasicAuthentication();
-        if (basicAuthentication != null && basicAuthentication.getUsername() != null && basicAuthentication.getPassword() != null) {
+        if (basicAuthentication != null) {
             StringBuilder sb = new StringBuilder(basicAuthentication.getUsername());
             sb.append(":");
             sb.append(basicAuthentication.getPassword());

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -86,14 +86,14 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
         metaData.put("trustAll", String.valueOf(properties.getDisableSslVerification()));
 
         metaData.put("url", properties.getUrl());
-        metaData.put("type", properties.getSubType());
+        metaData.put("type", endpoint.getSubType());
 
         if (properties.getSecretToken() != null && !properties.getSecretToken().isBlank()) {
             metaData.put(TOKEN_HEADER, properties.getSecretToken());
         }
 
         BasicAuthentication basicAuthentication = properties.getBasicAuthentication();
-        if (basicAuthentication != null) {
+        if (basicAuthentication != null && basicAuthentication.getUsername() != null && basicAuthentication.getPassword() != null) {
             StringBuilder sb = new StringBuilder(basicAuthentication.getUsername());
             sb.append(":");
             sb.append(basicAuthentication.getPassword());
@@ -121,7 +121,7 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
 
         String accountId = item.getEndpoint().getAccountId();
         // the next could give a CCE, but we only come here when it is a camel endpoint anyway
-        String subType = item.getEndpoint().getProperties(CamelProperties.class).getSubType();
+        String subType = item.getEndpoint().getSubType();
 
         return payload.onItem()
 


### PR DESCRIPTION
Exposes subtypes in the `Endpoint`. This allows to better filter the camel related subtypes to show in the UI

With this new addition, the `subType` is expected on the `Endpoint` level, for backwards compatibility, we are going to keep it on the Camel for a short time to allow migrations. 

The filter now accepts the subtypes of a specifc type separated by a colon i.e. `camel:splunk`
```
GET /api/integrations/v1.0/endpoints?limit=10&offset=0&type=webhook&type=camel%3Asplunk&type=camel%3Aanycamel
```

It has some backwards compatbility changes. We still have the `sub_type` on `CamelProperties` but it's readonly and backed by the endpoint.sub_type.

Includes work of: https://github.com/RedHatInsights/notifications-backend/pull/892