### PR TITLE
NOTIF-324 Allow to filter events by composite types

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -42,7 +42,7 @@ public class EndpointRepository {
     @Transactional
     public Endpoint createEndpoint(Endpoint endpoint) {
         // Todo: NOTIF-429 backward compatibility change - Remove soon.
-        if (endpoint.getType() == EndpointType.CAMEL) {
+        if (endpoint.getType() == EndpointType.CAMEL && endpoint.getProperties() != null) {
             CamelProperties properties = endpoint.getProperties(CamelProperties.class);
 
             if (endpoint.getSubType() == null && properties.getSubType() == null) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -125,7 +125,7 @@ public class EventRepository {
         if (checkEndpointType || checkInvocationResult) {
             List<String> subQueryConditions = new ArrayList<>();
             if (checkEndpointType) {
-                subQueryConditions.add("nh.endpointType IN (:endpointTypes)");
+                subQueryConditions.add("nh.compositeEndpointType.type IN (:endpointTypes)");
             }
             if (checkInvocationResult) {
                 subQueryConditions.add("nh.invocationResult IN (:invocationResults)");

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -123,7 +123,7 @@ public class EventRepository {
             hql += " AND e.created <= :endDate";
         }
 
-        boolean checkEndpointType = (endpointTypes != null && !endpointTypes.isEmpty()) || (compositeEndpointTypes != null && !compositeEndpointTypes.isEmpty()) ;
+        boolean checkEndpointType = (endpointTypes != null && !endpointTypes.isEmpty()) || (compositeEndpointTypes != null && !compositeEndpointTypes.isEmpty());
         boolean checkInvocationResult = invocationResults != null && !invocationResults.isEmpty();
         if (checkEndpointType || checkInvocationResult) {
             List<String> subQueryConditions = new ArrayList<>();

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -143,13 +143,8 @@ public class EndpointResource {
 
         if (targetType != null && targetType.size() > 0) {
             Set<CompositeEndpointType> compositeType = targetType.stream().map(s -> {
-                String[] pieces = s.split(":", 2);
                 try {
-                    if (pieces.length == 1) {
-                        return new CompositeEndpointType(EndpointType.valueOf(s.toUpperCase()));
-                    } else {
-                        return new CompositeEndpointType(EndpointType.valueOf(pieces[0].toUpperCase()), pieces[1]);
-                    }
+                    return CompositeEndpointType.fromString(s);
                 } catch (IllegalArgumentException e) {
                     throw new BadRequestException("Unknown endpoint type: [" + s + "]", e);
                 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -112,7 +112,11 @@ public class ResourceHelpers {
     }
 
     public Endpoint createEndpoint(String accountId, EndpointType type) {
-        return createEndpoint(accountId, type, "name", "description", null, FALSE);
+        return createEndpoint(accountId, type, null);
+    }
+
+    public Endpoint createEndpoint(String accountId, EndpointType type, String subType) {
+        return createEndpoint(accountId, type, subType, "name", "description", null, FALSE);
     }
 
     public UUID createWebhookEndpoint(String accountId) {
@@ -120,14 +124,15 @@ public class ResourceHelpers {
         properties.setMethod(HttpType.POST);
         properties.setUrl("https://localhost");
         String name = "Endpoint " + UUID.randomUUID();
-        return createEndpoint(accountId, WEBHOOK, name, "Automatically generated", properties, TRUE)
+        return createEndpoint(accountId, WEBHOOK, null, name, "Automatically generated", properties, TRUE)
                 .getId();
     }
 
-    public Endpoint createEndpoint(String accountId, EndpointType type, String name, String description, EndpointProperties properties, Boolean enabled) {
+    public Endpoint createEndpoint(String accountId, EndpointType type, String subType, String name, String description, EndpointProperties properties, Boolean enabled) {
         Endpoint endpoint = new Endpoint();
         endpoint.setAccountId(accountId);
         endpoint.setType(type);
+        endpoint.setSubType(subType);
         endpoint.setName(name);
         endpoint.setDescription(description);
         endpoint.setProperties(properties);
@@ -172,6 +177,7 @@ public class ResourceHelpers {
         history.setEvent(event);
         history.setEndpoint(endpoint);
         history.setEndpointType(endpoint.getType());
+        history.setEndpointSubType(endpoint.getSubType());
         history.prePersist();
         entityManager.persist(history);
         return history;

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
@@ -413,7 +413,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertLinks(page.getLinks(), "first", "last");
 
         /*
-         * Test #24
+         * Test #25
          * Account: DEFAULT_ACCOUNT_ID
          * Request: CAMEL:SLACK and EMAIL endpoints
          */

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
@@ -9,7 +9,6 @@ import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Endpoint;
-import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
@@ -40,6 +39,7 @@ import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.NOTIFIC
 import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.NOTIFICATIONS_READ_ACCESS_ONLY;
 import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.NO_ACCESS;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
+import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPTION;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
 import static com.redhat.cloud.notifications.routers.EventResource.PATH;
@@ -103,12 +103,15 @@ public class EventResourceTest extends DbIsolatedTest {
         Event event4 = createEvent(OTHER_ACCOUNT_ID, bundle2, app2, eventType2, NOW.minusDays(10L));
         Endpoint endpoint1 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, WEBHOOK);
         Endpoint endpoint2 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, EMAIL_SUBSCRIPTION);
+        Endpoint endpoint3 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, CAMEL, "SlAcK");
         NotificationHistory history1 = resourceHelpers.createNotificationHistory(event1, endpoint1, TRUE);
         NotificationHistory history2 = resourceHelpers.createNotificationHistory(event1, endpoint2, FALSE);
         NotificationHistory history3 = resourceHelpers.createNotificationHistory(event2, endpoint1, TRUE);
         NotificationHistory history4 = resourceHelpers.createNotificationHistory(event3, endpoint2, TRUE);
+        NotificationHistory history5 = resourceHelpers.createNotificationHistory(event3, endpoint3, TRUE);
         endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint1.getId());
         endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint2.getId());
+        endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint3.getId());
 
         /*
          * Test #1
@@ -120,7 +123,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertEquals(3, page.getMeta().getCount());
         assertEquals(3, page.getData().size());
         assertSameEvent(page.getData().get(0), event2, history3);
-        assertSameEvent(page.getData().get(1), event3, history4);
+        assertSameEvent(page.getData().get(1), event3, history4, history5);
         assertSameEvent(page.getData().get(2), event1, history1, history2);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
@@ -170,7 +173,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertEquals(3, page.getData().size());
         assertSameEvent(page.getData().get(0), event1, history1, history2);
         assertSameEvent(page.getData().get(1), event2, history3);
-        assertSameEvent(page.getData().get(2), event3, history4);
+        assertSameEvent(page.getData().get(2), event3, history4, history5);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
 
@@ -193,7 +196,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertEquals(2, page.getMeta().getCount());
         assertEquals(2, page.getData().size());
         assertSameEvent(page.getData().get(0), event2, history3);
-        assertSameEvent(page.getData().get(1), event3, history4);
+        assertSameEvent(page.getData().get(1), event3, history4, history5);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
 
@@ -207,7 +210,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertEquals(3, page.getData().size());
         assertSameEvent(page.getData().get(0), event1, history1, history2);
         assertSameEvent(page.getData().get(1), event2, history3);
-        assertSameEvent(page.getData().get(2), event3, history4);
+        assertSameEvent(page.getData().get(2), event3, history4, history5);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
 
@@ -242,7 +245,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertEquals(2, page.getMeta().getCount());
         assertEquals(2, page.getData().size());
         assertSameEvent(page.getData().get(0), event2, history3);
-        assertSameEvent(page.getData().get(1), event3, history4);
+        assertSameEvent(page.getData().get(1), event3, history4, history5);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
 
@@ -266,7 +269,7 @@ public class EventResourceTest extends DbIsolatedTest {
         page = getEventLogPage(defaultIdentityHeader, null, null, null, NOW.minusDays(3L), NOW.minusDays(1L), null, null, null, null, null, false, true);
         assertEquals(1, page.getMeta().getCount());
         assertEquals(1, page.getData().size());
-        assertSameEvent(page.getData().get(0), event3, history4);
+        assertSameEvent(page.getData().get(0), event3, history4, history5);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
 
@@ -275,10 +278,10 @@ public class EventResourceTest extends DbIsolatedTest {
          * Account: DEFAULT_ACCOUNT_ID
          * Request: Let's try all request params at once!
          */
-        page = getEventLogPage(defaultIdentityHeader, Set.of(bundle2.getId()), Set.of(app2.getId()), eventType2.getDisplayName(), NOW.minusDays(3L), NOW.minusDays(1L), Set.of(EMAIL_SUBSCRIPTION), Set.of(TRUE), 10, 0, "created:desc", true, true);
+        page = getEventLogPage(defaultIdentityHeader, Set.of(bundle2.getId()), Set.of(app2.getId()), eventType2.getDisplayName(), NOW.minusDays(3L), NOW.minusDays(1L), Set.of(EMAIL_SUBSCRIPTION.name()), Set.of(TRUE), 10, 0, "created:desc", true, true);
         assertEquals(1, page.getMeta().getCount());
         assertEquals(1, page.getData().size());
-        assertSameEvent(page.getData().get(0), event3, history4);
+        assertSameEvent(page.getData().get(0), event3, history4, history5);
         assertEquals(PAYLOAD, page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
 
@@ -291,7 +294,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertEquals(3, page.getMeta().getCount());
         assertEquals(2, page.getData().size());
         assertSameEvent(page.getData().get(0), event2, history3);
-        assertSameEvent(page.getData().get(1), event3, history4);
+        assertSameEvent(page.getData().get(1), event3, history4, history5);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last", "next");
 
@@ -317,7 +320,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertEquals(3, page.getData().size());
         assertSameEvent(page.getData().get(0), event1, history1, history2);
         assertSameEvent(page.getData().get(1), event2, history3);
-        assertSameEvent(page.getData().get(2), event3, history4);
+        assertSameEvent(page.getData().get(2), event3, history4, history5);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
 
@@ -326,7 +329,7 @@ public class EventResourceTest extends DbIsolatedTest {
          * Account: DEFAULT_ACCOUNT_ID
          * Request: WEBHOOK endpoints
          */
-        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, Set.of(WEBHOOK), null, null, null, null, false, true);
+        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, Set.of(WEBHOOK.name()), null, null, null, null, false, true);
         assertEquals(2, page.getMeta().getCount());
         assertEquals(2, page.getData().size());
         assertSameEvent(page.getData().get(0), event2, history3);
@@ -343,7 +346,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertEquals(3, page.getMeta().getCount());
         assertEquals(3, page.getData().size());
         assertSameEvent(page.getData().get(0), event2, history3);
-        assertSameEvent(page.getData().get(1), event3, history4);
+        assertSameEvent(page.getData().get(1), event3, history4, history5);
         assertSameEvent(page.getData().get(2), event1, history1, history2);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
@@ -353,7 +356,7 @@ public class EventResourceTest extends DbIsolatedTest {
          * Account: DEFAULT_ACCOUNT_ID
          * Request: EMAIL_SUBSCRIPTION endpoints and invocation failed
          */
-        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, Set.of(EMAIL_SUBSCRIPTION), Set.of(FALSE), null, null, null, false, true);
+        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, Set.of(EMAIL_SUBSCRIPTION.name()), Set.of(FALSE), null, null, null, false, true);
         assertEquals(1, page.getMeta().getCount());
         assertEquals(1, page.getData().size());
         assertSameEvent(page.getData().get(0), event1, history1, history2);
@@ -372,6 +375,53 @@ public class EventResourceTest extends DbIsolatedTest {
         assertSameEvent(page.getData().get(0), event2);
         assertSameEvent(page.getData().get(1), event3);
         assertSameEvent(page.getData().get(2), event1);
+        assertNull(page.getData().get(0).getPayload());
+        assertLinks(page.getLinks(), "first", "last");
+
+        /*
+         * Test #22
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: CAMEL endpoints
+         */
+        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, Set.of(CAMEL.name()), null, null, null, null, false, true);
+        assertEquals(1, page.getMeta().getCount());
+        assertEquals(1, page.getData().size());
+        assertSameEvent(page.getData().get(0), event3, history4, history5);
+        assertNull(page.getData().get(0).getPayload());
+        assertLinks(page.getLinks(), "first", "last");
+
+        /*
+         * Test #23
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: CAMEL:SPLUNK endpoints
+         */
+        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, Set.of("camel:splunk"), null, null, null, null, false, true);
+        assertEquals(0, page.getMeta().getCount());
+        assertEquals(0, page.getData().size());
+        assertLinks(page.getLinks(), "first", "last");
+
+        /*
+         * Test #24
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: CAMEL:SLACK endpoints
+         */
+        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, Set.of("camel:slack"), null, null, null, null, false, true);
+        assertEquals(1, page.getMeta().getCount());
+        assertEquals(1, page.getData().size());
+        assertSameEvent(page.getData().get(0), event3, history4, history5);
+        assertNull(page.getData().get(0).getPayload());
+        assertLinks(page.getLinks(), "first", "last");
+
+        /*
+         * Test #24
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: CAMEL:SLACK and EMAIL endpoints
+         */
+        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, Set.of("camel:SLACK", EMAIL_SUBSCRIPTION.name()), null, null, null, null, false, true);
+        assertEquals(2, page.getMeta().getCount());
+        assertEquals(2, page.getData().size());
+        assertSameEvent(page.getData().get(0), event3, history4, history5);
+        assertSameEvent(page.getData().get(1), event1, history1, history2);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
     }
@@ -451,7 +501,7 @@ public class EventResourceTest extends DbIsolatedTest {
     }
 
     private static Page<EventLogEntry> getEventLogPage(Header identityHeader, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
-                                                       LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes,
+                                                       LocalDateTime startDate, LocalDateTime endDate, Set<String> endpointTypes,
                                                        Set<Boolean> invocationResults, Integer limit, Integer offset, String sortBy, boolean includePayload, boolean includeActions) {
         RequestSpecification request = given()
                 .header(identityHeader);
@@ -516,6 +566,7 @@ public class EventResourceTest extends DbIsolatedTest {
                         .filter(entry -> entry.getId().equals(eventLogEntryAction.getId())).findAny();
                 assertTrue(historyEntry.isPresent());
                 assertEquals(historyEntry.get().getEndpointType(), eventLogEntryAction.getEndpointType());
+                assertEquals(historyEntry.get().getEndpointSubType(), eventLogEntryAction.getEndpointSubType());
                 assertEquals(historyEntry.get().isInvocationResult(), eventLogEntryAction.getInvocationResult());
             }
         }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CompositeEndpointType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CompositeEndpointType.java
@@ -20,6 +20,15 @@ public class CompositeEndpointType {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String subType;
 
+    public static CompositeEndpointType fromString(String type) {
+        String[] pieces = type.split(":", 2);
+        if (pieces.length == 1) {
+            return new CompositeEndpointType(EndpointType.valueOf(type.toUpperCase()));
+        } else {
+            return new CompositeEndpointType(EndpointType.valueOf(pieces[0].toUpperCase()), pieces[1]);
+        }
+    }
+
     public CompositeEndpointType() {
 
     }
@@ -30,7 +39,7 @@ public class CompositeEndpointType {
 
     public CompositeEndpointType(EndpointType type, String subType) {
         this.type = type;
-        this.subType = subType;
+        this.subType = subType.toLowerCase();
     }
 
     public EndpointType getType() {
@@ -46,7 +55,7 @@ public class CompositeEndpointType {
     }
 
     public void setSubType(String subType) {
-        this.subType = subType;
+        this.subType = subType == null ? null : subType.toLowerCase();
     }
 
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -2,10 +2,10 @@ package com.redhat.cloud.notifications.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.redhat.cloud.notifications.db.converters.EndpointTypeConverter;
 import com.redhat.cloud.notifications.db.converters.NotificationHistoryDetailsConverter;
 
 import javax.persistence.Convert;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -51,20 +51,13 @@ public class NotificationHistory extends CreationTimestamped {
     private Endpoint endpoint;
 
     /*
-     * This is a duplicate of the Endpoint#type field. We need it to guarantee that the endpoint type will remain
+     * This is a duplicate of the Endpoint#type and Endpoint#subType field. We need it to guarantee that the endpoint type will remain
      * available for the event log even if the endpoint is deleted by an org admin.
      */
     @NotNull
-    @Convert(converter = EndpointTypeConverter.class)
+    @Embedded
     @JsonIgnore
-    private EndpointType endpointType;
-
-    /*
-     * This is a duplicate of the Endpoint#subType field. We need it to guarantee that the endpoint type will remain
-     * available for the event log even if the endpoint is deleted by an org admin.
-     */
-    @JsonIgnore
-    private String endpointSubType;
+    private CompositeEndpointType compositeEndpointType = new CompositeEndpointType();
 
     @Convert(converter = NotificationHistoryDetailsConverter.class)
     private Map<String, Object> details;
@@ -137,19 +130,19 @@ public class NotificationHistory extends CreationTimestamped {
     }
 
     public EndpointType getEndpointType() {
-        return endpointType;
+        return compositeEndpointType.getType();
     }
 
     public void setEndpointType(EndpointType endpointType) {
-        this.endpointType = endpointType;
+        this.compositeEndpointType.setType(endpointType);
     }
 
     public String getEndpointSubType() {
-        return endpointSubType;
+        return this.compositeEndpointType.getSubType();
     }
 
     public void setEndpointSubType(String endpointSubType) {
-        this.endpointSubType = endpointSubType;
+        this.compositeEndpointType.setSubType(endpointSubType);
     }
 
     public Map<String, Object> getDetails() {

--- a/database/src/main/resources/db/migration/V1.49.0__NOTIF-324_ensure-subtypes-are-lower-case.sql
+++ b/database/src/main/resources/db/migration/V1.49.0__NOTIF-324_ensure-subtypes-are-lower-case.sql
@@ -1,0 +1,9 @@
+-- ensure the sub_types are lower case
+
+UPDATE endpoints
+    SET   endpoint_sub_type = LOWER(endpoint_sub_type)
+    WHERE endpoint_sub_type != LOWER(endpoint_sub_type);
+
+UPDATE notification_history
+    SET   endpoint_sub_type = LOWER(endpoint_sub_type)
+    WHERE endpoint_sub_type != LOWER(endpoint_sub_type)

--- a/database/src/main/resources/db/migration/V1.49.0__NOTIF-324_ensure-subtypes-are-lower-case.sql
+++ b/database/src/main/resources/db/migration/V1.49.0__NOTIF-324_ensure-subtypes-are-lower-case.sql
@@ -1,9 +1,0 @@
--- ensure the sub_types are lower case
-
-UPDATE endpoints
-    SET   endpoint_sub_type = LOWER(endpoint_sub_type)
-    WHERE endpoint_sub_type != LOWER(endpoint_sub_type);
-
-UPDATE notification_history
-    SET   endpoint_sub_type = LOWER(endpoint_sub_type)
-    WHERE endpoint_sub_type != LOWER(endpoint_sub_type)


### PR DESCRIPTION
There is a PR to add some filters on the frontend - one of these is the Splunk integration, which is of type camel and subtype splunk. 

Before this PR, EventLog API did not support searching for sub_types. This PR enables searching for type with optional subtypes.