### PR TITLE
RHICOMPL-2722 consume action.events instead of action.context

### DIFF
--- a/engine/src/main/resources/templates/Compliance/complianceBelowThresholdEmailBody.html
+++ b/engine/src/main/resources/templates/Compliance/complianceBelowThresholdEmailBody.html
@@ -35,10 +35,10 @@
                         <!-- Hi {{user.first_name}},
                         <br>
                         <br> -->
-                        Your system, <a class="rh-url" href="https://console.redhat.com/insights/compliance/systems/{action.context.host_id}"><b>{action.context.host_name}</b></a>, assigned to policy <a class="rh-url" href="https://console.redhat.com/insights/compliance/scappolicies/{action.context.policy_id}"><b>{action.context.policy_name}</b></a>, has been marked as non-compliant because its compliance score {action.context.compliance_score} dropped below the configured compliance threshold of {action.context.policy_threshold} for this policy.
+                        Your system, <a class="rh-url" href="https://console.redhat.com/insights/compliance/systems/{action.events[0].payload.host_id}"><b>{action.events[0].payload.host_name}</b></a>, assigned to policy <a class="rh-url" href="https://console.redhat.com/insights/compliance/scappolicies/{action.events[0].payload.policy_id}"><b>{action.events[0].payload.policy_name}</b></a>, has been marked as non-compliant because its compliance score {action.evemts[0].payload.compliance_score} dropped below the configured compliance threshold of {action.events[0].payload.policy_threshold} for this policy.
                     </p>
                     <p>
-                        Please review the <a class="rh-url" href="https://console.redhat.com/insights/compliance/reports/{action.context.policy_id}">detailed policy report for this system</a> and take the appropriate steps to bring this system into compliance. For additional details on how to  remediate compliance issues, learn more <a class="rh-url" href="https://access.redhat.com/documentation/en-us/red_hat_insights/2021/html/remediating_security-policy_compliance_issues_using_ansible_playbooks/index"><b>here</b></a>.
+                        Please review the <a class="rh-url" href="https://console.redhat.com/insights/compliance/reports/{action.events[0].payload.policy_id}">detailed policy report for this system</a> and take the appropriate steps to bring this system into compliance. For additional details on how to  remediate compliance issues, learn more <a class="rh-url" href="https://access.redhat.com/documentation/en-us/red_hat_insights/2021/html/remediating_security-policy_compliance_issues_using_ansible_playbooks/index"><b>here</b></a>.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Compliance/complianceBelowThresholdEmailTitle.txt
+++ b/engine/src/main/resources/templates/Compliance/complianceBelowThresholdEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.timestamp.toUtcFormat()} - System '{action.context.host_name}' is non-compliant with policy '{action.context.policy_name}'
+{action.timestamp.toUtcFormat()} - System '{action.events[0].payload.host_name}' is non-compliant with policy '{action.events[0].payload.policy_name}'

--- a/engine/src/main/resources/templates/Compliance/reportUploadFailedEmailBody.html
+++ b/engine/src/main/resources/templates/Compliance/reportUploadFailedEmailBody.html
@@ -35,9 +35,9 @@
                         <!-- Hi {{user.first_name}},
                         <br>
                         <br> -->
-                        Your system <a class="rh-url" href="https://console.redhat.com/insights/compliance/systems/{action.context.host_id}"><b>{action.context.host_name}</b></a>, assigned to policy <a class="rh-url" href="https://console.redhat.com/insights/compliance/scappolicies/{action.context.policy_id}"><b>{action.context.policy_name}</b></a> failed to upload a new compliance report. The error message returned by our system was:<br>
+                        Your system <a class="rh-url" href="https://console.redhat.com/insights/compliance/systems/{action.events[0].payload.host_id}"><b>{action.events[0].payload.host_name}</b></a>, assigned to policy <a class="rh-url" href="https://console.redhat.com/insights/compliance/scappolicies/{action.events[0].payload.policy_id}"><b>{action.events[0].payload.policy_name}</b></a> failed to upload a new compliance report. The error message returned by our system was:<br>
 
-                        <i>{ action.context.error_message }</i>
+                        <i>{ action.events[0].payload.error_message }</i>
                     </p>
                     <p>
                         To learn more about why reports can fail to upload and how to address this, refer to this <a class="rh-url" href="https://access.redhat.com/solutions/6675911">KCS article</a>.

--- a/engine/src/main/resources/templates/Compliance/reportUploadFailedEmailTitle.txt
+++ b/engine/src/main/resources/templates/Compliance/reportUploadFailedEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.timestamp.toUtcFormat()} - Failed to upload report of Policy '{action.context.policy_name}' from system '{action.context.host_name}'
+{action.timestamp.toUtcFormat()} - Failed to upload report of Policy '{action.events[0].payload.policy_name}' from system '{action.events[0].payload.host_name}'


### PR DESCRIPTION
I'm not entirely sure if something like this would work, but I was told that I should pass data through the payload as it's semantically more correct than using the context for everything. For these specific templates we would always have just a single event, so the question is if the template would be consumed this way or not.