### PR TITLE
NOTIF-482 Add roles to access/me response

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionService.java
@@ -20,9 +20,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.SecurityContext;
 
 import java.util.List;
 import java.util.Set;
@@ -48,7 +46,7 @@ public class InternalPermissionService {
     @Path("/me")
     @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_USER) // Overrides admin permission
-    public InternalUserPermissions getPermissions(@Context SecurityContext sec) {
+    public InternalUserPermissions getPermissions() {
         InternalUserPermissions permissions = new InternalUserPermissions();
         if (securityIdentity.hasRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
             permissions.setAdmin(true);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionService.java
@@ -20,7 +20,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
 
 import java.util.List;
 import java.util.Set;
@@ -46,7 +48,7 @@ public class InternalPermissionService {
     @Path("/me")
     @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_USER) // Overrides admin permission
-    public InternalUserPermissions getPermissions() {
+    public InternalUserPermissions getPermissions(@Context SecurityContext sec) {
         InternalUserPermissions permissions = new InternalUserPermissions();
         if (securityIdentity.hasRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
             permissions.setAdmin(true);
@@ -61,6 +63,7 @@ public class InternalPermissionService {
                 .filter(s -> s.startsWith(privateRolePrefix))
                 .map(s -> s.substring(privateRolePrefix.length()))
                 .collect(Collectors.toSet());
+        permissions.getRoles().addAll(roles);
 
         List<InternalRoleAccess> accessList = internalRoleAccessResources.getByRoles(roles);
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/InternalUserPermissions.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/InternalUserPermissions.java
@@ -1,13 +1,22 @@
 package com.redhat.cloud.notifications.routers.internal.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class InternalUserPermissions {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class Application {
+        @NotNull
         private UUID id;
+        @NotNull
         private String displayName;
 
         public Application() {
@@ -55,9 +64,16 @@ public class InternalUserPermissions {
         }
     }
 
+    @NotNull
     private boolean isAdmin;
+
+    @NotNull
     private final List<Application> applications = new ArrayList<>();
 
+    @NotNull
+    private final List<String> roles = new ArrayList<>();
+
+    @JsonProperty(value = "is_admin")
     public boolean isAdmin() {
         return isAdmin;
     }
@@ -72,5 +88,9 @@ public class InternalUserPermissions {
 
     public void addApplication(UUID id, String displayName) {
         this.applications.add(new Application(id, displayName));
+    }
+
+    public List<String> getRoles() {
+        return this.roles;
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -39,7 +39,7 @@ public class TestHelpers {
         return new String(Base64.getEncoder().encode(header.encode().getBytes(UTF_8)), UTF_8);
     }
 
-    public static String encodeTurnpikeIdentityInfo(String username, String group) {
+    public static String encodeTurnpikeIdentityInfo(String username, String... groups) {
         JsonObject identity = new JsonObject();
         JsonObject associate = new JsonObject();
         JsonArray roles = new JsonArray();
@@ -49,7 +49,9 @@ public class TestHelpers {
         identity.put("associate", associate);
         associate.put("email", username);
         associate.put("Role", roles);
-        roles.add(group);
+        for (String group: groups) {
+            roles.add(group);
+        }
 
         JsonObject header = new JsonObject();
         header.put("identity", identity);
@@ -61,7 +63,7 @@ public class TestHelpers {
         return new Header(X_RH_IDENTITY_HEADER, encodeRHIdentityInfo(tenant, username));
     }
 
-    public static Header createTurnpikeIdentityHeader(String username, String role) {
+    public static Header createTurnpikeIdentityHeader(String username, String... role) {
         return new Header(X_RH_IDENTITY_HEADER, encodeTurnpikeIdentityInfo(username, role));
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -63,8 +63,8 @@ public class TestHelpers {
         return new Header(X_RH_IDENTITY_HEADER, encodeRHIdentityInfo(tenant, username));
     }
 
-    public static Header createTurnpikeIdentityHeader(String username, String... role) {
-        return new Header(X_RH_IDENTITY_HEADER, encodeTurnpikeIdentityInfo(username, role));
+    public static Header createTurnpikeIdentityHeader(String username, String... roles) {
+        return new Header(X_RH_IDENTITY_HEADER, encodeTurnpikeIdentityInfo(username, roles));
     }
 
     public static Header createRHIdentityHeader(String encodedIdentityHeader) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionsServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionsServiceTest.java
@@ -76,6 +76,7 @@ public class InternalPermissionsServiceTest extends DbIsolatedTest {
 
         assertFalse(permissions.isAdmin());
         assertEquals(List.of(new InternalUserPermissions.Application(UUID.fromString(appId), appDisplayName)), permissions.getApplications());
+        assertEquals(List.of(appRole, otherRole), permissions.getRoles());
 
         // We can create the event type now
         String eventTypeId = CrudTestHelpers.createEventType(turnpikeAppDev, appId, "my-event", "My event", "Event description", 200).get();

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionsServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionsServiceTest.java
@@ -37,24 +37,27 @@ public class InternalPermissionsServiceTest extends DbIsolatedTest {
     @Test
     void userAccess() {
         String appRole = "crc-app-team";
+        String otherRole = "other-role";
         Header turnpikeAdminHeader = TestHelpers.createTurnpikeIdentityHeader("admin", adminRole);
-        Header turnpikeAppDev = TestHelpers.createTurnpikeIdentityHeader("app-admin", appRole);
+        Header turnpikeAppDev = TestHelpers.createTurnpikeIdentityHeader("app-admin", appRole, otherRole);
 
         String bundleId = CrudTestHelpers.createBundle(turnpikeAdminHeader, "test-permission-bundle", "Test permissions Bundle", 200).get();
         String appDisplayName = "Test permissions App";
         String appId = CrudTestHelpers.createApp(turnpikeAdminHeader, bundleId, "test-permission-app", appDisplayName, null, 200).get();
 
-        // admin - Has admin access and no applicationIds
+        // admin - Has admin access and no applicationIds and no roles.
         InternalUserPermissions permissions = permissions(turnpikeAdminHeader);
 
         assertTrue(permissions.isAdmin());
         assertTrue(permissions.getApplications().isEmpty());
+        assertTrue(permissions.getRoles().isEmpty());
 
-        // App admin - no permissions are set yet, no admin and no applicationIds
+        // App admin - no permissions are set yet, no admin, no applicationIds but has roles
         permissions = permissions(turnpikeAppDev);
 
         assertFalse(permissions.isAdmin());
         assertTrue(permissions.getApplications().isEmpty());
+        assertEquals(List.of(appRole, otherRole), permissions.getRoles());
 
         // Can't create an event type without the permission
         CrudTestHelpers.createEventType(turnpikeAppDev, appId, "my-event", "My event", "Event description", 403);
@@ -68,7 +71,7 @@ public class InternalPermissionsServiceTest extends DbIsolatedTest {
         // Non admins can't create a role - even if they have permissions to an app
         CrudTestHelpers.createInternalRoleAccess(turnpikeAppDev, appRole, appId, 403);
 
-        // App admin - no admin and applicationIds is [ appId ]
+        // App admin - no admin, applicationIds is [ appId ] and has roles
         permissions = permissions(turnpikeAppDev);
 
         assertFalse(permissions.isAdmin());


### PR DESCRIPTION
Adds the `roles` an user has to the `/access/me` response.

This will allow the UI to present some roles the user can access, to make it easier to create the applications.
