### PR TITLE
NOTIF-483 Speed up the last connection attempt frontend query

### DIFF
--- a/database/src/main/resources/db/migration/V1.38.0__notification_history_index.sql
+++ b/database/src/main/resources/db/migration/V1.38.0__notification_history_index.sql
@@ -1,0 +1,8 @@
+-- When the frontend integration page is displayed, the backend receives multiple REST queries to retrieve the last
+-- connection attempt of each integration. The backend then selects all history entries matching the given
+-- account/endpoint couple, then orders the records by descending order and finally returns a subset of the records
+-- because the request is limited. The following index will make the ordering step much faster because Postgres will
+-- no longer need to scan all notification_history records before sorting them.
+
+CREATE INDEX ix_notification_history_endpoint_id_created
+    ON notification_history (endpoint_id, created DESC);


### PR DESCRIPTION
This PR should hopefully speed up the query that is causing issues on stage with the QA account.

It will have an impact on this part of the code:

https://github.com/RedHatInsights/notifications-backend/blob/dd67d02115c1a661bb174dc262050a8d2eb4cdf3/backend/src/main/java/com/redhat/cloud/notifications/db/NotificationResources.java#L25-L56

See https://www.postgresql.org/docs/13/indexes-ordering.html for more details about the impact of indexes on sorting operations.