### PR TITLE
NOTIF-491 Merge getEventIds and count SQL queries

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
@@ -2,19 +2,30 @@ package com.redhat.cloud.notifications.db;
 
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
+import com.redhat.cloud.notifications.routers.models.EventLogEntry;
+import com.redhat.cloud.notifications.routers.models.EventLogEntryAction;
+import com.redhat.cloud.notifications.routers.models.Meta;
+import com.redhat.cloud.notifications.routers.models.Page;
+import com.redhat.cloud.notifications.routers.models.PageLinksBuilder;
 import io.smallrye.mutiny.Uni;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.math.BigInteger;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
+import static com.redhat.cloud.notifications.routers.EventService.PATH;
 import static com.redhat.cloud.notifications.routers.EventService.SORT_BY_PATTERN;
 
 @ApplicationScoped
@@ -23,104 +34,126 @@ public class EventResources {
     @Inject
     Mutiny.SessionFactory sessionFactory;
 
-    public Uni<List<Event>> getEvents(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
-                                      LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<Boolean> invocationResults,
-                                      Integer limit, Integer offset, String sortBy) {
+    public Uni<Page<EventLogEntry>> getEvents(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
+                                              LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<Boolean> invocationResults,
+                                              Integer limit, Integer offset, String sortBy, boolean includeDetails, boolean includePayload) {
         return sessionFactory.withSession(session -> {
-            Optional<String> orderByCondition = getOrderByCondition(sortBy);
-            return getEventIds(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults, limit, offset, orderByCondition)
-                    .onItem().transformToUni(eventIds -> {
-                        String hql = "SELECT DISTINCT e FROM Event e " +
-                                "JOIN FETCH e.eventType et JOIN FETCH et.application a JOIN FETCH a.bundle b " +
-                                "LEFT JOIN FETCH e.historyEntries he " +
-                                "WHERE e.accountId = :accountId AND e.id IN (:eventIds)";
+            return getEventIdsAndCount(session, accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults, limit, offset, sortBy)
+                    .onItem().transformToUni(records -> {
+                        if (records.isEmpty()) {
+                            return Uni.createFrom().item(() -> buildPage(Collections.emptyList(), 0L, limit, offset));
+                        } else {
+                            // The second field of each record contains the total count of events.
+                            long count = ((BigInteger) records.get(0)[1]).longValue();
+                            List<UUID> eventIds = parseEventIds(records);
 
-                        if (orderByCondition.isPresent()) {
-                            hql += orderByCondition.get();
+                            String hql = "SELECT DISTINCT e FROM Event e " +
+                                    "JOIN FETCH e.eventType et JOIN FETCH et.application a JOIN FETCH a.bundle b " +
+                                    "LEFT JOIN FETCH e.historyEntries he " +
+                                    "WHERE e.id IN (:eventIds)";
+
+                            Optional<String> orderByCondition = getOrderByCondition(sortBy, false);
+                            if (orderByCondition.isPresent()) {
+                                hql += orderByCondition.get();
+                            }
+
+                            return session.createQuery(hql, Event.class)
+                                    .setParameter("eventIds", eventIds)
+                                    .getResultList()
+                                    .onItem().transform(events -> {
+
+                                        List<EventLogEntry> entries = events.stream().map(event -> {
+                                            List<EventLogEntryAction> actions = event.getHistoryEntries().stream().map(historyEntry -> {
+                                                return buildEventLogEntryAction(
+                                                        historyEntry.getId(),
+                                                        historyEntry.getEndpointId(),
+                                                        historyEntry.getEndpointType(),
+                                                        historyEntry.getEndpointSubType(),
+                                                        historyEntry.isInvocationResult(),
+                                                        includeDetails ? historyEntry.getDetails() : null
+                                                );
+                                            }).collect(Collectors.toList());
+                                            return buildEventLogEntry(
+                                                    event.getId(),
+                                                    event.getCreated(),
+                                                    event.getEventType().getApplication().getBundle().getDisplayName(),
+                                                    event.getEventType().getApplication().getDisplayName(),
+                                                    event.getEventType().getDisplayName(),
+                                                    includePayload ? event.getPayload() : null,
+                                                    actions
+                                            );
+                                        }).collect(Collectors.toList());
+
+                                        return buildPage(entries, count, limit, offset);
+                                    });
                         }
-
-                        return session.createQuery(hql, Event.class)
-                                .setParameter("accountId", accountId)
-                                .setParameter("eventIds", eventIds)
-                                .getResultList();
                     });
         });
     }
 
-    public Uni<Long> count(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
-                      LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<Boolean> invocationResults) {
-        return sessionFactory.withSession(session -> {
-            String hql = "SELECT COUNT(*) FROM Event e JOIN e.eventType et JOIN et.application a JOIN a.bundle b " +
-                    "WHERE e.accountId = :accountId";
-
-            hql = addHqlConditions(hql, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults);
-
-            Mutiny.Query<Long> query = session.createQuery(hql, Long.class);
-            setQueryParams(query, accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults);
-
-            return query.getSingleResult();
-        });
-    }
-
-    private Optional<String> getOrderByCondition(String sortBy) {
+    private Optional<String> getOrderByCondition(String sortBy, boolean nativeQuery) {
         if (sortBy == null) {
             return Optional.of(" ORDER BY e.created DESC");
         } else {
             Matcher sortByMatcher = SORT_BY_PATTERN.matcher(sortBy);
             if (sortByMatcher.matches()) {
-                String sortField = getSortField(sortByMatcher.group(1));
+                String sortField = getSortField(sortByMatcher.group(1), nativeQuery);
                 String sortDirection = sortByMatcher.group(2);
-                return Optional.of(" ORDER BY " + sortField + " " + sortDirection + ", e.created DESC");
+                String result = " ORDER BY " + sortField + " " + sortDirection;
+                if (!sortField.equals("e.created")) {
+                    result += ", e.created DESC";
+                }
+                return Optional.of(result);
             } else {
                 return Optional.empty();
             }
         }
     }
 
-    private Uni<List<UUID>> getEventIds(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
-                                        LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<Boolean> invocationResults,
-                                        Integer limit, Integer offset, Optional<String> orderByCondition) {
-        return sessionFactory.withSession(session -> {
-            String hql = "SELECT e.id FROM Event e JOIN e.eventType et JOIN et.application a JOIN a.bundle b " +
-                    "WHERE e.accountId = :accountId";
+    private Uni<List<Object[]>> getEventIdsAndCount(Mutiny.Session session, String accountId, Set<UUID> bundleIds, Set<UUID> appIds,
+                                                    String eventTypeDisplayName, LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes,
+                                                    Set<Boolean> invocationResults, Integer limit, Integer offset, String sortBy) {
 
-            hql = addHqlConditions(hql, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults);
+        String sql = "SELECT CAST(e.id AS VARCHAR), COUNT(*) OVER() FROM event e, event_type et, applications a, bundles b " +
+                "WHERE e.account_id = :accountId AND e.event_type_id = et.id AND et.application_id = a.id AND a.bundle_id = b.id";
 
-            if (orderByCondition.isPresent()) {
-                hql += orderByCondition.get();
-            }
+        sql = addSqlConditions(sql, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults);
 
-            Mutiny.Query<UUID> query = session.createQuery(hql, UUID.class);
-            setQueryParams(query, accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults);
+        Optional<String> orderByCondition = getOrderByCondition(sortBy, true);
+        if (orderByCondition.isPresent()) {
+            sql += orderByCondition.get();
+        }
 
-            if (limit != null) {
-                query.setMaxResults(limit);
-            }
-            if (offset != null) {
-                query.setFirstResult(offset);
-            }
+        Mutiny.Query<Object[]> query = session.createNativeQuery(sql);
+        setQueryParams(query, accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults);
 
-            return query.getResultList();
-        });
+        if (limit != null) {
+            query.setMaxResults(limit);
+        }
+        if (offset != null) {
+            query.setFirstResult(offset);
+        }
+
+        return query.getResultList();
     }
 
-    private static String addHqlConditions(String hql, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
+    private static String addSqlConditions(String sql, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                            LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<Boolean> invocationResults) {
         if (bundleIds != null && !bundleIds.isEmpty()) {
-            hql += " AND b.id IN (:bundleIds)";
+            sql += " AND b.id IN (:bundleIds)";
         }
         if (appIds != null && !appIds.isEmpty()) {
-            hql += " AND a.id IN (:appIds)";
+            sql += " AND a.id IN (:appIds)";
         }
         if (eventTypeDisplayName != null) {
-            hql += " AND LOWER(et.displayName) LIKE :eventTypeDisplayName";
+            sql += " AND LOWER(et.display_name) LIKE :eventTypeDisplayName";
         }
         if (startDate != null && endDate != null) {
-            hql += " AND DATE(e.created) BETWEEN :startDate AND :endDate";
+            sql += " AND DATE(e.created) BETWEEN :startDate AND :endDate";
         } else if (startDate != null) {
-            hql += " AND DATE(e.created) >= :startDate";
+            sql += " AND DATE(e.created) >= :startDate";
         } else if (endDate != null) {
-            hql += " AND DATE(e.created) <= :endDate";
+            sql += " AND DATE(e.created) <= :endDate";
         }
 
         boolean checkEndpointType = endpointTypes != null && !endpointTypes.isEmpty();
@@ -128,18 +161,17 @@ public class EventResources {
         if (checkEndpointType || checkInvocationResult) {
             List<String> subQueryConditions = new ArrayList<>();
             if (checkEndpointType) {
-                subQueryConditions.add("nh.endpointType IN (:endpointTypes)");
+                subQueryConditions.add("nh.endpoint_type IN (:endpointTypes)");
             }
             if (checkInvocationResult) {
-                subQueryConditions.add("nh.invocationResult IN (:invocationResults)");
+                subQueryConditions.add("nh.invocation_result IN (:invocationResults)");
             }
-            hql += " AND EXISTS (SELECT 1 FROM NotificationHistory nh WHERE nh.event = e AND " + String.join(" AND ", subQueryConditions) + ")";
+            sql += " AND EXISTS (SELECT 1 FROM notification_history nh WHERE nh.event_id = e.id AND " + String.join(" AND ", subQueryConditions) + ")";
         }
-
-        return hql;
+        return sql;
     }
 
-    private static void setQueryParams(Mutiny.Query<?> query, String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeName,
+    private static void setQueryParams(Mutiny.Query<?> query, String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                        LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<Boolean> invocationResults) {
         query.setParameter("accountId", accountId);
         if (bundleIds != null && !bundleIds.isEmpty()) {
@@ -148,8 +180,8 @@ public class EventResources {
         if (appIds != null && !appIds.isEmpty()) {
             query.setParameter("appIds", appIds);
         }
-        if (eventTypeName != null) {
-            query.setParameter("eventTypeDisplayName", "%" + eventTypeName.toLowerCase() + "%");
+        if (eventTypeDisplayName != null) {
+            query.setParameter("eventTypeDisplayName", "%" + eventTypeDisplayName.toLowerCase() + "%");
         }
         if (startDate != null) {
             query.setParameter("startDate", startDate);
@@ -158,25 +190,69 @@ public class EventResources {
             query.setParameter("endDate", endDate);
         }
         if (endpointTypes != null && !endpointTypes.isEmpty()) {
-            query.setParameter("endpointTypes", endpointTypes);
+            query.setParameter("endpointTypes", endpointTypes.stream().map(EndpointType::ordinal).collect(Collectors.toSet()));
         }
         if (invocationResults != null && !invocationResults.isEmpty()) {
             query.setParameter("invocationResults", invocationResults);
         }
     }
 
-    private static String getSortField(String field) {
+    private static String getSortField(String field, boolean nativeQuery) {
         switch (field) {
             case "bundle":
-                return "b.displayName";
+                return nativeQuery ? "b.display_name" : "b.displayName";
             case "application":
-                return "a.displayName";
+                return nativeQuery ? "a.display_name" : "a.displayName";
             case "event":
-                return "et.displayName";
+                return nativeQuery ? "et.display_name" : "et.displayName";
             case "created":
                 return "e.created";
             default:
                 throw new IllegalArgumentException("Unknown sort field: " + field);
         }
+    }
+
+    private static List<UUID> parseEventIds(List<Object[]> records) {
+        List<UUID> result = new ArrayList<>();
+        for (Object[] record : records) {
+            result.add(UUID.fromString((String) record[0]));
+        }
+        return result;
+    }
+
+    private static EventLogEntry buildEventLogEntry(UUID id, LocalDateTime created, String bundle, String app, String eventType, String payload, List<EventLogEntryAction> actions) {
+        EventLogEntry entry = new EventLogEntry();
+        entry.setId(id);
+        entry.setCreated(created);
+        entry.setBundle(bundle);
+        entry.setApplication(app);
+        entry.setEventType(eventType);
+        entry.setActions(actions);
+        entry.setPayload(payload);
+        return entry;
+    }
+
+    private static EventLogEntryAction buildEventLogEntryAction(UUID id, UUID endpointId, EndpointType endpointType, String endpointSubType, Boolean invocationResult, Map<String, Object> details) {
+        EventLogEntryAction action = new EventLogEntryAction();
+        action.setId(id);
+        action.setEndpointId(endpointId);
+        action.setEndpointType(endpointType);
+        action.setEndpointSubType(endpointSubType);
+        action.setInvocationResult(invocationResult);
+        action.setDetails(details);
+        return action;
+    }
+
+    private static Page<EventLogEntry> buildPage(List<EventLogEntry> events, long count, long limit, long offset) {
+        Meta meta = new Meta();
+        meta.setCount(count);
+
+        Map<String, String> links = PageLinksBuilder.build(PATH, count, limit, offset);
+
+        Page<EventLogEntry> page = new Page<>();
+        page.setData(events);
+        page.setMeta(meta);
+        page.setLinks(links);
+        return page;
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
@@ -212,6 +212,11 @@ public class EventResources {
         }
     }
 
+    /*
+     * Each entry of the 'records' arg contains two values:
+     * - records[0]: an eventId
+     * - records[1]: the total count of events (that value is identical for all records)
+     */
     private static List<UUID> parseEventIds(List<Object[]> records) {
         List<UUID> result = new ArrayList<>();
         for (Object[] record : records) {


### PR DESCRIPTION
This PR is based on the results from the analysis described in [NOTIF-491](https://issues.redhat.com/browse/NOTIF-491).

Postgre's `EXPLAIN ANALYZE` showed that half of the DB time was spent retrieving the events identifiers and the other half was spent counting the events. This PR merges these two operations into a single one, thanks to Postgre's `COUNT(*) OVER()` [window function](https://www.postgresql.org/docs/13/tutorial-window.html). When used in a limited query, that function returns the total count of records that would have been returned without the limit.

Hopefully, this will have some kind of impact on prod...