### PR TITLE
NOTIF-488 Make all Kafka messages processing methods blocking

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/events/FromCamelHistoryFiller.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/FromCamelHistoryFiller.java
@@ -9,6 +9,7 @@ import com.redhat.cloud.notifications.ingress.Recipient;
 import com.redhat.cloud.notifications.models.Endpoint;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import io.vertx.core.json.Json;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -73,6 +74,7 @@ public class FromCamelHistoryFiller {
 
     @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
     @Incoming(FROMCAMEL_CHANNEL)
+    @Blocking
     public void processAsync(String payload) {
         try {
             log.infof("Processing return from camel: %s", payload);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -25,6 +25,7 @@ import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.qute.TemplateInstance;
+import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.vertx.core.json.JsonObject;
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -160,6 +161,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
 
     @Incoming(AGGREGATION_CHANNEL)
     @Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
+    @Blocking
     public void consumeEmailAggregations(String aggregationCommandJson) {
         AggregationCommand aggregationCommand;
         try {


### PR DESCRIPTION
#1033 fixed one issue and revealed another one:
```
2022-03-09 10:00:25,548 DEBUG [com.red.clo.not.pro.web.WebhookTypeProcessor] (vert.x-eventloop-thread-0) Failed: The current thread cannot be blocked: vert.x-eventloop-thread-0
2022-03-09 10:00:25,549 INFO [com.red.clo.not.pro.ema.EmailSubscriptionTypeProcessor] (vert.x-eventloop-thread-0) Error while processing aggregation: io.quarkus.runtime.BlockingOperationNotAllowedException: Cannot start a JTA transaction from the IO thread.
```