### PR TITLE
Expose Git commit hash with /internal/version

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalServiceTest.java
@@ -38,6 +38,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
@@ -335,6 +336,19 @@ public class InternalServiceTest extends DbIsolatedTest {
                 .extract().asString();
 
         assertEquals("Action parsing failed for payload: I am invalid!", new JsonObject(responseBody).getString("message"));
+    }
+
+    @Test
+    void testVersion() {
+        String responseBody = given()
+                .basePath(API_INTERNAL)
+                .when()
+                .get("/version")
+                .then()
+                .contentType(TEXT)
+                .statusCode(200)
+                .extract().asString();
+        assertTrue(responseBody.matches("^[0-9a-f]{7}$"));
     }
 
     private static Bundle buildBundle(String name, String displayName) {

--- a/common/src/main/java/com/redhat/cloud/notifications/StartupUtils.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/StartupUtils.java
@@ -6,8 +6,10 @@ import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
@@ -27,9 +29,17 @@ public class StartupUtils {
     }
 
     public void logGitProperties() {
+        try {
+            LOG.info(readGitProperties());
+        } catch (Exception e) {
+            LOG.error("Could not read git.properties", e);
+        }
+    }
+
+    public String readGitProperties() {
         try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("git.properties")) {
             if (inputStream == null) {
-                LOG.info("git.properties is not available");
+                return "git.properties is not available";
             } else {
                 StringBuilder result = new StringBuilder();
                 try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
@@ -40,10 +50,10 @@ public class StartupUtils {
                         }
                     }
                 }
-                LOG.info(result.toString());
+                return result.toString();
             }
-        } catch (Exception e) {
-            LOG.error("Could not read git.properties", e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 


### PR DESCRIPTION
@dgaikwad With this PR, `GET /internal/version` will return the Git commit short hash that can be used to identify the version of the code that is tested.

For example, the endpoint could return `3b2e51c` which would identify https://github.com/RedHatInsights/notifications-backend/commit/3b2e51c. This short hash is also the tag of the Docker image we push on [Quay](https://quay.io/repository/cloudservices/notifications-backend?tab=tags).