### PR TITLE
NOTIF-484 Store email templates in the database

### DIFF
--- a/database/src/main/resources/db/migration/V1.46.0__NOTIF-484_templates_in_database.sql
+++ b/database/src/main/resources/db/migration/V1.46.0__NOTIF-484_templates_in_database.sql
@@ -1,0 +1,33 @@
+CREATE TABLE template (
+    id UUID NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    data VARCHAR NOT NULL,
+    created TIMESTAMP NOT NULL,
+    updated TIMESTAMP,
+    CONSTRAINT pk_template PRIMARY KEY (id)
+);
+
+CREATE TABLE instant_email_template (
+   event_type_id UUID NOT NULL,
+   subject_template_id UUID NOT NULL,
+   body_template_id UUID NOT NULL,
+   created TIMESTAMP NOT NULL,
+   updated TIMESTAMP,
+   CONSTRAINT pk_instant_email_template PRIMARY KEY (event_type_id),
+   CONSTRAINT fk_instant_email_template_event_type_id FOREIGN KEY (event_type_id) REFERENCES event_type (id) ON DELETE CASCADE,
+   CONSTRAINT fk_instant_email_template_subject_template_id FOREIGN KEY (subject_template_id) REFERENCES template (id) ON DELETE CASCADE,
+   CONSTRAINT fk_instant_email_template_body_template_id FOREIGN KEY (body_template_id) REFERENCES template (id) ON DELETE CASCADE
+);
+
+CREATE TABLE aggregation_email_template (
+    application_id UUID NOT NULL,
+    subscription_type VARCHAR(50) NOT NULL,
+    subject_template_id UUID NOT NULL,
+    body_template_id UUID NOT NULL,
+    created TIMESTAMP NOT NULL,
+    updated TIMESTAMP,
+    CONSTRAINT pk_aggregation_email_template PRIMARY KEY (application_id, subscription_type),
+    CONSTRAINT fk_aggregation_email_template_application_id FOREIGN KEY (application_id) REFERENCES applications (id) ON DELETE CASCADE,
+    CONSTRAINT fk_aggregation_email_template_subject_template_id FOREIGN KEY (subject_template_id) REFERENCES template (id) ON DELETE CASCADE,
+    CONSTRAINT fk_aggregation_email_template_body_template_id FOREIGN KEY (body_template_id) REFERENCES template (id) ON DELETE CASCADE
+);

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
@@ -1,0 +1,74 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.db.StatelessSessionFactory;
+import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
+import com.redhat.cloud.notifications.models.EmailSubscriptionType;
+import com.redhat.cloud.notifications.models.InstantEmailTemplate;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.NoResultException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.models.EmailSubscriptionType.INSTANT;
+
+@ApplicationScoped
+public class TemplateRepository {
+
+    @Inject
+    StatelessSessionFactory statelessSessionFactory;
+
+    public boolean isEmailSubscriptionSupported(String bundleName, String appName, EmailSubscriptionType subscriptionType) {
+        if (subscriptionType == INSTANT) {
+            String hql = "SELECT COUNT(*) FROM InstantEmailTemplate " +
+                    "WHERE eventType.application.bundle.name = :bundleName AND eventType.application.name = :appName";
+            return statelessSessionFactory.getCurrentSession().createQuery(hql, Long.class)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("appName", appName)
+                    .getSingleResult() > 0;
+        } else {
+            return isEmailAggregationSupported(bundleName, appName, List.of(subscriptionType));
+        }
+    }
+
+    public boolean isEmailAggregationSupported(String bundleName, String appName, List<EmailSubscriptionType> subscriptionTypes) {
+        String hql = "SELECT COUNT(*) FROM AggregationEmailTemplate WHERE application.bundle.name = :bundleName " +
+                "AND application.name = :appName AND id.subscriptionType IN (:subscriptionTypes)";
+        return statelessSessionFactory.getCurrentSession().createQuery(hql, Long.class)
+                .setParameter("bundleName", bundleName)
+                .setParameter("appName", appName)
+                .setParameter("subscriptionTypes", subscriptionTypes)
+                .getSingleResult() > 0;
+    }
+
+    public Optional<InstantEmailTemplate> findInstantEmailTemplate(UUID eventTypeId) {
+        String hql = "FROM InstantEmailTemplate t JOIN FETCH t.subjectTemplate JOIN FETCH t.bodyTemplate " +
+                "WHERE t.id = :eventTypeId";
+        try {
+            InstantEmailTemplate emailTemplate = statelessSessionFactory.getCurrentSession().createQuery(hql, InstantEmailTemplate.class)
+                    .setParameter("eventTypeId", eventTypeId)
+                    .getSingleResult();
+            return Optional.of(emailTemplate);
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<AggregationEmailTemplate> findAggregationEmailTemplate(String bundleName, String appName, EmailSubscriptionType subscriptionType) {
+        String hql = "FROM AggregationEmailTemplate t JOIN FETCH t.subjectTemplate JOIN FETCH t.bodyTemplate " +
+                "WHERE t.application.bundle.name = :bundleName AND t.application.name = :appName " +
+                "AND t.id.subscriptionType = :subscriptionType";
+        try {
+            AggregationEmailTemplate emailTemplate = statelessSessionFactory.getCurrentSession().createQuery(hql, AggregationEmailTemplate.class)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("appName", appName)
+                    .setParameter("subscriptionType", subscriptionType)
+                    .getSingleResult();
+            return Optional.of(emailTemplate);
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/models/AggregationEmailTemplate.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/models/AggregationEmailTemplate.java
@@ -1,0 +1,83 @@
+package com.redhat.cloud.notifications.models;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+@Entity
+@Table(name = "aggregation_email_template")
+public class AggregationEmailTemplate extends CreationUpdateTimestamped {
+
+    @EmbeddedId
+    private AggregationEmailTemplateId id = new AggregationEmailTemplateId();
+
+    @ManyToOne
+    @MapsId("applicationId")
+    @JoinColumn(name = "application_id")
+    @NotNull
+    private Application application;
+
+    @ManyToOne
+    @JoinColumn(name = "subject_template_id")
+    @NotNull
+    private Template subjectTemplate;
+
+    @ManyToOne
+    @JoinColumn(name = "body_template_id")
+    @NotNull
+    private Template bodyTemplate;
+
+    public AggregationEmailTemplateId getId() {
+        return id;
+    }
+
+    public void setId(AggregationEmailTemplateId id) {
+        this.id = id;
+    }
+
+    public Application getApplication() {
+        return application;
+    }
+
+    public void setApplication(Application application) {
+        this.application = application;
+    }
+
+    public Template getSubjectTemplate() {
+        return subjectTemplate;
+    }
+
+    public void setSubjectTemplate(Template subjectTemplate) {
+        this.subjectTemplate = subjectTemplate;
+    }
+
+    public Template getBodyTemplate() {
+        return bodyTemplate;
+    }
+
+    public void setBodyTemplate(Template bodyTemplate) {
+        this.bodyTemplate = bodyTemplate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof AggregationEmailTemplate) {
+            AggregationEmailTemplate other = (AggregationEmailTemplate) o;
+            return Objects.equals(id, other.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/models/AggregationEmailTemplateId.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/models/AggregationEmailTemplateId.java
@@ -1,0 +1,41 @@
+package com.redhat.cloud.notifications.models;
+
+import com.redhat.cloud.notifications.db.converters.EmailSubscriptionTypeConverter;
+
+import javax.persistence.Convert;
+import javax.persistence.Embeddable;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+@Embeddable
+public class AggregationEmailTemplateId implements Serializable {
+
+    @NotNull
+    public UUID applicationId;
+
+    @NotNull
+    @Size(max = 50)
+    @Convert(converter = EmailSubscriptionTypeConverter.class)
+    public EmailSubscriptionType subscriptionType;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof AggregationEmailTemplateId) {
+            AggregationEmailTemplateId other = (AggregationEmailTemplateId) o;
+            return Objects.equals(applicationId, other.applicationId) &&
+                    Objects.equals(subscriptionType, other.subscriptionType);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(applicationId, subscriptionType);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/models/InstantEmailTemplate.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/models/InstantEmailTemplate.java
@@ -1,0 +1,88 @@
+package com.redhat.cloud.notifications.models;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "instant_email_template")
+public class InstantEmailTemplate extends CreationUpdateTimestamped {
+
+    /*
+     * Because of the @MapsId annotation on the `eventType` field, an InstantEmailTemplate instance and its parent
+     * EventType instance will share the same @Id value. As a consequence, the `id` field doesn't need to be generated.
+     */
+    @Id
+    private UUID id;
+
+    @MapsId
+    @ManyToOne
+    @JoinColumn(name = "event_type_id")
+    @NotNull
+    private EventType eventType;
+
+    @ManyToOne
+    @JoinColumn(name = "subject_template_id")
+    @NotNull
+    private Template subjectTemplate;
+
+    @ManyToOne
+    @JoinColumn(name = "body_template_id")
+    @NotNull
+    private Template bodyTemplate;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(EventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public Template getSubjectTemplate() {
+        return subjectTemplate;
+    }
+
+    public void setSubjectTemplate(Template subjectTemplate) {
+        this.subjectTemplate = subjectTemplate;
+    }
+
+    public Template getBodyTemplate() {
+        return bodyTemplate;
+    }
+
+    public void setBodyTemplate(Template bodyTemplate) {
+        this.bodyTemplate = bodyTemplate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof InstantEmailTemplate) {
+            InstantEmailTemplate other = (InstantEmailTemplate) o;
+            return Objects.equals(id, other.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/models/Template.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/models/Template.java
@@ -1,0 +1,68 @@
+package com.redhat.cloud.notifications.models;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.Objects;
+import java.util.UUID;
+
+// TODO NOTIF-484 Add templates ownership and restrict access to the templates.
+@Entity
+@Table(name = "template")
+public class Template extends CreationUpdateTimestamped {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @NotNull
+    @Size(max = 100)
+    private String name;
+
+    @NotNull
+    private String data;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof Template) {
+            Template other = (Template) o;
+            return Objects.equals(id, other.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
@@ -9,7 +9,7 @@ import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.processors.webclient.BopWebClient;
 import com.redhat.cloud.notifications.processors.webhooks.WebhookTypeProcessor;
 import com.redhat.cloud.notifications.recipients.User;
-import com.redhat.cloud.notifications.templates.EmailTemplateService;
+import com.redhat.cloud.notifications.templates.TemplateService;
 import com.redhat.cloud.notifications.utils.LineBreakCleaner;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -65,7 +65,7 @@ public class EmailSender {
     EndpointRepository endpointRepository;
 
     @Inject
-    EmailTemplateService emailTemplateService;
+    TemplateService templateService;
 
     @Inject
     MeterRegistry registry;
@@ -123,8 +123,8 @@ public class EmailSender {
         String renderedSubject;
         String renderedBody;
         try {
-            renderedSubject = emailTemplateService.renderTemplate(user, action, subject);
-            renderedBody = emailTemplateService.renderTemplate(user, action, body);
+            renderedSubject = templateService.renderTemplate(user, action, subject);
+            renderedBody = templateService.renderTemplate(user, action, body);
         } catch (Exception e) {
             logger.warnf(e,
                     "Unable to render template for bundle: [%s] application: [%s], eventType: [%s].",

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -5,13 +5,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
 import com.redhat.cloud.notifications.db.repositories.EmailSubscriptionRepository;
+import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.models.AggregationCommand;
+import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.models.EmailAggregationKey;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.Event;
+import com.redhat.cloud.notifications.models.InstantEmailTemplate;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.processors.EndpointTypeProcessor;
 import com.redhat.cloud.notifications.recipients.RecipientResolver;
@@ -21,12 +24,14 @@ import com.redhat.cloud.notifications.recipients.request.ActionRecipientSettings
 import com.redhat.cloud.notifications.recipients.request.EndpointRecipientSettings;
 import com.redhat.cloud.notifications.templates.EmailTemplate;
 import com.redhat.cloud.notifications.templates.EmailTemplateFactory;
+import com.redhat.cloud.notifications.templates.TemplateService;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.qute.TemplateInstance;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.vertx.core.json.JsonObject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.jboss.logging.Logger;
@@ -54,6 +59,13 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
     public static final String AGGREGATION_COMMAND_ERROR_COUNTER_NAME = "aggregation.command.error";
 
     private static final Logger LOGGER = Logger.getLogger(EmailSubscriptionTypeProcessor.class);
+
+    private static final List<EmailSubscriptionType> NON_INSTANT_SUBSCRIPTION_TYPES = Arrays.stream(EmailSubscriptionType.values())
+            .filter(emailSubscriptionType -> emailSubscriptionType != EmailSubscriptionType.INSTANT)
+            .collect(Collectors.toList());
+
+    @ConfigProperty(name = "notifications.use-templates-from-db", defaultValue = "false")
+    boolean useTemplatesFromDb;
 
     @Inject
     EmailSubscriptionRepository emailSubscriptionRepository;
@@ -85,6 +97,12 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
     @Inject
     MeterRegistry registry;
 
+    @Inject
+    TemplateRepository templateRepository;
+
+    @Inject
+    TemplateService templateService;
+
     private Counter processedEmailCount;
     private Counter rejectedAggregationCommandCount;
     private Counter processedAggregationCommandCount;
@@ -105,9 +123,13 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
         } else {
             Action action = event.getAction();
             final EmailTemplate template = emailTemplateFactory.get(action.getBundle(), action.getApplication());
-            final boolean shouldSaveAggregation = Arrays.stream(EmailSubscriptionType.values())
-                    .filter(emailSubscriptionType -> emailSubscriptionType != EmailSubscriptionType.INSTANT)
-                    .anyMatch(emailSubscriptionType -> template.isSupported(action.getEventType(), emailSubscriptionType));
+            boolean shouldSaveAggregation;
+            if (useTemplatesFromDb) {
+                shouldSaveAggregation = templateRepository.isEmailAggregationSupported(action.getBundle(), action.getApplication(), NON_INSTANT_SUBSCRIPTION_TYPES);
+            } else {
+                shouldSaveAggregation = NON_INSTANT_SUBSCRIPTION_TYPES.stream()
+                        .anyMatch(emailSubscriptionType -> template.isSupported(action.getEventType(), emailSubscriptionType));
+            }
 
             if (shouldSaveAggregation) {
                 EmailAggregation aggregation = new EmailAggregation();
@@ -123,21 +145,37 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
             return sendEmail(
                     event,
                     Set.copyOf(endpoints),
-                    EmailSubscriptionType.INSTANT,
                     template
             );
         }
     }
 
-    private List<NotificationHistory> sendEmail(Event event, Set<Endpoint> endpoints, EmailSubscriptionType emailSubscriptionType, EmailTemplate emailTemplate) {
+    private List<NotificationHistory> sendEmail(Event event, Set<Endpoint> endpoints, EmailTemplate emailTemplate) {
+        EmailSubscriptionType emailSubscriptionType = EmailSubscriptionType.INSTANT;
         processedEmailCount.increment();
         Action action = event.getAction();
-        if (!emailTemplate.isSupported(action.getEventType(), emailSubscriptionType)) {
-            return Collections.emptyList();
-        }
 
-        TemplateInstance subject = emailTemplate.getTitle(action.getEventType(), emailSubscriptionType);
-        TemplateInstance body = emailTemplate.getBody(action.getEventType(), emailSubscriptionType);
+        TemplateInstance subject;
+        TemplateInstance body;
+
+        if (useTemplatesFromDb) {
+            Optional<InstantEmailTemplate> instantEmailTemplate = templateRepository
+                    .findInstantEmailTemplate(event.getEventType().getId());
+            if (instantEmailTemplate.isEmpty()) {
+                return Collections.emptyList();
+            } else {
+                String subjectData = instantEmailTemplate.get().getSubjectTemplate().getData();
+                subject = templateService.compileTemplate(subjectData, "subject");
+                String bodyData = instantEmailTemplate.get().getBodyTemplate().getData();
+                body = templateService.compileTemplate(bodyData, "body");
+            }
+        } else {
+            if (!emailTemplate.isSupported(action.getEventType(), emailSubscriptionType)) {
+                return Collections.emptyList();
+            }
+            subject = emailTemplate.getTitle(action.getEventType(), emailSubscriptionType);
+            body = emailTemplate.getBody(action.getEventType(), emailSubscriptionType);
+        }
 
         if (subject == null || body == null) {
             return Collections.emptyList();
@@ -194,15 +232,34 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
     private void processAggregateEmailsByAggregationKey(EmailAggregationKey aggregationKey, LocalDateTime startTime, LocalDateTime endTime, EmailSubscriptionType emailSubscriptionType, boolean delete) {
         final EmailTemplate emailTemplate = emailTemplateFactory.get(aggregationKey.getBundle(), aggregationKey.getApplication());
 
-        if (!emailTemplate.isEmailSubscriptionSupported(emailSubscriptionType)) {
-            if (delete) {
-                emailAggregationRepository.purgeOldAggregation(aggregationKey, endTime);
-            }
-            return;
-        }
+        TemplateInstance subject;
+        TemplateInstance body;
 
-        TemplateInstance subject = emailTemplate.getTitle(null, emailSubscriptionType);
-        TemplateInstance body = emailTemplate.getBody(null, emailSubscriptionType);
+        if (useTemplatesFromDb) {
+            Optional<AggregationEmailTemplate> aggregationEmailTemplate = templateRepository
+                    .findAggregationEmailTemplate(aggregationKey.getBundle(), aggregationKey.getApplication(), emailSubscriptionType);
+            if (aggregationEmailTemplate.isEmpty()) {
+                if (delete) {
+                    emailAggregationRepository.purgeOldAggregation(aggregationKey, endTime);
+                }
+                return;
+            } else {
+                String subjectData = aggregationEmailTemplate.get().getSubjectTemplate().getData();
+                subject = templateService.compileTemplate(subjectData, "subject");
+                String bodyData = aggregationEmailTemplate.get().getBodyTemplate().getData();
+                body = templateService.compileTemplate(bodyData, "body");
+            }
+        } else {
+            if (!emailTemplate.isEmailSubscriptionSupported(emailSubscriptionType)) {
+                if (delete) {
+                    emailAggregationRepository.purgeOldAggregation(aggregationKey, endTime);
+                }
+                return;
+            }
+
+            subject = emailTemplate.getTitle(null, emailSubscriptionType);
+            body = emailTemplate.getBody(null, emailSubscriptionType);
+        }
 
         if (subject == null || body == null) {
             if (delete) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateService.java
@@ -10,7 +10,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 @ApplicationScoped
-public class EmailTemplateService {
+public class TemplateService {
 
     @Inject
     Engine engine;

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -1,17 +1,32 @@
 package com.redhat.cloud.notifications.db;
 
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
+import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.InstantEmailTemplate;
+import com.redhat.cloud.notifications.models.Template;
 import io.vertx.core.json.JsonObject;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
 
 @ApplicationScoped
 public class ResourceHelpers {
 
     @Inject
     EmailAggregationRepository emailAggregationRepository;
+
+    @Inject
+    EntityManager entityManager;
 
     public Boolean addEmailAggregation(String accountId, String bundleName, String applicationName, JsonObject payload) {
         EmailAggregation aggregation = new EmailAggregation();
@@ -20,5 +35,71 @@ public class ResourceHelpers {
         aggregation.setApplicationName(applicationName);
         aggregation.setPayload(payload);
         return emailAggregationRepository.addEmailAggregation(aggregation);
+    }
+
+    @Transactional
+    public Bundle createBundle(String bundleName) {
+        Bundle bundle = new Bundle(bundleName, "A bundle");
+        entityManager.persist(bundle);
+        return bundle;
+    }
+
+    @Transactional
+    public Application createApp(UUID bundleId, String appName) {
+        Application app = new Application();
+        app.setBundle(entityManager.find(Bundle.class, bundleId));
+        app.setBundleId(bundleId);
+        app.setName(appName);
+        app.setDisplayName("The best app in the life");
+        entityManager.persist(app);
+        return app;
+    }
+
+    @Transactional
+    public EventType createEventType(UUID appId, String eventTypeName) {
+        EventType eventType = new EventType();
+        eventType.setApplication(entityManager.find(Application.class, appId));
+        eventType.setApplicationId(appId);
+        eventType.setName(eventTypeName);
+        eventType.setDisplayName("Policies will take care of the rules");
+        eventType.setDescription("Policies is super cool, you should use it");
+        entityManager.persist(eventType);
+        return eventType;
+    }
+
+    @Transactional
+    public Template createTemplate(String name, String data) {
+        Template template = new Template();
+        template.setName(name);
+        template.setData(data);
+        entityManager.persist(template);
+        return template;
+    }
+
+    @Transactional
+    public InstantEmailTemplate createInstantEmailTemplate(UUID eventTypeId, UUID subjectTemplateId, UUID bodyTemplateId) {
+        InstantEmailTemplate instantEmailTemplate = new InstantEmailTemplate();
+        instantEmailTemplate.setEventType(entityManager.find(EventType.class, eventTypeId));
+        instantEmailTemplate.setSubjectTemplate(entityManager.find(Template.class, subjectTemplateId));
+        instantEmailTemplate.setBodyTemplate(entityManager.find(Template.class, bodyTemplateId));
+        entityManager.persist(instantEmailTemplate);
+        return instantEmailTemplate;
+    }
+
+    @Transactional
+    public AggregationEmailTemplate createAggregationEmailTemplate(UUID appId, UUID subjectTemplateId, UUID bodyTemplateId) {
+        AggregationEmailTemplate aggregationEmailTemplate = new AggregationEmailTemplate();
+        aggregationEmailTemplate.setApplication(entityManager.find(Application.class, appId));
+        aggregationEmailTemplate.setSubjectTemplate(entityManager.find(Template.class, subjectTemplateId));
+        aggregationEmailTemplate.setBodyTemplate(entityManager.find(Template.class, bodyTemplateId));
+        aggregationEmailTemplate.getId().subscriptionType = DAILY;
+        entityManager.persist(aggregationEmailTemplate);
+        return aggregationEmailTemplate;
+    }
+
+    @Transactional
+    public void deleteAllEmailTemplates() {
+        entityManager.createQuery("DELETE FROM InstantEmailTemplate").executeUpdate();
+        entityManager.createQuery("DELETE FROM AggregationEmailTemplate").executeUpdate();
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
@@ -1,0 +1,180 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.StatelessSessionFactory;
+import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.InstantEmailTemplate;
+import com.redhat.cloud.notifications.models.Template;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
+import static com.redhat.cloud.notifications.models.EmailSubscriptionType.INSTANT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class TemplateRepositoryTest {
+
+    @Inject
+    TemplateRepository templateRepository;
+
+    @Inject
+    StatelessSessionFactory statelessSessionFactory;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    private Bundle bundle;
+    private Application app1;
+    private Application app2;
+    private EventType eventType1;
+    private EventType eventType2;
+    private Template subjectTemplate;
+    private Template bodyTemplate;
+
+    @BeforeEach
+    void beforeEach() {
+        bundle = resourceHelpers.createBundle("bundle-" + UUID.randomUUID());
+
+        app1 = resourceHelpers.createApp(bundle.getId(), "app-1-" + UUID.randomUUID());
+        eventType1 = resourceHelpers.createEventType(app1.getId(), "event-type-1-" + UUID.randomUUID());
+
+        app2 = resourceHelpers.createApp(bundle.getId(), "app-2-" + UUID.randomUUID());
+        eventType2 = resourceHelpers.createEventType(app2.getId(), "event-type-2-" + UUID.randomUUID());
+
+        subjectTemplate = resourceHelpers.createTemplate("subject-template", "You have a notification!");
+        bodyTemplate = resourceHelpers.createTemplate("body-template", "Something happened!");
+    }
+
+    @Test
+    void testIsEmailSubscriptionSupported() {
+        statelessSessionFactory.withSession(statelessSession -> {
+            // First, email subscription is not supported by any application.
+            assertIsEmailSubscriptionSupported(false, false, false, false, false, false);
+
+            // Then we link an instant email template with event-type-1 (which is a child entity of app-1).
+            resourceHelpers.createInstantEmailTemplate(eventType1.getId(), subjectTemplate.getId(), bodyTemplate.getId());
+
+            /*
+             * Expectations:
+             * - app-1 should now support INSTANT email subscription, but not DAILY
+             * - other applications shouldn't support any kind of email subscription
+             */
+            assertIsEmailSubscriptionSupported(true, false, false, false, false, false);
+
+            // Then we link an aggregation (DAILY) email template with event-type2 (which is a child entity of app-2).
+            resourceHelpers.createAggregationEmailTemplate(app2.getId(), subjectTemplate.getId(), bodyTemplate.getId());
+
+            /*
+             * Expectations:
+             * - app-1 should now support INSTANT email subscription, but not DAILY
+             * - app-2 should now support DAILY email subscription, but not INSTANT
+             * - other applications shouldn't support any kind of email subscription
+             */
+            assertIsEmailSubscriptionSupported(true, false, false, true, false, false);
+
+            resourceHelpers.deleteAllEmailTemplates();
+        });
+    }
+
+    private void assertIsEmailSubscriptionSupported(boolean app1Instant, boolean app1Daily, boolean app2Instant,
+                                                    boolean app2Daily, boolean unknownAppInstant, boolean unknownAppDaily) {
+
+        // bundle / app-1 / event-type-1
+        assertEquals(app1Instant, templateRepository.isEmailSubscriptionSupported(bundle.getName(), app1.getName(), INSTANT));
+        assertEquals(app1Daily, templateRepository.isEmailSubscriptionSupported(bundle.getName(), app1.getName(), DAILY));
+
+        // bundle / app-2 / event-type-2
+        assertEquals(app2Instant, templateRepository.isEmailSubscriptionSupported(bundle.getName(), app2.getName(), INSTANT));
+        assertEquals(app2Daily, templateRepository.isEmailSubscriptionSupported(bundle.getName(), app2.getName(), DAILY));
+
+        // unknown-bundle / unknown-app
+        assertEquals(unknownAppInstant, templateRepository.isEmailSubscriptionSupported("unknown-bundle", "unknown-app", INSTANT));
+        assertEquals(unknownAppDaily, templateRepository.isEmailSubscriptionSupported("unknown-bundle", "unknown-app", DAILY));
+    }
+
+    @Test
+    void testIsEmailAggregationSupported() {
+        statelessSessionFactory.withSession(statelessSession -> {
+            // First, email aggregation is not supported by any application.
+            assertIsEmailAggregationSupported(false, false);
+
+            // Then we link an aggregation (DAILY) email template with app-1.
+            resourceHelpers.createAggregationEmailTemplate(app1.getId(), subjectTemplate.getId(), bodyTemplate.getId());
+
+            /*
+             * Expectations:
+             * - app-1 should now support email aggregation
+             * - app-2 should still not support email aggregation
+             */
+            assertIsEmailAggregationSupported(true, false);
+
+            resourceHelpers.deleteAllEmailTemplates();
+        });
+    }
+
+    private void assertIsEmailAggregationSupported(boolean app1, boolean app2) {
+        assertEquals(app1, templateRepository.isEmailAggregationSupported(bundle.getName(), this.app1.getName(), List.of(DAILY)));
+        assertEquals(app2, templateRepository.isEmailAggregationSupported(bundle.getName(), this.app2.getName(), List.of(DAILY)));
+    }
+
+    @Test
+    void testFindInstantEmailTemplate() {
+        statelessSessionFactory.withSession(statelessSession -> {
+            // First, none of the event types are linked with an instant email template.
+            assertTrue(templateRepository.findInstantEmailTemplate(eventType1.getId()).isEmpty());
+            assertTrue(templateRepository.findInstantEmailTemplate(eventType2.getId()).isEmpty());
+
+            // Then we link an instant email template with event-type-1...
+            resourceHelpers.createInstantEmailTemplate(eventType1.getId(), subjectTemplate.getId(), bodyTemplate.getId());
+            // ... and retrieve it from the DB using the repository.
+            Optional<InstantEmailTemplate> instantTemplate = templateRepository.findInstantEmailTemplate(eventType1.getId());
+
+            // The retrieved instant email template should contain the subject/body templates that were created with the helper.
+            assertEquals(subjectTemplate, instantTemplate.get().getSubjectTemplate());
+            assertEquals(bodyTemplate, instantTemplate.get().getBodyTemplate());
+
+            // event-type-2 should still not be linked to any instant email template.
+            assertTrue(templateRepository.findInstantEmailTemplate(eventType2.getId()).isEmpty());
+
+            resourceHelpers.deleteAllEmailTemplates();
+        });
+    }
+
+    @Test
+    void testFindAggregationEmailTemplate() {
+        statelessSessionFactory.withSession(statelessSession -> {
+            // First, none of the applications are linked with an aggregation email template.
+            assertTrue(templateRepository.findAggregationEmailTemplate(bundle.getName(), app1.getName(), DAILY).isEmpty());
+            assertTrue(templateRepository.findAggregationEmailTemplate(bundle.getName(), app2.getName(), DAILY).isEmpty());
+
+            // Then we link an aggregation email template with app-1...
+            resourceHelpers.createAggregationEmailTemplate(app1.getId(), subjectTemplate.getId(), bodyTemplate.getId());
+            // ... and retrieve it from the DB using the repository.
+            Optional<AggregationEmailTemplate> aggregationTemplate = templateRepository.findAggregationEmailTemplate(bundle.getName(), app1.getName(), DAILY);
+
+            // The retrieved aggregation email template should contain the subject/body templates that were created with the helper.
+            assertEquals(subjectTemplate, aggregationTemplate.get().getSubjectTemplate());
+            assertEquals(bodyTemplate, aggregationTemplate.get().getBodyTemplate());
+
+            // app-2 should still not be linked to any aggregation email template.
+            assertTrue(templateRepository.findAggregationEmailTemplate(bundle.getName(), app2.getName(), DAILY).isEmpty());
+
+            resourceHelpers.deleteAllEmailTemplates();
+        });
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.MicrometerAssertionHelper;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.ingress.Action;
@@ -117,6 +118,9 @@ public class LifecycleITest {
     @Inject
     StatelessSessionFactory statelessSessionFactory;
 
+    @Inject
+    ResourceHelpers resourceHelpers;
+
     @Test
     void test() {
         final String accountId = "tenant";
@@ -124,9 +128,9 @@ public class LifecycleITest {
         setupEmailMock(accountId, username);
 
         // First, we need a bundle, an app and an event type. Let's create them!
-        Bundle bundle = createBundle();
-        Application app = createApp(bundle);
-        EventType eventType = createEventType(app);
+        Bundle bundle = resourceHelpers.createBundle(BUNDLE_NAME);
+        Application app = resourceHelpers.createApp(bundle.getId(), APP_NAME);
+        EventType eventType = resourceHelpers.createEventType(app.getId(), EVENT_TYPE_NAME);
 
         // We also need behavior groups.
         BehaviorGroup behaviorGroup1 = createBehaviorGroup(accountId, bundle);
@@ -232,36 +236,6 @@ public class LifecycleITest {
 
         // We'll finish with a bundle removal.
         deleteBundle(bundle);
-    }
-
-    @Transactional
-    Bundle createBundle() {
-        Bundle bundle = new Bundle(BUNDLE_NAME, "A bundle");
-        entityManager.persist(bundle);
-        return bundle;
-    }
-
-    @Transactional
-    Application createApp(Bundle bundle) {
-        Application app = new Application();
-        app.setBundle(bundle);
-        app.setBundleId(bundle.getId());
-        app.setName(APP_NAME);
-        app.setDisplayName("The best app in the life");
-        entityManager.persist(app);
-        return app;
-    }
-
-    @Transactional
-    EventType createEventType(Application app) {
-        EventType eventType = new EventType();
-        eventType.setApplication(app);
-        eventType.setApplicationId(app.getId());
-        eventType.setName(EVENT_TYPE_NAME);
-        eventType.setDisplayName("Policies will take care of the rules");
-        eventType.setDescription("Policies is super cool, you should use it");
-        entityManager.persist(eventType);
-        return eventType;
     }
 
     @Transactional


### PR DESCRIPTION
This PR introduces the following classes:
- `Template` is used to store in the DB the content of the current HTML templates files.
- `InstantEmailTemplate` is used to store in the DB the link between an event type, a subject `Template` and a body `Template`.
- `AggregationEmailTemplate` is used to store in the DB the link between an application, a subscription type (currently only `DAILY`), a subject `Template` and a body `Template`.
- `TemplateRepository` is used to retrieve templates information from the DB. It is meant to replace both `EmailTemplateFactory` and the various `EmailTemplate` implementations that currently exist (`Policies`, `Advisor`, `Rhosak`...).

This PR does NOT contain:
- The `backend` module code that will be used in production to store/edit/delete the templates.
- The REST endpoints that will be used from the frontend.
- The migration code that will be needed to transform the current HTML files and Java logic into DB data.

This will all be done in subsequent PRs.

ℹ️ All the changes from this PR are disabled by default and can be enabled from configuration. Merging the PR should not affect in any way the templates rendering on prod.