### PR TITLE
Fix EndpointRepository startup warning

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -38,8 +38,6 @@ public class EndpointRepository {
     @Inject
     EntityManager entityManager;
 
-
-
     @Transactional
     public Endpoint createEndpoint(Endpoint endpoint) {
         // Todo: NOTIF-429 backward compatibility change - Remove soon.
@@ -205,7 +203,7 @@ public class EndpointRepository {
     }
 
     @Transactional
-    private boolean modifyEndpointStatus(String tenant, UUID id, boolean enabled) {
+    boolean modifyEndpointStatus(String tenant, UUID id, boolean enabled) {
         String query = "UPDATE Endpoint SET enabled = :enabled WHERE accountId = :accountId AND id = :id";
         int rowCount = entityManager.createQuery(query)
                 .setParameter("id", id)


### PR DESCRIPTION
Fixes
```
2022-04-06 16:55:25,156 WARN  [io.qua.arc.pro.Methods] (build-60) @Transactional will have no effect on method com.redhat.cloud.notifications.db.repositories.EndpointRepository.modifyEndpointStatus() because the method is private
```