### PR TITLE
Make notifications-engine ClowdApp dependency optional

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -14,8 +14,9 @@ objects:
     envName: ${ENV_NAME}
     dependencies:
     - ingress
-    - notifications-engine
     - rbac
+    optionalDependencies:
+    - notifications-engine
     database:
       name: notifications-backend
       version: 12


### PR DESCRIPTION
Since the `engine` hasn't been deployed yet on prod, the ClowdApp dependency has to be optional. Otherwise, we can't deploy the `backend` on prod.