### PR TITLE
Fix deprecated CronJob apiVersion

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -156,7 +156,7 @@ objects:
     clean.sql: |
       CALL cleanEventLog();
       CALL cleanKafkaMessagesIds();
-- apiVersion: batch/v1beta1
+- apiVersion: batch/v1
   kind: CronJob
   metadata:
     name: notifications-db-cleaner-cronjob


### PR DESCRIPTION
Fixes
```
11:47:34 2022-01-25 10:47:34 [    INFO] [           pid-26005]  |stderr| W0125 10:47:34.765681   26005 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```