### PR TITLE
NOTIF-491 Return events actions on demand

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
@@ -28,14 +28,14 @@ public class EventResources {
 
     public Uni<List<Event>> getEvents(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<Boolean> invocationResults,
-                                      Integer limit, Integer offset, String sortBy) {
+                                      boolean fetchNotificationHistory, Integer limit, Integer offset, String sortBy) {
         return sessionFactory.withSession(session -> {
             Optional<String> orderByCondition = getOrderByCondition(sortBy);
             return getEventIds(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults, limit, offset, orderByCondition)
                     .onItem().transformToUni(eventIds -> {
-                        String hql = "SELECT DISTINCT e FROM Event e " +
+                        String hql = "SELECT " + (fetchNotificationHistory ? "DISTINCT " : "") + "e FROM Event e " +
                                 "JOIN FETCH e.eventType et JOIN FETCH et.application a JOIN FETCH a.bundle b " +
-                                "LEFT JOIN FETCH e.historyEntries he " +
+                                (fetchNotificationHistory ? "LEFT JOIN FETCH e.historyEntries he " : "") +
                                 "WHERE e.accountId = :accountId AND e.id IN (:eventIds)";
 
                         if (orderByCondition.isPresent()) {


### PR DESCRIPTION
This is a new attempt at improving the response time of the `GET /events` endpoint.

Last week, we deployed on stage a version with modified SQL queries (#987) but the results were really bad so that PR was reverted.

Log entries showed that we spend a significant amount of time outside of Postgres, so I am now focusing on Jackson's serialization time. Since we return the events and their actions in a single response, the important data volume could cause a slow serialization.

Depending on the results of this PR, we may split the `/events` endpoint into two endpoints:
- one would still return the events **_without_** the actions
- the other one would take an events identifiers list and return the corresponding actions