### PR TITLE
NOTIF-491 Remove date conversion function in SQL queries

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/EventResources.java
@@ -8,7 +8,9 @@ import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -125,11 +127,11 @@ public class EventResources {
             hql += " AND LOWER(et.displayName) LIKE :eventTypeDisplayName";
         }
         if (startDate != null && endDate != null) {
-            hql += " AND DATE(e.created) BETWEEN :startDate AND :endDate";
+            hql += " AND e.created BETWEEN :startDate AND :endDate";
         } else if (startDate != null) {
-            hql += " AND DATE(e.created) >= :startDate";
+            hql += " AND e.created >= :startDate";
         } else if (endDate != null) {
-            hql += " AND DATE(e.created) <= :endDate";
+            hql += " AND e.created <= :endDate";
         }
 
         boolean checkEndpointType = endpointTypes != null && !endpointTypes.isEmpty();
@@ -161,10 +163,10 @@ public class EventResources {
             query.setParameter("eventTypeDisplayName", "%" + eventTypeName.toLowerCase() + "%");
         }
         if (startDate != null) {
-            query.setParameter("startDate", startDate);
+            query.setParameter("startDate", Timestamp.valueOf(startDate.atStartOfDay()));
         }
         if (endDate != null) {
-            query.setParameter("endDate", endDate);
+            query.setParameter("endDate", Timestamp.valueOf(endDate.atTime(LocalTime.MAX))); // at end of day
         }
         if (endpointTypes != null && !endpointTypes.isEmpty()) {
             query.setParameter("endpointTypes", endpointTypes);

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
@@ -8,23 +8,29 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
+import static java.time.ZoneOffset.UTC;
 import static javax.persistence.CascadeType.REMOVE;
 
 @Entity
 @Table(name = "event")
-public class Event extends CreationTimestamped {
+public class Event {
 
     @Id
     @GeneratedValue
     private UUID id;
+
+    private Timestamp created;
 
     @NotNull
     @Size(max = 50)
@@ -58,6 +64,19 @@ public class Event extends CreationTimestamped {
 
     public void setId(UUID id) {
         this.id = id;
+    }
+
+    public LocalDateTime getCreated() {
+        return created.toLocalDateTime();
+    }
+
+    public void setCreated(LocalDateTime created) {
+        this.created = Timestamp.valueOf(created);
+    }
+
+    @PrePersist
+    public void prePersist() {
+        created = Timestamp.valueOf(LocalDateTime.now(UTC));
     }
 
     public String getAccountId() {


### PR DESCRIPTION
I just realized we could get rid of the `DATE()` function is `/events` SQL queries. That function is slowing things down so it's better if we remove it.