### PR TITLE
API fixes to templates/email/instant/eventType/{eventTypeId}

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotFoundExceptionMapper.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotFoundExceptionMapper.java
@@ -1,0 +1,20 @@
+package com.redhat.cloud.notifications.routers;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
+
+    @Override
+    public Response toResponse(NotFoundException exception) {
+        return Response
+                .status(exception.getResponse().getStatus())
+                .type(MediaType.TEXT_PLAIN)
+                .entity(exception.getMessage())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.models.Template;
 import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateRequest;
 import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateResponse;
 import com.redhat.cloud.notifications.templates.TemplateEngineClient;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
@@ -118,8 +119,11 @@ public class TemplateResource {
 
     @GET
     @Path("/email/instant/eventType/{eventTypeId}")
-    @Produces(APPLICATION_JSON)
     @RolesAllowed(RBAC_INTERNAL_USER)
+    @APIResponses(value = {
+            @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = InstantEmailTemplate.class))),
+            @APIResponse(responseCode = "404", description = "No instant email found for the event type", content = @Content(mediaType = TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING)))
+    })
     public InstantEmailTemplate getInstantEmailTemplateByEventType(@RestPath UUID eventTypeId) {
         return templateRepository.findInstantEmailTemplateByEventType(eventTypeId);
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/CrudTestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/CrudTestHelpers.java
@@ -601,7 +601,7 @@ public abstract class CrudTestHelpers {
                 .get("/templates/{templateId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(JSON)
+                .contentType(expectedStatusCode == 404 ? TEXT : JSON)
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {
@@ -708,7 +708,7 @@ public abstract class CrudTestHelpers {
                 .get("/templates/email/instant/{templateId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(JSON)
+                .contentType(expectedStatusCode == 404 ? TEXT : JSON)
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {
@@ -790,7 +790,7 @@ public abstract class CrudTestHelpers {
                 .when().get("/templates/email/instant/eventType/{eventTypeId}")
                 .then()
                 .statusCode(isExpectedToBeFound ? 200 : 404)
-                .contentType(JSON)
+                .contentType(isExpectedToBeFound ? JSON : TEXT)
                 .extract().asString();
 
         if (isExpectedToBeFound) {
@@ -871,7 +871,7 @@ public abstract class CrudTestHelpers {
                 .get("/templates/email/aggregation/{templateId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(JSON)
+                .contentType(expectedStatusCode == 404 ? TEXT : JSON)
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/CrudTestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/CrudTestHelpers.java
@@ -11,6 +11,7 @@ import com.redhat.cloud.notifications.models.Template;
 import com.redhat.cloud.notifications.routers.internal.models.AddAccessRequest;
 import com.redhat.cloud.notifications.routers.internal.models.AddApplicationRequest;
 import com.redhat.cloud.notifications.routers.internal.models.InternalApplicationUserPermission;
+import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
@@ -33,6 +34,7 @@ import static javax.ws.rs.core.Response.Status.Family.familyOf;
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.NOT_FOUND;
 import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -42,6 +44,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 public abstract class CrudTestHelpers {
 
     private static final String JSON_UTF8 = "application/json;charset=UTF-8";
+
+    public static ContentType contentTypeForStatusCode(int statusCode, ContentType defaultContentType) {
+        if (statusCode == NOT_FOUND) {
+            return TEXT;
+        }
+
+        return defaultContentType;
+    }
 
     public static Bundle buildBundle(String name, String displayName) {
         Bundle bundle = new Bundle();
@@ -90,7 +100,7 @@ public abstract class CrudTestHelpers {
                 .get("/internal/bundles/{bundleId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(JSON)
+                .contentType(contentTypeForStatusCode(expectedStatusCode, JSON))
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {
@@ -208,7 +218,7 @@ public abstract class CrudTestHelpers {
                 .get("/internal/bundles/{bundleId}/applications")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(JSON)
+                .contentType(contentTypeForStatusCode(expectedStatusCode, JSON))
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {
@@ -229,7 +239,7 @@ public abstract class CrudTestHelpers {
                 .get("/internal/applications/{appId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(JSON)
+                .contentType(contentTypeForStatusCode(expectedStatusCode, JSON))
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {
@@ -336,7 +346,7 @@ public abstract class CrudTestHelpers {
                 .get("/internal/applications/{appId}/eventTypes")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(JSON)
+                .contentType(contentTypeForStatusCode(expectedStatusCode, JSON))
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {
@@ -601,7 +611,7 @@ public abstract class CrudTestHelpers {
                 .get("/templates/{templateId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(expectedStatusCode == 404 ? TEXT : JSON)
+                .contentType(contentTypeForStatusCode(expectedStatusCode, JSON))
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {
@@ -708,7 +718,7 @@ public abstract class CrudTestHelpers {
                 .get("/templates/email/instant/{templateId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(expectedStatusCode == 404 ? TEXT : JSON)
+                .contentType(contentTypeForStatusCode(expectedStatusCode, JSON))
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {
@@ -871,7 +881,7 @@ public abstract class CrudTestHelpers {
                 .get("/templates/email/aggregation/{templateId}")
                 .then()
                 .statusCode(expectedStatusCode)
-                .contentType(expectedStatusCode == 404 ? TEXT : JSON)
+                .contentType(contentTypeForStatusCode(expectedStatusCode, JSON))
                 .extract().asString();
 
         if (familyOf(expectedStatusCode) == SUCCESSFUL) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -198,7 +198,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .when().get("/endpoints/" + responsePoint.getString("id"))
                 .then()
                 .statusCode(404)
-                .contentType(JSON);
+                .contentType(TEXT);
 
         // Fetch all, nothing should be left
         given()
@@ -1144,25 +1144,25 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .when()
                 .delete("/endpoints/email/subscription/rhel/" + TEST_APP_NAME + "/instant")
                 .then().statusCode(404)
-                .contentType(JSON);
+                .contentType(TEXT);
         given()
                 .header(identityHeader)
                 .when()
                 .delete("/endpoints/email/subscription/" + TEST_BUNDLE_NAME + "/policies/instant")
                 .then().statusCode(404)
-                .contentType(JSON);
+                .contentType(TEXT);
         given()
                 .header(identityHeader)
                 .when()
                 .put("/endpoints/email/subscription/rhel/" + TEST_APP_NAME + "/instant")
                 .then().statusCode(404)
-                .contentType(JSON);
+                .contentType(TEXT);
         given()
                 .header(identityHeader)
                 .when()
                 .put("/endpoints/email/subscription/" + TEST_BUNDLE_NAME + "/policies/instant")
                 .then().statusCode(404)
-                .contentType(JSON);
+                .contentType(TEXT);
 
         // Unknown bundle/apps give 404
         given()
@@ -1170,13 +1170,13 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .when()
                 .delete("/endpoints/email/subscription/idontexist/meneither/instant")
                 .then().statusCode(404)
-                .contentType(JSON);
+                .contentType(TEXT);
         given()
                 .header(identityHeader)
                 .when()
                 .put("/endpoints/email/subscription/idontexist/meneither/instant")
                 .then().statusCode(404)
-                .contentType(JSON);
+                .contentType(TEXT);
 
         // Disable everything as preparation
         // rhel/policies instant and daily


### PR DESCRIPTION
 - Adding NotFoundExceptionMapper to ensure NFE are always plain text
 - Specify the 404 state of the template in the openapi