### PR TITLE
NOTIF-450 Fix Sentry warning

### DIFF
--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -47,7 +47,6 @@ mp.messaging.incoming.fromCamel.value.deserializer=org.apache.kafka.common.seria
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
 quarkus.datasource.password=postgres
-quarkus.datasource.jdbc=false
 quarkus.datasource.reactive.url=postgresql://127.0.0.1:5432/notifications
 
 quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.notifications.db.naming.SnakeCasePhysicalNamingStrategy


### PR DESCRIPTION
Fixes
```
Unrecognized configuration key "quarkus.datasource.jdbc" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```