### PR TITLE
Increase bonfire deployment timeout on ephemeral

### DIFF
--- a/.rhcicd/pr_check_backend.sh
+++ b/.rhcicd/pr_check_backend.sh
@@ -4,7 +4,7 @@
 export APP_NAME="notifications"
 export COMPONENT_NAME="notifications-backend"
 export IMAGE="quay.io/cloudservices/notifications-backend"
-export DEPLOY_TIMEOUT="480"
+export DEPLOY_TIMEOUT="600"
 
 # IQE plugin config
 export IQE_PLUGINS="notifications"


### PR DESCRIPTION
The number of our transitive Clowder dependencies increased on ephemeral and it causes frequent PR check failures, so we need to increase the deployment timeout.