### PR TITLE
Increase backend probes initial delay

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -46,21 +46,21 @@ objects:
             path: /health/ready
             port: 8000
             scheme: HTTP
-          initialDelaySeconds: 40
+          initialDelaySeconds: 120
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 10
         livenessProbe:
           httpGet:
             path: /health/live
             port: 8000
             scheme: HTTP
-          initialDelaySeconds: 40
+          initialDelaySeconds: 120
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 10
         env:
         - name: ENV_NAME
           value: ${ENV_NAME}


### PR DESCRIPTION
Temporary commit.

The pod is killed on prod before it's done migrating the DB.