### PR TITLE
Increase backend PR check timeout

### DIFF
--- a/.rhcicd/pr_check_backend.sh
+++ b/.rhcicd/pr_check_backend.sh
@@ -4,7 +4,7 @@
 export APP_NAME="notifications"
 export COMPONENT_NAME="notifications-backend"
 export IMAGE="quay.io/cloudservices/notifications-backend"
-export DEPLOY_TIMEOUT="600"
+export DEPLOY_TIMEOUT="900"
 
 # IQE plugin config
 export IQE_PLUGINS="notifications"


### PR DESCRIPTION
The number of our ClowdApp transitive dependencies keeps increasing and with it the time required for a full deployment on ephemeral. This should fix the timeouts during PR checks.