### PR TITLE
Bump MockServer to 5.13.2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,19 @@
 When using IntelliJ IDEA, use the 'default' style. This is matched by checkstyle,
 which is invoked when running maven.
 
+== Enabling the MockServer log during tests
+
+This project uses link:https://www.mock-server.com[MockServer] to mock external services during the tests execution.
+
+The MockServer log is disabled by default to reduce the noise in the application log.
+It can be enabled by adding the following argument to the Maven build command:
+
+```
+-Dmockserver.logLevel=WARN|INFO|DEBUG|TRACE
+```
+
+Details about each MockServer log level are available in the link:https://www.mock-server.com/mock_server/debugging_issues.html[MockServer documentation].
+
 ## Usage of the Clowder Config Source
 
 This project uses the Clowder Config Source from https://github.com/RedHatInsights/clowder-quarkus-config-source.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -157,8 +157,8 @@
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-client-java</artifactId>
-            <version>${mockserver-client-java.version}</version>
+            <artifactId>mockserver-netty-no-dependencies</artifactId>
+            <version>${mockserver-netty-no-dependencies.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -10,6 +10,8 @@ import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
+
 public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
 
     PostgreSQLContainer<?> postgreSQLContainer;
@@ -60,8 +62,8 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
 
     void setupMockEngine(Map<String, String> props) {
         MockServerLifecycleManager.start();
-        props.put("quarkus.rest-client.rbac-authentication.url", MockServerLifecycleManager.getContainerUrl());
-        props.put("quarkus.rest-client.ob.url", MockServerLifecycleManager.getContainerUrl());
-        props.put("quarkus.rest-client.kc.url", MockServerLifecycleManager.getContainerUrl());
+        props.put("quarkus.rest-client.rbac-authentication.url", getMockServerUrl());
+        props.put("quarkus.rest-client.ob.url", getMockServerUrl());
+        props.put("quarkus.rest-client.kc.url", getMockServerUrl());
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.events;
 
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MockServerConfig;
-import com.redhat.cloud.notifications.MockServerLifecycleManager;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
@@ -41,6 +40,7 @@ import java.util.function.Supplier;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess;
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
 import static com.redhat.cloud.notifications.TestConstants.API_INTEGRATIONS_V_1_0;
 import static com.redhat.cloud.notifications.TestConstants.API_NOTIFICATIONS_V_1_0;
 import static com.redhat.cloud.notifications.TestHelpers.createTurnpikeIdentityHeader;
@@ -453,7 +453,7 @@ public class LifecycleITest extends DbIsolatedTest {
         properties.setMethod(HttpType.POST);
         properties.setDisableSslVerification(true);
         properties.setSecretToken(secretToken);
-        properties.setUrl(MockServerLifecycleManager.getContainerUrl() + WEBHOOK_MOCK_PATH);
+        properties.setUrl(getMockServerUrl() + WEBHOOK_MOCK_PATH);
 
         Endpoint endpoint = new Endpoint();
         endpoint.setType(EndpointType.WEBHOOK);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MockServerConfig;
-import com.redhat.cloud.notifications.MockServerLifecycleManager;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
@@ -43,6 +42,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_APP_NAME;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_BUNDLE_NAME;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
@@ -110,7 +110,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         properties.setMethod(HttpType.POST);
         properties.setDisableSslVerification(false);
         properties.setSecretToken("my-super-secret-token");
-        properties.setUrl(MockServerLifecycleManager.getContainerUrl());
+        properties.setUrl(getMockServerUrl());
 
         Endpoint ep = new Endpoint();
         ep.setType(EndpointType.WEBHOOK);
@@ -256,7 +256,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         properties.setMethod(HttpType.POST);
         properties.setDisableSslVerification(false);
         properties.setSecretToken("my-super-secret-token");
-        properties.setUrl(MockServerLifecycleManager.getContainerUrl());
+        properties.setUrl(getMockServerUrl());
 
         // Test with properties, but without endpoint type
         ep.setProperties(properties);
@@ -303,7 +303,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         CamelProperties cAttr = new CamelProperties();
         cAttr.setDisableSslVerification(false);
-        cAttr.setUrl(MockServerLifecycleManager.getContainerUrl());
+        cAttr.setUrl(getMockServerUrl());
         cAttr.setBasicAuthentication(new BasicAuthentication("testuser", "secret"));
         Map<String, String> extras = new HashMap<>();
         extras.put("template", "11");
@@ -376,7 +376,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         CamelProperties cAttr = new CamelProperties();
         cAttr.setDisableSslVerification(false);
-        cAttr.setUrl(MockServerLifecycleManager.getContainerUrl());
+        cAttr.setUrl(getMockServerUrl());
         cAttr.setBasicAuthentication(new BasicAuthentication("testuser", "secret"));
         Map<String, String> extras = new HashMap<>();
         extras.put("template", "11");
@@ -426,7 +426,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         CamelProperties cAttr = new CamelProperties();
         cAttr.setDisableSslVerification(false);
-        cAttr.setUrl(MockServerLifecycleManager.getContainerUrl());
+        cAttr.setUrl(getMockServerUrl());
         Map<String, String> extras = new HashMap<>();
         extras.put("channel", "#notifications");
         cAttr.setExtras(extras);
@@ -527,7 +527,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         properties.setMethod(HttpType.POST);
         properties.setDisableSslVerification(false);
         properties.setSecretToken("my-super-secret-token");
-        properties.setUrl(MockServerLifecycleManager.getContainerUrl());
+        properties.setUrl(getMockServerUrl());
 
         Endpoint ep = new Endpoint();
         ep.setType(EndpointType.WEBHOOK);
@@ -628,7 +628,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         properties.setMethod(HttpType.POST);
         properties.setDisableSslVerification(false);
         properties.setSecretToken("my-super-secret-token");
-        properties.setUrl(MockServerLifecycleManager.getContainerUrl());
+        properties.setUrl(getMockServerUrl());
 
         Endpoint ep = new Endpoint();
         ep.setType(EndpointType.WEBHOOK);
@@ -656,7 +656,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         CamelProperties camelProperties = new CamelProperties();
         camelProperties.setDisableSslVerification(false);
         camelProperties.setSecretToken("my-super-secret-token");
-        camelProperties.setUrl(MockServerLifecycleManager.getContainerUrl());
+        camelProperties.setUrl(getMockServerUrl());
         camelProperties.setExtras(new HashMap<>());
 
         Endpoint camelEp = new Endpoint();
@@ -841,7 +841,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         properties.setDisableSslVerification(false);
         properties.setSecretToken("my-super-secret-token");
         properties.setBasicAuthentication(new BasicAuthentication("myuser", "mypassword"));
-        properties.setUrl(MockServerLifecycleManager.getContainerUrl());
+        properties.setUrl(getMockServerUrl());
 
         Endpoint ep = new Endpoint();
         ep.setType(EndpointType.WEBHOOK);
@@ -1030,7 +1030,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         webhookProperties.setMethod(HttpType.POST);
         webhookProperties.setDisableSslVerification(false);
         webhookProperties.setSecretToken("my-super-secret-token");
-        webhookProperties.setUrl(MockServerLifecycleManager.getContainerUrl());
+        webhookProperties.setUrl(getMockServerUrl());
         ep.setProperties(webhookProperties);
 
         stringResponse = given()
@@ -1314,7 +1314,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             properties.setMethod(HttpType.POST);
             properties.setDisableSslVerification(false);
             properties.setSecretToken("my-super-secret-token");
-            properties.setUrl(MockServerLifecycleManager.getContainerUrl());
+            properties.setUrl(getMockServerUrl());
 
             Endpoint ep = new Endpoint();
             ep.setType(EndpointType.WEBHOOK);
@@ -1452,7 +1452,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             properties.setMethod(HttpType.POST);
             properties.setDisableSslVerification(false);
             properties.setSecretToken("my-super-secret-token");
-            properties.setUrl(MockServerLifecycleManager.getContainerUrl() + "/" + i);
+            properties.setUrl(getMockServerUrl() + "/" + i);
 
             Endpoint ep = new Endpoint();
             ep.setType(EndpointType.WEBHOOK);

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -61,8 +61,8 @@
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-client-java</artifactId>
-            <version>${mockserver-client-java.version}</version>
+            <artifactId>mockserver-netty-no-dependencies</artifactId>
+            <version>${mockserver-netty-no-dependencies.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/common/src/test/java/com/redhat/cloud/notifications/MockServerLifecycleManager.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/MockServerLifecycleManager.java
@@ -1,39 +1,34 @@
 package com.redhat.cloud.notifications;
 
-import org.mockserver.client.MockServerClient;
-import org.testcontainers.containers.MockServerContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.mockserver.integration.ClientAndServer;
+
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 public class MockServerLifecycleManager {
 
-    // Keep the version synced with pom.xml.
-    private static final DockerImageName DOCKER_IMAGE = DockerImageName.parse("mockserver/mockserver").withTag("mockserver-5.5.4");
+    private static final String LOG_LEVEL_KEY = "mockserver.logLevel";
 
-    private static MockServerContainer container;
-    private static String containerUrl;
-    private static MockServerClient client;
+    private static ClientAndServer mockServer;
+    private static String mockServerUrl;
 
     public static void start() {
-        container = new MockServerContainer(DOCKER_IMAGE);
-        container.start();
-        containerUrl = "http://" + container.getContainerIpAddress() + ":" + container.getServerPort();
-        client = new MockServerClient(container.getContainerIpAddress(), container.getServerPort());
+        if (System.getProperty(LOG_LEVEL_KEY) == null) {
+            System.setProperty(LOG_LEVEL_KEY, "OFF");
+            System.out.println("MockServer log is disabled. Use '-D" + LOG_LEVEL_KEY + "=WARN|INFO|DEBUG|TRACE' to enable it.");
+        }
+        mockServer = startClientAndServer();
+        mockServerUrl = "http://localhost:" + mockServer.getPort();
     }
 
-    public static String getContainerUrl() {
-        return containerUrl;
+    public static String getMockServerUrl() {
+        return mockServerUrl;
     }
 
-    public static MockServerClient getClient() {
-        return client;
+    public static ClientAndServer getClient() {
+        return mockServer;
     }
 
     public static void stop() {
-        if (client != null) {
-            client.stop();
-        }
-        if (container != null) {
-            container.stop();
-        }
+        mockServer.stop();
     }
 }

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -144,8 +144,8 @@
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-client-java</artifactId>
-            <version>${mockserver-client-java.version}</version>
+            <artifactId>mockserver-netty-no-dependencies</artifactId>
+            <version>${mockserver-netty-no-dependencies.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -11,6 +11,7 @@ import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
 import static com.redhat.cloud.notifications.events.EventConsumer.INGRESS_CHANNEL;
 import static com.redhat.cloud.notifications.events.FromCamelHistoryFiller.EGRESS_CHANNEL;
 import static com.redhat.cloud.notifications.events.FromCamelHistoryFiller.FROMCAMEL_CHANNEL;
@@ -82,9 +83,9 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
 
     void setupMockEngine(Map<String, String> props) {
         MockServerLifecycleManager.start();
-        props.put("quarkus.rest-client.rbac-s2s.url", MockServerLifecycleManager.getContainerUrl());
-        props.put("quarkus.rest-client.it-s2s.url", MockServerLifecycleManager.getContainerUrl());
-        props.put("quarkus.rest-client.ob.url", MockServerLifecycleManager.getContainerUrl());
-        props.put("quarkus.rest-client.kc.url", MockServerLifecycleManager.getContainerUrl());
+        props.put("quarkus.rest-client.rbac-s2s.url", getMockServerUrl());
+        props.put("quarkus.rest-client.it-s2s.url", getMockServerUrl());
+        props.put("quarkus.rest-client.ob.url", getMockServerUrl());
+        props.put("quarkus.rest-client.kc.url", getMockServerUrl());
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -56,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
 import static com.redhat.cloud.notifications.ReflectionHelper.updateField;
 import static com.redhat.cloud.notifications.TestHelpers.serializeAction;
 import static com.redhat.cloud.notifications.events.EndpointProcessor.PROCESSED_ENDPOINTS_COUNTER_NAME;
@@ -261,7 +262,7 @@ public class LifecycleITest {
         properties.setMethod(HttpType.POST);
         properties.setDisableSslVerification(true);
         properties.setSecretToken(secretToken);
-        properties.setUrl(MockServerLifecycleManager.getContainerUrl() + WEBHOOK_MOCK_PATH);
+        properties.setUrl(getMockServerUrl() + WEBHOOK_MOCK_PATH);
         return createEndpoint(accountId, WEBHOOK, "endpoint", "Endpoint", properties);
     }
 
@@ -397,7 +398,7 @@ public class LifecycleITest {
         updateField(
                 emailSender,
                 "bopUrl",
-                MockServerLifecycleManager.getContainerUrl() + EMAIL_SENDER_MOCK_PATH,
+                getMockServerUrl() + EMAIL_SENDER_MOCK_PATH,
                 EmailSender.class
         );
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.processors.camel;
 
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
 import com.redhat.cloud.notifications.MockServerConfig;
-import com.redhat.cloud.notifications.MockServerLifecycleManager;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.converters.MapConverter;
 import com.redhat.cloud.notifications.ingress.Action;
@@ -37,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
 import static com.redhat.cloud.notifications.events.KafkaMessageDeduplicator.MESSAGE_ID_HEADER;
 import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.processors.camel.CamelTypeProcessor.CAMEL_SUBTYPE_HEADER;
@@ -169,7 +169,7 @@ public class CamelTypeProcessorTest {
         assertTrue(details.containsKey("failure"));
 
         // Now set up some mock OB endpoints (simulate valid bridge)
-        String eventsEndpoint = MockServerLifecycleManager.getContainerUrl() + "/events";
+        String eventsEndpoint = getMockServerUrl() + "/events";
         System.out.println("==> Setting events endpoint to " + eventsEndpoint);
         Bridge bridge = new Bridge("321", eventsEndpoint, "my bridge");
         Map<String, String> auth = new HashMap<>();

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -54,7 +55,7 @@ public class WebhookTest {
 
     @Test
     void testWebhook() {
-        String url = MockServerLifecycleManager.getContainerUrl() + "/foobar";
+        String url = getMockServerUrl() + "/foobar";
 
         final List<String> bodyRequests = new ArrayList<>();
         ExpectationResponseCallback verifyEmptyRequest = req -> {
@@ -115,7 +116,7 @@ public class WebhookTest {
     }
 
     private void testRetry(boolean shouldSucceedEventually) {
-        String url = MockServerLifecycleManager.getContainerUrl() + "/foobar";
+        String url = getMockServerUrl() + "/foobar";
 
         AtomicInteger callsCounter = new AtomicInteger();
         ExpectationResponseCallback expectationResponseCallback = request -> {

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,7 @@
         <openapi-parser.version>4.0.4</openapi-parser.version>
         <failsafe.version>3.2.3</failsafe.version>
 
-        <!-- Keep the version synced with MockServerLifecycleManager -->
-        <mockserver-client-java.version>5.5.4</mockserver-client-java.version>
+        <mockserver-netty-no-dependencies.version>5.13.2</mockserver-netty-no-dependencies.version>
 
         <insights-notification-schemas-java.version>0.6</insights-notification-schemas-java.version>
         <clowder-quarkus-config-source.version>1.0.0</clowder-quarkus-config-source.version>


### PR DESCRIPTION
Our build is unstable on GitHub when the `mockserver-client-java` version is higher than `5.5.4`.

This branch will be used to try and stabilize the build with the latest mockserver version.