### PR TITLE
NOTIF-510 begin UI mock for email templates

### DIFF
--- a/admin-console/src/main/webapp/src/pages/CreateEmailTemplatePage.tsx
+++ b/admin-console/src/main/webapp/src/pages/CreateEmailTemplatePage.tsx
@@ -1,0 +1,57 @@
+import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import { ActionGroup, Button, PageSection, Split, SplitItem, Title } from '@patternfly/react-core';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { linkTo } from '../Routes';
+
+export const CreateEmailTemplatePage: React.FunctionComponent = () => {
+    return (
+        <>
+
+            <PageSection>
+                <Split>
+                    <SplitItem isFilled>
+                        <Title headingLevel="h1">Create/Edit Email Template for $applicationDisplayName</Title>
+                    </SplitItem>
+                    <SplitItem>
+                        <Button variant="primary" component={ (props: any) =>
+                            <Link { ...props } to={ linkTo.application } /> } isDisabled={ true }>Go back</Button>
+                    </SplitItem>
+                </Split>
+            </PageSection>
+            <PageSection>
+                <Title headingLevel="h2">Title template</Title>
+                <CodeEditor
+                    isLineNumbersVisible
+                    height="50px"
+                />
+            </PageSection>
+            <PageSection>
+                <Title headingLevel="h2">Body template</Title>
+                <CodeEditor
+                    isLineNumbersVisible
+                    isMinimapVisible={ false }
+                    height="300px"
+                />
+            </PageSection>
+            <PageSection>
+                <Title headingLevel="h2">Payload</Title>
+                <CodeEditor
+                    isLineNumbersVisible
+                    height="100px"
+                    isLanguageLabelVisible
+                    language={ Language.json }
+                />
+            </PageSection>
+            <PageSection>
+                <ActionGroup>
+                    <Button variant='primary' type='submit' isDisabled={ true }>Save</Button>
+                    <Button variant='link' type='reset' isDisabled={ true }>Cancel</Button>
+                </ActionGroup>
+            </PageSection>
+        </>
+
+    );
+
+};


### PR DESCRIPTION
first look at UI mock for email templates
On the Application page I put an email template table that would hold stored templates with ability to view/edit/delete. 

- Does the view option actually make sense? 
- Would it make sense to divide the table into "title templates" and " body templates"? or by "Daily Templates" and "Instant Notification"?
- email templates would be linked to their Application, while event-types would be linked to an email template

From there, create a new template would take you to a new page where you would be able to create/edit the template. I am not sure how this will be handled but we talked about having to differentiate between a daily email and an instant notification, therefore I added a simple checkbox that could tag the template in such a way.


https://user-images.githubusercontent.com/86322239/157925845-5ebf2681-3595-4a06-96d3-8215b45d75ce.mov

