### PR TITLE
NOTIF-621 Allow to retrieve the event log for one event

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -58,6 +58,21 @@ public class EventRepository {
         return query.getSingleResult();
     }
 
+    public Event getEventById(UUID eventId, boolean fetchNotificationHistory) {
+
+        String hql;
+
+        if (fetchNotificationHistory) {
+            hql = "SELECT DISTINCT e FROM Event e LEFT JOIN FETCH e.historyEntries he WHERE e.id = :eventId ";
+        } else {
+            hql = "FROM Event e WHERE e.id = :eventId";
+        }
+
+        return entityManager.createQuery(hql, Event.class)
+                .setParameter("eventId", eventId)
+                .getSingleResult();
+    }
+
     private Optional<String> getOrderByCondition(String sortBy) {
         if (sortBy == null) {
             return Optional.of(" ORDER BY e.created DESC");


### PR DESCRIPTION
This is a RFC.

It allows to get the event log for one single event to populate more details on the chips of a event, like the failure one here: 

![Bildschirmfoto 2022-03-29 um 17 28 35](https://user-images.githubusercontent.com/208246/160648382-96c5e4bf-6324-4112-85c2-17bbc03186a1.png)

The idea is not to load all the details etc, as they are not needed for the list, but to interactively fetch when the user clicks on a chip

```
❯ curl -i -HX-rh-identity:`cat rhid.txt` localhost:8085/api/notifications/v1.0/notifications/events/97189817-e0eb-4b66-981d-51632e944721
HTTP/1.1 200 OK
content-length: 767
Content-Type: application/json

[{"id":"97189817-e0eb-4b66-981d-51632e944721","created":"2022-03-22T10:08:25.344896","bundle":"Red Hat Enterprise Linux","application":"Policies","event_type":"Policy triggered","payload":"{\"bundle\":\"rhel\",\"application\":\"policies\",\"event_type\":\"policy-triggered\",\"timestamp\":\"2021-09-08T09:31:39\",\"account_id\":\"54321\",\"context\":\"{\\\"ckey1\\\":\\\"cvalue\\\",\\\"ckey2\\\":\\\"cvalue2\\\"}\",\"events\":[{\"metadata\":{},\"payload\":\"{\\\"key1\\\":\\\"value\\\",\\\"key2\\\":\\\"value2\\\"}\"}],\"version\":\"v1.0.0\",\"recipients\":[]}","actions":[{"id":"cdac470c-4468-4998-8c38-28a58a0f8660","endpoint_type":"camel","endpoint_sub_type":"slack","invocation_result":false,"endpoint_id":"3018d124-16dc-42f0-ba98-448a802301e9","details":null}]}]%  
```