### PR TITLE
Add gauge for the actual count of users used

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
@@ -60,7 +60,7 @@ public class RecipientResolver {
             users = filterUsers(users, subscribers);
         }
 
-        usersCount.set(users.size());
+        updateUsersUsedGauge(users.size());
 
         return users;
     }
@@ -73,5 +73,9 @@ public class RecipientResolver {
                             .anyMatch(requested -> requested.equalsIgnoreCase(user.getUsername()))
                 )
                 .collect(Collectors.toSet());
+    }
+
+    private void updateUsersUsedGauge(int users) {
+        usersCount.set(users);
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
@@ -68,9 +68,9 @@ public class RecipientResolver {
     private Set<User> filterUsers(Set<User> users, Set<String> target) {
         return users.stream()
                 .filter(
-                        user -> target
-                                .stream()
-                                .anyMatch(requested -> requested.equalsIgnoreCase(user.getUsername()))
+                    user -> target
+                            .stream()
+                            .anyMatch(requested -> requested.equalsIgnoreCase(user.getUsername()))
                 )
                 .collect(Collectors.toSet());
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
@@ -24,7 +24,7 @@ public class RecipientResolver {
 
     @PostConstruct
     public void init() {
-        meterRegistry.gauge("get-users.used", usersCount);
+        meterRegistry.gauge("email-processor.recipients-resolved", usersCount);
     }
 
     public Set<User> recipientUsers(String accountId, Set<RecipientSettings> requests, Set<String> subscribers) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
@@ -1,18 +1,31 @@
 package com.redhat.cloud.notifications.recipients;
 
 import com.redhat.cloud.notifications.recipients.rbac.RbacRecipientUsersProvider;
+import io.micrometer.core.instrument.MeterRegistry;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class RecipientResolver {
 
+    private final AtomicInteger usersCount = new AtomicInteger(0);
+
     @Inject
     RbacRecipientUsersProvider rbacRecipientUsersProvider;
+
+    @Inject
+    MeterRegistry meterRegistry;
+
+    @PostConstruct
+    public void init() {
+        meterRegistry.gauge("get-users.used", usersCount);
+    }
 
     public Set<User> recipientUsers(String accountId, Set<RecipientSettings> requests, Set<String> subscribers) {
         return requests.stream()
@@ -47,15 +60,17 @@ public class RecipientResolver {
             users = filterUsers(users, subscribers);
         }
 
+        usersCount.set(users.size());
+
         return users;
     }
 
     private Set<User> filterUsers(Set<User> users, Set<String> target) {
         return users.stream()
                 .filter(
-                    user -> target
-                            .stream()
-                            .anyMatch(requested -> requested.equalsIgnoreCase(user.getUsername()))
+                        user -> target
+                                .stream()
+                                .anyMatch(requested -> requested.equalsIgnoreCase(user.getUsername()))
                 )
                 .collect(Collectors.toSet());
     }


### PR DESCRIPTION
coming from a discussion with @josejulio some minutes ago. We would like to get to know how many users we are fetching from IT User Service and how many of them we are actually using after fetching. With this gauge we can compare both.