### PR TITLE
Remove HTTP config keys from aggregator

### DIFF
--- a/.rhcicd/clowdapp-aggregator.yaml
+++ b/.rhcicd/clowdapp-aggregator.yaml
@@ -47,8 +47,6 @@ objects:
         env:
         - name: ENV_NAME
           value: ${ENV_NAME}
-        - name: QUARKUS_HTTP_PORT
-          value: "8000"
         - name: QUARKUS_LOG_CATEGORY__COM_REDHAT_CLOUD_NOTIFICATIONS__LEVEL
           value: ${NOTIFICATIONS_LOG_LEVEL}
         - name: QUARKUS_LOG_CLOUDWATCH_ENABLED

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -20,6 +20,7 @@
     </properties>
 
     <dependencies>
+
         <!-- Quarkus -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -29,13 +30,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient_pushgateway</artifactId>
-            <version>${pushgateway.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm</artifactId>
@@ -44,16 +38,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-sentry</artifactId>
+        </dependency>
 
+        <!-- Quarkiverse -->
         <dependency>
             <groupId>io.quarkiverse.logging.cloudwatch</groupId>
             <artifactId>quarkus-logging-cloudwatch</artifactId>
             <version>${cloudwatch.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-logging-sentry</artifactId>
         </dependency>
 
         <!-- Insights -->
@@ -68,6 +62,12 @@
             <groupId>com.redhat.cloud.common</groupId>
             <artifactId>clowder-quarkus-config-source</artifactId>
             <version>${clowder-quarkus-config-source.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_pushgateway</artifactId>
+            <version>${pushgateway.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
@@ -2,48 +2,28 @@ package com.redhat.cloud.notifications;
 
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import javax.inject.Inject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @QuarkusMain
 public class NotificationsApp implements QuarkusApplication {
 
-    private static final String FILTER_REGEX = ".*(/health(/\\w+)?|/metrics) HTTP/[0-9].[0-9]\" 200.*\\n?";
-    private static final Pattern PATTERN = Pattern.compile(FILTER_REGEX);
-
     private static final Logger LOG = Logger.getLogger(NotificationsApp.class);
-
-    @ConfigProperty(name = "quarkus.http.access-log.category")
-    String loggerName;
 
     @Inject
     DailyEmailAggregationJob dailyEmailAggregationJob;
 
     @Override
     public int run(String... args) {
-        initAccessLogFilter();
-
         LOG.info(readGitProperties());
 
         dailyEmailAggregationJob.processDailyEmail();
 
         return 0;
-    }
-
-    private void initAccessLogFilter() {
-        java.util.logging.Logger accessLog = java.util.logging.Logger.getLogger(loggerName);
-        accessLog.setFilter(record -> {
-            final String logMessage = record.getMessage();
-            Matcher matcher = PATTERN.matcher(logMessage);
-            return !matcher.matches();
-        });
     }
 
     private String readGitProperties() {

--- a/aggregator/src/main/resources/application.properties
+++ b/aggregator/src/main/resources/application.properties
@@ -1,9 +1,3 @@
-quarkus.http.port=8086
-
-# Change port for tests to avoid messing with local Kafka instance
-%test.quarkus.http.port=9086
-%test.quarkus.http.test-port=9086
-
 # configure your datasource
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
@@ -18,15 +12,7 @@ mp.messaging.outgoing.aggregation.group.id=integrations
 mp.messaging.outgoing.aggregation.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.aggregation.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
-quarkus.http.access-log.enabled=true
-quarkus.http.access-log.category=access_log
-quarkus.http.access-log.pattern=combined
 quarkus.log.category."com.redhat.cloud.notifications".level=INFO
-
-%test.quarkus.http.access-log.category=info
-
-# Quarkus since 1.11 redirects non-apps to /q/. We need to prevent this
-quarkus.http.non-application-root-path=/
 
 # Sentry logging. Off by default, enabled on OpenShift
 # See https://quarkus.io/guides/logging-sentry#in-app-packages


### PR DESCRIPTION
Apparently all config keys starting with `quarkus.http` are no longer supported if the Quarkus app does depend on an HTTP-related extension. We received an alert on Sentry from stage because of that.