### PR TITLE
Fix NPE in notifications REST API

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -234,6 +234,9 @@ public class NotificationResource {
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
     public Response updateEventTypeBehaviors(@Context SecurityContext sec, @PathParam("eventTypeId") UUID eventTypeId, Set<UUID> behaviorGroupIds) {
+        if (behaviorGroupIds == null) {
+            throw new BadRequestException("The request body must contain a list of behavior groups identifiers");
+        }
         // RESTEasy does not reject an invalid List<UUID> body (even when @Valid is used) so we have to do an additional check here.
         if (behaviorGroupIds.contains(null)) {
             throw new BadRequestException("The behavior groups identifiers list should not contain empty values");


### PR DESCRIPTION
We received a Sentry alert on stage about the following exception:
```
java.lang.NullPointerException: null
    at com.redhat.cloud.notifications.routers.NotificationResource.updateEventTypeBehaviors(NotificationResource.java:238)
```
This PR replaces the exception with a proper HTTP 400 status code.