### PR TITLE
Getting the AuthToken must be request scoped

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/openbridge/BridgeHelper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/openbridge/BridgeHelper.java
@@ -6,6 +6,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
@@ -83,12 +84,14 @@ public class BridgeHelper {
         return bridge;
     }
 
-    @ApplicationScoped
+    @RequestScoped
     @Produces
     public BridgeAuth getAuthToken() {
         if (!obEnabled) {
             return new BridgeAuth("- OB not enabled token -");
         }
+
+        LOGGER.debug("In getAuthToken()");
 
         BridgeAuth ba = null;
         try {


### PR DESCRIPTION
Getting the AuthToken must be request scoped, as it would otherwise not expire locally, but in OpenBridge.
As it is currently CDI is sort of caching the token forever.