### PR TITLE
NOTIF-450 Make the backend ClowdApp depend on engine

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -13,8 +13,9 @@ objects:
   spec:
     envName: ${ENV_NAME}
     dependencies:
-    - rbac
     - ingress
+    - notifications-engine
+    - rbac
     database:
       name: notifications-backend
       version: 12

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -13,9 +13,9 @@ objects:
   spec:
     envName: ${ENV_NAME}
     dependencies:
+    - ingress
     - notifications-backend
     - rbac
-    - ingress
     database:
       sharedDbAppName: notifications-backend
     kafkaTopics:

--- a/.rhcicd/pr_check_backend.sh
+++ b/.rhcicd/pr_check_backend.sh
@@ -4,7 +4,7 @@
 export APP_NAME="notifications"
 export COMPONENT_NAME="notifications-backend"
 export IMAGE="quay.io/cloudservices/notifications-backend"
-export DEPLOY_TIMEOUT="420"
+export DEPLOY_TIMEOUT="480"
 
 # IQE plugin config
 export IQE_PLUGINS="notifications"


### PR DESCRIPTION
This will be needed as soon as the `engine` becomes responsible for rendering all templates.