### PR TITLE
Downgrade mockserver to 5.5.4

### DIFF
--- a/common/src/test/java/com/redhat/cloud/notifications/MockServerLifecycleManager.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/MockServerLifecycleManager.java
@@ -7,7 +7,7 @@ import org.testcontainers.utility.DockerImageName;
 public class MockServerLifecycleManager {
 
     // Keep the version synced with pom.xml.
-    private static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.13.0");
+    private static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.5.4");
 
     private static MockServerContainer container;
     private static String containerUrl;

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
         <openapi-parser.version>4.0.4</openapi-parser.version>
         <failsafe.version>3.2.3</failsafe.version>
 
-        <!-- Keep the version synced with TestLifecycleManager -->
-        <mockserver-client-java.version>5.13.0</mockserver-client-java.version>
+        <!-- Keep the version synced with MockServerLifecycleManager -->
+        <mockserver-client-java.version>5.5.4</mockserver-client-java.version>
 
         <insights-notification-schemas-java.version>0.6</insights-notification-schemas-java.version>
         <clowder-quarkus-config-source.version>1.0.0</clowder-quarkus-config-source.version>


### PR DESCRIPTION
It looks like we're still stuck with `mockserver-client-java 5.5.4`... I'll keep looking for a way to use the latest version, but in the meantime this PR will fix the current instabilities.