### PR TITLE
Rename repositories and JAX-RS resources

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -1,5 +1,6 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.builder.JoinBuilder;
 import com.redhat.cloud.notifications.db.builder.QueryBuilder;
 import com.redhat.cloud.notifications.db.builder.WhereBuilder;
@@ -20,7 +21,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @ApplicationScoped
-public class ApplicationResources {
+public class ApplicationRepository {
 
     @Inject
     EntityManager entityManager;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -1,5 +1,6 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
@@ -24,7 +25,7 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 
 @ApplicationScoped
-public class BehaviorGroupResources {
+public class BehaviorGroupRepository {
 
     private static final ZoneId UTC = ZoneId.of("UTC");
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BundleRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BundleRepository.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.UUID;
 
 @ApplicationScoped
-public class BundleResources {
+public class BundleRepository {
 
     @Inject
     EntityManager entityManager;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.models.EmailSubscription;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
@@ -11,7 +11,7 @@ import javax.transaction.Transactional;
 import java.util.List;
 
 @ApplicationScoped
-public class EndpointEmailSubscriptionResources {
+public class EmailSubscriptionRepository {
 
     @Inject
     EntityManager entityManager;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -1,5 +1,6 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.builder.QueryBuilder;
 import com.redhat.cloud.notifications.db.builder.WhereBuilder;
 import com.redhat.cloud.notifications.models.CamelProperties;
@@ -30,9 +31,9 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class EndpointResources {
+public class EndpointRepository {
 
-    private static final Logger LOGGER = Logger.getLogger(EndpointResources.class);
+    private static final Logger LOGGER = Logger.getLogger(EndpointRepository.class);
 
     @Inject
     EntityManager entityManager;
@@ -85,7 +86,7 @@ public class EndpointResources {
 
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Query.Sort sort = limiter == null ? null : limiter.getSort();
-        List<Endpoint> endpoints = EndpointResources.queryBuilderEndpointsPerType(accountId, name, type, activeOnly)
+        List<Endpoint> endpoints = EndpointRepository.queryBuilderEndpointsPerType(accountId, name, type, activeOnly)
                 .limit(limit)
                 .sort(sort)
                 .build(entityManager::createQuery)
@@ -129,7 +130,7 @@ public class EndpointResources {
     }
 
     public Long getEndpointsCountPerCompositeType(String tenant, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly) {
-        return EndpointResources.queryBuilderEndpointsPerType(tenant, name, type, activeOnly)
+        return EndpointRepository.queryBuilderEndpointsPerType(tenant, name, type, activeOnly)
                 .buildCount(entityManager::createQuery)
                 .getSingleResult();
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
@@ -17,10 +17,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 
-import static com.redhat.cloud.notifications.routers.EventService.SORT_BY_PATTERN;
+import static com.redhat.cloud.notifications.routers.EventResource.SORT_BY_PATTERN;
 
 @ApplicationScoped
-public class EventResources {
+public class EventRepository {
 
     @Inject
     EntityManager entityManager;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/InternalRoleAccessRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/InternalRoleAccessRepository.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.models.InternalRoleAccess;
 
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.UUID;
 
 @ApplicationScoped
-public class InternalRoleAccessResources {
+public class InternalRoleAccessRepository {
 
     @Inject
     EntityManager entityManager;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
@@ -1,5 +1,6 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import io.vertx.core.json.JsonObject;
 import org.jboss.logging.Logger;
@@ -14,11 +15,11 @@ import java.util.Map;
 import java.util.UUID;
 
 @ApplicationScoped
-public class NotificationResources {
+public class NotificationRepository {
 
     public static final int MAX_NOTIFICATION_HISTORY_RESULTS = 500;
 
-    private static final Logger LOGGER = Logger.getLogger(NotificationResources.class);
+    private static final Logger LOGGER = Logger.getLogger(NotificationRepository.class);
 
     @Inject
     EntityManager entityManager;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/StatusRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/StatusRepository.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.models.CurrentStatus;
 
@@ -8,7 +8,7 @@ import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 
 @ApplicationScoped
-public class StatusResources {
+public class StatusRepository {
 
     @Inject
     EntityManager entityManager;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.routers;
 
-import com.redhat.cloud.notifications.db.EventResources;
+import com.redhat.cloud.notifications.db.repositories.EventRepository;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.routers.models.EventLogEntry;
@@ -31,19 +31,19 @@ import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
 import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS;
-import static com.redhat.cloud.notifications.routers.EventService.PATH;
+import static com.redhat.cloud.notifications.routers.EventResource.PATH;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getAccountId;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path(PATH)
-public class EventService {
+public class EventResource {
 
     public static final String PATH = API_NOTIFICATIONS_V_1_0 + "/notifications/events";
     public static final Pattern SORT_BY_PATTERN = Pattern.compile("^([a-z0-9_-]+):(asc|desc)$", CASE_INSENSITIVE);
 
     @Inject
-    EventResources eventResources;
+    EventRepository eventRepository;
 
     @GET
     @Produces(APPLICATION_JSON)
@@ -61,7 +61,7 @@ public class EventService {
             throw new BadRequestException("Invalid 'sortBy' query parameter");
         }
         String accountId = getAccountId(securityContext);
-        List<Event> events = eventResources.getEvents(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults, includeActions, limit, offset, sortBy);
+        List<Event> events = eventRepository.getEvents(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults, includeActions, limit, offset, sortBy);
         List<EventLogEntry> eventLogEntries = events.stream().map(event -> {
             List<EventLogEntryAction> actions;
             if (!includeActions) {
@@ -93,7 +93,7 @@ public class EventService {
             }
             return entry;
         }).collect(Collectors.toList());
-        Long count = eventResources.count(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults);
+        Long count = eventRepository.count(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults);
 
         Meta meta = new Meta();
         meta.setCount(count);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/OApiResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/OApiResource.java
@@ -13,7 +13,7 @@ import javax.ws.rs.core.MediaType;
  * Serve the final OpenAPI documents.
  */
 @Path("/api")
-public class OApiService {
+public class OApiResource {
 
     @Inject
     OApiFilter oApiFilter;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/SecurityContextUtil.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/SecurityContextUtil.java
@@ -2,8 +2,8 @@ package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
 import com.redhat.cloud.notifications.auth.principal.rhid.RhIdPrincipal;
-import com.redhat.cloud.notifications.db.ApplicationResources;
-import com.redhat.cloud.notifications.db.InternalRoleAccessResources;
+import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
+import com.redhat.cloud.notifications.db.repositories.InternalRoleAccessRepository;
 import com.redhat.cloud.notifications.models.InternalRoleAccess;
 import io.quarkus.security.ForbiddenException;
 
@@ -17,10 +17,10 @@ import java.util.UUID;
 public class SecurityContextUtil {
 
     @Inject
-    InternalRoleAccessResources internalRoleAccessResources;
+    InternalRoleAccessRepository internalRoleAccessRepository;
 
     @Inject
-    ApplicationResources applicationResources;
+    ApplicationRepository applicationRepository;
 
     public static String getAccountId(SecurityContext securityContext) {
         RhIdPrincipal principal = (RhIdPrincipal) securityContext.getUserPrincipal();
@@ -42,7 +42,7 @@ public class SecurityContextUtil {
             return;
         }
 
-        UUID applicationId = applicationResources.getApplicationIdOfEventType(eventTypeId);
+        UUID applicationId = applicationRepository.getApplicationIdOfEventType(eventTypeId);
         hasPermissionForApplication(securityContext, applicationId);
     }
 
@@ -51,7 +51,7 @@ public class SecurityContextUtil {
             return;
         }
 
-        List<InternalRoleAccess> internalRoleAccessList = internalRoleAccessResources.getByApplication(applicationId);
+        List<InternalRoleAccess> internalRoleAccessList = internalRoleAccessRepository.getByApplication(applicationId);
 
         boolean hasAccess = internalRoleAccessList
                 .stream()

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/StatusResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/StatusResource.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.routers;
 
-import com.redhat.cloud.notifications.db.StatusResources;
+import com.redhat.cloud.notifications.db.repositories.StatusRepository;
 import com.redhat.cloud.notifications.models.CurrentStatus;
 import com.redhat.cloud.notifications.oapi.OApiFilter;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -14,15 +14,15 @@ import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path(API_NOTIFICATIONS_V_1_0 + "/status")
-public class StatusService {
+public class StatusResource {
 
     @Inject
-    StatusResources statusResources;
+    StatusRepository statusRepository;
 
     @GET
     @Produces(APPLICATION_JSON)
     @Tag(name = OApiFilter.PRIVATE)
     public CurrentStatus getCurrentStatus() {
-        return statusResources.getCurrentStatus();
+        return statusRepository.getCurrentStatus();
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/filters/MaintenanceModeRequestFilter.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/filters/MaintenanceModeRequestFilter.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.routers.filters;
 
-import com.redhat.cloud.notifications.db.StatusResources;
+import com.redhat.cloud.notifications.db.repositories.StatusRepository;
 import io.quarkus.cache.CacheResult;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.server.ServerRequestFilter;
@@ -33,7 +33,7 @@ public class MaintenanceModeRequestFilter {
     private static final Response MAINTENANCE_IN_PROGRESS = Response.status(SERVICE_UNAVAILABLE).entity("Maintenance in progress").build();
 
     @Inject
-    StatusResources statusResources;
+    StatusRepository statusRepository;
 
     @ServerRequestFilter
     public Response filter(ContainerRequestContext requestContext) {
@@ -71,6 +71,6 @@ public class MaintenanceModeRequestFilter {
 
     @CacheResult(cacheName = "maintenance")
     public Boolean isMaintenance() {
-        return statusResources.getCurrentStatus().status == MAINTENANCE;
+        return statusRepository.getCurrentStatus().status == MAINTENANCE;
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/AdminResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/AdminResource.java
@@ -26,7 +26,7 @@ import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
  */
 @RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)
 @Path(API_INTERNAL + "/admin")
-public class AdminService {
+public class AdminResource {
 
     @Inject
     @RestClient

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionResource.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.notifications.routers.internal;
 
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
-import com.redhat.cloud.notifications.db.ApplicationResources;
-import com.redhat.cloud.notifications.db.InternalRoleAccessResources;
+import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
+import com.redhat.cloud.notifications.db.repositories.InternalRoleAccessRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.InternalRoleAccess;
 import com.redhat.cloud.notifications.routers.internal.models.AddAccessRequest;
@@ -31,13 +31,13 @@ import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 
 @RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)
 @Path(API_INTERNAL + "/access")
-public class InternalPermissionService {
+public class InternalPermissionResource {
 
     @Inject
-    InternalRoleAccessResources internalRoleAccessResources;
+    InternalRoleAccessRepository internalRoleAccessRepository;
 
     @Inject
-    ApplicationResources applicationResources;
+    ApplicationRepository applicationRepository;
 
     @Inject
     SecurityIdentity securityIdentity;
@@ -63,7 +63,7 @@ public class InternalPermissionService {
                 .collect(Collectors.toSet());
         permissions.getRoles().addAll(roles);
 
-        List<InternalRoleAccess> accessList = internalRoleAccessResources.getByRoles(roles);
+        List<InternalRoleAccess> accessList = internalRoleAccessRepository.getByRoles(roles);
 
         for (InternalRoleAccess access : accessList) {
             permissions.addApplication(access.getApplicationId(), access.getApplication().getDisplayName());
@@ -76,7 +76,7 @@ public class InternalPermissionService {
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
     public List<InternalApplicationUserPermission> getAccessList() {
-        List<InternalRoleAccess> accessList = internalRoleAccessResources.getAll();
+        List<InternalRoleAccess> accessList = internalRoleAccessRepository.getAll();
 
         return accessList.stream().map(access -> {
             InternalApplicationUserPermission permission = new InternalApplicationUserPermission();
@@ -93,17 +93,17 @@ public class InternalPermissionService {
     @Produces(MediaType.APPLICATION_JSON)
     public InternalRoleAccess addAccess(@Valid AddAccessRequest addAccessRequest) {
         InternalRoleAccess access = new InternalRoleAccess();
-        Application application = applicationResources.getApplication(addAccessRequest.applicationId);
+        Application application = applicationRepository.getApplication(addAccessRequest.applicationId);
         access.setApplicationId(addAccessRequest.applicationId);
         access.setRole(addAccessRequest.role);
         access.setApplication(application);
-        return internalRoleAccessResources.addAccess(access);
+        return internalRoleAccessRepository.addAccess(access);
     }
 
     @DELETE
     @Path("/{internalRoleAccessId}")
     public void deleteAccess(@Valid @PathParam("internalRoleAccessId") UUID internalRoleAccessId) {
-        internalRoleAccessResources.removeAccess(internalRoleAccessId);
+        internalRoleAccessRepository.removeAccess(internalRoleAccessId);
     }
 
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/ValidationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/ValidationResource.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.routers.internal;
 
-import com.redhat.cloud.notifications.db.ApplicationResources;
+import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.models.EventType;
 import org.jboss.resteasy.reactive.RestQuery;
 
@@ -15,19 +15,19 @@ import javax.ws.rs.core.Response;
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 
 @Path(API_INTERNAL + "/validation")
-public class ValidationEndpoint {
+public class ValidationResource {
 
     private static final String EVENT_TYPE_NOT_FOUND_MSG = "No event type found for [bundle=%s, application=%s, eventType=%s]";
 
     @Inject
-    ApplicationResources appResources;
+    ApplicationRepository applicationRepository;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/baet")
     public Response validate(@RestQuery String bundle, @RestQuery String application, @RestQuery String eventType) {
         try {
-            return convertToOkayResponse(appResources.getEventType(bundle, application, eventType));
+            return convertToOkayResponse(applicationRepository.getEventType(bundle, application, eventType));
         } catch (NoResultException e) {
             return convertToNotFoundResponse(bundle, application, eventType);
         }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/DbCleaner.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.db;
 
+import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
+import com.redhat.cloud.notifications.db.repositories.BundleRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.BehaviorGroupAction;
@@ -50,10 +52,10 @@ public class DbCleaner {
     EntityManager entityManager;
 
     @Inject
-    BundleResources bundleResources;
+    BundleRepository bundleRepository;
 
     @Inject
-    ApplicationResources appResources;
+    ApplicationRepository applicationRepository;
 
     /**
      * Deletes all records from all database tables (except for flyway_schema_history) and restores the default records.
@@ -67,20 +69,20 @@ public class DbCleaner {
         }
 
         Bundle bundle = new Bundle(DEFAULT_BUNDLE_NAME, DEFAULT_BUNDLE_DISPLAY_NAME);
-        bundleResources.createBundle(bundle);
+        bundleRepository.createBundle(bundle);
 
         Application app = new Application();
         app.setBundleId(bundle.getId());
         app.setName(DEFAULT_APP_NAME);
         app.setDisplayName(DEFAULT_APP_DISPLAY_NAME);
-        appResources.createApp(app);
+        applicationRepository.createApp(app);
 
         EventType eventType = new EventType();
         eventType.setApplicationId(app.getId());
         eventType.setName(DEFAULT_EVENT_TYPE_NAME);
         eventType.setDisplayName(DEFAULT_EVENT_TYPE_DISPLAY_NAME);
         eventType.setDescription(DEFAULT_EVENT_TYPE_DESCRIPTION);
-        appResources.createEventType(eventType);
+        applicationRepository.createEventType(eventType);
 
         entityManager.createQuery("UPDATE CurrentStatus SET status = :status")
                 .setParameter("status", Status.UP)

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -1,5 +1,9 @@
 package com.redhat.cloud.notifications.db;
 
+import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
+import com.redhat.cloud.notifications.db.repositories.BehaviorGroupRepository;
+import com.redhat.cloud.notifications.db.repositories.BundleRepository;
+import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
@@ -34,16 +38,16 @@ public class ResourceHelpers {
     public static final String TEST_BUNDLE_NAME = "testbundle";
 
     @Inject
-    EndpointResources endpointResources;
+    EndpointRepository endpointRepository;
 
     @Inject
-    ApplicationResources appResources;
+    ApplicationRepository applicationRepository;
 
     @Inject
-    BundleResources bundleResources;
+    BundleRepository bundleRepository;
 
     @Inject
-    BehaviorGroupResources behaviorGroupResources;
+    BehaviorGroupRepository behaviorGroupRepository;
 
     @Inject
     EntityManager entityManager;
@@ -54,11 +58,11 @@ public class ResourceHelpers {
 
     public Bundle createBundle(String name, String displayName) {
         Bundle bundle = new Bundle(name, displayName);
-        return bundleResources.createBundle(bundle);
+        return bundleRepository.createBundle(bundle);
     }
 
     public UUID getBundleId(String bundleName) {
-        return bundleResources.getBundle(bundleName)
+        return bundleRepository.getBundle(bundleName)
                 .getId();
     }
 
@@ -71,11 +75,11 @@ public class ResourceHelpers {
         app.setBundleId(bundleId);
         app.setName(name);
         app.setDisplayName(displayName);
-        return appResources.createApp(app);
+        return applicationRepository.createApp(app);
     }
 
     public UUID createEventType(String bundleName, String applicationName, String eventTypeName) {
-        Application app = appResources.getApplication(bundleName, applicationName);
+        Application app = applicationRepository.getApplication(bundleName, applicationName);
         return createEventType(app.getId(), eventTypeName, eventTypeName, "new event type")
                 .getId();
     }
@@ -86,7 +90,7 @@ public class ResourceHelpers {
         eventType.setDisplayName(displayName);
         eventType.setDescription(description);
         eventType.setApplicationId(applicationId);
-        return appResources.createEventType(eventType);
+        return applicationRepository.createEventType(eventType);
     }
 
     public UUID createTestAppAndEventTypes() {
@@ -128,7 +132,7 @@ public class ResourceHelpers {
         endpoint.setDescription(description);
         endpoint.setProperties(properties);
         endpoint.setEnabled(enabled);
-        return endpointResources.createEndpoint(endpoint);
+        return endpointRepository.createEndpoint(endpoint);
     }
 
     public int[] createTestEndpoints(String tenant, int count) {
@@ -155,7 +159,7 @@ public class ResourceHelpers {
             }
 
             ep.setAccountId(tenant);
-            endpointResources.createEndpoint(ep);
+            endpointRepository.createEndpoint(ep);
         }
         return statsValues;
     }
@@ -177,41 +181,41 @@ public class ResourceHelpers {
         BehaviorGroup behaviorGroup = new BehaviorGroup();
         behaviorGroup.setDisplayName(displayName);
         behaviorGroup.setBundleId(bundleId);
-        return behaviorGroupResources.create(accountId, behaviorGroup);
+        return behaviorGroupRepository.create(accountId, behaviorGroup);
     }
 
     public BehaviorGroup createDefaultBehaviorGroup(String displayName, UUID bundleId) {
         BehaviorGroup behaviorGroup = new BehaviorGroup();
         behaviorGroup.setDisplayName(displayName);
         behaviorGroup.setBundleId(bundleId);
-        return behaviorGroupResources.createDefault(behaviorGroup);
+        return behaviorGroupRepository.createDefault(behaviorGroup);
     }
 
     public List<EventType> findEventTypesByBehaviorGroupId(UUID behaviorGroupId) {
-        return behaviorGroupResources.findEventTypesByBehaviorGroupId(DEFAULT_ACCOUNT_ID, behaviorGroupId);
+        return behaviorGroupRepository.findEventTypesByBehaviorGroupId(DEFAULT_ACCOUNT_ID, behaviorGroupId);
     }
 
     public List<BehaviorGroup> findBehaviorGroupsByEventTypeId(UUID eventTypeId) {
-        return behaviorGroupResources.findBehaviorGroupsByEventTypeId(DEFAULT_ACCOUNT_ID, eventTypeId, new Query());
+        return behaviorGroupRepository.findBehaviorGroupsByEventTypeId(DEFAULT_ACCOUNT_ID, eventTypeId, new Query());
     }
 
     public List<BehaviorGroup> findBehaviorGroupsByEndpointId(UUID endpointId) {
-        return behaviorGroupResources.findBehaviorGroupsByEndpointId(DEFAULT_ACCOUNT_ID, endpointId);
+        return behaviorGroupRepository.findBehaviorGroupsByEndpointId(DEFAULT_ACCOUNT_ID, endpointId);
     }
 
     public Boolean updateBehaviorGroup(BehaviorGroup behaviorGroup) {
-        return behaviorGroupResources.update(DEFAULT_ACCOUNT_ID, behaviorGroup);
+        return behaviorGroupRepository.update(DEFAULT_ACCOUNT_ID, behaviorGroup);
     }
 
     public Boolean deleteBehaviorGroup(UUID behaviorGroupId) {
-        return behaviorGroupResources.delete(DEFAULT_ACCOUNT_ID, behaviorGroupId);
+        return behaviorGroupRepository.delete(DEFAULT_ACCOUNT_ID, behaviorGroupId);
     }
 
     public Boolean updateDefaultBehaviorGroup(BehaviorGroup behaviorGroup) {
-        return behaviorGroupResources.updateDefault(behaviorGroup);
+        return behaviorGroupRepository.updateDefault(behaviorGroup);
     }
 
     public Boolean deleteDefaultBehaviorGroup(UUID behaviorGroupId) {
-        return behaviorGroupResources.deleteDefault(behaviorGroupId);
+        return behaviorGroupRepository.deleteDefault(behaviorGroupId);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -1,6 +1,8 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.BehaviorGroupAction;
@@ -37,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class BehaviorGroupResourcesTest extends DbIsolatedTest {
+public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
 
     @Inject
     EntityManager entityManager;
@@ -46,7 +48,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
     ResourceHelpers resourceHelpers;
 
     @Inject
-    BehaviorGroupResources behaviorGroupResources;
+    BehaviorGroupRepository behaviorGroupRepository;
 
     @Test
     void testCreateAndUpdateAndDeleteBehaviorGroup() {
@@ -56,7 +58,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
 
         // Create behavior group.
         BehaviorGroup behaviorGroup = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, "displayName", bundle.getId());
-        List<BehaviorGroup> behaviorGroups = behaviorGroupResources.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
+        List<BehaviorGroup> behaviorGroups = behaviorGroupRepository.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
         assertEquals(1, behaviorGroups.size());
         assertEquals(behaviorGroup, behaviorGroups.get(0));
         assertEquals(behaviorGroup.getDisplayName(), behaviorGroups.get(0).getDisplayName());
@@ -67,7 +69,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
         assertTrue(updateBehaviorGroup(behaviorGroup.getId(), newDisplayName));
         entityManager.clear(); // We need to clear the session L1 cache before checking the update result.
 
-        behaviorGroups = behaviorGroupResources.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
+        behaviorGroups = behaviorGroupRepository.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
         assertEquals(1, behaviorGroups.size());
         assertEquals(behaviorGroup.getId(), behaviorGroups.get(0).getId());
         assertEquals(newDisplayName, behaviorGroups.get(0).getDisplayName());
@@ -76,7 +78,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
         // Delete behavior group.
         assertTrue(resourceHelpers.deleteBehaviorGroup(behaviorGroup.getId()));
 
-        behaviorGroups = behaviorGroupResources.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
+        behaviorGroups = behaviorGroupRepository.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
         assertTrue(behaviorGroups.isEmpty());
     }
 
@@ -89,7 +91,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
         // Create behavior group.
         BehaviorGroup behaviorGroup = resourceHelpers.createDefaultBehaviorGroup("displayName", bundle.getId());
 
-        List<BehaviorGroup> behaviorGroups = behaviorGroupResources.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
+        List<BehaviorGroup> behaviorGroups = behaviorGroupRepository.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
         assertEquals(1, behaviorGroups.size());
         assertEquals(behaviorGroup, behaviorGroups.get(0));
         assertEquals(behaviorGroup.getDisplayName(), behaviorGroups.get(0).getDisplayName());
@@ -100,7 +102,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
         assertTrue(updateDefaultBehaviorGroup(behaviorGroup.getId(), newDisplayName));
         entityManager.clear(); // We need to clear the session L1 cache before checking the update result.
 
-        behaviorGroups = behaviorGroupResources.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
+        behaviorGroups = behaviorGroupRepository.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
         assertEquals(1, behaviorGroups.size());
         assertEquals(behaviorGroup.getId(), behaviorGroups.get(0).getId());
         assertEquals(newDisplayName, behaviorGroups.get(0).getDisplayName());
@@ -109,7 +111,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
         // Delete behavior group.
         assertTrue(resourceHelpers.deleteDefaultBehaviorGroup(behaviorGroup.getId()));
 
-        behaviorGroups = behaviorGroupResources.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
+        behaviorGroups = behaviorGroupRepository.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
         assertTrue(behaviorGroups.isEmpty());
     }
 
@@ -150,7 +152,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
         BehaviorGroup behaviorGroup1 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, "displayName", bundle.getId());
         BehaviorGroup behaviorGroup2 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, "displayName", bundle.getId());
         BehaviorGroup behaviorGroup3 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, "displayName", bundle.getId());
-        List<BehaviorGroup> behaviorGroups = behaviorGroupResources.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
+        List<BehaviorGroup> behaviorGroups = behaviorGroupRepository.findByBundleId(DEFAULT_ACCOUNT_ID, bundle.getId());
         assertEquals(3, behaviorGroups.size());
         // Behavior groups should be sorted on descending creation date.
         assertEquals(behaviorGroup3, behaviorGroups.get(0));
@@ -280,7 +282,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
 
     @Transactional
     void updateAndCheckEventTypeBehaviors(String accountId, UUID eventTypeId, boolean expectedResult, UUID... behaviorGroupIds) {
-        boolean updated = behaviorGroupResources.updateEventTypeBehaviors(accountId, eventTypeId, Set.of(behaviorGroupIds));
+        boolean updated = behaviorGroupRepository.updateEventTypeBehaviors(accountId, eventTypeId, Set.of(behaviorGroupIds));
         // Is the update result the one we expected?
         assertEquals(expectedResult, updated);
         if (expectedResult) {
@@ -303,7 +305,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
 
     @Transactional
     void updateAndCheckBehaviorGroupActions(String accountId, UUID bundleId, UUID behaviorGroupId, Status expectedResult, UUID... endpointIds) {
-        Status status = behaviorGroupResources.updateBehaviorGroupActions(accountId, behaviorGroupId, Arrays.asList(endpointIds));
+        Status status = behaviorGroupRepository.updateBehaviorGroupActions(accountId, behaviorGroupId, Arrays.asList(endpointIds));
         // Is the update result the one we expected?
         assertEquals(expectedResult, status);
         if (expectedResult == Status.OK) {
@@ -318,7 +320,7 @@ public class BehaviorGroupResourcesTest extends DbIsolatedTest {
     }
 
     private List<BehaviorGroupAction> findBehaviorGroupActions(String accountId, UUID bundleId, UUID behaviorGroupId) {
-        return behaviorGroupResources.findByBundleId(accountId, bundleId)
+        return behaviorGroupRepository.findByBundleId(accountId, bundleId)
                 .stream().filter(behaviorGroup -> behaviorGroup.getId().equals(behaviorGroupId))
                 .findFirst().get().getActions();
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.db;
+package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.Endpoint;
@@ -16,14 +16,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-public class EndpointResourcesTest {
+public class EndpointRepositoryTest {
 
     @Test
     public void queryBuilderTest() {
         TypedQuery<Endpoint> query = mock(TypedQuery.class);
 
         // types with subtype and without it
-        EndpointResources.queryBuilderEndpointsPerType(
+        EndpointRepository.queryBuilderEndpointsPerType(
                 null,
                 null,
                 Set.of(
@@ -41,7 +41,7 @@ public class EndpointResourcesTest {
         clearInvocations(query);
 
         // without sub-types
-        EndpointResources.queryBuilderEndpointsPerType(
+        EndpointRepository.queryBuilderEndpointsPerType(
                 null,
                 null,
                 Set.of(
@@ -58,7 +58,7 @@ public class EndpointResourcesTest {
         clearInvocations(query);
 
         // with sub-types
-        EndpointResources.queryBuilderEndpointsPerType(
+        EndpointRepository.queryBuilderEndpointsPerType(
                 null,
                 null,
                 Set.of(

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -7,8 +7,8 @@ import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
-import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.repositories.EmailSubscriptionRepository;
 import com.redhat.cloud.notifications.models.BasicAuthentication;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class EndpointServiceTest extends DbIsolatedTest {
+public class EndpointResourceTest extends DbIsolatedTest {
 
     /*
      * In the tests below, most JSON responses are verified using JsonObject/JsonArray instead of deserializing these
@@ -78,7 +78,7 @@ public class EndpointServiceTest extends DbIsolatedTest {
     ResourceHelpers helpers;
 
     @Inject
-    EndpointEmailSubscriptionResources subscriptionResources;
+    EmailSubscriptionRepository emailSubscriptionRepository;
 
     @Test
     void testEndpointAdding() {
@@ -976,10 +976,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .then().statusCode(200)
                 .contentType(JSON);
 
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Enable instant on rhel.policies
         given()
@@ -988,10 +988,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/rhel/policies/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Enable daily on rhel.policies
         given()
@@ -1000,10 +1000,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/rhel/policies/daily")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Enable instant on TEST_BUNDLE_NAME.TEST_APP_NAME
         given()
@@ -1012,10 +1012,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/" + TEST_BUNDLE_NAME + "/" + TEST_APP_NAME + "/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Disable daily on rhel.policies
         given()
@@ -1024,10 +1024,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .delete("/endpoints/email/subscription/rhel/policies/daily")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Disable instant on rhel.policies
         given()
@@ -1036,10 +1036,10 @@ public class EndpointServiceTest extends DbIsolatedTest {
                 .delete("/endpoints/email/subscription/rhel/policies/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNotNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
     }
 
     @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
@@ -5,8 +5,8 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
-import com.redhat.cloud.notifications.db.EndpointResources;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Endpoint;
@@ -43,7 +43,7 @@ import static com.redhat.cloud.notifications.MockServerClientConfig.RbacAccess.N
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPTION;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
-import static com.redhat.cloud.notifications.routers.EventService.PATH;
+import static com.redhat.cloud.notifications.routers.EventResource.PATH;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.Boolean.FALSE;
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class EventServiceTest extends DbIsolatedTest {
+public class EventResourceTest extends DbIsolatedTest {
 
     private static final String OTHER_ACCOUNT_ID = "other-account-id";
     private static final LocalDateTime NOW = LocalDateTime.now(UTC);
@@ -69,7 +69,7 @@ public class EventServiceTest extends DbIsolatedTest {
     ResourceHelpers resourceHelpers;
 
     @Inject
-    EndpointResources endpointResources;
+    EndpointRepository endpointRepository;
 
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
@@ -111,8 +111,8 @@ public class EventServiceTest extends DbIsolatedTest {
         NotificationHistory history2 = resourceHelpers.createNotificationHistory(event1, endpoint2, FALSE);
         NotificationHistory history3 = resourceHelpers.createNotificationHistory(event2, endpoint1, TRUE);
         NotificationHistory history4 = resourceHelpers.createNotificationHistory(event3, endpoint2, TRUE);
-        endpointResources.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint1.getId());
-        endpointResources.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint2.getId());
+        endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint1.getId());
+        endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint2.getId());
 
         /*
          * Test #1

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalResourceTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class InternalServiceTest extends DbIsolatedTest {
+public class InternalResourceTest extends DbIsolatedTest {
 
     /*
      * In the tests below, most JSON responses are verified using JsonObject/JsonArray instead of deserializing these

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
@@ -7,7 +7,7 @@ import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
-import com.redhat.cloud.notifications.db.EndpointEmailSubscriptionResources;
+import com.redhat.cloud.notifications.db.repositories.EmailSubscriptionRepository;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.routers.models.SettingsValueJsonForm;
 import com.redhat.cloud.notifications.routers.models.SettingsValueJsonForm.Field;
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class UserConfigServiceTest extends DbIsolatedTest {
+public class UserConfigResourceTest extends DbIsolatedTest {
 
     @BeforeEach
     void beforeEach() {
@@ -51,7 +51,7 @@ public class UserConfigServiceTest extends DbIsolatedTest {
     MockServerClientConfig mockServerConfig;
 
     @Inject
-    EndpointEmailSubscriptionResources subscriptionResources;
+    EmailSubscriptionRepository emailSubscriptionRepository;
 
     @InjectMock
     TemplateEngineClient templateEngineClient;
@@ -255,7 +255,7 @@ public class UserConfigServiceTest extends DbIsolatedTest {
         assertEquals(true, preferences.getInstantEmail());
 
         // does not fail if we have unknown apps in our bundle's settings
-        subscriptionResources.subscribe(tenant, username, bundle, "not-found-app", DAILY);
+        emailSubscriptionRepository.subscribe(tenant, username, bundle, "not-found-app", DAILY);
 
         given()
                 .header(identityHeader)
@@ -266,7 +266,7 @@ public class UserConfigServiceTest extends DbIsolatedTest {
                 .statusCode(200)
                 .contentType(JSON);
 
-        subscriptionResources.unsubscribe(tenant, username, "not-found-bundle", "not-found-app", DAILY);
+        emailSubscriptionRepository.unsubscribe(tenant, username, "not-found-bundle", "not-found-app", DAILY);
 
         // Fails if we don't specify the bundleName
         given()
@@ -288,8 +288,8 @@ public class UserConfigServiceTest extends DbIsolatedTest {
                 .then()
                 .statusCode(200)
                 .contentType(TEXT);
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "not-found-bundle-2", "not-found-app-2", DAILY));
-        assertNull(subscriptionResources.getEmailSubscription(tenant, username, "not-found-bundle", "not-found-app", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "not-found-bundle-2", "not-found-app-2", DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "not-found-bundle", "not-found-app", INSTANT));
 
         // Does not add event type if is not supported by the templates
         when(templateEngineClient.isSubscriptionTypeSupported(bundle, application, DAILY)).thenReturn(FALSE);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/ValidationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/ValidationResourceTest.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.routers;
 import com.redhat.cloud.notifications.MockServerClientConfig;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestHelpers;
-import com.redhat.cloud.notifications.db.ApplicationResources;
+import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.models.EventType;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
@@ -20,17 +20,17 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
-class ValidationEndpointTest {
+class ValidationResourceTest {
 
     @MockServerConfig
     MockServerClientConfig mockServerConfig;
 
     @InjectMock
-    ApplicationResources appResources;
+    ApplicationRepository applicationRepository;
 
     @Test
     void shouldReturnNotFoundWhenTripleIsInvalid() {
-        when(appResources.getEventType(eq("blabla"), eq("Notifications"), eq("Any"))).thenThrow(new NoResultException());
+        when(applicationRepository.getEventType(eq("blabla"), eq("Notifications"), eq("Any"))).thenThrow(new NoResultException());
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("empty", "user");
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -54,7 +54,7 @@ class ValidationEndpointTest {
     @Test
     void shouldReturnStatusOkWhenTripleExists() {
         EventType eventType = new EventType();
-        when(appResources.getEventType(eq("my-bundle"), eq("Policies"), eq("Any"))).thenReturn(eventType);
+        when(applicationRepository.getEventType(eq("my-bundle"), eq("Policies"), eq("Any"))).thenReturn(eventType);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("empty", "user");
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);


### PR DESCRIPTION
In the JAX-RS world, a class that exposes REST endpoints is called a `resource`.

In the _modern_ design patterns world, what we do with our current `*Resources` classes matches the usual definition of the `Repository` pattern.

So let's give these classes the name they deserve 😁

ℹ️ I will not disrupt any exiting PR with conflicts that would result from merging this.