### PR TITLE
NOTIF-603 Add orgId to IT User Service requests

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/itservice/pojo/request/AllOf.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/itservice/pojo/request/AllOf.java
@@ -1,8 +1,15 @@
 package com.redhat.cloud.notifications.recipients.itservice.pojo.request;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
 public class AllOf {
 
+    @JsonInclude(NON_EMPTY)
     public String ebsAccountNumber;
+    @JsonInclude(NON_EMPTY)
+    public String accountId;
     public String status;
     public PermissionCode permissionCode;
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/itservice/pojo/request/ITUserRequest.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/itservice/pojo/request/ITUserRequest.java
@@ -10,13 +10,18 @@ public class ITUserRequest {
     public ITUserRequestBy by;
     public Include include;
 
-    public ITUserRequest(String accountId, String orgId, boolean adminsOnly, int firstResult, int maxResults) {
+    public ITUserRequest(String accountId, String orgId, boolean useOrgId, boolean adminsOnly, int firstResult, int maxResults) {
         final ITUserRequestBy by = new ITUserRequestBy();
         AllOf allOf = new AllOf();
         allOf.status = "enabled";
 
-        // TODO NOTIF-603 replace the ebsAccountNumber with orgId. Means: replace this query object so it matches the expectec it user service query.
-        allOf.ebsAccountNumber = accountId;
+        if (useOrgId) {
+            allOf.ebsAccountNumber = null;
+            allOf.accountId = orgId;
+        } else {
+            allOf.ebsAccountNumber = accountId;
+            allOf.accountId = null;
+        }
 
         if (adminsOnly) {
             PermissionCode permissionCode = new PermissionCode();

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
@@ -41,6 +41,11 @@ public class RbacRecipientUsersProvider {
 
     public static final String ORG_ADMIN_PERMISSION = "admin:org:all";
 
+    public static final String USE_ORG_ID = "notifications.use-org-id";
+
+    @ConfigProperty(name = USE_ORG_ID, defaultValue = "false")
+    public boolean useOrgId;
+
     @Inject
     @RestClient
     RbacServiceToService rbacServiceToService;
@@ -127,7 +132,7 @@ public class RbacRecipientUsersProvider {
         int firstResult = 0;
 
         do {
-            ITUserRequest request = new ITUserRequest(accountId, orgId, adminsOnly, firstResult, maxResultsPerPage);
+            ITUserRequest request = new ITUserRequest(accountId, orgId, useOrgId, adminsOnly, firstResult, maxResultsPerPage);
             usersPaging = retryOnItError(() -> itUserService.getUsers(request));
             usersTotal.addAll(usersPaging);
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/recipients/itservice/pojo/request/AllOfTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/recipients/itservice/pojo/request/AllOfTest.java
@@ -1,0 +1,76 @@
+package com.redhat.cloud.notifications.recipients.itservice.pojo.request;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AllOfTest {
+
+    private AllOf testee;
+
+    @BeforeEach
+    void setUp() {
+        this.testee = new AllOf();
+    }
+
+    @Test
+    void shouldNotContainOrgIdWhenNotPresent() throws JsonProcessingException {
+        testee.ebsAccountNumber = "someEbsAccountNumber";
+
+        String result = new ObjectMapper().writeValueAsString(testee);
+
+        assertEquals("{\"ebsAccountNumber\":\"someEbsAccountNumber\",\"status\":null,\"permissionCode\":null}", result);
+    }
+
+    @Test
+    void shouldContainOrgId() throws JsonProcessingException {
+        testee.accountId = "someOrgId";
+
+        String result = new ObjectMapper().writeValueAsString(testee);
+
+        assertEquals("{\"accountId\":\"someOrgId\",\"status\":null,\"permissionCode\":null}", result);
+    }
+
+    @Test
+    void shouldNotContainEbsAccountNumberWhenItIsEmpty() throws JsonProcessingException {
+        testee.accountId = "someOrgId";
+        testee.ebsAccountNumber = "";
+
+        String result = new ObjectMapper().writeValueAsString(testee);
+
+        assertEquals("{\"accountId\":\"someOrgId\",\"status\":null,\"permissionCode\":null}", result);
+    }
+
+    @Test
+    void shouldNotContainOrgIdWhenItIsEmpty() throws JsonProcessingException {
+        testee.accountId = "";
+        testee.ebsAccountNumber = "someEbsAccountNumber";
+
+        String result = new ObjectMapper().writeValueAsString(testee);
+
+        assertEquals("{\"ebsAccountNumber\":\"someEbsAccountNumber\",\"status\":null,\"permissionCode\":null}", result);
+    }
+
+    @Test
+    void shouldNotContainEbsAccountNumberWhenItIsNull() throws JsonProcessingException {
+        testee.accountId = "someOrgId";
+        testee.ebsAccountNumber = null;
+
+        String result = new ObjectMapper().writeValueAsString(testee);
+
+        assertEquals("{\"accountId\":\"someOrgId\",\"status\":null,\"permissionCode\":null}", result);
+    }
+
+    @Test
+    void shouldNotContainOrgIdWhenItIsNull() throws JsonProcessingException {
+        testee.accountId = null;
+        testee.ebsAccountNumber = "someEbsAccountNumber";
+
+        String result = new ObjectMapper().writeValueAsString(testee);
+
+        assertEquals("{\"ebsAccountNumber\":\"someEbsAccountNumber\",\"status\":null,\"permissionCode\":null}", result);
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/recipients/itservice/pojo/request/ITUserRequestTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/recipients/itservice/pojo/request/ITUserRequestTest.java
@@ -6,10 +6,11 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ITUserRequestTest {
 
-    private final ITUserRequest testee = new ITUserRequest("someAccountId", "someOrgId", true, 0, 101);
+    private final ITUserRequest testee = new ITUserRequest("someAccountId", "someOrgId", false, true, 0, 101);
 
     @Test
     void shouldSetPermissionCodeWhenAdminsOnly() {
@@ -35,5 +36,18 @@ class ITUserRequestTest {
     @Test
     void shouldContainAccountIdAsEbsAccountNumber() {
         assertEquals("someAccountId", testee.by.allOf.ebsAccountNumber);
+    }
+
+    @Test
+    void shouldNotContainOrgIdByDefault() {
+        assertNull(testee.by.allOf.accountId);
+    }
+
+    @Test
+    void shouldContainOrgIdWhenOrgIdFlagIsTrue() {
+        ITUserRequest testee = new ITUserRequest("someAccountId", "someOrgId", true, true, 0, 101);
+
+        assertEquals("someOrgId", testee.by.allOf.accountId);
+        assertNull(testee.by.allOf.ebsAccountNumber);
     }
 }


### PR DESCRIPTION
It's still a pita to get a certificate, but we will have to do the change of the query anyway. I could not integration test (only comparing sample requests so far) the new query against the real IT User Service API for now.