### PR TITLE
Fix keystore location for MP rest-client

### DIFF
--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -75,7 +75,7 @@ rbac-s2s/mp-rest/readTimeout=120000
 # these entries are needed because of a bug in quarkus: https://github.com/quarkusio/quarkus/issues/8384
 com.redhat.cloud.notifications.recipients.itservice.ITUserService/mp-rest/url=${IT_S2S_MP_REST_URL}
 com.redhat.cloud.notifications.recipients.itservice.ITUserService/mp-rest/keyStoreType=${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE_TYPE}
-com.redhat.cloud.notifications.recipients.itservice.ITUserService/mp-rest/keyStore=classpath:${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE}
+com.redhat.cloud.notifications.recipients.itservice.ITUserService/mp-rest/keyStore=file:${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE}
 com.redhat.cloud.notifications.recipients.itservice.ITUserService/mp-rest/keyStorePassword=${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_PASSWORD}
 
 # Used for service to service communication


### PR DESCRIPTION
See [this](https://github.com/quarkusio/quarkus/blob/03746b894bcdf9b83f12c7ab77ebd4bc2c0d52ec/extensions/resteasy-reactive/rest-client-reactive/runtime/src/main/java/io/quarkus/rest/client/reactive/runtime/RestClientCDIDelegateBuilder.java#L219-L239).