### PR TITLE
NOTIF-628 Return 404 when id not found

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.db.repositories;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EventType;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -117,7 +118,7 @@ public class BehaviorGroupRepository {
             q = q.setParameter("accountId", accountId);
         }
 
-        return q.executeUpdate()  > 0;
+        return q.executeUpdate() > 0;
     }
 
     public boolean delete(String accountId, UUID behaviorGroupId) {
@@ -356,6 +357,11 @@ public class BehaviorGroupRepository {
     }
 
     public List<BehaviorGroup> findBehaviorGroupsByEndpointId(String accountId, UUID endpointId) {
+        Endpoint endpoint = entityManager.find(Endpoint.class, endpointId);
+        if (endpoint == null) {
+            throw new NotFoundException("Endpoint not found");
+        }
+
         String query = "SELECT bg FROM BehaviorGroup bg LEFT JOIN FETCH bg.bundle JOIN bg.actions a WHERE bg.accountId = :accountId AND a.endpoint.id = :endpointId";
         List<BehaviorGroup> behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
                 .setParameter("accountId", accountId)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -186,7 +186,7 @@ public class BehaviorGroupRepository {
         // First, let's make sure the event type exists.
         EventType eventType = entityManager.find(EventType.class, eventTypeId);
         if (eventType == null) {
-            return false;
+            throw new NotFoundException("Event type not found");
         } else {
 
             // An event type should only be linked to behavior groups from the same bundle.

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -179,7 +179,7 @@ public class EndpointRepository {
             loadProperties(endpoint);
             return endpoint;
         } catch (NoResultException e) {
-            throw new NotFoundException("Endpoint not found");
+            return null;
         }
     }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -179,7 +179,7 @@ public class EndpointRepository {
             loadProperties(endpoint);
             return endpoint;
         } catch (NoResultException e) {
-            return null;
+            throw new NotFoundException("Endpoint not found");
         }
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -547,4 +547,16 @@ public class NotificationResourceTest extends DbIsolatedTest {
                 .then()
                 .statusCode(404);
     }
+
+    @Test
+    void testBehaviorGroupsAffectedByRemovalOfUnknownEndpointId() {
+        Header identityHeader = initRbacMock("tenant", "user", FULL_ACCESS);
+        given()
+                .header(identityHeader)
+                .pathParam("endpointId", UUID.randomUUID())
+                .when()
+                .get("/notifications/behaviorGroups/affectedByRemovalOfEndpoint/{endpointId}")
+                .then()
+                .statusCode(404);
+    }
 }


### PR DESCRIPTION

The endpoints when passed an invalid ID with the correct "ID" format return an empty list with a 200 status code. should return a 404 "Not Found" exception.