### PR TITLE
Put old Junit 4 Test annotation on the forbidden list.

### DIFF
--- a/checkstyle/src/main/resources/checkstyle/checkstyle.xml
+++ b/checkstyle/src/main/resources/checkstyle/checkstyle.xml
@@ -79,9 +79,8 @@
 <!--        </module>-->
 
         <module name="IllegalImport">
-            <property regexp="true" />
             <property name="illegalPkgs" value="junit\.framework" />
-            <property name="illegalClasses" value="org\.junit\..*"  />
+            <property name="illegalClasses" value="org.junit.Test, org.junit.Before, org.junit.After, org.junit.AfterClass, org.junit.BeforeClass, org.junit.Assert" />
         </module>
 
         <!-- Modifier Checks -->

--- a/checkstyle/src/main/resources/checkstyle/checkstyle.xml
+++ b/checkstyle/src/main/resources/checkstyle/checkstyle.xml
@@ -80,6 +80,7 @@
 
         <module name="IllegalImport">
             <property name="illegalPkgs" value="junit.framework" />
+            <property name="illegalClasses" value="org.junit.Test" />
         </module>
 
         <!-- Modifier Checks -->

--- a/checkstyle/src/main/resources/checkstyle/checkstyle.xml
+++ b/checkstyle/src/main/resources/checkstyle/checkstyle.xml
@@ -79,8 +79,9 @@
 <!--        </module>-->
 
         <module name="IllegalImport">
-            <property name="illegalPkgs" value="junit.framework" />
-            <property name="illegalClasses" value="org.junit.Test" />
+            <property regexp="true" />
+            <property name="illegalPkgs" value="junit\.framework" />
+            <property name="illegalClasses" value="org\.junit\..*"  />
         </module>
 
         <!-- Modifier Checks -->


### PR DESCRIPTION
This is to help developers to make sure the Jupiter `@Test` is used and not the one from Junit4