### PR TITLE
NOTIF-488 Add @Blocking to RBAC rest client methods

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacServiceToService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacServiceToService.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.recipients.rbac;
 
 import com.redhat.cloud.notifications.routers.models.Page;
+import io.smallrye.common.annotation.Blocking;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -21,6 +22,7 @@ public interface RbacServiceToService {
     @GET
     @Path("/principals/") // trailing slash is required by api
     @Produces(MediaType.APPLICATION_JSON)
+    @Blocking
     Page<RbacUser> getUsers(
             @HeaderParam("x-rh-rbac-account") String accountId,
             @QueryParam("admin_only") Boolean adminOnly,
@@ -31,6 +33,7 @@ public interface RbacServiceToService {
     @GET
     @Path("/groups/") // trailing slash is required by api
     @Produces(MediaType.APPLICATION_JSON)
+    @Blocking
     Page<RbacGroup> getGroups(
             @HeaderParam("x-rh-rbac-account") String accountId,
             @QueryParam("offset") Integer offset,
@@ -40,15 +43,16 @@ public interface RbacServiceToService {
     @GET
     @Path("/groups/{groupId}/") // trailing slash is required by api
     @Produces(MediaType.APPLICATION_JSON)
+    @Blocking
     RbacGroup getGroup(
             @HeaderParam("x-rh-rbac-account") String accountId,
             @PathParam("groupId") UUID groupId
     );
 
-
     @GET
     @Path("/groups/{groupId}/principals/") // trailing slash is required by api
     @Produces(MediaType.APPLICATION_JSON)
+    @Blocking
     Page<RbacUser> getGroupUsers(
             @HeaderParam("x-rh-rbac-account") String accountId,
             @PathParam("groupId") UUID groupId,


### PR DESCRIPTION
Stage is broken because of a `BlockingNotAllowedException` when the RBAC rest client is invoked.