### PR TITLE
NOTIF-491 Change events purge and vacuum strategy

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -94,10 +94,14 @@ objects:
     name: notifications-db-cleaner-config
   data:
     clean.sh: |
-      cat /notifications-db-cleaner/clean.sql | psql > /dev/null
+      cat /notifications-db-cleaner/clean.sql | psql
     clean.sql: |
+      \timing
       CALL cleanEventLog();
+      VACUUM event;
+      VACUUM notification_history;
       CALL cleanKafkaMessagesIds();
+      VACUUM kafka_message;
 - apiVersion: batch/v1
   kind: CronJob
   metadata:
@@ -160,7 +164,7 @@ parameters:
   value: 500m
 - name: DB_CLEANER_SCHEDULE
   description: Execution time specified in cron format
-  value: "*/10 * * * *"
+  value: "0 1 * * *"
 - name: DB_NAME
   description: Database name used by the notifications-db-cleaner CronJob
   value: notifications_backend

--- a/database/src/main/resources/db/migration/V1.41.0__NOTIF-491_autovacuum_settings.sql
+++ b/database/src/main/resources/db/migration/V1.41.0__NOTIF-491_autovacuum_settings.sql
@@ -1,0 +1,5 @@
+-- We no longer need Postgres to run the VACUUM operation automatically on the 'event' and 'notification_history' tables
+-- because we are now running a manual VACUUM ANALYZE during the DB cleaning cron job execution.
+
+ALTER TABLE event RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_threshold);
+ALTER TABLE notification_history RESET (autovacuum_vacuum_scale_factor, autovacuum_vacuum_threshold);

--- a/database/src/main/resources/db/migration/V1.42.0__NOTIF-491_initial_manual_vacuum.sql
+++ b/database/src/main/resources/db/migration/V1.42.0__NOTIF-491_initial_manual_vacuum.sql
@@ -1,0 +1,6 @@
+-- This script should allow Postgres to run index-only scans on the following tables immediately, without waiting for
+-- the next DB cleaning cron job execution.
+
+VACUUM ANALYZE event;
+VACUUM ANALYZE notification_history;
+VACUUM ANALYZE kafka_message;


### PR DESCRIPTION
The following results from the investigation conducted with `gabi` on stage.

`EXPLAIN ANALYZE` on the `COUNT(*)` query from the `/events` endpoint showed that Postgres is sometimes unable to perform [index-only scans](https://www.postgresql.org/docs/13/indexes-index-only-scans.html) during that query because it has to fetch records that have been deleted by the DB cleaning cron job.

```
EXPLAIN ANALYZE SELECT COUNT(*) FROM event e...
[...]
        ->  Index Only Scan using ix_event_service_index_only_scan_desc on event e  (cost=0.42..8138.76 rows=31651 width=16) (actual time=16.074..26.006 rows=3446 loops=11)
              Index Cond: ((account_id = 'HIDDEN'::text) AND (created >= '2022-02-03 00:00:00'::timestamp without time zone) AND (created <= '2022-02-10 00:00:00'::timestamp without time zone) AND (event_type_id = et.id))
              Heap Fetches: 51"
[...]
```

Queries on the `pg_locks` table also showed that Postgres locks the `event` table with an `AccessShareLock` when it has to fetch records during a `COUNT(*)`.

The idea of this PR is to synchronize the `event` purge with the `VACUUM` operation so that Postgres will never have to fetch any `event` record while running `COUNT(*)`. That way, Postgres should always use index-only scans and execute the query at maximum speed.