### PR TITLE
Revert "Increase backend probes initial delay (#1013)"

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -46,21 +46,21 @@ objects:
             path: /health/ready
             port: 8000
             scheme: HTTP
-          initialDelaySeconds: 120
+          initialDelaySeconds: 40
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 10
+          failureThreshold: 3
         livenessProbe:
           httpGet:
             path: /health/live
             port: 8000
             scheme: HTTP
-          initialDelaySeconds: 120
+          initialDelaySeconds: 40
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 10
+          failureThreshold: 3
         env:
         - name: ENV_NAME
           value: ${ENV_NAME}


### PR DESCRIPTION
Prod has been deployed. We can go back to the old probes values.