### PR TITLE
NOTIF-484 Introduce templates migration service

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/AdminResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/AdminResource.java
@@ -4,12 +4,15 @@ import com.redhat.cloud.notifications.StuffHolder;
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
 import com.redhat.cloud.notifications.auth.rbac.RbacRaw;
 import com.redhat.cloud.notifications.auth.rbac.RbacServer;
+import com.redhat.cloud.notifications.templates.TemplateEngineClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -31,6 +34,10 @@ public class AdminResource {
     @Inject
     @RestClient
     RbacServer rbacServer;
+
+    @Inject
+    @RestClient
+    TemplateEngineClient templateEngine;
 
     @GET
     @Produces(APPLICATION_JSON)
@@ -79,4 +86,17 @@ public class AdminResource {
         return builder.build();
     }
 
+    // TODO NOTIF-484 Remove this method when the templates DB migration is finished.
+    @DELETE
+    @Path("/templates/migrate")
+    public void deleteAllTemplates() {
+        templateEngine.deleteAllTemplates();
+    }
+
+    // TODO NOTIF-484 Remove this method when the templates DB migration is finished.
+    @PUT
+    @Path("/templates/migrate")
+    public void migrate() {
+        templateEngine.migrate();
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineClient.java
@@ -10,6 +10,7 @@ import org.jboss.resteasy.reactive.RestQuery;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -36,4 +37,14 @@ public interface TemplateEngineClient {
     @Produces(APPLICATION_JSON)
     @Operation(hidden = true)
     Response render(@NotNull @Valid RenderEmailTemplateRequest renderEmailTemplateRequest);
+
+    @DELETE
+    @Path("/migrate")
+    @Operation(hidden = true)
+    void deleteAllTemplates();
+
+    @PUT
+    @Path("/migrate")
+    @Operation(hidden = true)
+    void migrate();
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -224,7 +224,7 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 "rhel", "vulnerability", List.of("any-cve-known-exploit"),
                 "Vulnerability/anyCveKnownExploitTitle", "txt", "Vulnerability any CVE known exploit email title",
-                "Vulnerability/anyCveKnownExploitBody", "html", "Vulnerability any CVE exploit email body"
+                "Vulnerability/anyCveKnownExploitBody", "html", "Vulnerability any CVE known exploit email body"
         );
         createInstantEmailTemplate(
                 "rhel", "vulnerability", List.of("new-cve-severity"),

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -14,16 +14,19 @@ import javax.transaction.Transactional;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 // TODO NOTIF-484 Remove this class when the templates DB migration is finished.
 @Path(API_INTERNAL + "/template-engine/migrate")
@@ -49,26 +52,28 @@ public class EmailTemplateMigrationService {
 
     @PUT
     @Transactional
-    public void migrate() {
+    @Produces(APPLICATION_JSON)
+    public List<String> migrate() {
+        List<String> warnings = new ArrayList<>();
 
         LOGGER.debug("Migration starting");
 
         /*
          * Former src/main/resources/templates/Advisor folder.
          */
-        getOrCreateTemplate("Advisor/insightsEmailBody", "html", "Advisor Insights email body");
+        getOrCreateTemplate(warnings, "Advisor/insightsEmailBody", "html", "Advisor Insights email body");
         createInstantEmailTemplate(
-                "rhel", "advisor", List.of("deactivated-recommendation"),
+                warnings, "rhel", "advisor", List.of("deactivated-recommendation"),
                 "Advisor/deactivatedRecommendationInstantEmailTitle", "txt", "Advisor deactivated recommendation email title",
                 "Advisor/deactivatedRecommendationInstantEmailBody", "html", "Advisor deactivated recommendation email body"
         );
         createInstantEmailTemplate(
-                "rhel", "advisor", List.of("new-recommendation"),
+                warnings, "rhel", "advisor", List.of("new-recommendation"),
                 "Advisor/newRecommendationInstantEmailTitle", "txt", "Advisor new recommendation email title",
                 "Advisor/newRecommendationInstantEmailBody", "html", "Advisor new recommendation email body"
         );
         createInstantEmailTemplate(
-                "rhel", "advisor", List.of("resolved-recommendation"),
+                warnings, "rhel", "advisor", List.of("resolved-recommendation"),
                 "Advisor/resolvedRecommendationInstantEmailTitle", "txt", "Advisor resolved recommendation email title",
                 "Advisor/resolvedRecommendationInstantEmailBody", "html", "Advisor resolved recommendation email body"
         );
@@ -76,9 +81,9 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/AdvisorOpenshift folder.
          */
-        getOrCreateTemplate("AdvisorOpenshift/insightsEmailBody", "html", "AdvisorOpenshift Insights email body");
+        getOrCreateTemplate(warnings, "AdvisorOpenshift/insightsEmailBody", "html", "AdvisorOpenshift Insights email body");
         createInstantEmailTemplate(
-                "openshift", "advisor", List.of("new-recommendation"),
+                warnings, "openshift", "advisor", List.of("new-recommendation"),
                 "AdvisorOpenshift/newRecommendationInstantEmailTitle", "txt", "AdvisorOpenshift new recommendation email title",
                 "AdvisorOpenshift/newRecommendationInstantEmailBody", "html", "AdvisorOpenshift new recommendation email body"
         );
@@ -86,9 +91,9 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Ansible folder.
          */
-        getOrCreateTemplate("Ansible/insightsEmailBody", "html", "Ansible Insights email body");
+        getOrCreateTemplate(warnings, "Ansible/insightsEmailBody", "html", "Ansible Insights email body");
         createInstantEmailTemplate(
-                "ansible", "reports", List.of("report-available"),
+                warnings, "ansible", "reports", List.of("report-available"),
                 "Ansible/instantEmailTitle", "txt", "Ansible instant email title",
                 "Ansible/instantEmailBody", "html", "Ansible instant email body"
         );
@@ -96,19 +101,19 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Compliance folder.
          */
-        getOrCreateTemplate("Compliance/insightsEmailBody", "html", "Compliance Insights email body");
+        getOrCreateTemplate(warnings, "Compliance/insightsEmailBody", "html", "Compliance Insights email body");
         createInstantEmailTemplate(
-                "rhel", "compliance", List.of("compliance-below-threshold"),
+                warnings, "rhel", "compliance", List.of("compliance-below-threshold"),
                 "Compliance/complianceBelowThresholdEmailTitle", "txt", "Compliance below threshold email title",
                 "Compliance/complianceBelowThresholdEmailBody", "html", "Compliance below threshold email body"
         );
         createInstantEmailTemplate(
-                "rhel", "compliance", List.of("report-upload-failed"),
+                warnings, "rhel", "compliance", List.of("report-upload-failed"),
                 "Compliance/reportUploadFailedEmailTitle", "txt", "Compliance report upload failed email title",
                 "Compliance/reportUploadFailedEmailBody", "html", "Compliance report upload failed email body"
         );
         createDailyEmailTemplate(
-                "rhel", "compliance",
+                warnings, "rhel", "compliance",
                 "Compliance/dailyEmailTitle", "txt", "Compliance daily email title",
                 "Compliance/dailyEmailBody", "html", "Compliance daily email body"
         );
@@ -117,7 +122,7 @@ public class EmailTemplateMigrationService {
          * Former src/main/resources/templates/ConsoleNotifications folder.
          */
         createInstantEmailTemplate(
-                "console", "notifications", List.of("failed-integration"),
+                warnings, "console", "notifications", List.of("failed-integration"),
                 "ConsoleNotifications/failedIntegrationTitle", "txt", "Notifications failed integration email title",
                 "ConsoleNotifications/failedIntegrationBody", "txt", "Notifications failed integration email body"
         );
@@ -125,14 +130,14 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Drift folder.
          */
-        getOrCreateTemplate("Drift/insightsEmailBody", "html", "Drift Insights email body");
+        getOrCreateTemplate(warnings, "Drift/insightsEmailBody", "html", "Drift Insights email body");
         createInstantEmailTemplate(
-                "rhel", "drift", List.of("drift-baseline-detected"),
+                warnings, "rhel", "drift", List.of("drift-baseline-detected"),
                 "Drift/newBaselineDriftInstantEmailTitle", "txt", "Drift new baseline drift email title",
                 "Drift/newBaselineDriftInstantEmailBody", "html", "Drift new baseline drift email body"
         );
         createDailyEmailTemplate(
-                "rhel", "drift",
+                warnings, "rhel", "drift",
                 "Drift/dailyEmailTitle", "txt", "Drift daily email title",
                 "Drift/dailyEmailBody", "html", "Drift daily email body"
         );
@@ -140,14 +145,14 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Policies folder.
          */
-        getOrCreateTemplate("Policies/insightsEmailBody", "html", "Policies Insights email body");
+        getOrCreateTemplate(warnings, "Policies/insightsEmailBody", "html", "Policies Insights email body");
         createInstantEmailTemplate(
-                "rhel", "policies", List.of("policy-triggered"),
+                warnings, "rhel", "policies", List.of("policy-triggered"),
                 "Policies/instantEmailTitle", "txt", "Policies instant email title",
                 "Policies/instantEmailBody", "html", "Policies instant email body"
         );
         createDailyEmailTemplate(
-                "rhel", "policies",
+                warnings, "rhel", "policies",
                 "Policies/dailyEmailTitle", "txt", "Policies daily email title",
                 "Policies/dailyEmailBody", "html", "Policies daily email body"
         );
@@ -155,19 +160,19 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Rbac folder.
          */
-        getOrCreateTemplate("Rbac/insightsEmailBody", "html", "Rbac Insights email body");
+        getOrCreateTemplate(warnings, "Rbac/insightsEmailBody", "html", "Rbac Insights email body");
         createInstantEmailTemplate(
-                "console", "rbac", List.of("rh-new-role-available", "rh-platform-default-role-updated", "rh-non-platform-default-role-updated", "custom-role-created", "custom-role-updated", "custom-role-deleted"),
+                warnings, "console", "rbac", List.of("rh-new-role-available", "rh-platform-default-role-updated", "rh-non-platform-default-role-updated", "custom-role-created", "custom-role-updated", "custom-role-deleted"),
                 "Rbac/roleChangeEmailTitle", "txt", "Rbac role change email title",
                 "Rbac/roleChangeEmailBody", "html", "Rbac role change email body"
         );
         createInstantEmailTemplate(
-                "console", "rbac", List.of("rh-new-role-added-to-default-access", "rh-role-removed-from-default-access", "custom-default-access-updated", "group-created", "group-updated", "group-deleted"),
+                warnings, "console", "rbac", List.of("rh-new-role-added-to-default-access", "rh-role-removed-from-default-access", "custom-default-access-updated", "group-created", "group-updated", "group-deleted"),
                 "Rbac/groupChangeEmailTitle", "txt", "Rbac group change email title",
                 "Rbac/groupChangeEmailBody", "html", "Rbac group change email body"
         );
         createInstantEmailTemplate(
-                "console", "rbac", List.of("platform-default-group-turned-into-custom"),
+                warnings, "console", "rbac", List.of("platform-default-group-turned-into-custom"),
                 "Rbac/platformGroup2CustomEmailTitle", "txt", "Rbac platform group 2 custom email title",
                 "Rbac/platformGroup2CustomEmailBody", "html", "Rbac platform group 2 custom email body"
         );
@@ -175,34 +180,34 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Rhosak folder.
          */
-        getOrCreateTemplate("Rhosak/rhosakEmailBody", "html", "Rhosak email body");
+        getOrCreateTemplate(warnings, "Rhosak/rhosakEmailBody", "html", "Rhosak email body");
         createInstantEmailTemplate(
-                "application-services", "rhosak", List.of("disruption"),
+                warnings, "application-services", "rhosak", List.of("disruption"),
                 "Rhosak/serviceDisruptionTitle", "txt", "Rhosak service disruption email title",
                 "Rhosak/serviceDisruptionBody", "html", "Rhosak service disruption email body"
         );
         createInstantEmailTemplate(
-                "application-services", "rhosak", List.of("instance-created"),
+                warnings, "application-services", "rhosak", List.of("instance-created"),
                 "Rhosak/instanceCreatedTitle", "txt", "Rhosak instance created email title",
                 "Rhosak/instanceCreatedBody", "html", "Rhosak instance created email body"
         );
         createInstantEmailTemplate(
-                "application-services", "rhosak", List.of("instance-deleted"),
+                warnings, "application-services", "rhosak", List.of("instance-deleted"),
                 "Rhosak/instanceDeletedTitle", "txt", "Rhosak instance deleted email title",
                 "Rhosak/instanceDeletedBody", "html", "Rhosak instance deleted email body"
         );
         createInstantEmailTemplate(
-                "application-services", "rhosak", List.of("action-required"),
+                warnings, "application-services", "rhosak", List.of("action-required"),
                 "Rhosak/actionRequiredTitle", "txt", "Rhosak action required email title",
                 "Rhosak/actionRequiredBody", "html", "Rhosak action required email body"
         );
         createInstantEmailTemplate(
-                "application-services", "rhosak", List.of("scheduled-upgrade"),
+                warnings, "application-services", "rhosak", List.of("scheduled-upgrade"),
                 "Rhosak/scheduledUpgradeTitle", "txt", "Rhosak scheduled upgrade email title",
                 "Rhosak/scheduledUpgradeBody", "html", "Rhosak scheduled upgrade email body"
         );
         createDailyEmailTemplate(
-                "application-services", "rhosak",
+                warnings, "application-services", "rhosak",
                 "Rhosak/dailyRhosakEmailsTitle", "txt", "Rhosak daily email title",
                 "Rhosak/dailyRhosakEmailsBody", "html", "Rhosak daily email body"
         );
@@ -210,9 +215,9 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Sources folder.
          */
-        getOrCreateTemplate("Sources/insightsEmailBody", "html", "Sources Insights email body");
+        getOrCreateTemplate(warnings, "Sources/insightsEmailBody", "html", "Sources Insights email body");
         createInstantEmailTemplate(
-                "console", "sources", List.of("availability-status"),
+                warnings, "console", "sources", List.of("availability-status"),
                 "Sources/availabilityStatusEmailTitle", "txt", "Sources availability status email title",
                 "Sources/availabilityStatusEmailBody", "html", "Sources availability status email body"
         );
@@ -220,41 +225,43 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Vulnerability folder.
          */
-        getOrCreateTemplate("Vulnerability/insightsEmailBody", "html", "Vulnerability Insights email body");
+        getOrCreateTemplate(warnings, "Vulnerability/insightsEmailBody", "html", "Vulnerability Insights email body");
         createInstantEmailTemplate(
-                "rhel", "vulnerability", List.of("any-cve-known-exploit"),
+                warnings, "rhel", "vulnerability", List.of("any-cve-known-exploit"),
                 "Vulnerability/anyCveKnownExploitTitle", "txt", "Vulnerability any CVE known exploit email title",
                 "Vulnerability/anyCveKnownExploitBody", "html", "Vulnerability any CVE known exploit email body"
         );
         createInstantEmailTemplate(
-                "rhel", "vulnerability", List.of("new-cve-severity"),
+                warnings, "rhel", "vulnerability", List.of("new-cve-severity"),
                 "Vulnerability/newCveCritSeverityEmailTitle", "txt", "Vulnerability new CVE crit severity email title",
                 "Vulnerability/newCveCritSeverityEmailBody", "html", "Vulnerability new CVE crit severity email body"
         );
         createInstantEmailTemplate(
-                "rhel", "vulnerability", List.of("new-cve-cvss"),
+                warnings, "rhel", "vulnerability", List.of("new-cve-cvss"),
                 "Vulnerability/newCveHighCvssEmailTitle", "txt", "Vulnerability new CVE high cvss email title",
                 "Vulnerability/newCveHighCvssEmailBody", "html", "Vulnerability new CVE high cvss email body"
         );
         createInstantEmailTemplate(
-                "rhel", "vulnerability", List.of("new-cve-security-rule"),
+                warnings, "rhel", "vulnerability", List.of("new-cve-security-rule"),
                 "Vulnerability/newCveSecurityRuleTitle", "txt", "Vulnerability new CVE security rule email title",
                 "Vulnerability/newCveSecurityRuleBody", "html", "Vulnerability new CVE security rule email body"
         );
 
         LOGGER.debug("Migration ended");
+
+        return warnings;
     }
 
     /*
      * Creates a template only if it does not already exist in the DB.
      * Existing templates are never updated by this migration service.
      */
-    Template getOrCreateTemplate(String name, String extension, String description) {
+    Template getOrCreateTemplate(List<String> warnings, String name, String extension, String description) {
         try {
             Template template = entityManager.createQuery("FROM Template WHERE name = :name", Template.class)
                     .setParameter("name", name)
                     .getSingleResult();
-            LOGGER.infof("Template found in DB: %s", name);
+            warnings.add(String.format("Template found in DB: %s", name));
             return template;
         } catch (NoResultException e) {
             LOGGER.infof("Creating template: %s", name);
@@ -286,32 +293,35 @@ public class EmailTemplateMigrationService {
      * - the instant email template does not already exist in the DB
      * Existing instant email templates are never updated by this migration service.
      */
-    private void createInstantEmailTemplate(String bundleName, String appName, List<String> eventTypeNames,
+    private void createInstantEmailTemplate(List<String> warnings, String bundleName, String appName, List<String> eventTypeNames,
             String subjectTemplateName, String subjectTemplateExtension, String subjectTemplateDescription,
             String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription) {
 
         for (String eventTypeName : eventTypeNames) {
-            Optional<EventType> eventType = findEventType(bundleName, appName, eventTypeName);
-            if (eventType.isPresent() && !instantEmailTemplateExists(eventType.get())) {
+            Optional<EventType> eventType = findEventType(warnings, bundleName, appName, eventTypeName);
+            if (eventType.isPresent()) {
+                if (instantEmailTemplateExists(eventType.get())) {
+                    warnings.add(String.format("Instant email template found in DB for event type: %s/%s/%s", bundleName, appName, eventTypeName));
+                } else {
+                    Template subjectTemplate = getOrCreateTemplate(warnings, subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
+                    Template bodyTemplate = getOrCreateTemplate(warnings, bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
 
-                Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
-                Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
+                    LOGGER.infof("Creating instant email template for event type: %s/%s/%s", bundleName, appName, eventTypeName);
 
-                LOGGER.infof("Creating instant email template for event type: %s/%s/%s", bundleName, appName, eventTypeName);
+                    InstantEmailTemplate emailTemplate = new InstantEmailTemplate();
+                    emailTemplate.setEventType(eventType.get());
+                    emailTemplate.setSubjectTemplate(subjectTemplate);
+                    emailTemplate.setSubjectTemplateId(subjectTemplate.getId());
+                    emailTemplate.setBodyTemplate(bodyTemplate);
+                    emailTemplate.setBodyTemplateId(bodyTemplate.getId());
 
-                InstantEmailTemplate emailTemplate = new InstantEmailTemplate();
-                emailTemplate.setEventType(eventType.get());
-                emailTemplate.setSubjectTemplate(subjectTemplate);
-                emailTemplate.setSubjectTemplateId(subjectTemplate.getId());
-                emailTemplate.setBodyTemplate(bodyTemplate);
-                emailTemplate.setBodyTemplateId(bodyTemplate.getId());
-
-                entityManager.persist(emailTemplate);
+                    entityManager.persist(emailTemplate);
+                }
             }
         }
     }
 
-    private Optional<EventType> findEventType(String bundleName, String appName, String eventTypeName) {
+    private Optional<EventType> findEventType(List<String> warnings, String bundleName, String appName, String eventTypeName) {
         String hql = "FROM EventType WHERE name = :eventTypeName AND application.name = :appName " +
                 "AND application.bundle.name = :bundleName";
         try {
@@ -322,7 +332,7 @@ public class EmailTemplateMigrationService {
                     .getSingleResult();
             return Optional.of(eventType);
         } catch (NoResultException e) {
-            LOGGER.infof("Event type not found: %s/%s/%s", bundleName, appName, eventTypeName);
+            warnings.add(String.format("Event type not found: %s/%s/%s", bundleName, appName, eventTypeName));
             return Optional.empty();
         }
     }
@@ -341,31 +351,34 @@ public class EmailTemplateMigrationService {
      * - the aggregation email template does not already exist in the DB
      * Existing aggregation email templates are never updated by this migration service.
      */
-    private void createDailyEmailTemplate(String bundleName, String appName,
+    private void createDailyEmailTemplate(List<String> warnings, String bundleName, String appName,
                                           String subjectTemplateName, String subjectTemplateExtension, String subjectTemplateDescription,
                                           String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription) {
 
-        Optional<Application> app = findApplication(bundleName, appName);
-        if (app.isPresent() && !aggregationEmailTemplateExists(app.get())) {
+        Optional<Application> app = findApplication(warnings, bundleName, appName);
+        if (app.isPresent()) {
+            if (aggregationEmailTemplateExists(app.get())) {
+                warnings.add(String.format("Aggregation email template found in DB for application: %s/%s", bundleName, appName));
+            } else {
+                Template subjectTemplate = getOrCreateTemplate(warnings, subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
+                Template bodyTemplate = getOrCreateTemplate(warnings, bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
 
-            Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
-            Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
+                LOGGER.infof("Creating daily email template for application: %s/%s", bundleName, appName);
 
-            LOGGER.infof("Creating daily email template for application: %s/%s", bundleName, appName);
+                AggregationEmailTemplate emailTemplate = new AggregationEmailTemplate();
+                emailTemplate.setApplication(app.get());
+                emailTemplate.setSubscriptionType(DAILY);
+                emailTemplate.setSubjectTemplate(subjectTemplate);
+                emailTemplate.setSubjectTemplateId(subjectTemplate.getId());
+                emailTemplate.setBodyTemplate(bodyTemplate);
+                emailTemplate.setBodyTemplateId(bodyTemplate.getId());
 
-            AggregationEmailTemplate emailTemplate = new AggregationEmailTemplate();
-            emailTemplate.setApplication(app.get());
-            emailTemplate.setSubscriptionType(DAILY);
-            emailTemplate.setSubjectTemplate(subjectTemplate);
-            emailTemplate.setSubjectTemplateId(subjectTemplate.getId());
-            emailTemplate.setBodyTemplate(bodyTemplate);
-            emailTemplate.setBodyTemplateId(bodyTemplate.getId());
-
-            entityManager.persist(emailTemplate);
+                entityManager.persist(emailTemplate);
+            }
         }
     }
 
-    private Optional<Application> findApplication(String bundleName, String appName) {
+    private Optional<Application> findApplication(List<String> warnings, String bundleName, String appName) {
         String hql = "FROM Application WHERE name = :appName AND bundle.name = :bundleName";
         try {
             Application app = entityManager.createQuery(hql, Application.class)
@@ -374,7 +387,7 @@ public class EmailTemplateMigrationService {
                     .getSingleResult();
             return Optional.of(app);
         } catch (NoResultException e) {
-            LOGGER.infof("Application not found: %s/%s", bundleName, appName);
+            warnings.add(String.format("Application not found: %s/%s", bundleName, appName));
             return Optional.empty();
         }
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -1,0 +1,391 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.InstantEmailTemplate;
+import com.redhat.cloud.notifications.models.Template;
+import org.jboss.logging.Logger;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.transaction.Transactional;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+// TODO NOTIF-484 Remove this class when the templates DB migration is finished.
+@Path(API_INTERNAL + "/template-engine/migrate")
+public class EmailTemplateMigrationService {
+
+    private static final Logger LOGGER = Logger.getLogger(EmailTemplateMigrationService.class);
+
+    @Inject
+    EntityManager entityManager;
+
+    /*
+     * Templates from resources may evolve after the first migration to DB templates, before we enable DB templates
+     * everywhere in notifications. This endpoint can be used to delete all DB templates before we trigger another
+     * migration from resources to DB.
+     */
+    @DELETE
+    @Transactional
+    public void deleteAllTemplates() {
+        entityManager.createQuery("DELETE FROM InstantEmailTemplate").executeUpdate();
+        entityManager.createQuery("DELETE FROM AggregationEmailTemplate").executeUpdate();
+        entityManager.createQuery("DELETE FROM Template").executeUpdate();
+    }
+
+    @PUT
+    @Transactional
+    public void migrate() {
+
+        LOGGER.debug("Migration starting");
+
+        /*
+         * Former src/main/resources/templates/Advisor folder.
+         */
+        getOrCreateTemplate("Advisor/insightsEmailBody", "html", "Advisor Insights email body");
+        createInstantEmailTemplate(
+                "rhel", "advisor", List.of("deactivated-recommendation"),
+                "Advisor/deactivatedRecommendationInstantEmailTitle", "txt", "Advisor deactivated recommendation email title",
+                "Advisor/deactivatedRecommendationInstantEmailBody", "html", "Advisor deactivated recommendation email body"
+        );
+        createInstantEmailTemplate(
+                "rhel", "advisor", List.of("new-recommendation"),
+                "Advisor/newRecommendationInstantEmailTitle", "txt", "Advisor new recommendation email title",
+                "Advisor/newRecommendationInstantEmailBody", "html", "Advisor new recommendation email body"
+        );
+        createInstantEmailTemplate(
+                "rhel", "advisor", List.of("resolved-recommendation"),
+                "Advisor/resolvedRecommendationInstantEmailTitle", "txt", "Advisor resolved recommendation email title",
+                "Advisor/resolvedRecommendationInstantEmailBody", "html", "Advisor resolved recommendation email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/AdvisorOpenshift folder.
+         */
+        getOrCreateTemplate("AdvisorOpenshift/insightsEmailBody", "html", "AdvisorOpenshift Insights email body");
+        createInstantEmailTemplate(
+                "openshift", "advisor", List.of("new-recommendation"),
+                "AdvisorOpenshift/newRecommendationInstantEmailTitle", "txt", "AdvisorOpenshift new recommendation email title",
+                "AdvisorOpenshift/newRecommendationInstantEmailBody", "html", "AdvisorOpenshift new recommendation email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/Ansible folder.
+         */
+        getOrCreateTemplate("Ansible/insightsEmailBody", "html", "Ansible Insights email body");
+        createInstantEmailTemplate(
+                "ansible", "reports", List.of("report-available"),
+                "Ansible/instantEmailTitle", "txt", "Ansible instant email title",
+                "Ansible/instantEmailBody", "html", "Ansible instant email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/Compliance folder.
+         */
+        getOrCreateTemplate("Compliance/insightsEmailBody", "html", "Compliance Insights email body");
+        createInstantEmailTemplate(
+                "rhel", "compliance", List.of("compliance-below-threshold"),
+                "Compliance/complianceBelowThresholdEmailTitle", "txt", "Compliance below threshold email title",
+                "Compliance/complianceBelowThresholdEmailBody", "html", "Compliance below threshold email body"
+        );
+        createInstantEmailTemplate(
+                "rhel", "compliance", List.of("report-upload-failed"),
+                "Compliance/reportUploadFailedEmailTitle", "txt", "Compliance report upload failed email title",
+                "Compliance/reportUploadFailedEmailBody", "html", "Compliance report upload failed email body"
+        );
+        createDailyEmailTemplate(
+                "rhel", "compliance",
+                "Compliance/dailyEmailTitle", "txt", "Compliance daily email title",
+                "Compliance/dailyEmailBody", "html", "Compliance daily email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/ConsoleNotifications folder.
+         */
+        createInstantEmailTemplate(
+                "console", "notifications", List.of("failed-integration"),
+                "ConsoleNotifications/failedIntegrationTitle", "txt", "Notifications failed integration email title",
+                "ConsoleNotifications/failedIntegrationBody", "txt", "Notifications failed integration email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/Drift folder.
+         */
+        getOrCreateTemplate("Drift/insightsEmailBody", "html", "Drift Insights email body");
+        createInstantEmailTemplate(
+                "rhel", "drift", List.of("drift-baseline-detected"),
+                "Drift/newBaselineDriftInstantEmailTitle", "txt", "Drift new baseline drift email title",
+                "Drift/newBaselineDriftInstantEmailBody", "html", "Drift new baseline drift email body"
+        );
+        createDailyEmailTemplate(
+                "rhel", "drift",
+                "Drift/dailyEmailTitle", "txt", "Drift daily email title",
+                "Drift/dailyEmailBody", "html", "Drift daily email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/Policies folder.
+         */
+        getOrCreateTemplate("Policies/insightsEmailBody", "html", "Policies Insights email body");
+        createInstantEmailTemplate(
+                "rhel", "policies", List.of("policy-triggered"),
+                "Policies/instantEmailTitle", "txt", "Policies instant email title",
+                "Policies/instantEmailBody", "html", "Policies instant email body"
+        );
+        createDailyEmailTemplate(
+                "rhel", "policies",
+                "Policies/dailyEmailTitle", "txt", "Policies daily email title",
+                "Policies/dailyEmailBody", "html", "Policies daily email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/Rbac folder.
+         */
+        getOrCreateTemplate("Rbac/insightsEmailBody", "html", "Rbac Insights email body");
+        createInstantEmailTemplate(
+                "console", "rbac", List.of("rh-new-role-available", "rh-platform-default-role-updated", "rh-non-platform-default-role-updated", "custom-role-created", "custom-role-updated", "custom-role-deleted"),
+                "Rbac/roleChangeEmailTitle", "txt", "Rbac role change email title",
+                "Rbac/roleChangeEmailBody", "html", "Rbac role change email body"
+        );
+        createInstantEmailTemplate(
+                "console", "rbac", List.of("rh-new-role-added-to-default-access", "rh-role-removed-from-default-access", "custom-default-access-updated", "group-created", "group-updated", "group-deleted"),
+                "Rbac/groupChangeEmailTitle", "txt", "Rbac group change email title",
+                "Rbac/groupChangeEmailBody", "html", "Rbac group change email body"
+        );
+        createInstantEmailTemplate(
+                "console", "rbac", List.of("platform-default-group-turned-into-custom"),
+                "Rbac/platformGroup2CustomEmailTitle", "txt", "Rbac platform group 2 custom email title",
+                "Rbac/platformGroup2CustomEmailBody", "html", "Rbac platform group 2 custom email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/Rhosak folder.
+         */
+        getOrCreateTemplate("Rhosak/rhosakEmailBody", "html", "Rhosak email body");
+        createInstantEmailTemplate(
+                "application-services", "rhosak", List.of("disruption"),
+                "Rhosak/serviceDisruptionTitle", "txt", "Rhosak service disruption email title",
+                "Rhosak/serviceDisruptionBody", "html", "Rhosak service disruption email body"
+        );
+        createInstantEmailTemplate(
+                "application-services", "rhosak", List.of("instance-created"),
+                "Rhosak/instanceCreatedTitle", "txt", "Rhosak instance created email title",
+                "Rhosak/instanceCreatedBody", "html", "Rhosak instance created email body"
+        );
+        createInstantEmailTemplate(
+                "application-services", "rhosak", List.of("instance-deleted"),
+                "Rhosak/instanceDeletedTitle", "txt", "Rhosak instance deleted email title",
+                "Rhosak/instanceDeletedBody", "html", "Rhosak instance deleted email body"
+        );
+        createInstantEmailTemplate(
+                "application-services", "rhosak", List.of("action-required"),
+                "Rhosak/actionRequiredTitle", "txt", "Rhosak action required email title",
+                "Rhosak/actionRequiredBody", "html", "Rhosak action required email body"
+        );
+        createInstantEmailTemplate(
+                "application-services", "rhosak", List.of("scheduled-upgrade"),
+                "Rhosak/scheduledUpgradeTitle", "txt", "Rhosak scheduled upgrade email title",
+                "Rhosak/scheduledUpgradeBody", "html", "Rhosak scheduled upgrade email body"
+        );
+        createDailyEmailTemplate(
+                "application-services", "rhosak",
+                "Rhosak/dailyRhosakEmailsTitle", "txt", "Rhosak daily email title",
+                "Rhosak/dailyRhosakEmailsBody", "html", "Rhosak daily email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/Sources folder.
+         */
+        getOrCreateTemplate("Sources/insightsEmailBody", "html", "Sources Insights email body");
+        createInstantEmailTemplate(
+                "console", "sources", List.of("availability-status"),
+                "Sources/availabilityStatusEmailTitle", "txt", "Sources availability status email title",
+                "Sources/availabilityStatusEmailBody", "html", "Sources availability status email body"
+        );
+
+        /*
+         * Former src/main/resources/templates/Vulnerability folder.
+         */
+        getOrCreateTemplate("Vulnerability/insightsEmailBody", "html", "Vulnerability Insights email body");
+        createInstantEmailTemplate(
+                "rhel", "vulnerability", List.of("any-cve-known-exploit"),
+                "Vulnerability/anyCveKnownExploitTitle", "txt", "Vulnerability any CVE known exploit email title",
+                "Vulnerability/anyCveKnownExploitBody", "html", "Vulnerability any CVE exploit email body"
+        );
+        createInstantEmailTemplate(
+                "rhel", "vulnerability", List.of("new-cve-severity"),
+                "Vulnerability/newCveCritSeverityEmailTitle", "txt", "Vulnerability new CVE crit severity email title",
+                "Vulnerability/newCveCritSeverityEmailBody", "html", "Vulnerability new CVE crit severity email body"
+        );
+        createInstantEmailTemplate(
+                "rhel", "vulnerability", List.of("new-cve-cvss"),
+                "Vulnerability/newCveHighCvssEmailTitle", "txt", "Vulnerability new CVE high cvss email title",
+                "Vulnerability/newCveHighCvssEmailBody", "html", "Vulnerability new CVE high cvss email body"
+        );
+        createInstantEmailTemplate(
+                "rhel", "vulnerability", List.of("new-cve-security-rule"),
+                "Vulnerability/newCveSecurityRuleTitle", "txt", "Vulnerability new CVE security rule email title",
+                "Vulnerability/newCveSecurityRuleBody", "html", "Vulnerability new CVE security rule email body"
+        );
+
+        LOGGER.debug("Migration ended");
+    }
+
+    /*
+     * Creates a template only if it does not already exist in the DB.
+     * Existing templates are never updated by this migration service.
+     */
+    Template getOrCreateTemplate(String name, String extension, String description) {
+        try {
+            Template template = entityManager.createQuery("FROM Template WHERE name = :name", Template.class)
+                    .setParameter("name", name)
+                    .getSingleResult();
+            LOGGER.infof("Template found in DB: %s", name);
+            return template;
+        } catch (NoResultException e) {
+            LOGGER.infof("Creating template: %s", name);
+            Template template = new Template();
+            template.setName(name);
+            template.setDescription(description);
+            template.setData(loadResourceTemplate(name, extension));
+            entityManager.persist(template);
+            return template;
+        }
+    }
+
+    private String loadResourceTemplate(String name, String extension) {
+        String path = "/templates/" + name + "." + extension;
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(path)) {
+            if (inputStream == null) {
+                throw new IllegalStateException("Template resource file not found: " + path);
+            } else {
+                return new String(inputStream.readAllBytes(), UTF_8);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Template loading from resource file failed: " + path, e);
+        }
+    }
+
+    /*
+     * Creates an instant email template and the underlying templates only if:
+     * - the event type exists in the DB
+     * - the instant email template does not already exist in the DB
+     * Existing instant email templates are never updated by this migration service.
+     */
+    private void createInstantEmailTemplate(String bundleName, String appName, List<String> eventTypeNames,
+            String subjectTemplateName, String subjectTemplateExtension, String subjectTemplateDescription,
+            String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription) {
+
+        for (String eventTypeName : eventTypeNames) {
+            Optional<EventType> eventType = findEventType(bundleName, appName, eventTypeName);
+            if (eventType.isPresent() && !instantEmailTemplateExists(eventType.get())) {
+
+                Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
+                Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
+
+                LOGGER.infof("Creating instant email template for event type: %s/%s/%s", bundleName, appName, eventTypeName);
+
+                InstantEmailTemplate emailTemplate = new InstantEmailTemplate();
+                emailTemplate.setEventType(eventType.get());
+                emailTemplate.setSubjectTemplate(subjectTemplate);
+                emailTemplate.setSubjectTemplateId(subjectTemplate.getId());
+                emailTemplate.setBodyTemplate(bodyTemplate);
+                emailTemplate.setBodyTemplateId(bodyTemplate.getId());
+
+                entityManager.persist(emailTemplate);
+            }
+        }
+    }
+
+    private Optional<EventType> findEventType(String bundleName, String appName, String eventTypeName) {
+        String hql = "FROM EventType WHERE name = :eventTypeName AND application.name = :appName " +
+                "AND application.bundle.name = :bundleName";
+        try {
+            EventType eventType = entityManager.createQuery(hql, EventType.class)
+                    .setParameter("eventTypeName", eventTypeName)
+                    .setParameter("appName", appName)
+                    .setParameter("bundleName", bundleName)
+                    .getSingleResult();
+            return Optional.of(eventType);
+        } catch (NoResultException e) {
+            LOGGER.infof("Event type not found: %s/%s/%s", bundleName, appName, eventTypeName);
+            return Optional.empty();
+        }
+    }
+
+    private boolean instantEmailTemplateExists(EventType eventType) {
+        String hql = "SELECT COUNT(*) FROM InstantEmailTemplate WHERE eventType = :eventType";
+        long count = entityManager.createQuery(hql, Long.class)
+                .setParameter("eventType", eventType)
+                .getSingleResult();
+        return count > 0;
+    }
+
+    /*
+     * Creates an aggregation email template and the underlying templates only if:
+     * - the application exists in the DB
+     * - the aggregation email template does not already exist in the DB
+     * Existing aggregation email templates are never updated by this migration service.
+     */
+    private void createDailyEmailTemplate(String bundleName, String appName,
+                                          String subjectTemplateName, String subjectTemplateExtension, String subjectTemplateDescription,
+                                          String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription) {
+
+        Optional<Application> app = findApplication(bundleName, appName);
+        if (app.isPresent() && !aggregationEmailTemplateExists(app.get())) {
+
+            Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
+            Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
+
+            LOGGER.infof("Creating daily email template for application: %s/%s", bundleName, appName);
+
+            AggregationEmailTemplate emailTemplate = new AggregationEmailTemplate();
+            emailTemplate.setApplication(app.get());
+            emailTemplate.setSubscriptionType(DAILY);
+            emailTemplate.setSubjectTemplate(subjectTemplate);
+            emailTemplate.setSubjectTemplateId(subjectTemplate.getId());
+            emailTemplate.setBodyTemplate(bodyTemplate);
+            emailTemplate.setBodyTemplateId(bodyTemplate.getId());
+
+            entityManager.persist(emailTemplate);
+        }
+    }
+
+    private Optional<Application> findApplication(String bundleName, String appName) {
+        String hql = "FROM Application WHERE name = :appName AND bundle.name = :bundleName";
+        try {
+            Application app = entityManager.createQuery(hql, Application.class)
+                    .setParameter("appName", appName)
+                    .setParameter("bundleName", bundleName)
+                    .getSingleResult();
+            return Optional.of(app);
+        } catch (NoResultException e) {
+            LOGGER.infof("Application not found: %s/%s", bundleName, appName);
+            return Optional.empty();
+        }
+    }
+
+    private boolean aggregationEmailTemplateExists(Application app) {
+        String hql = "SELECT COUNT(*) FROM AggregationEmailTemplate WHERE application = :app " +
+                "AND subscriptionType = :subscriptionType";
+        long count = entityManager.createQuery(hql, Long.class)
+                .setParameter("app", app)
+                .setParameter("subscriptionType", DAILY)
+                .getSingleResult();
+        return count > 0;
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
@@ -26,6 +26,7 @@ import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
 import static com.redhat.cloud.notifications.templates.TemplateService.USE_TEMPLATES_FROM_DB_KEY;
 import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -147,7 +148,8 @@ public class EmailTemplateMigrationServiceTest {
                 .when()
                 .put("/template-engine/migrate")
                 .then()
-                .statusCode(204);
+                .statusCode(200)
+                .contentType(JSON);
 
         statelessSessionFactory.withSession(statelessSession -> {
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
@@ -1,0 +1,283 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.StatelessSessionFactory;
+import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
+import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.EmailSubscriptionType;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.InstantEmailTemplate;
+import com.redhat.cloud.notifications.models.Template;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
+import static com.redhat.cloud.notifications.templates.TemplateService.USE_TEMPLATES_FROM_DB_KEY;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class EmailTemplateMigrationServiceTest {
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @Inject
+    EntityManager entityManager;
+
+    @Inject
+    TemplateRepository templateRepository;
+
+    @Inject
+    TemplateService templateService;
+
+    @Inject
+    StatelessSessionFactory statelessSessionFactory;
+
+    @BeforeEach
+    void beforeEach() {
+        System.setProperty(USE_TEMPLATES_FROM_DB_KEY, "true");
+    }
+
+    @AfterEach
+    void afterEach() {
+        System.clearProperty(USE_TEMPLATES_FROM_DB_KEY);
+    }
+
+    @Test
+    void testMigration() {
+        /*
+         * Bundle: rhel
+         */
+        Bundle rhel = findBundle("rhel");
+        // App: advisor
+        Application advisor = resourceHelpers.createApp(rhel.getId(), "advisor");
+        EventType newRecommendation = resourceHelpers.createEventType(advisor.getId(), "new-recommendation");
+        EventType resolvedRecommendation = resourceHelpers.createEventType(advisor.getId(), "resolved-recommendation");
+        EventType deactivatedRecommendation = resourceHelpers.createEventType(advisor.getId(), "deactivated-recommendation");
+        // App: compliance
+        Application compliance = resourceHelpers.createApp(rhel.getId(), "compliance");
+        EventType complianceBelowThreshold = resourceHelpers.createEventType(compliance.getId(), "compliance-below-threshold");
+        EventType reportUploadFailed = resourceHelpers.createEventType(compliance.getId(), "report-upload-failed");
+        // App: drift
+        Application drift = resourceHelpers.createApp(rhel.getId(), "drift");
+        EventType driftBaselineDetected = resourceHelpers.createEventType(drift.getId(), "drift-baseline-detected");
+        // App: policies
+        Application policies = findApp("rhel", "policies");
+        EventType policyTriggered = findEventType("rhel", "policies", "policy-triggered");
+        // App: vulnerability
+        Application vulnerability = resourceHelpers.createApp(rhel.getId(), "vulnerability");
+        EventType newCveCvss = resourceHelpers.createEventType(vulnerability.getId(), "new-cve-cvss");
+        EventType newCveSeverity = resourceHelpers.createEventType(vulnerability.getId(), "new-cve-severity");
+        EventType newCveSecurityRule = resourceHelpers.createEventType(vulnerability.getId(), "new-cve-security-rule");
+        EventType anyCveKnownExploit = resourceHelpers.createEventType(vulnerability.getId(), "any-cve-known-exploit");
+
+        /*
+         * Bundle: openshift
+         */
+        Bundle openshift = resourceHelpers.createBundle("openshift");
+        // App: advisor
+        Application advisorOpenshift = resourceHelpers.createApp(openshift.getId(), "advisor");
+        EventType newRecommendationOpenshift = resourceHelpers.createEventType(advisorOpenshift.getId(), "new-recommendation");
+
+        /*
+         * Bundle: application-services
+         */
+        Bundle applicationServices = resourceHelpers.createBundle("application-services");
+        // App: rhosak
+        Application rhosak = resourceHelpers.createApp(applicationServices.getId(), "rhosak");
+        EventType scheduledUpgrade = resourceHelpers.createEventType(rhosak.getId(), "scheduled-upgrade");
+        EventType disruption = resourceHelpers.createEventType(rhosak.getId(), "disruption");
+        EventType instanceCreated = resourceHelpers.createEventType(rhosak.getId(), "instance-created");
+        EventType instanceDeleted = resourceHelpers.createEventType(rhosak.getId(), "instance-deleted");
+        EventType actionRequired = resourceHelpers.createEventType(rhosak.getId(), "action-required");
+
+        /*
+         * Bundle: ansible
+         */
+        Bundle ansible = resourceHelpers.createBundle("ansible");
+        // App: reports
+        Application reports = resourceHelpers.createApp(ansible.getId(), "reports");
+        EventType reportAvailable = resourceHelpers.createEventType(reports.getId(), "report-available");
+
+        /*
+         * Bundle: console
+         */
+        Bundle console = findBundle("console");
+        // App: notifications
+        Application notifications = findApp("console", "notifications");
+        EventType failedIntegration = resourceHelpers.createEventType(notifications.getId(), "failed-integration");
+        // App: sources
+        Application sources = resourceHelpers.createApp(console.getId(), "sources");
+        EventType availabilityStatus = resourceHelpers.createEventType(sources.getId(), "availability-status");
+        // App: rbac
+        Application rbac = resourceHelpers.createApp(console.getId(), "rbac");
+        EventType rhNewRoleAvailable = resourceHelpers.createEventType(rbac.getId(), "rh-new-role-available");
+        EventType rhPlatformDefaultRoleUpdated = resourceHelpers.createEventType(rbac.getId(), "rh-platform-default-role-updated");
+        EventType rhNonPlatformDefaultRoleUpdated = resourceHelpers.createEventType(rbac.getId(), "rh-non-platform-default-role-updated");
+        EventType customRoleCreated = resourceHelpers.createEventType(rbac.getId(), "custom-role-created");
+        EventType customRoleUpdated = resourceHelpers.createEventType(rbac.getId(), "custom-role-updated");
+        EventType customRoleDeleted = resourceHelpers.createEventType(rbac.getId(), "custom-role-deleted");
+        EventType rhNewRoleAddedToDefaultAccess = resourceHelpers.createEventType(rbac.getId(), "rh-new-role-added-to-default-access");
+        EventType rhRoleRemovedFromDefaultAccess = resourceHelpers.createEventType(rbac.getId(), "rh-role-removed-from-default-access");
+        EventType customDefaultAccessUpdated = resourceHelpers.createEventType(rbac.getId(), "custom-default-access-updated");
+        EventType groupCreated = resourceHelpers.createEventType(rbac.getId(), "group-created");
+        EventType groupUpdated = resourceHelpers.createEventType(rbac.getId(), "group-updated");
+        EventType groupDeleted = resourceHelpers.createEventType(rbac.getId(), "group-deleted");
+        EventType platformDefaultGroupTurnedIntoCustom = resourceHelpers.createEventType(rbac.getId(), "platform-default-group-turned-into-custom");
+
+        clearDbTemplates();
+
+        given()
+                .basePath(API_INTERNAL)
+                .when()
+                .put("/template-engine/migrate")
+                .then()
+                .statusCode(204);
+
+        statelessSessionFactory.withSession(statelessSession -> {
+
+            /*
+             * Bundle: rhel
+             */
+            // App: advisor
+            findAndCompileInstantEmailTemplate(newRecommendation.getId());
+            findAndCompileInstantEmailTemplate(resolvedRecommendation.getId());
+            findAndCompileInstantEmailTemplate(deactivatedRecommendation.getId());
+            assertTrue(templateRepository.findAggregationEmailTemplate(rhel.getName(), advisor.getName(), DAILY).isEmpty());
+            // App: compliance
+            findAndCompileInstantEmailTemplate(complianceBelowThreshold.getId());
+            findAndCompileInstantEmailTemplate(reportUploadFailed.getId());
+            findAndCompileAggregationEmailTemplate(rhel.getName(), compliance.getName(), DAILY);
+            // App: drift
+            findAndCompileInstantEmailTemplate(driftBaselineDetected.getId());
+            findAndCompileAggregationEmailTemplate(rhel.getName(), drift.getName(), DAILY);
+            // App: policies
+            findAndCompileInstantEmailTemplate(policyTriggered.getId());
+            findAndCompileAggregationEmailTemplate(rhel.getName(), policies.getName(), DAILY);
+            // App: vulnerability
+            findAndCompileInstantEmailTemplate(newCveCvss.getId());
+            findAndCompileInstantEmailTemplate(newCveSecurityRule.getId());
+            findAndCompileInstantEmailTemplate(newCveSeverity.getId());
+            findAndCompileInstantEmailTemplate(anyCveKnownExploit.getId());
+            assertTrue(templateRepository.findAggregationEmailTemplate(rhel.getName(), vulnerability.getName(), DAILY).isEmpty());
+
+            /*
+             * Bundle: openshift
+             */
+            // App: advisor
+            findAndCompileInstantEmailTemplate(newRecommendationOpenshift.getId());
+            assertTrue(templateRepository.findAggregationEmailTemplate(openshift.getName(), advisorOpenshift.getName(), DAILY).isEmpty());
+
+            /*
+             * Bundle: application-services
+             */
+            // App: rhosak
+            findAndCompileInstantEmailTemplate(scheduledUpgrade.getId());
+            findAndCompileInstantEmailTemplate(disruption.getId());
+            findAndCompileInstantEmailTemplate(instanceCreated.getId());
+            findAndCompileInstantEmailTemplate(instanceDeleted.getId());
+            findAndCompileInstantEmailTemplate(actionRequired.getId());
+            findAndCompileAggregationEmailTemplate(applicationServices.getName(), rhosak.getName(), DAILY);
+
+            /*
+             * Bundle: ansible
+             */
+            // App: reports
+            findAndCompileInstantEmailTemplate(reportAvailable.getId());
+            assertTrue(templateRepository.findAggregationEmailTemplate(ansible.getName(), reports.getName(), DAILY).isEmpty());
+
+            /*
+             * Bundle: console
+             */
+            // App: notifications
+            findAndCompileInstantEmailTemplate(failedIntegration.getId());
+            assertTrue(templateRepository.findAggregationEmailTemplate(console.getName(), notifications.getName(), DAILY).isEmpty());
+            // App: sources
+            findAndCompileInstantEmailTemplate(availabilityStatus.getId());
+            assertTrue(templateRepository.findAggregationEmailTemplate(console.getName(), sources.getName(), DAILY).isEmpty());
+            // App: rbac
+            findAndCompileInstantEmailTemplate(rhNewRoleAvailable.getId());
+            findAndCompileInstantEmailTemplate(rhPlatformDefaultRoleUpdated.getId());
+            findAndCompileInstantEmailTemplate(rhNonPlatformDefaultRoleUpdated.getId());
+            findAndCompileInstantEmailTemplate(customRoleCreated.getId());
+            findAndCompileInstantEmailTemplate(customRoleUpdated.getId());
+            findAndCompileInstantEmailTemplate(customRoleDeleted.getId());
+            findAndCompileInstantEmailTemplate(rhNewRoleAddedToDefaultAccess.getId());
+            findAndCompileInstantEmailTemplate(rhRoleRemovedFromDefaultAccess.getId());
+            findAndCompileInstantEmailTemplate(customDefaultAccessUpdated.getId());
+            findAndCompileInstantEmailTemplate(groupCreated.getId());
+            findAndCompileInstantEmailTemplate(groupUpdated.getId());
+            findAndCompileInstantEmailTemplate(groupDeleted.getId());
+            findAndCompileInstantEmailTemplate(platformDefaultGroupTurnedIntoCustom.getId());
+            assertTrue(templateRepository.findAggregationEmailTemplate(console.getName(), rbac.getName(), DAILY).isEmpty());
+
+        });
+
+        clearDbTemplates();
+    }
+
+    private Bundle findBundle(String name) {
+        return entityManager.createQuery("FROM Bundle WHERE name = :name", Bundle.class)
+                .setParameter("name", name)
+                .getSingleResult();
+    }
+
+    private Application findApp(String bundleName, String appName) {
+        return entityManager.createQuery("FROM Application WHERE name = :appName AND bundle.name = :bundleName", Application.class)
+                .setParameter("appName", appName)
+                .setParameter("bundleName", bundleName)
+                .getSingleResult();
+    }
+
+    private EventType findEventType(String bundleName, String appName, String eventTypeName) {
+        return entityManager.createQuery("FROM EventType WHERE name = :eventTypeName AND application.name = :appName AND application.bundle.name = :bundleName", EventType.class)
+                .setParameter("eventTypeName", eventTypeName)
+                .setParameter("appName", appName)
+                .setParameter("bundleName", bundleName)
+                .getSingleResult();
+    }
+
+    private void clearDbTemplates() {
+        given()
+                .basePath(API_INTERNAL)
+                .when().delete("/template-engine/migrate")
+                .then()
+                .statusCode(204);
+        assertDbEmpty(Template.class, InstantEmailTemplate.class, AggregationEmailTemplate.class);
+    }
+
+    private void assertDbEmpty(Class<?>... entityClasses) {
+        for (Class<?> entityClass : entityClasses) {
+            long count = entityManager.createQuery("SELECT COUNT(*) FROM " + entityClass.getSimpleName(), Long.class)
+                    .getSingleResult();
+            assertEquals(0, count);
+        }
+    }
+
+    private void findAndCompileInstantEmailTemplate(UUID eventTypeId) {
+        InstantEmailTemplate emailTemplate = templateRepository.findInstantEmailTemplate(eventTypeId).get();
+        templateService.compileTemplate(emailTemplate.getSubjectTemplate().getData(), emailTemplate.getSubjectTemplate().getName());
+        templateService.compileTemplate(emailTemplate.getBodyTemplate().getData(), emailTemplate.getBodyTemplate().getName());
+    }
+
+    private void findAndCompileAggregationEmailTemplate(String bundleName, String appName, EmailSubscriptionType subscriptionType) {
+        AggregationEmailTemplate emailTemplate = templateRepository.findAggregationEmailTemplate(bundleName, appName, subscriptionType).get();
+        templateService.compileTemplate(emailTemplate.getSubjectTemplate().getData(), emailTemplate.getSubjectTemplate().getName());
+        templateService.compileTemplate(emailTemplate.getBodyTemplate().getData(), emailTemplate.getBodyTemplate().getName());
+    }
+}


### PR DESCRIPTION
- The migration will be triggered with a REST call to `/internal/admin/templates/migrate`.
- `backend` is exposing the migration endpoint and forwarding the request to `engine` which does the actual migration work.
- We can run the migration multiple times. If a template was previously migrated, it won't be changed by a new run.
- The DB templates can be wiped if there's a problem with the migration result on stage, allowing multiple attempts if necessary.
- ℹ️ As usual, this PR does not affect prod.