### PR TITLE
NOTIF-484 Render DB templates with standalone Qute engine

### DIFF
--- a/database/src/main/resources/db/migration/V1.48.0__NOTIF-484_template_name_unique.sql
+++ b/database/src/main/resources/db/migration/V1.48.0__NOTIF-484_template_name_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE template
+    ADD CONSTRAINT uq_template_name UNIQUE (name);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -50,6 +50,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.redhat.cloud.notifications.templates.TemplateService.USE_TEMPLATES_FROM_DB_KEY;
+
 @ApplicationScoped
 public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
 
@@ -64,7 +66,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
             .filter(emailSubscriptionType -> emailSubscriptionType != EmailSubscriptionType.INSTANT)
             .collect(Collectors.toList());
 
-    @ConfigProperty(name = "notifications.use-templates-from-db", defaultValue = "false")
+    @ConfigProperty(name = USE_TEMPLATES_FROM_DB_KEY)
     boolean useTemplatesFromDb;
 
     @Inject

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/DbTemplateLocator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/DbTemplateLocator.java
@@ -1,0 +1,54 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.models.Template;
+import io.quarkus.qute.TemplateLocator;
+import io.quarkus.qute.Variant;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Optional;
+
+@ApplicationScoped
+public class DbTemplateLocator implements TemplateLocator {
+
+    private static Logger LOGGER = Logger.getLogger(DbTemplateLocator.class);
+
+    @Inject
+    EntityManager entityManager;
+
+    @Override
+    public Optional<TemplateLocation> locate(String name) {
+        String hql = "FROM Template WHERE name = :name";
+        try {
+            Template template = entityManager.createQuery(hql, Template.class)
+                    .setParameter("name", name)
+                    .getSingleResult();
+            LOGGER.tracef("Template with [name=%s] found in the database", name);
+            return Optional.of(buildTemplateLocation(template.getData()));
+        } catch (NoResultException e) {
+            LOGGER.tracef("Template with [name=%s] not found in the database", name);
+            return Optional.empty();
+        }
+    }
+
+    private TemplateLocation buildTemplateLocation(String templateData) {
+
+        return new TemplateLocation() {
+
+            @Override
+            public Reader read() {
+                return new StringReader(templateData);
+            }
+
+            @Override
+            public Optional<Variant> getVariant() {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineResource.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineResource.java
@@ -22,12 +22,13 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+import static com.redhat.cloud.notifications.templates.TemplateService.USE_TEMPLATES_FROM_DB_KEY;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path(API_INTERNAL + "/template-engine")
 public class TemplateEngineResource {
 
-    @ConfigProperty(name = "notifications.use-templates-from-db", defaultValue = "false")
+    @ConfigProperty(name = USE_TEMPLATES_FROM_DB_KEY)
     boolean useTemplatesFromDb;
 
     @Inject

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateService.java
@@ -2,15 +2,28 @@ package com.redhat.cloud.notifications.templates;
 
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.recipients.User;
+import com.redhat.cloud.notifications.templates.extensions.LocalDateTimeExtension;
 import com.redhat.cloud.notifications.templates.models.Environment;
 import io.quarkus.qute.Engine;
+import io.quarkus.qute.EvalContext;
+import io.quarkus.qute.ReflectionValueResolver;
 import io.quarkus.qute.TemplateInstance;
+import io.quarkus.qute.ValueResolver;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.time.LocalDateTime;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class TemplateService {
+
+    public static final String USE_TEMPLATES_FROM_DB_KEY = "notifications.use-templates-from-db";
+
+    private static final Logger LOGGER = Logger.getLogger(TemplateService.class);
 
     @Inject
     Engine engine;
@@ -18,8 +31,40 @@ public class TemplateService {
     @Inject
     Environment environment;
 
+    @Inject
+    DbTemplateLocator dbTemplateLocator;
+
+    Engine dbEngine;
+
+    @PostConstruct
+    void postConstruct() {
+        if (ConfigProvider.getConfig().getValue(USE_TEMPLATES_FROM_DB_KEY, Boolean.class)) {
+            LOGGER.info("Using templates from the database");
+        }
+        dbEngine = Engine.builder()
+                .addDefaults()
+                .addValueResolver(new ReflectionValueResolver()) // Recommended by the Qute doc.
+                .addValueResolver(buildValueResolver(LocalDateTime.class, "toUtcFormat", LocalDateTimeExtension::toUtcFormat))
+                .addValueResolver(buildValueResolver(String.class, "toUtcFormat", LocalDateTimeExtension::toUtcFormat))
+                .addValueResolver(buildValueResolver(LocalDateTime.class, "toStringFormat", LocalDateTimeExtension::toStringFormat))
+                .addValueResolver(buildValueResolver(String.class, "toStringFormat", LocalDateTimeExtension::toStringFormat))
+                .addValueResolver(buildValueResolver(LocalDateTime.class, "toTimeAgo", LocalDateTimeExtension::toTimeAgo))
+                .addValueResolver(buildValueResolver(String.class, "toTimeAgo", LocalDateTimeExtension::toTimeAgo))
+                .addValueResolver(buildValueResolver(String.class, "fromIsoLocalDateTime", LocalDateTimeExtension::fromIsoLocalDateTime))
+                .addLocator(dbTemplateLocator)
+                .build();
+    }
+
     public TemplateInstance compileTemplate(String template, String name) {
-        return engine.parse(template, null, name).instance();
+        return getEngine().parse(template, null, name).instance();
+    }
+
+    private Engine getEngine() {
+        if (ConfigProvider.getConfig().getValue(USE_TEMPLATES_FROM_DB_KEY, Boolean.class)) {
+            return dbEngine;
+        } else {
+            return engine;
+        }
     }
 
     public String renderTemplate(User user, Action action, TemplateInstance templateInstance) {
@@ -28,5 +73,18 @@ public class TemplateService {
                 .data("user", user)
                 .data("environment", environment)
                 .render();
+    }
+
+    private static <T> ValueResolver buildValueResolver(Class<T> baseClass, String extensionName, Function<T, Object> valueTransformer) {
+        return ValueResolver.builder()
+                .applyToBaseClass(baseClass)
+                .applyToName(extensionName)
+                .resolveSync(new Function<EvalContext, Object>() {
+                    @Override
+                    public Object apply(EvalContext evalContext) {
+                        return valueTransformer.apply((T) evalContext.getBase());
+                    }
+                })
+                .build();
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/extensions/LocalDateTimeExtension.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/extensions/LocalDateTimeExtension.java
@@ -8,6 +8,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
+// TODO NOTIF-484 Remove this annotation, it has no effect while using a standalone Qute engine.
 @TemplateExtension
 public class LocalDateTimeExtension {
 

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -129,3 +129,6 @@ ob.token.pass=<ob-pass-for-token>
 quarkus.rest-client.ob.url=https://bridge.acme.org
 quarkus.rest-client.kc.url=https://keycloak.acme.org
 quarkus.cache.caffeine.kc-cache.expire-after-write=PT120s
+
+# Use this property to load the templates from the DB. Temp, to be removed soon.
+notifications.use-templates-from-db=false

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
@@ -56,8 +56,8 @@ public class TemplateRepositoryTest {
         app2 = resourceHelpers.createApp(bundle.getId(), "app-2-" + UUID.randomUUID());
         eventType2 = resourceHelpers.createEventType(app2.getId(), "event-type-2-" + UUID.randomUUID());
 
-        subjectTemplate = resourceHelpers.createTemplate("subject-template", "Subject template", "You have a notification!");
-        bodyTemplate = resourceHelpers.createTemplate("body-template", "Body template", "Something happened!");
+        subjectTemplate = resourceHelpers.createTemplate("subject-template-" + UUID.randomUUID(), "Subject template", "You have a notification!");
+        bodyTemplate = resourceHelpers.createTemplate("body-template-" + UUID.randomUUID(), "Body template", "Something happened!");
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
@@ -97,6 +97,7 @@ public class DbQuteEngineTest {
     Template createTemplate(String name, String data) {
         Template template = new Template();
         template.setName(name);
+        template.setDescription("The best template ever created");
         template.setData(data);
         entityManager.persist(template);
         return template;

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
@@ -1,0 +1,104 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.models.Template;
+import io.quarkus.qute.TemplateException;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+
+import static com.redhat.cloud.notifications.templates.TemplateService.USE_TEMPLATES_FROM_DB_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class DbQuteEngineTest {
+
+    @Inject
+    EntityManager entityManager;
+
+    @Inject
+    TemplateService templateService;
+
+    @BeforeEach
+    void beforeEach() {
+        System.setProperty(USE_TEMPLATES_FROM_DB_KEY, "true");
+    }
+
+    @AfterEach
+    void afterEach() {
+        System.clearProperty(USE_TEMPLATES_FROM_DB_KEY);
+    }
+
+    @Test
+    void testIncludeExistingTemplate() {
+        Template outerTemplate = createTemplate("outer-template", "Hello, {#include inner-template /}");
+        createTemplate("inner-template", "World!");
+        String renderedOuterTemplate = templateService.compileTemplate(outerTemplate.getData(), outerTemplate.getName()).render();
+        assertEquals("Hello, World!", renderedOuterTemplate);
+    }
+
+    @Test
+    void testIncludeUnknownTemplate() {
+        Template outerTemplate = createTemplate("other-outer-template", "Hello, {#include unknown-inner-template /}");
+        TemplateException e = assertThrows(TemplateException.class, () -> {
+            templateService.compileTemplate(outerTemplate.getData(), outerTemplate.getName()).render();
+        });
+        assertEquals("Template not found: unknown-inner-template", e.getMessage());
+    }
+
+    @Test
+    void testToUtcFormatExtension() {
+        Template template = createTemplate("to-utc-format-template", "{date.toUtcFormat()}");
+        LocalDateTime date = LocalDateTime.of(2022, Month.JANUARY, 1, 0, 0);
+        TemplateInstance templateInstance = templateService.compileTemplate(template.getData(), template.getName());
+        assertEquals("01 Jan 2022 00:00 UTC", templateInstance.data("date", date).render());
+        assertEquals("01 Jan 2022 00:00 UTC", templateInstance.data("date", date.toString()).render());
+    }
+
+    @Test
+    void testToStringFormatExtension() {
+        Template template = createTemplate("to-string-format-template", "{date.toStringFormat()}");
+        LocalDateTime date = LocalDateTime.of(2022, Month.JANUARY, 1, 0, 0);
+        TemplateInstance templateInstance = templateService.compileTemplate(template.getData(), template.getName());
+        assertEquals("01 Jan 2022", templateInstance.data("date", date).render());
+        assertEquals("01 Jan 2022", templateInstance.data("date", date.toString()).render());
+    }
+
+    @Test
+    void testToTimeAgoExtension() {
+        Template template = createTemplate("to-time-ago-template", "{date.toTimeAgo()}");
+        LocalDateTime date = LocalDateTime.now().minusDays(2L);
+        TemplateInstance templateInstance = templateService.compileTemplate(template.getData(), template.getName());
+        assertEquals("2 days ago", templateInstance.data("date", date).render());
+        assertEquals("2 days ago", templateInstance.data("date", date.toString()).render());
+    }
+
+    @Test
+    void testFromIsoLocalDateTimeExtension() {
+        Template template = createTemplate("from-iso-local-date-time-template", "{date.fromIsoLocalDateTime()}");
+        LocalDateTime date = LocalDateTime.of(2022, Month.JANUARY, 1, 0, 0);
+        TemplateInstance templateInstance = templateService.compileTemplate(template.getData(), template.getName());
+        assertEquals("2022-01-01T00:00", templateInstance.data("date", date.toString()).render());
+    }
+
+    @Transactional
+    Template createTemplate(String name, String data) {
+        Template template = new Template();
+        template.setName(name);
+        template.setData(data);
+        entityManager.persist(template);
+        return template;
+    }
+}


### PR DESCRIPTION
This PR is necessary to allow the injection of a DB template into another DB template.

Outer template:
```
Hello, {#include inner-template /}
```
Inner template:
```
World!
```
Rendering outcome:
```
Hello, World!
```

It is based on [this part](https://quarkus.io/guides/qute-reference#standalone) of the Qute doc.

ℹ️ This PR has not impact on prod. It can be safely merged.