### PR TITLE
NOTIF-450 Share the DB pod between backend and engine

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -13,11 +13,11 @@ objects:
   spec:
     envName: ${ENV_NAME}
     dependencies:
+    - notifications-backend
     - rbac
     - ingress
     database:
-      name: notifications-backend
-      version: 12
+      sharedDbAppName: notifications-backend
     kafkaTopics:
     - topicName: platform.notifications.ingress
       partitions: 3


### PR DESCRIPTION
Two DB pods are currently deployed on ephemeral because `sharedDbAppName` in missing in the `engine` template.