### PR TITLE
RHICOMPL-2763: implemented the compliance aggregator

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ComplianceEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ComplianceEmailAggregator.java
@@ -1,16 +1,55 @@
 package com.redhat.cloud.notifications.processors.email.aggregators;
 
 import com.redhat.cloud.notifications.models.EmailAggregation;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class ComplianceEmailAggregator extends AbstractEmailPayloadAggregator {
 
-    public ComplianceEmailAggregator() {
+    private static final String EVENT_TYPE = "event_type";
+    private static final String REPORT_UPLOAD_FAILED = "report-upload-failed";
+    private static final String SYSTEM_NON_COMPLIANT = "compliance-below-threshold";
+    // private static final String SYSTEM_NOT_REPORTING = "system-not-reporting";
 
+    private static final List<String> EVENT_TYPES = Arrays.asList(REPORT_UPLOAD_FAILED, SYSTEM_NON_COMPLIANT);
+    // private static final List<String> EVENT_TYPES = Arrays.asList(REPORT_UPLOAD_FAILED, SYSTEM_NON_COMPLIANT, SYSTEM_NOT_REPORTING);
+
+    private static final String COMPLIANCE_KEY = "compliance";
+    private static final String CONTEXT_KEY = "context";
+    private static final String EVENTS_KEY = "events";
+    private static final String PAYLOAD_KEY = "payload";
+
+    public ComplianceEmailAggregator() {
+        JsonObject compliance = new JsonObject();
+
+        compliance.put(REPORT_UPLOAD_FAILED, new JsonArray());
+        compliance.put(SYSTEM_NON_COMPLIANT, new JsonArray());
+        // compliance.put(SYSTEM_NOT_REPORTING, new JsonArray());
+
+        context.put(COMPLIANCE_KEY, compliance);
     }
 
     @Override
-    void processEmailAggregation(EmailAggregation aggregation) {
-        throw new RuntimeException("Not implemented yet");
-    }
+    void processEmailAggregation(EmailAggregation notification) {
+        JsonObject notificationJson = notification.getPayload();
+        String eventType = notificationJson.getString(EVENT_TYPE);
 
+        JsonObject compliance = this.context.getJsonObject(COMPLIANCE_KEY);
+
+        // Ignore events that are not declared among the supported event types
+        if (!EVENT_TYPES.contains(eventType)) {
+            return;
+        }
+
+        notificationJson.getJsonArray(EVENTS_KEY).stream().forEach(eventObject -> {
+            JsonObject event = (JsonObject) eventObject;
+            JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
+
+            JsonArray collection = compliance.getJsonArray(eventType);
+            collection.add(payload);
+        });
+    }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/ComplianceTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ComplianceTestHelpers.java
@@ -1,0 +1,60 @@
+package com.redhat.cloud.notifications;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.transformers.BaseTransformer;
+import io.vertx.core.json.JsonObject;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.ZoneOffset.UTC;
+
+public class ComplianceTestHelpers {
+
+    public static BaseTransformer baseTransformer = new BaseTransformer();
+
+    public static EmailAggregation createEmailAggregation(String tenant, String bundle, String application, String eventType, String policyId, String inventoryId) {
+        EmailAggregation aggregation = new EmailAggregation();
+        aggregation.setBundleName(bundle);
+        aggregation.setApplicationName(application);
+        aggregation.setAccountId(tenant);
+        aggregation.setCreated(LocalDateTime.now(UTC).minusHours(5L));
+
+        Action emailActionMessage = new Action();
+        emailActionMessage.setBundle(bundle);
+        emailActionMessage.setApplication(application);
+        emailActionMessage.setTimestamp(LocalDateTime.now());
+        emailActionMessage.setEventType(eventType);
+
+        emailActionMessage.setContext(Map.of(
+                "inventory_id", inventoryId,
+                "system_check_in", "2020-08-03T15:22:42.199046",
+                "display_name", "My test machine",
+                "tags", List.of()
+        ));
+        emailActionMessage.setEvents(List.of(
+                Event
+                        .newBuilder()
+                        .setMetadataBuilder(Metadata.newBuilder())
+                        .setPayload(Map.of(
+                                "policy_id", policyId,
+                                "policy_name", "not-tested-name",
+                                "policy_description", "not-used-desc",
+                                "policy_condition", "not-used-condition"
+                        ))
+                        .build()
+        ));
+
+        emailActionMessage.setAccountId(tenant);
+
+        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        aggregation.setPayload(payload);
+
+        return aggregation;
+    }
+
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ComplianceEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ComplianceEmailAggregatorTest.java
@@ -1,0 +1,51 @@
+package com.redhat.cloud.notifications.processors.email.aggregators;
+
+import com.redhat.cloud.notifications.ComplianceTestHelpers;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+class ComplianceEmailAggregatorTest {
+
+    private ComplianceEmailAggregator aggregator;
+
+    @BeforeEach
+    void setUp() {
+        aggregator = new ComplianceEmailAggregator();
+    }
+
+    @Test
+    void emptyAggregatorHasNoAccountId() {
+        Assertions.assertNull(aggregator.getAccountId(), "Empty aggregator has no accountId");
+    }
+
+    @Test
+    void shouldSetAccountNumber() {
+        aggregator.aggregate(ComplianceTestHelpers.createEmailAggregation("tenant", "rhel", "compliance", "report-upload-failed", "policyId", "inventoryId"));
+        Assertions.assertEquals("tenant", aggregator.getAccountId());
+    }
+
+    @Test
+    void validatePayload() {
+        aggregator.aggregate(ComplianceTestHelpers.createEmailAggregation("tenant", "rhel", "compliance", "foo", "policy0", "host0"));
+        aggregator.aggregate(ComplianceTestHelpers.createEmailAggregation("tenant", "rhel", "compliance", "report-upload-failed", "policy1", "host1"));
+        aggregator.aggregate(ComplianceTestHelpers.createEmailAggregation("tenant", "rhel", "compliance", "report-upload-failed", "policy2", "host2"));
+        aggregator.aggregate(ComplianceTestHelpers.createEmailAggregation("tenant", "rhel", "compliance", "compliance-below-threshold", "policy3", "host3"));
+        aggregator.aggregate(ComplianceTestHelpers.createEmailAggregation("tenant", "rhel", "compliance", "compliance-below-threshold", "policy4", "host4"));
+        // aggregator.aggregate(ComplianceTestHelpers.createEmailAggregation("tenant", "rhel", "compliance", "system-not-reporting", "policy5", "host5"));
+        // aggregator.aggregate(ComplianceTestHelpers.createEmailAggregation("tenant", "rhel", "compliance", "system-not-reporting", "policy6", "host6"));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject compliance = JsonObject.mapFrom(context).getJsonObject("compliance");
+        System.out.println(compliance.toString());
+
+        Assertions.assertFalse(compliance.containsKey("foo"));
+        Assertions.assertEquals(compliance.getJsonArray("report-upload-failed").size(), 2);
+        Assertions.assertEquals(compliance.getJsonArray("compliance-below-threshold").size(), 2);
+        Assertions.assertEquals(compliance.getJsonArray("compliance-below-threshold").size(), 2);
+        // Assertions.assertEquals(compliance.getJsonArray("system-not-reporting").size(), 2);
+    }
+}


### PR DESCRIPTION
From the test output:
```json
{
  "compliance": {
    "report-upload-failed": [
      {
        "policy_condition": "not-used-condition",
        "policy_description": "not-used-desc",
        "policy_id": "policy1",
        "policy_name": "not-tested-name"
      },
      {
        "policy_condition": "not-used-condition",
        "policy_description": "not-used-desc",
        "policy_id": "policy2",
        "policy_name": "not-tested-name"
      }
    ],
    "compliance-below-threshold": [
      {
        "policy_condition": "not-used-condition",
        "policy_description": "not-used-desc",
        "policy_id": "policy3",
        "policy_name": "not-tested-name"
      },
      {
        "policy_condition": "not-used-condition",
        "policy_description": "not-used-desc",
        "policy_id": "policy4",
        "policy_name": "not-tested-name"
      }
    ]
  },
  "start_time": null,
  "end_time": null
}

```