### PR TITLE
NOTIF-491 Allow index-only scan in the events table

### DIFF
--- a/database/src/main/resources/db/migration/V1.40.0__events_order_by_indexes.sql
+++ b/database/src/main/resources/db/migration/V1.40.0__events_order_by_indexes.sql
@@ -1,0 +1,12 @@
+-- This changes the following indexes scan type from 'Bitmap Index Scan' to 'Index Only Scan' which should be much
+-- faster as Postgre won't need to check for dead tuples before returning the result.
+
+DROP index ix_event_account_id_created_asc;
+
+CREATE INDEX ix_event_service_index_only_scan_asc
+    ON event (account_id, created, event_type_id, id);
+
+DROP index ix_event_account_id_created_desc;
+
+CREATE INDEX ix_event_service_index_only_scan_desc
+    ON event (account_id, created DESC, event_type_id, id);


### PR DESCRIPTION
This PR takes advantage of [Postgres' index-only scans](https://www.postgresql.org/docs/13/indexes-index-only-scans.html) for the `event` table.

When all columns (selected or filtered on) from a query are available in the index, Postgres can return a result without using the indexed table at all. Otherwise, Postgres first identifies candidate rows in the index, then checks if they are still alive and finally retrieves the data from the indexed table.