### PR TITLE
NOTIF-347 Allow to create endpoints with rbac groups

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProvider.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProvider.java
@@ -171,6 +171,8 @@ public class ConsoleIdentityProvider implements IdentityProvider<ConsoleAuthenti
 
     private static ConsoleIdentity getRhIdentityFromString(String xRhIdHeader) {
         String xRhDecoded = new String(Base64.getDecoder().decode(xRhIdHeader.getBytes(UTF_8)), UTF_8);
-        return Json.decodeValue(xRhDecoded, ConsoleIdentityWrapper.class).getIdentity();
+        ConsoleIdentity identity = Json.decodeValue(xRhDecoded, ConsoleIdentityWrapper.class).getIdentity();
+        identity.rawIdentity = xRhIdHeader;
+        return identity;
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/ConsoleIdentity.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/ConsoleIdentity.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.auth.principal;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -29,6 +30,9 @@ import com.redhat.cloud.notifications.auth.principal.turnpike.TurnpikeX509Identi
 public abstract class ConsoleIdentity {
     @JsonProperty(required = true)
     public String type;
+
+    @JsonIgnore
+    public String rawIdentity;
 
     public abstract String getName();
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroup.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroup.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.auth.rbac;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.ClientWebApplicationException;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroup.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroup.java
@@ -2,6 +2,8 @@ package com.redhat.cloud.notifications.auth.rbac;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -21,10 +23,19 @@ public class RbacGroup {
 
     public boolean validate(UUID groupId, String rhIdentity) {
         if (isRbacEnabled) {
-            Response response = rbacServer.getGroup(groupId, rhIdentity)
-                    .await()
-                    .atMost(Duration.ofSeconds(2L));
-            return response.getStatus() == 200;
+            try {
+                Response response = rbacServer.getGroup(groupId, rhIdentity)
+                        .await()
+                        .atMost(Duration.ofSeconds(2L));
+                return response.getStatus() == 200;
+            } catch (ClientWebApplicationException errorException) {
+                if (errorException.getResponse().getStatus() == 404) {
+                    // This is fine, the group was not found
+                    return false;
+                }
+
+                throw errorException;
+            }
         }
 
         return true;

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroup.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroup.java
@@ -11,14 +11,14 @@ import java.time.Duration;
 import java.util.UUID;
 
 @ApplicationScoped
-public class RbacGroup {
+public class RbacGroupValidator {
 
     @Inject
     @RestClient
     RbacServer rbacServer;
 
     @ConfigProperty(name = "rbac.enabled", defaultValue = "true")
-    Boolean isRbacEnabled;
+    boolean isRbacEnabled;
 
     public boolean validate(UUID groupId, String rhIdentity) {
         if (isRbacEnabled) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroup.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroup.java
@@ -1,0 +1,32 @@
+package com.redhat.cloud.notifications.auth.rbac;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import java.time.Duration;
+import java.util.UUID;
+
+@ApplicationScoped
+public class RbacGroup {
+
+    @Inject
+    @RestClient
+    RbacServer rbacServer;
+
+    @ConfigProperty(name = "rbac.enabled", defaultValue = "true")
+    Boolean isRbacEnabled;
+
+    public boolean validate(UUID groupId, String rhIdentity) {
+        if (isRbacEnabled) {
+            Response response = rbacServer.getGroup(groupId, rhIdentity)
+                    .await()
+                    .atMost(Duration.ofSeconds(2L));
+            return response.getStatus() == 200;
+        }
+
+        return true;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroupValidator.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacGroupValidator.java
@@ -7,7 +7,6 @@ import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.core.Response;
-import java.time.Duration;
 import java.util.UUID;
 
 @ApplicationScoped
@@ -23,9 +22,7 @@ public class RbacGroupValidator {
     public boolean validate(UUID groupId, String rhIdentity) {
         if (isRbacEnabled) {
             try {
-                Response response = rbacServer.getGroup(groupId, rhIdentity)
-                        .await()
-                        .atMost(Duration.ofSeconds(2L));
+                Response response = rbacServer.getGroup(groupId, rhIdentity);
                 return response.getStatus() == 200;
             } catch (ClientWebApplicationException errorException) {
                 if (errorException.getResponse().getStatus() == 404) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
@@ -9,8 +9,12 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import java.util.UUID;
 
 import static com.redhat.cloud.notifications.Constants.X_RH_IDENTITY_HEADER;
 
@@ -29,4 +33,9 @@ public interface RbacServer {
                              @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity
 
     );
+
+    @GET
+    @Path("/groups/{groupID}/") // trailing slash is required by api
+    @Produces("application/json")
+    Uni<Response> getGroup(@PathParam("groupID") UUID groupId, @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity);
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
@@ -37,5 +37,5 @@ public interface RbacServer {
     @GET
     @Path("/groups/{groupID}/") // trailing slash is required by api
     @Produces("application/json")
-    Uni<Response> getGroup(@PathParam("groupID") UUID groupId, @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity);
+    Response getGroup(@PathParam("groupID") UUID groupId, @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity);
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.routers;
 import com.redhat.cloud.notifications.Constants;
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
 import com.redhat.cloud.notifications.auth.principal.rhid.RhIdPrincipal;
-import com.redhat.cloud.notifications.auth.rbac.RbacGroup;
+import com.redhat.cloud.notifications.auth.rbac.RbacGroupValidator;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.db.repositories.EmailSubscriptionRepository;
@@ -97,7 +97,7 @@ public class EndpointResource {
     ApplicationRepository applicationRepository;
 
     @Inject
-    RbacGroup rbacGroup;
+    RbacGroupValidator rbacGroupValidator;
 
     @ConfigProperty(name = "ob.enabled", defaultValue = "false")
     boolean obEnabled;
@@ -230,7 +230,7 @@ public class EndpointResource {
         }
 
         if (requestProps.getGroupId() != null) {
-            boolean isValid = rbacGroup.validate(requestProps.getGroupId(), principal.getIdentity().rawIdentity);
+            boolean isValid = rbacGroupValidator.validate(requestProps.getGroupId(), principal.getIdentity().rawIdentity);
             if (!isValid) {
                 throw new BadRequestException(String.format("Invalid RBAC group identified with id %s", requestProps.getGroupId()));
             }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -225,6 +225,10 @@ public class EndpointResource {
     public Endpoint getOrCreateEmailSubscriptionEndpoint(@Context SecurityContext sec, @NotNull @Valid RequestEmailSubscriptionProperties requestProps) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
 
+        if (requestProps.getGroupId() != null && requestProps.isOnlyAdmins()) {
+            throw new BadRequestException(String.format("Cannot use RBAC groups and only admins in the same endpoint"));
+        }
+
         if (requestProps.getGroupId() != null) {
             boolean isValid = rbacGroup.validate(requestProps.getGroupId(), principal.getIdentity().rawIdentity);
             if (!isValid) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RequestEmailSubscriptionProperties.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/RequestEmailSubscriptionProperties.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import javax.validation.constraints.NotNull;
+import java.util.UUID;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RequestEmailSubscriptionProperties {
     @NotNull
     private boolean onlyAdmins;
+    private UUID groupId;
 
     public boolean isOnlyAdmins() {
         return onlyAdmins;
@@ -16,5 +18,13 @@ public class RequestEmailSubscriptionProperties {
 
     public void setOnlyAdmins(boolean onlyAdmins) {
         this.onlyAdmins = onlyAdmins;
+    }
+
+    public UUID getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(UUID groupId) {
+        this.groupId = groupId;
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
@@ -52,7 +52,7 @@ public class MockServerConfig {
     public static void addGroupResponse(String xRhIdentity, String groupId, int statusCode) {
         getClient()
             .when(request()
-                    .withPath(String.format("/api/rbac/v1/groups/%s", groupId))
+                    .withPath(String.format("/api/rbac/v1/groups/%s/", groupId))
                     .withHeader(X_RH_IDENTITY_HEADER, xRhIdentity)
             )
             .respond(response()

--- a/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
@@ -49,8 +49,21 @@ public class MockServerConfig {
                         .withBody(access.getPayload()));
     }
 
-    public static void addHttpTestEndpoint(HttpRequest request, HttpResponse response, boolean secure) {
+    public void addGroupResponse(String xRhIdentity, String groupId, int statusCode) {
         getClient()
+                .when(request()
+                        .withPath(String.format("/api/rbac/v1/groups/%s", groupId))
+                        .withHeader(X_RH_IDENTITY_HEADER, xRhIdentity)
+                )
+                .respond(response()
+                        .withStatusCode(statusCode)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")
+                );
+    }
+
+    public void addHttpTestEndpoint(HttpRequest request, HttpResponse response, boolean secure) {
+            getClient()
                 .withSecure(secure)
                 .when(request)
                 .respond(response);

--- a/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
@@ -49,24 +49,24 @@ public class MockServerConfig {
                         .withBody(access.getPayload()));
     }
 
-    public void addGroupResponse(String xRhIdentity, String groupId, int statusCode) {
+    public static void addGroupResponse(String xRhIdentity, String groupId, int statusCode) {
         getClient()
-                .when(request()
-                        .withPath(String.format("/api/rbac/v1/groups/%s", groupId))
-                        .withHeader(X_RH_IDENTITY_HEADER, xRhIdentity)
-                )
-                .respond(response()
-                        .withStatusCode(statusCode)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody("{}")
-                );
+            .when(request()
+                    .withPath(String.format("/api/rbac/v1/groups/%s", groupId))
+                    .withHeader(X_RH_IDENTITY_HEADER, xRhIdentity)
+            )
+            .respond(response()
+                    .withStatusCode(statusCode)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{}")
+            );
     }
 
     public void addHttpTestEndpoint(HttpRequest request, HttpResponse response, boolean secure) {
-            getClient()
-                .withSecure(secure)
-                .when(request)
-                .respond(response);
+        getClient()
+            .withSecure(secure)
+            .when(request)
+            .respond(response);
     }
 
     public static void clearRbac() {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -1054,9 +1054,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(tenant, userName);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
 
-        mockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
-        mockServerConfig.addGroupResponse(identityHeaderValue, validGroupId, 200);
-        mockServerConfig.addGroupResponse(identityHeaderValue, unknownGroupId, 404);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+        MockServerConfig.addGroupResponse(identityHeaderValue, validGroupId, 200);
+        MockServerConfig.addGroupResponse(identityHeaderValue, unknownGroupId, 404);
 
         // valid group id
         RequestEmailSubscriptionProperties requestProps = new RequestEmailSubscriptionProperties();

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -43,7 +43,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.redhat.cloud.notifications.Constants.X_RH_IDENTITY_HEADER;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_APP_NAME;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_BUNDLE_NAME;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
@@ -58,8 +57,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -39,9 +39,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.redhat.cloud.notifications.Constants.X_RH_IDENTITY_HEADER;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_APP_NAME;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_BUNDLE_NAME;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
@@ -56,6 +58,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
@@ -1041,6 +1045,84 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .statusCode(400)
                 .extract().asString();
         assertSystemEndpointTypeError(stringResponse, EndpointType.EMAIL_SUBSCRIPTION);
+    }
+
+    @Test
+    void testAddEndpointEmailSubscriptionRbac() {
+        String tenant = "adding-email-subscription";
+        String userName = "user";
+        String validGroupId = "f85517d0-063b-4eed-a501-e79ffc1f5ad3";
+        String unknownGroupId = "f44f50d5-acab-482c-a3cf-087faf2c709c";
+
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(tenant, userName);
+        Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+
+        mockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerClientConfig.RbacAccess.FULL_ACCESS);
+        mockServerConfig.addGroupResponse(identityHeaderValue, validGroupId, 200);
+        mockServerConfig.addGroupResponse(identityHeaderValue, unknownGroupId, 404);
+
+        // valid group id
+        RequestEmailSubscriptionProperties requestProps = new RequestEmailSubscriptionProperties();
+        requestProps.setGroupId(UUID.fromString(validGroupId));
+
+        Response response = given()
+                .header(identityHeader)
+                .when()
+                .contentType(JSON)
+                .body(Json.encode(requestProps))
+                .post("/endpoints/system/email_subscription")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().response();
+
+        JsonObject responsePoint = new JsonObject(response.getBody().asString());
+        responsePoint.mapTo(Endpoint.class);
+        String endpointId = responsePoint.getString("id");
+        assertNotNull(endpointId);
+
+        // Same group again yields the same endpoint id
+        response = given()
+                .header(identityHeader)
+                .when()
+                .contentType(JSON)
+                .body(Json.encode(requestProps))
+                .post("/endpoints/system/email_subscription")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().response();
+
+        responsePoint = new JsonObject(response.getBody().asString());
+        responsePoint.mapTo(Endpoint.class);
+        assertEquals(endpointId, responsePoint.getString("id"));
+
+        // Invalid group is a bad request (i.e. group does not exist)
+        requestProps.setGroupId(UUID.fromString(unknownGroupId));
+        given()
+                .header(identityHeader)
+                .when()
+                .contentType(JSON)
+                .body(Json.encode(requestProps))
+                .post("/endpoints/system/email_subscription")
+                .then()
+                .statusCode(400)
+                .contentType(JSON)
+                .extract().response();
+
+        // Can't specify admin and group - bad request
+        requestProps.setGroupId(UUID.fromString(validGroupId));
+        requestProps.setOnlyAdmins(true);
+        given()
+                .header(identityHeader)
+                .when()
+                .contentType(JSON)
+                .body(Json.encode(requestProps))
+                .post("/endpoints/system/email_subscription")
+                .then()
+                .statusCode(400)
+                .contentType(JSON)
+                .extract().response();
     }
 
     @Test


### PR DESCRIPTION
Requires doing a validation with rbac to confirm the group id really exists.
We might need a way to delete rbac groups that are deleted. 