### PR TITLE
Revert back to user and password being null

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthentication.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthentication.java
@@ -1,12 +1,9 @@
 package com.redhat.cloud.notifications.models;
 
-import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
 public class BasicAuthentication {
-    @NotNull
     private String username;
-    @NotNull
     private String password;
 
     public BasicAuthentication() { }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -93,7 +93,7 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
         }
 
         BasicAuthentication basicAuthentication = properties.getBasicAuthentication();
-        if (basicAuthentication != null) {
+        if (basicAuthentication != null && basicAuthentication.getUsername() != null && basicAuthentication.getPassword() != null) {
             StringBuilder sb = new StringBuilder(basicAuthentication.getUsername());
             sb.append(":");
             sb.append(basicAuthentication.getPassword());


### PR DESCRIPTION
Fixes the issue seen when loading splunk types.

The validation allowed it to be null/undefined, and even when it was null, these 2 fields were being populated as null.
There is no need to deploy this one to fix the issue, the UI already has the types from this code.

Related:  https://github.com/RedHatInsights/notifications-frontend/pull/238