### PR TITLE
Remove endpoints subtype migration query

### DIFF
--- a/database/src/main/resources/db/migration/V1.37.0__add_subtype_to_endpoint.sql
+++ b/database/src/main/resources/db/migration/V1.37.0__add_subtype_to_endpoint.sql
@@ -10,8 +10,5 @@ CREATE INDEX ix_endpoints_type_sub_type ON endpoints (endpoint_type, endpoint_su
 -- Migrate camel sub_types
 UPDATE endpoints as e SET endpoint_sub_type = (SELECT sub_type FROM camel_properties WHERE id = e.id);
 
--- Populate notification_history endpoint_sub_type
-UPDATE notification_history as n SET endpoint_sub_type = e.endpoint_sub_type FROM endpoints e WHERE e.id = n.endpoint_id;
-
 -- Drop column
 ALTER TABLE camel_properties DROP COLUMN sub_type;


### PR DESCRIPTION
That query caused a lock on stage twice because of the huge amount of history data.

If possible, it would be safer to remove it and wait for the `notification_history` table to be filled with records containing the subtype, which should take 31 days after the endpoints subtype code deployment.