### PR TITLE
Reject hyphen in sort_by filtering param

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -10,7 +10,7 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public class Query {
 
-    private static final Pattern SORT_FIELD_PATTERN = Pattern.compile("^[a-z0-9._-]+$", CASE_INSENSITIVE);
+    private static final Pattern SORT_FIELD_PATTERN = Pattern.compile("^[a-z0-9._]+$", CASE_INSENSITIVE);
     private static final int DEFAULT_RESULTS_PER_PAGE  = 20;
 
     @QueryParam("limit")


### PR DESCRIPTION
The hyphen character doesn't work out of the box with Postgres and our code does not include the small details that could make it work.

This change will prevent some Sentry alerts we got over last night because of illegal SQL queries.