### PR TITLE
Fix NPE in endpoints REST API

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -93,18 +93,6 @@ public class EndpointRepository {
         return endpoints;
     }
 
-    public EndpointType getEndpointTypeById(String accountId, UUID endpointId) {
-        String query = "Select e.compositeType.type from Endpoint e WHERE e.accountId = :accountId AND e.id = :endpointId";
-        try {
-            return entityManager.createQuery(query, EndpointType.class)
-                    .setParameter("accountId", accountId)
-                    .setParameter("endpointId", endpointId)
-                    .getSingleResult();
-        } catch (NoResultException e) {
-            return null;
-        }
-    }
-
     @Transactional
     public Endpoint getOrCreateEmailSubscriptionEndpoint(String accountId, EmailSubscriptionProperties properties) {
         List<Endpoint> emailEndpoints = getEndpointsPerCompositeType(accountId, null, Set.of(new CompositeEndpointType(EndpointType.EMAIL_SUBSCRIPTION)), null, null);

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -19,6 +19,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.transaction.Transactional;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -91,6 +92,18 @@ public class EndpointRepository {
                 .getResultList();
         loadProperties(endpoints);
         return endpoints;
+    }
+
+    public EndpointType getEndpointTypeById(String accountId, UUID endpointId) {
+        String query = "Select e.compositeType.type from Endpoint e WHERE e.accountId = :accountId AND e.id = :endpointId";
+        try {
+            return entityManager.createQuery(query, EndpointType.class)
+                    .setParameter("accountId", accountId)
+                    .setParameter("endpointId", endpointId)
+                    .getSingleResult();
+        } catch (NoResultException e) {
+            throw new NotFoundException("Endpoint not found");
+        }
     }
 
     @Transactional

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -265,8 +265,11 @@ public class EndpointResource {
     @Transactional
     public Response deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        EndpointType endpointType = endpointRepository.getEndpointTypeById(principal.getAccount(), id);
-        checkSystemEndpoint(endpointType);
+        Endpoint endpoint = endpointRepository.getEndpoint(principal.getAccount(), id);
+        if (endpoint == null) {
+            throw new NotFoundException("Endpoint not found");
+        }
+        checkSystemEndpoint(endpoint.getType());
 
         if (obEnabled) {
             Endpoint e = endpointRepository.getEndpoint(principal.getAccount(), id);
@@ -305,8 +308,11 @@ public class EndpointResource {
     @Transactional
     public Response enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        EndpointType endpointType = endpointRepository.getEndpointTypeById(principal.getAccount(), id);
-        checkSystemEndpoint(endpointType);
+        Endpoint endpoint = endpointRepository.getEndpoint(principal.getAccount(), id);
+        if (endpoint == null) {
+            throw new NotFoundException("Endpoint not found");
+        }
+        checkSystemEndpoint(endpoint.getType());
         endpointRepository.enableEndpoint(principal.getAccount(), id);
         return Response.ok().build();
     }
@@ -318,8 +324,11 @@ public class EndpointResource {
     @Transactional
     public Response disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        EndpointType endpointType = endpointRepository.getEndpointTypeById(principal.getAccount(), id);
-        checkSystemEndpoint(endpointType);
+        Endpoint endpoint = endpointRepository.getEndpoint(principal.getAccount(), id);
+        if (endpoint == null) {
+            throw new NotFoundException("Endpoint not found");
+        }
+        checkSystemEndpoint(endpoint.getType());
         endpointRepository.disableEndpoint(principal.getAccount(), id);
         return Response.noContent().build();
     }
@@ -338,9 +347,12 @@ public class EndpointResource {
         endpoint.setAccountId(principal.getAccount());
         endpoint.setId(id);
 
-        EndpointType endpointType = endpointRepository.getEndpointTypeById(principal.getAccount(), id);
+        Endpoint ep = endpointRepository.getEndpoint(principal.getAccount(), id);
+        if (ep == null) {
+            throw new NotFoundException("Endpoint not found");
+        }
         // This prevents from updating an endpoint from system EndpointType to a whatever EndpointType
-        checkSystemEndpoint(endpointType);
+        checkSystemEndpoint(ep.getType());
         endpointRepository.updateEndpoint(endpoint);
         return Response.ok().build();
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -265,11 +265,8 @@ public class EndpointResource {
     @Transactional
     public Response deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        Endpoint endpoint = endpointRepository.getEndpoint(principal.getAccount(), id);
-        if (endpoint == null) {
-            throw new NotFoundException("Endpoint not found");
-        }
-        checkSystemEndpoint(endpoint.getType());
+        EndpointType endpointType = endpointRepository.getEndpointTypeById(principal.getAccount(), id);
+        checkSystemEndpoint(endpointType);
 
         if (obEnabled) {
             Endpoint e = endpointRepository.getEndpoint(principal.getAccount(), id);
@@ -308,11 +305,8 @@ public class EndpointResource {
     @Transactional
     public Response enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        Endpoint endpoint = endpointRepository.getEndpoint(principal.getAccount(), id);
-        if (endpoint == null) {
-            throw new NotFoundException("Endpoint not found");
-        }
-        checkSystemEndpoint(endpoint.getType());
+        EndpointType endpointType = endpointRepository.getEndpointTypeById(principal.getAccount(), id);
+        checkSystemEndpoint(endpointType);
         endpointRepository.enableEndpoint(principal.getAccount(), id);
         return Response.ok().build();
     }
@@ -324,11 +318,8 @@ public class EndpointResource {
     @Transactional
     public Response disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
-        Endpoint endpoint = endpointRepository.getEndpoint(principal.getAccount(), id);
-        if (endpoint == null) {
-            throw new NotFoundException("Endpoint not found");
-        }
-        checkSystemEndpoint(endpoint.getType());
+        EndpointType endpointType = endpointRepository.getEndpointTypeById(principal.getAccount(), id);
+        checkSystemEndpoint(endpointType);
         endpointRepository.disableEndpoint(principal.getAccount(), id);
         return Response.noContent().build();
     }
@@ -347,12 +338,9 @@ public class EndpointResource {
         endpoint.setAccountId(principal.getAccount());
         endpoint.setId(id);
 
-        Endpoint ep = endpointRepository.getEndpoint(principal.getAccount(), id);
-        if (ep == null) {
-            throw new NotFoundException("Endpoint not found");
-        }
+        EndpointType endpointType = endpointRepository.getEndpointTypeById(principal.getAccount(), id);
         // This prevents from updating an endpoint from system EndpointType to a whatever EndpointType
-        checkSystemEndpoint(ep.getType());
+        checkSystemEndpoint(endpointType);
         endpointRepository.updateEndpoint(endpoint);
         return Response.ok().build();
     }


### PR DESCRIPTION
This PR should fix the following exception which reached our Sentry channel on stage:
```
java.lang.NullPointerException: null
    at java.util.Objects.requireNonNull(Objects.java:221)
    at java.util.ImmutableCollections$AbstractImmutableList.indexOf(ImmutableCollections.java:170)
    at java.util.ImmutableCollections$AbstractImmutableList.contains(ImmutableCollections.java:201)
    at com.redhat.cloud.notifications.routers.EndpointResource.checkSystemEndpoint(EndpointResource.java:447)
    at com.redhat.cloud.notifications.routers.EndpointResource.deleteEndpoint(EndpointResource.java:269)
```
ℹ️ I checked the DB with `gabi`, all endpoints have a non-null `endpoint_type` field on stage.