### PR TITLE
Removing 'users' tag on rbac.get-users.total Prometheus metric

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
@@ -141,7 +141,7 @@ public class RbacRecipientUsersProvider {
 
         // Micrometer doesn't like when tags are null and throws a NPE.
         String accountIdTag = accountId == null ? "" : accountId;
-        getUsersTotalTimer.stop(meterRegistry.timer("rbac.get-users.total", "accountId", accountIdTag, "users", String.valueOf(users.size())));
+        getUsersTotalTimer.stop(meterRegistry.timer("rbac.get-users.total", "accountId", accountIdTag));
         rbacUsers.set(users.size());
 
         return users;

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
@@ -150,8 +150,8 @@ public class RbacRecipientUsersProvider {
     }
 
     private AtomicInteger getRbacUsersGauge(String accountIdTag) {
-        return rbacUsers.computeIfAbsent(accountIdTag, /* accountIdTag */ key -> {
-            Set<Tag> tags = Set.of(Tag.of("accountId", key));
+        return rbacUsers.computeIfAbsent(accountIdTag, accountId -> {
+            Set<Tag> tags = Set.of(Tag.of("accountId", accountId));
             return meterRegistry.gauge("rbac.users", tags, new AtomicInteger());
         });
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
@@ -13,6 +13,7 @@ import dev.failsafe.RetryPolicy;
 import dev.failsafe.function.CheckedSupplier;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.ConnectTimeoutException;
 import io.quarkus.cache.CacheResult;
@@ -29,7 +30,10 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -81,18 +85,16 @@ public class RbacRecipientUsersProvider {
 
     private Counter rbacFailuresCounter;
 
-    private final AtomicInteger rbacUsers = new AtomicInteger(0);
-
     private RetryPolicy<Object> rbacRetryPolicy;
 
     private Counter itFailuresCounter;
     private RetryPolicy<Object> itRetryPolicy;
 
+    private Map</* accountId */ String, AtomicInteger> rbacUsers = new ConcurrentHashMap<>();
+
     @PostConstruct
     public void init() {
         rbacFailuresCounter = meterRegistry.counter("rbac.failures");
-
-        meterRegistry.gauge("rbac.users", rbacUsers);
 
         rbacRetryPolicy = RetryPolicy.builder()
                 .onRetry(event -> rbacFailuresCounter.increment())
@@ -142,9 +144,16 @@ public class RbacRecipientUsersProvider {
         // Micrometer doesn't like when tags are null and throws a NPE.
         String accountIdTag = accountId == null ? "" : accountId;
         getUsersTotalTimer.stop(meterRegistry.timer("rbac.get-users.total", "accountId", accountIdTag));
-        rbacUsers.set(users.size());
+        getRbacUsersGauge(accountIdTag).set(users.size());
 
         return users;
+    }
+
+    private AtomicInteger getRbacUsersGauge(String accountIdTag) {
+        return rbacUsers.computeIfAbsent(accountIdTag, /* accountIdTag */ key -> {
+            Set<Tag> tags = Set.of(Tag.of("accountId", key));
+            return meterRegistry.gauge("rbac.users", tags, new AtomicInteger());
+        });
     }
 
     @CacheResult(cacheName = "rbac-recipient-users-provider-get-group-users")


### PR DESCRIPTION
It was useful to have, but now it adds extra cardinality and makes queries more complex when comparing accounts