### PR TITLE
Support external API path for frontend

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -77,6 +77,7 @@ objects:
       webServices:
         public:
           enabled: true
+          apiPath: notifications
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         resources:


### PR DESCRIPTION
Adds `apiPath` to fix frontend <--> backend networking in Ingress. Without this field, Clowder will use the app name `notifications-backend-service` by default. 