### PR TITLE
Fix mount path typo

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -61,7 +61,7 @@ objects:
           mountPath: /tmp
         - name: keystore
           readOnly: true
-          mountpath: /mnt/secrets
+          mountPath: /mnt/secrets
         readinessProbe:
           httpGet:
             path: /health/ready


### PR DESCRIPTION
This should fix:
```
[2022-02-10 17:04:55] [ERROR] [openshift_base.py:_realize_resource_data:474] - [crcs02ue1/notifications-stage] [https://api.crcs02ue1.urby.p1.openshiftapps.com:6443/]: The ClowdApp "notifications-engine" is invalid: spec.deployments.podSpec.volumeMounts.mountPath: Required value
 (error details: https://github.com/RedHatInsights/notifications-backend/blob/fa551d53b8edf40993115bda269cabc8fa0dcc99/.rhcicd/clowdapp-engine.yaml)
```