### PR TITLE
NOTIF-488 Make the aggregation purge query transactional

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepository.java
@@ -7,6 +7,7 @@ import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -40,6 +41,7 @@ public class EmailAggregationRepository {
                 .getResultList();
     }
 
+    @Transactional
     public int purgeOldAggregation(EmailAggregationKey key, LocalDateTime lastUsedTime) {
         String query = "DELETE FROM EmailAggregation WHERE accountId = :accountId AND bundleName = :bundleName AND applicationName = :applicationName AND created <= :created";
         return statelessSessionFactory.getCurrentSession().createQuery(query)

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepositoryTest.java
@@ -73,7 +73,7 @@ public class EmailAggregationRepositoryTest {
             assertEquals(BUNDLE_NAME, keys.get(0).getBundle());
             assertEquals(APP_NAME, keys.get(0).getApplication());
 
-            assertEquals(2, purgeOldAggregation(key, end));
+            assertEquals(2, emailAggregationRepository.purgeOldAggregation(key, end));
             assertEquals(0, emailAggregationRepository.getEmailAggregation(key, start, end).size());
             assertEquals(3, getApplicationsWithPendingAggregation(start, end).size());
 
@@ -98,11 +98,6 @@ public class EmailAggregationRepositoryTest {
                 .setParameter("start", start)
                 .setParameter("end", end)
                 .getResultList();
-    }
-
-    @Transactional
-    int purgeOldAggregation(EmailAggregationKey key, LocalDateTime lastUsedTime) {
-        return emailAggregationRepository.purgeOldAggregation(key, lastUsedTime);
     }
 
     @Transactional


### PR DESCRIPTION
This should fix the following issue on stage:
```
2022-03-09 05:00:15,579 INFO  [com.red.clo.not.pro.ema.EmailSubscriptionTypeProcessor] (vert.x-eventloop-thread-0) Error while processing aggregation: javax.persistence.TransactionRequiredException: Executing an update/delete query
	at org.hibernate.internal.AbstractSharedSessionContract.checkTransactionNeededForUpdateOperation(AbstractSharedSessionContract.java:431)
	at org.hibernate.query.internal.AbstractProducedQuery.executeUpdate(AbstractProducedQuery.java:1692)
	at com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository.purgeOldAggregation(EmailAggregationRepository.java:50)
```