### PR TITLE
Fix NPE in NotificationRepository

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
@@ -63,7 +63,11 @@ public class NotificationRepository {
                     .setParameter("endpointId", endpoint)
                     .setParameter("historyId", historyId)
                     .getSingleResult();
-            return new JsonObject(map);
+            if (map == null) {
+                return null;
+            } else {
+                return new JsonObject(map);
+            }
         } catch (NoResultException e) {
             return null;
         }


### PR DESCRIPTION
Fixes
```
2022-05-23 12:29:43,312 ERROR [io.qua.ver.htt.run.QuarkusErrorHandler] (executor-thread-13) HTTP Request to /api/integrations/v1.0/endpoints/c0e716da-3641-49cc-8cd2-5bec8eb6f17d/history/7832943c-5064-4c0d-8d40-1c45e251b42f/details failed, error id: e403de80-6246-4614-b62a-d623979e15f0-1: java.lang.NullPointerException
	at io.vertx.core.json.JsonObject.<init>(JsonObject.java:71)
	at com.redhat.cloud.notifications.db.repositories.NotificationRepository.getNotificationDetails(NotificationRepository.java:66)
	at com.redhat.cloud.notifications.db.repositories.NotificationRepository_ClientProxy.getNotificationDetails(Unknown Source)
	at com.redhat.cloud.notifications.routers.EndpointResource.getDetailedEndpointHistory(EndpointResource.java:381)
	at com.redhat.cloud.notifications.routers.EndpointResource_Subclass.getDetailedEndpointHistory$$superforward1(Unknown Source)
	at com.redhat.cloud.notifications.routers.EndpointResource_Subclass$$function$$11.apply(Unknown Source)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:54)
	at io.quarkus.security.runtime.interceptor.SecurityHandler.handle(SecurityHandler.java:47)
	at io.quarkus.security.runtime.interceptor.RolesAllowedInterceptor.intercept(RolesAllowedInterceptor.java:29)
	at io.quarkus.security.runtime.interceptor.RolesAllowedInterceptor_Bean.intercept(Unknown Source)
	at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:41)
	at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:32)
	at com.redhat.cloud.notifications.routers.EndpointResource_Subclass.getDetailedEndpointHistory(Unknown Source)
	at com.redhat.cloud.notifications.routers.EndpointResource$quarkusrestinvoker$getDetailedEndpointHistory_8142714c8a5a012c7ad38e5bce8d7e4152b3c371.invoke(Unknown Source)
	at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
	at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:108)
	at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:141)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:550)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```