### PR TITLE
NOTIF-491 Remove duplicate DB health check

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/HealthCheckTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/HealthCheckTest.java
@@ -3,6 +3,8 @@ package com.redhat.cloud.notifications.routers;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
+import java.util.regex.Pattern;
+
 import static io.restassured.RestAssured.when;
 import static io.restassured.RestAssured.with;
 import static io.restassured.http.ContentType.TEXT;
@@ -15,6 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @QuarkusTest
 public class HealthCheckTest {
+
+    private static final Pattern PATTERN = Pattern.compile("\"name\": \"Reactive PostgreSQL connections health check\",\\R[ ]+\"status\": \"UP\"");
 
     @Test
     void testNormalHealth() {
@@ -67,7 +71,7 @@ public class HealthCheckTest {
     void testRepeatedHealth() {
         for (int i = 0; i < 150; i++) {
             String body = normalHealthCheck();
-            assertTrue(body.contains("\"reactive-db-check\": true"));
+            assertTrue(PATTERN.matcher(body).find());
         }
     }
 }


### PR DESCRIPTION
`SELECT * FROM pg_stat_activity` shows that 6 `SELECT 1` queries are executed each second on stage. This puts a lot of pressure on the datasource connection pool for nothing.

Our query isn't needed because Quarkus already runs it. Removing it will decrease the number from 6 to 3 on stage.

~The 6 queries on stage come from 3 different IP addresses. We could try to understand why 3 machines are calling our `/health` each second, but that will be for another time.~ That's actually one query per replica which is totally normal 😄 