### PR TITLE
NOTIF-674 Limit fields of sort expressions.

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.db;
 
+import io.quarkus.logging.Log;
+
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
@@ -132,7 +134,8 @@ public class Query {
             throw new BadRequestException("Invalid 'sort_by' query parameter");
         } else {
             Sort sort = new Sort(sortSplit[0]);
-            if (!sortFields.contains(sort.sortColumn)) {
+            if (!sortFields.contains(sort.sortColumn.toLowerCase())) {
+                Log.warnf("Unknown sort field passed: ", sort.sortColumn);
                 throw new BadRequestException("Unknown sort field " + sort.sortColumn);
             }
             if (sortSplit.length > 1) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 @ApplicationScoped
 public class ApplicationRepository {
 
-    private static final String[] EVENT_TYPE_SORT_FIELDS = {"name", "displayName"};
+
     @Inject
     EntityManager entityManager;
 
@@ -181,7 +181,7 @@ public class ApplicationRepository {
     }
 
     public List<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId, String eventTypeName) {
-        limiter.setSortFields(EVENT_TYPE_SORT_FIELDS);
+        limiter.setSortFields(EventType.SORT_FIELDS);
         return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName)
                 .join(JoinBuilder.builder().leftJoinFetch("e.application"))
                 .limit(limiter != null ? limiter.getLimit() : null)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 @ApplicationScoped
 public class ApplicationRepository {
 
+    private static final String[] EVENT_TYPE_SORT_FIELDS = {"name", "displayName"};
     @Inject
     EntityManager entityManager;
 
@@ -180,6 +181,7 @@ public class ApplicationRepository {
     }
 
     public List<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId, String eventTypeName) {
+        limiter.setSortFields(EVENT_TYPE_SORT_FIELDS);
         return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName)
                 .join(JoinBuilder.builder().leftJoinFetch("e.application"))
                 .limit(limiter != null ? limiter.getLimit() : null)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -263,6 +263,7 @@ public class BehaviorGroupRepository {
         String query = "SELECT bg FROM BehaviorGroup bg JOIN bg.behaviors b WHERE (bg.accountId = :accountId OR bg.accountId IS NULL) AND b.eventType.id = :eventTypeId";
 
         if (limiter != null) {
+            limiter.setSortFields(BehaviorGroup.SORT_FIELDS);
             query = limiter.getModifiedQuery(query);
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -36,7 +36,6 @@ public class EndpointRepository {
 
     private static final Logger LOGGER = Logger.getLogger(EndpointRepository.class);
 
-    private static final String[] ENDPOINT_SORT_FIELDS = {"name", "enabled", "endpoint_type"};
 
     @Inject
     EntityManager entityManager;
@@ -152,7 +151,7 @@ public class EndpointRepository {
 
     public List<Endpoint> getEndpoints(String tenant, @Nullable String name, Query limiter) {
 
-        limiter.setSortFields(ENDPOINT_SORT_FIELDS);
+        limiter.setSortFields(Endpoint.SORT_FIELDS);
 
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Query.Sort sort = limiter == null ? null : limiter.getSort();

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -36,6 +36,8 @@ public class EndpointRepository {
 
     private static final Logger LOGGER = Logger.getLogger(EndpointRepository.class);
 
+    private static final String[] ENDPOINT_SORT_FIELDS = {"name", "enabled", "endpoint_type"};
+
     @Inject
     EntityManager entityManager;
 
@@ -149,6 +151,9 @@ public class EndpointRepository {
     }
 
     public List<Endpoint> getEndpoints(String tenant, @Nullable String name, Query limiter) {
+
+        limiter.setSortFields(ENDPOINT_SORT_FIELDS);
+
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Query.Sort sort = limiter == null ? null : limiter.getSort();
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
@@ -32,6 +32,7 @@ public class NotificationRepository {
         query += ") FROM NotificationHistory nh WHERE nh.event.accountId = :accountId AND nh.endpoint.id = :endpointId";
 
         if (limiter != null) {
+            limiter.setSortFields(NotificationHistory.SORT_FIELDS);
             query = limiter.getModifiedQuery(query);
         }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -827,6 +827,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
         assertEquals("Endpoint 1", endpoints[endpoints.length - 1].getName());
         assertEquals("Endpoint 10", endpoints[endpoints.length - 2].getName());
         assertEquals("Endpoint 27", endpoints[0].getName());
+
+        given()
+                .header(identityHeader)
+                .queryParam("sort_by", "hulla:desc")
+                .when()
+                .get("/endpoints?limit=100")
+                .then()
+                .statusCode(400);
+
     }
 
     @Test

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -53,6 +53,7 @@ import static org.hibernate.jpa.QueryHints.HINT_PASS_DISTINCT_THROUGH;
 )
 public class BehaviorGroup extends CreationUpdateTimestamped {
 
+    public static final String[] SORT_FIELDS = {"displayName"};
     @Id
     @GeneratedValue
     @JsonProperty(access = READ_ONLY)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -31,6 +31,8 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @JsonNaming(SnakeCaseStrategy.class)
 public class Endpoint extends CreationUpdateTimestamped {
 
+    public static final String[] SORT_FIELDS = {"name", "enabled", "endpoint_type"};
+
     @Id
     @GeneratedValue
     @JsonProperty(access = READ_ONLY)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -34,6 +34,8 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @JsonFilter(ApiResponseFilter.NAME)
 public class EventType {
 
+    public static final String[] SORT_FIELDS = {"name", "displayName"};
+
     @Id
     @GeneratedValue
     @JsonProperty(access = READ_ONLY)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -25,6 +25,7 @@ import static javax.persistence.FetchType.LAZY;
 @Table(name = "notification_history")
 public class NotificationHistory extends CreationTimestamped {
 
+    public static final String[] SORT_FIELDS = {"invocationResult"};
     @Id
     // We can not use @GeneratedValue as the ID needs to be sent over to Camel
     @JsonProperty(access = READ_ONLY)
@@ -57,7 +58,7 @@ public class NotificationHistory extends CreationTimestamped {
     @NotNull
     @Embedded
     @JsonIgnore
-    private CompositeEndpointType compositeEndpointType = new CompositeEndpointType();
+    private final CompositeEndpointType compositeEndpointType = new CompositeEndpointType();
 
     @Convert(converter = NotificationHistoryDetailsConverter.class)
     private Map<String, Object> details;


### PR DESCRIPTION
Limit the fields that are acceptable for sorting to fixed lists of field names.

Open questions:
- should we accept any case?
- should we move the definitions to models and then also list them e.g. in the OpenApi's operation?
- What fields are needed beyond what is in this PR?