### PR TITLE
NOTIF-646 Emit Camel metrics with subtype as tag.

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -75,11 +75,8 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
     @Inject
     BridgeAuth bridgeAuth;
 
-    private Counter processedCount;
-
     @PostConstruct
     public void init() {
-        processedCount = registry.counter(PROCESSED_COUNTER_NAME);
     }
 
     @Override
@@ -93,8 +90,12 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
     }
 
     private NotificationHistory process(Notification item) {
-        processedCount.increment();
         Endpoint endpoint = item.getEndpoint();
+        String subType = endpoint.getSubType();
+
+        Counter processedCount = registry.counter(PROCESSED_COUNTER_NAME, "subType", subType);
+        processedCount.increment();
+
         CamelProperties properties = (CamelProperties) endpoint.getProperties();
 
         Map<String, String> metaData = new HashMap<>();
@@ -102,7 +103,7 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
         metaData.put("trustAll", String.valueOf(properties.getDisableSslVerification()));
 
         metaData.put("url", properties.getUrl());
-        metaData.put("type", endpoint.getSubType());
+        metaData.put("type", subType);
 
         if (properties.getSecretToken() != null && !properties.getSecretToken().isBlank()) {
             metaData.put(TOKEN_HEADER, properties.getSecretToken());

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -28,7 +28,6 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.logging.Logger;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.net.URI;
@@ -74,10 +73,6 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
 
     @Inject
     BridgeAuth bridgeAuth;
-
-    @PostConstruct
-    public void init() {
-    }
 
     @Override
     public List<NotificationHistory> process(Event event, List<Endpoint> endpoints) {

--- a/engine/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
@@ -33,6 +33,12 @@ public class MicrometerAssertionHelper {
         }
     }
 
+    public void assertCounterIncrement(String counterName, double expectedIncrement, String... tags) {
+        double actualIncrement = registry.counter(counterName, tags).count() - counterValuesBeforeTest.getOrDefault(counterName + tags, 0D);
+        assertEquals(expectedIncrement, actualIncrement);
+    }
+
+
     public void assertCounterIncrement(String counterName, double expectedIncrement) {
         double actualIncrement = registry.counter(counterName).count() - counterValuesBeforeTest.getOrDefault(counterName, 0D);
         assertEquals(expectedIncrement, actualIncrement);
@@ -81,5 +87,9 @@ public class MicrometerAssertionHelper {
      */
     private Collection<Timer> findTimersByNameOnly(String name) {
         return registry.find(name).timers();
+    }
+
+    java.util.List<io.micrometer.core.instrument.Meter> listMeters() {
+        return registry.getMeters();
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -77,7 +77,7 @@ public class CamelTypeProcessorTest {
 
     @BeforeEach
     void beforeEach() {
-        micrometerAssertionHelper.saveCounterValuesBeforeTest(PROCESSED_COUNTER_NAME);
+        micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(PROCESSED_COUNTER_NAME, SUB_TYPE_KEY);
     }
 
     @AfterEach

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -60,6 +60,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTestResource(TestLifecycleManager.class)
 public class CamelTypeProcessorTest {
 
+    public static final String SUB_TYPE_KEY = "subType";
+    public static final String SUB_TYPE = "sub-type";
     @Inject
     @Any
     InMemoryConnector inMemoryConnector;
@@ -98,7 +100,9 @@ public class CamelTypeProcessorTest {
         // Two endpoints should have been processed.
         assertEquals(2, result.size());
         // Metrics should report the same thing.
-        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 2);
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 2, SUB_TYPE_KEY, SUB_TYPE);
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 0, SUB_TYPE_KEY, "other-type");
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 0);
 
         // Let's have a look at the first result entry fields.
         assertEquals(event, result.get(0).getEvent());
@@ -158,7 +162,10 @@ public class CamelTypeProcessorTest {
         // One endpoint should have been processed.
         assertEquals(1, result.size());
         // Metrics should report the same thing.
-        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 1);
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 0, SUB_TYPE_KEY, SUB_TYPE);
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 1, SUB_TYPE_KEY, "slack");
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 0, SUB_TYPE_KEY, "other-type");
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 0);
 
         // Let's have a look at the first result entry fields.
         NotificationHistory historyItem = result.get(0);
@@ -191,7 +198,7 @@ public class CamelTypeProcessorTest {
         // One endpoint should have been processed.
         assertEquals(1, result.size());
         // Metrics should report the same thing.
-        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 2);
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 2, SUB_TYPE_KEY, "slack");
 
         // Let's have a look at the first result entry fields.
         historyItem = result.get(0);
@@ -206,7 +213,7 @@ public class CamelTypeProcessorTest {
         result = processor.process(event, List.of(endpoint));
         assertEquals(1, result.size());
         // Metrics should report the same thing.
-        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 3);
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_COUNTER_NAME, 3, SUB_TYPE_KEY, "slack");
 
         // Let's have a look at the first result entry fields.
         historyItem = result.get(0);
@@ -265,12 +272,12 @@ public class CamelTypeProcessorTest {
         properties.setBasicAuthentication(basicAuth);
         properties.setExtras(Map.of("foo", "bar"));
         // Todo: NOTIF-429 backward compatibility change - Remove soon.
-        properties.setSubType("sub-type");
+        properties.setSubType(SUB_TYPE);
 
         Endpoint endpoint = new Endpoint();
         endpoint.setAccountId(accountId);
         endpoint.setType(CAMEL);
-        endpoint.setSubType("sub-type");
+        endpoint.setSubType(SUB_TYPE);
         endpoint.setProperties(properties);
         return endpoint;
     }


### PR DESCRIPTION
Metrics after sending 2 events to slack

```
# HELP processor_camel_processed_total  
# TYPE processor_camel_processed_total counter
processor_camel_processed_total{subType="slack",} 2.0
```

Not sure why there is an additional `,` in the output, but that is what `curl localhost:8087/metrics | grep processor  ` shows