### PR TITLE
Bump mockserver-client-java to 5.13.0

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
 
     // Keep the version synced with pom.xml.
-    private static final DockerImageName MOCK_SERVER_DOCKER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.5.4");
+    private static final DockerImageName MOCK_SERVER_DOCKER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.13.0");
 
     PostgreSQLContainer<?> postgreSQLContainer;
     MockServerContainer mockEngineServer;

--- a/engine/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
@@ -7,9 +7,9 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,7 +25,7 @@ public class MicrometerAssertionHelper {
     @Inject
     MeterRegistry registry;
 
-    private final Map<String, Double> counterValuesBeforeTest = new HashMap<>();
+    private final Map<String, Double> counterValuesBeforeTest = new ConcurrentHashMap<>();
 
     public void saveCounterValuesBeforeTest(String... counterNames) {
         for (String counterName : counterNames) {

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -23,7 +23,7 @@ import static com.redhat.cloud.notifications.processors.email.EmailSubscriptionT
 public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
 
     // Keep the version synced with pom.xml.
-    private static final DockerImageName MOCK_SERVER_DOCKER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.5.4");
+    private static final DockerImageName MOCK_SERVER_DOCKER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.13.0");
 
     PostgreSQLContainer<?> postgreSQLContainer;
     MockServerContainer mockEngineServer;

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,7 @@
         <failsafe.version>3.2.3</failsafe.version>
 
         <!-- Keep the version synced with TestLifecycleManager -->
-        <!-- Be careful with bumps, version 5.11.2 caused tests instability so we had to rollback to 5.5.4 -->
-        <mockserver-client-java.version>5.5.4</mockserver-client-java.version>
+        <mockserver-client-java.version>5.13.0</mockserver-client-java.version>
 
         <insights-notification-schemas-java.version>0.6</insights-notification-schemas-java.version>
         <clowder-quarkus-config-source.version>1.0.0</clowder-quarkus-config-source.version>


### PR DESCRIPTION
`5.11.2` didn't work well but let's see how it goes with `5.12.0`.