### PR TITLE
NOTIF-347 Check if the group exists

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
@@ -19,6 +19,7 @@ import io.quarkus.cache.CacheResult;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -160,7 +161,18 @@ public class RbacRecipientUsersProvider {
     @CacheResult(cacheName = "rbac-recipient-users-provider-get-group-users")
     public List<User> getGroupUsers(String accountId, boolean adminOnly, UUID groupId) {
         Timer.Sample getGroupUsersTotalTimer = Timer.start(meterRegistry);
-        RbacGroup rbacGroup = retryOnRbacError(() -> rbacServiceToService.getGroup(accountId, groupId));
+        RbacGroup rbacGroup;
+        try {
+            rbacGroup = retryOnRbacError(() -> rbacServiceToService.getGroup(accountId, groupId));
+        } catch (ClientWebApplicationException exception) {
+            // The group does not exist (or no longer exists - ignore)
+            if (exception.getResponse().getStatus() == 404) {
+                return List.of();
+            }
+
+            throw exception;
+        }
+
         List<User> users;
         if (rbacGroup.isPlatformDefault()) {
             users = getUsers(accountId, adminOnly);

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
@@ -24,6 +24,7 @@ import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -166,7 +167,7 @@ public class RbacRecipientUsersProvider {
             rbacGroup = retryOnRbacError(() -> rbacServiceToService.getGroup(accountId, groupId));
         } catch (ClientWebApplicationException exception) {
             // The group does not exist (or no longer exists - ignore)
-            if (exception.getResponse().getStatus() == 404) {
+            if (exception.getResponse().getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
                 return List.of();
             }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProviderTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProviderTest.java
@@ -16,6 +16,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -122,6 +123,16 @@ public class RbacRecipientUsersProviderTest {
         }
     }
 
+
+    @Test
+    public void getUsersFromNonExistentGroupResultsInNoUsers() {
+        UUID nonExistentGroup = UUID.randomUUID();
+        mockNotFoundGroup(nonExistentGroup);
+
+        List<User> users = rbacRecipientUsersProvider.getGroupUsers(accountId, false, nonExistentGroup);
+        assertEquals(0, users.size());
+    }
+
     @Test
     public void getAllUsersCache() {
         int initialSize = 1095;
@@ -185,6 +196,13 @@ public class RbacRecipientUsersProviderTest {
                 Mockito.eq(accountId),
                 Mockito.eq(group.getUuid())
         )).thenReturn(group);
+    }
+
+    private void mockNotFoundGroup(UUID groupId) {
+        when(rbacServiceToService.getGroup(
+                Mockito.eq(accountId),
+                Mockito.eq(groupId)
+        )).thenThrow(new ClientWebApplicationException(404));
     }
 
     private void mockGetGroupUsers(int elements, UUID groupId) {

--- a/engine/src/test/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProviderTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProviderTest.java
@@ -123,9 +123,8 @@ public class RbacRecipientUsersProviderTest {
         }
     }
 
-
     @Test
-    public void getUsersFromNonExistentGroupResultsInNoUsers() {
+    public void shouldReturnNoUsersWhenGroupNotFound() {
         UUID nonExistentGroup = UUID.randomUUID();
         mockNotFoundGroup(nonExistentGroup);
 


### PR DESCRIPTION
 If the group no longer exists, just ignore it.

Now that we are going to accept groups, they could be deleted without us noticing it. So instead of failing, lets just ignore it.