### PR TITLE
NOTIF-491 Denormalize events

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -72,6 +72,8 @@ objects:
               optional: true
         - name: NOTIFICATIONS_EVENT_SERVICE_LEGACY_MODE
           value: ${NOTIFICATIONS_EVENT_SERVICE_LEGACY_MODE}
+        - name: NOTIFICATIONS_EVENT_SERVICE_USE_DENORMALIZED_EVENTS
+          value: ${NOTIFICATIONS_EVENT_SERVICE_USE_DENORMALIZED_EVENTS}
         - name: RBAC_AUTHENTICATION_MP_REST_READTIMEOUT
           value: ${RBAC_AUTHENTICATION_READ_TIMEOUT}
         - name: QUARKUS_HTTP_PORT
@@ -199,6 +201,9 @@ parameters:
 - name: NOTIFICATIONS_EVENT_SERVICE_LEGACY_MODE
   description: Temp param used to test an /events response time improvement attempt on stage
   value: "true"
+- name: NOTIFICATIONS_EVENT_SERVICE_USE_DENORMALIZED_EVENTS
+  description: Temp param used to test another /events response time improvement attempt on stage
+  value: "false"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
   value: INFO

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/DenormalizedEventsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/DenormalizedEventsMigrationService.java
@@ -1,0 +1,29 @@
+package com.redhat.cloud.notifications.db;
+
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+// TODO NOTIF-491 Delete this class when the migration is complete.
+@Path("/internal/denormalizedEvents/migrate")
+public class DenormalizedEventsMigrationService {
+
+    @Inject
+    Mutiny.SessionFactory sessionFactory;
+
+    @GET
+    public Uni<Integer> migrate() {
+        return sessionFactory.withTransaction((session, transaction) -> {
+            // This query may take a very long time to run, which is why it won't be run at server startup.
+            String hql = "UPDATE event e " +
+                    "SET bundle_id = b.id, bundle_display_name = b.display_name, application_id = a.id, application_display_name = a.display_name, event_type_display_name = et.display_name " +
+                    "FROM event_type et, applications a, bundles b " +
+                    "WHERE e.bundle_id IS NULL AND e.event_type_id = et.id AND et.application_id = a.id AND a.bundle_id = b.id";
+            return session.createNativeQuery(hql)
+                    .executeUpdate();
+        });
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
@@ -539,7 +539,12 @@ public class EventServiceTest extends DbIsolatedTest {
     private Uni<Event> createEvent(String accountId, EventType eventType, LocalDateTime created) {
         Event event = new Event();
         event.setAccountId(accountId);
+        event.setBundleId(eventType.getApplication().getBundle().getId());
+        event.setBundleDisplayName(eventType.getApplication().getBundle().getDisplayName());
+        event.setApplicationId(eventType.getApplication().getId());
+        event.setApplicationDisplayName(eventType.getApplication().getDisplayName());
         event.setEventType(eventType);
+        event.setEventTypeDisplayName(eventType.getDisplayName());
         event.setCreated(created);
         event.setPayload(PAYLOAD);
         return sessionFactory.withStatelessSession(statelessSession -> statelessSession.insert(event)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventServiceTest.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.MockServerClientConfig.RbacAccess;
 import static com.redhat.cloud.notifications.MockServerClientConfig.RbacAccess.FULL_ACCESS;
 import static com.redhat.cloud.notifications.MockServerClientConfig.RbacAccess.NOTIFICATIONS_ACCESS_ONLY;
@@ -469,7 +470,16 @@ public class EventServiceTest extends DbIsolatedTest {
                 .chain(runOnWorkerThread(() -> {
                     // TODO Temp test, remove ASAP
                     System.setProperty("notifications.event-service.legacy-mode", "false");
-                    return getEventLogPage(defaultIdentityHeader, null, null, null, null, null, null, null, null, null, null, false);
+                    getEventLogPage(defaultIdentityHeader, null, null, null, null, null, null, null, null, null, null, false);
+                    System.setProperty("notifications.event-service.legacy-mode", "true");
+                    given()
+                            .basePath(API_INTERNAL)
+                            .when()
+                            .get("/denormalizedEvents/migrate")
+                            .then()
+                            .statusCode(200);
+                    System.setProperty("notifications.event-service.use-denormalized-events", "true");
+                    getEventLogPage(defaultIdentityHeader, Set.of(model.bundles.get(1).getId()), Set.of(model.applications.get(1).getId()), model.eventTypes.get(1).getDisplayName(), NOW.minusDays(3L), NOW.minusDays(1L), Set.of(EMAIL_SUBSCRIPTION), Set.of(TRUE), 10, 0, "created:desc", true);
                 }))
         ).await().indefinitely();
     }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static javax.persistence.CascadeType.REMOVE;
+import static javax.persistence.FetchType.LAZY;
 
 @Entity
 @Table(name = "event")
@@ -45,7 +46,7 @@ public class Event extends CreationTimestamped {
     private String applicationDisplayName;
 
     @NotNull
-    @ManyToOne(optional = false)
+    @ManyToOne(fetch = LAZY, optional = false)
     @JoinColumn(name = "event_type_id")
     private EventType eventType;
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
@@ -30,10 +30,28 @@ public class Event extends CreationTimestamped {
     @Size(max = 50)
     private String accountId;
 
+    // TODO NOTIF-491 Make this field not nullable here and in the DB after the data migration.
+    private UUID bundleId;
+
+    // TODO NOTIF-491 Make this field not nullable here and in the DB after the data migration.
+    // TODO NOTIF-491 Should we update this if the bundle is updated?
+    private String bundleDisplayName;
+
+    // TODO NOTIF-491 Make this field not nullable here and in the DB after the data migration.
+    private UUID applicationId;
+
+    // TODO NOTIF-491 Make this field not nullable here and in the DB after the data migration.
+    // TODO NOTIF-491 Should we update this if the application is updated?
+    private String applicationDisplayName;
+
     @NotNull
     @ManyToOne(optional = false)
     @JoinColumn(name = "event_type_id")
     private EventType eventType;
+
+    // TODO NOTIF-491 Make this field not nullable here and in the DB after the data migration.
+    // TODO NOTIF-491 Should we update this if the event type is updated?
+    private String eventTypeDisplayName;
 
     @OneToMany(mappedBy = "event", cascade = REMOVE)
     Set<NotificationHistory> historyEntries;
@@ -50,6 +68,11 @@ public class Event extends CreationTimestamped {
         this.eventType = eventType;
         this.payload = payload;
         this.action = action;
+        bundleId = eventType.getApplication().getBundle().getId();
+        bundleDisplayName = eventType.getApplication().getBundle().getDisplayName();
+        applicationId = eventType.getApplication().getId();
+        applicationDisplayName = eventType.getApplication().getDisplayName();
+        eventTypeDisplayName = eventType.getDisplayName();
     }
 
     public UUID getId() {
@@ -68,12 +91,52 @@ public class Event extends CreationTimestamped {
         this.accountId = accountId;
     }
 
+    public UUID getBundleId() {
+        return bundleId;
+    }
+
+    public void setBundleId(UUID bundleId) {
+        this.bundleId = bundleId;
+    }
+
+    public String getBundleDisplayName() {
+        return bundleDisplayName;
+    }
+
+    public void setBundleDisplayName(String bundleDisplayName) {
+        this.bundleDisplayName = bundleDisplayName;
+    }
+
+    public UUID getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(UUID applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getApplicationDisplayName() {
+        return applicationDisplayName;
+    }
+
+    public void setApplicationDisplayName(String applicationDisplayName) {
+        this.applicationDisplayName = applicationDisplayName;
+    }
+
     public EventType getEventType() {
         return eventType;
     }
 
     public void setEventType(EventType eventType) {
         this.eventType = eventType;
+    }
+
+    public String getEventTypeDisplayName() {
+        return eventTypeDisplayName;
+    }
+
+    public void setEventTypeDisplayName(String eventTypeDisplayName) {
+        this.eventTypeDisplayName = eventTypeDisplayName;
     }
 
     public Set<NotificationHistory> getHistoryEntries() {

--- a/database/src/main/resources/db/migration/V1.43.0__NOTIF-491_denormalize_events.sql
+++ b/database/src/main/resources/db/migration/V1.43.0__NOTIF-491_denormalize_events.sql
@@ -1,0 +1,10 @@
+ALTER TABLE event
+    ADD COLUMN bundle_id UUID,
+    ADD COLUMN bundle_display_name VARCHAR,
+    ADD COLUMN application_id UUID,
+    ADD COLUMN application_display_name VARCHAR,
+    ADD COLUMN event_type_display_name VARCHAR,
+    ADD CONSTRAINT fk_event_bundle_id FOREIGN KEY (bundle_id) REFERENCES bundles (id) ON DELETE CASCADE,
+    ADD CONSTRAINT fk_event_application_id FOREIGN KEY (application_id) REFERENCES applications (id) ON DELETE CASCADE;
+
+CREATE INDEX ix_event_index_only_scan ON event (account_id, bundle_id, application_id, event_type_display_name, created DESC, id);

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EventTypeRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EventTypeRepository.java
@@ -14,7 +14,8 @@ public class EventTypeRepository {
     Mutiny.SessionFactory sessionFactory;
 
     public Uni<EventType> getEventType(String bundleName, String applicationName, String eventTypeName) {
-        final String query = "FROM EventType WHERE name = :eventTypeName AND application.name = :applicationName AND application.bundle.name = :bundleName";
+        String query = "FROM EventType e JOIN FETCH e.application a JOIN FETCH a.bundle b " +
+                "WHERE e.name = :eventTypeName AND a.name = :applicationName AND b.name = :bundleName";
         return sessionFactory.withStatelessSession(statelessSession -> {
             return statelessSession.createQuery(query, EventType.class)
                     .setParameter("bundleName", bundleName)

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -6,6 +6,8 @@ import com.redhat.cloud.notifications.db.repositories.EventRepository;
 import com.redhat.cloud.notifications.db.repositories.EventTypeRepository;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -277,7 +279,16 @@ public class EventConsumerTest {
     }
 
     private EventType mockGetEventTypeAndCreateEvent() {
+        Bundle bundle = new Bundle();
+        bundle.setDisplayName("Bundle");
+
+        Application app = new Application();
+        app.setDisplayName("Application");
+        app.setBundle(bundle);
+
         EventType eventType = new EventType();
+        eventType.setDisplayName("Event type");
+        eventType.setApplication(app);
         when(eventTypeRepository.getEventType(eq(BUNDLE), eq(APP), eq(EVENT_TYPE))).thenReturn(
                 Uni.createFrom().item(eventType)
         );


### PR DESCRIPTION
This PR adds a new (and disabled by default) way to retrieve the events data from the DB. The `event` table now contains denormalized data that can be used to answer to `GET /events` requests.

If `notifications.event-service.use-denormalized-events` is `true`, then the denormalized data will be used. Otherwise, the old normalized data will be used.

A data migration is required for the events that already exist in the DB. I expect it to be quite long which is why I didn't put that migration in a Flyway script. It will be run from an internal REST request instead.

Both the PR and the data migration can be easily reverted in case something goes wrong or if the performance impact isn't good enough.

@josejulio Let's try this on stage 😃 