### PR TITLE
Updating Enviroment.url methods from templates

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/models/Environment.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/models/Environment.java
@@ -15,28 +15,14 @@ public class Environment {
     }
 
     public String url() {
-        return url("");
-    }
-
-    public String url(String path) {
-        final String base;
 
         switch (environment) {
             case "prod":
-                base = "https://console.redhat.com";
-                break;
+                return "https://console.redhat.com";
             case "stage":
-                base = "https://console.stage.redhat.com";
-                break;
+                return "https://console.stage.redhat.com";
             default:
-                base = "";
-                break;
+                return "/";
         }
-
-        if (!path.startsWith("/")) {
-            path = "/" + path;
-        }
-
-        return base + path;
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/models/Environment.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/models/Environment.java
@@ -15,7 +15,7 @@ public class Environment {
     }
 
     public String url() {
-        return url("/");
+        return url("");
     }
 
     public String url(String path) {

--- a/engine/src/main/resources/templates/Compliance/complianceBelowThresholdEmailBody.html
+++ b/engine/src/main/resources/templates/Compliance/complianceBelowThresholdEmailBody.html
@@ -35,10 +35,10 @@
                         <!-- Hi {{user.first_name}},
                         <br>
                         <br> -->
-                        Your system, <a class="rh-url" href="{environment.url('/insights/compliance/systems/')}{action.events[0].payload.host_id}"><b>{action.events[0].payload.host_name}</b></a>, assigned to policy <a class="rh-url" href="{environment.url('/insights/compliance/scappolicies/')}{action.events[0].payload.policy_id}"><b>{action.events[0].payload.policy_name}</b></a>, has been marked as non-compliant because its compliance score {action.events[0].payload.compliance_score}% dropped below the configured compliance threshold of {action.events[0].payload.policy_threshold}% for this policy.
+                        Your system, <a class="rh-url" href="{environment.url}/insights/compliance/systems/{action.events[0].payload.host_id}"><b>{action.events[0].payload.host_name}</b></a>, assigned to policy <a class="rh-url" href="{environment.url}/insights/compliance/scappolicies/{action.events[0].payload.policy_id}"><b>{action.events[0].payload.policy_name}</b></a>, has been marked as non-compliant because its compliance score {action.events[0].payload.compliance_score}% dropped below the configured compliance threshold of {action.events[0].payload.policy_threshold}% for this policy.
                     </p>
                     <p>
-                        Please review the <a class="rh-url" href="{environment.url('/insights/compliance/reports/')}{action.events[0].payload.policy_id}">detailed policy report for this system</a> and take the appropriate steps to bring this system into compliance. For additional details on how to  remediate compliance issues, learn more <a class="rh-url" href="https://access.redhat.com/documentation/en-us/red_hat_insights/2021/html/remediating_security-policy_compliance_issues_using_ansible_playbooks/index"><b>here</b></a>.
+                        Please review the <a class="rh-url" href="{environment.url}/insights/compliance/reports/{action.events[0].payload.policy_id}">detailed policy report for this system</a> and take the appropriate steps to bring this system into compliance. For additional details on how to  remediate compliance issues, learn more <a class="rh-url" href="https://access.redhat.com/documentation/en-us/red_hat_insights/2021/html/remediating_security-policy_compliance_issues_using_ansible_playbooks/index"><b>here</b></a>.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Compliance/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Compliance/dailyEmailBody.html
@@ -35,7 +35,7 @@
                         <!-- Hi {{user.first_name}},
                         <br>
                         <br> -->
-                        Red Hat Insights has identified one or more systems that have reported with a compliance level below your specified threshold or have not reported at all. Please review the <a class="rh-url" href="{environment.url('/insights/compliance/reports')}">Insights Compliance service</a> to further assess and determine next steps.
+                        Red Hat Insights has identified one or more systems that have reported with a compliance level below your specified threshold or have not reported at all. Please review the <a class="rh-url" href="{environment.url}/insights/compliance/reports">Insights Compliance service</a> to further assess and determine next steps.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Compliance/reportUploadFailedEmailBody.html
+++ b/engine/src/main/resources/templates/Compliance/reportUploadFailedEmailBody.html
@@ -35,7 +35,7 @@
                         <!-- Hi {{user.first_name}},
                         <br>
                         <br> -->
-                        Your system <a class="rh-url" href="{environment.url('/insights/compliance/systems/')}{action.events[0].payload.host_id}"><b>{action.events[0].payload.host_name}</b></a> failed to upload a new compliance report. The error message returned by our system for the request <i>{action.events[0].payload.request_id}</i> was:<br>
+                        Your system <a class="rh-url" href="{environment.url}/insights/compliance/systems/{action.events[0].payload.host_id}"><b>{action.events[0].payload.host_name}</b></a> failed to upload a new compliance report. The error message returned by our system for the request <i>{action.events[0].payload.request_id}</i> was:<br>
 
                         <i>{action.events[0].payload.error}</i>
                     </p>

--- a/engine/src/main/resources/templates/EdgeManagement/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/EdgeManagement/insightsEmailBody.html
@@ -492,8 +492,8 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="{environment.url('/')}" target="_blank" class="rh-masthead__brand-link">
-                                            <img src="{environment.url('/apps/frontend-assets/email-assets/logo_insights.jpg')}" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
+                                        <a href="{environment.url}/" target="_blank" class="rh-masthead__brand-link">
+                                            <img src="{environment.url}/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>
                                 </tr>
@@ -523,7 +523,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        This email was sent by Red Hat Edge |<a href="{environment.url('/user-preferences/notifications/rhel')}" target="_blank">&nbsp;Manage notification preferences</a>
+                                        This email was sent by Red Hat Edge |<a href="{environment.url}/user-preferences/notifications/rhel" target="_blank">&nbsp;Manage notification preferences</a>
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/Patch/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Patch/dailyEmailBody.html
@@ -182,7 +182,7 @@
               class="rh-button-table">
               <tr>
                 <td class="rh-cta-link" align="center">
-                  <a target="_blank" class="rh-url" href="{environment.url()}/insights/patch/advisories">
+                  <a target="_blank" class="rh-url" href="{environment.url}/insights/patch/advisories">
                     <span>
                       Go to Advisories
                     </span>
@@ -220,7 +220,7 @@
                 {#for advisory in action.context.patch.get(key).get("advisories").keySet()}
                 <tr>
                   <td>
-                    <a class="rh-url" href="{environment.url()}/insights/patch/advisories/{advisory}">{advisory}</a>
+                    <a class="rh-url" href="{environment.url}/insights/patch/advisories/{advisory}">{advisory}</a>
                   </td>
                 </tr>
                 {/for}

--- a/engine/src/main/resources/templates/Patch/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Patch/dailyEmailBody.html
@@ -182,7 +182,7 @@
               class="rh-button-table">
               <tr>
                 <td class="rh-cta-link" align="center">
-                  <a target="_blank" class="rh-url" href="{environment.url()}insights/patch/advisories">
+                  <a target="_blank" class="rh-url" href="{environment.url()}/insights/patch/advisories">
                     <span>
                       Go to Advisories
                     </span>
@@ -220,7 +220,7 @@
                 {#for advisory in action.context.patch.get(key).get("advisories").keySet()}
                 <tr>
                   <td>
-                    <a class="rh-url" href="{environment.url()}insights/patch/advisories/{advisory}">{advisory}</a>
+                    <a class="rh-url" href="{environment.url()}/insights/patch/advisories/{advisory}">{advisory}</a>
                   </td>
                 </tr>
                 {/for}

--- a/engine/src/main/resources/templates/Patch/newAdvisoriesInstantEmailBody.html
+++ b/engine/src/main/resources/templates/Patch/newAdvisoriesInstantEmailBody.html
@@ -60,7 +60,7 @@
                 <tr>
                   <td>
                     <a class="rh-url"
-                      href="{environment.url()}insights/patch/advisories/{it.payload.advisory_name}">{it.payload.advisory_name}</a>
+                      href="{environment.url()}/insights/patch/advisories/{it.payload.advisory_name}">{it.payload.advisory_name}</a>
                   </td>
                   <td class="rh-severity">
                     {it.payload.synopsis}

--- a/engine/src/main/resources/templates/Patch/newAdvisoriesInstantEmailBody.html
+++ b/engine/src/main/resources/templates/Patch/newAdvisoriesInstantEmailBody.html
@@ -60,7 +60,7 @@
                 <tr>
                   <td>
                     <a class="rh-url"
-                      href="{environment.url()}/insights/patch/advisories/{it.payload.advisory_name}">{it.payload.advisory_name}</a>
+                      href="{environment.url}/insights/patch/advisories/{it.payload.advisory_name}">{it.payload.advisory_name}</a>
                   </td>
                   <td class="rh-severity">
                     {it.payload.synopsis}

--- a/engine/src/main/resources/templates/Rbac/customGroupCreatedEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/customGroupCreatedEmailBody.html
@@ -37,7 +37,7 @@
                         <br>
                         A custom group has been created by {action.events[0].payload.username}.
                         <br>
-                        Check the created group <a class="rh-url" href="{environment.url('/settings/rbac/groups/detail/')}{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
+                        Check the created group <a class="rh-url" href="{environment.url}/settings/rbac/groups/detail/{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Rbac/customGroupUpdatedEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/customGroupUpdatedEmailBody.html
@@ -39,20 +39,20 @@
                         <br>
                         {#if action.events[0].payload.role}
                         <p>
-                            The role <a class="rh-url" href="{environment.url('/settings/rbac/roles/detail/')}{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> has been
-                            {action.events[0].payload.operation} {#if action.events[0].payload.operation == "added"}to{#else}from{/if} 
+                            The role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> has been
+                            {action.events[0].payload.operation} {#if action.events[0].payload.operation == "added"}to{#else}from{/if}
                             the group.
                         </p>
                         {/if}
                         {#if action.events[0].payload.principal}
                         <p>
                             The user {action.events[0].payload.principal} has been
-                            {action.events[0].payload.operation} {#if action.events[0].payload.operation == "added"}to{#else}from{/if} 
+                            {action.events[0].payload.operation} {#if action.events[0].payload.operation == "added"}to{#else}from{/if}
                             the group.
                         </p>
                         {/if}
                         <br>
-                        Check the updated group <a class="rh-url" href="{environment.url('/settings/rbac/groups/detail/')}{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
+                        Check the updated group <a class="rh-url" href="{environment.url}/settings/rbac/groups/detail/{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Rbac/customPlatformGroupUpdatedEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/customPlatformGroupUpdatedEmailBody.html
@@ -39,13 +39,13 @@
                         <br>
                         {#if action.events[0].payload.role}
                         <p>
-                            The role <a class="rh-url" href="{environment.url('/settings/rbac/roles/detail/')}{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> has been
-                            {action.events[0].payload.operation} {#if action.events[0].payload.operation == "added"}to{#else}from{/if} 
+                            The role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> has been
+                            {action.events[0].payload.operation} {#if action.events[0].payload.operation == "added"}to{#else}from{/if}
                             the group.
                         </p>
                         {/if}
                         <br>
-                        Check the updated group <a class="rh-url" href="{environment.url('/settings/rbac/groups/detail/')}{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
+                        Check the updated group <a class="rh-url" href="{environment.url}/settings/rbac/groups/detail/{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Rbac/customRoleCreatedEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/customRoleCreatedEmailBody.html
@@ -37,7 +37,7 @@
                         <br>
                         A new custom role has been created by {action.events[0].payload.username}.
                         <br>
-                        Check the created role <a class="rh-url" href="{environment.url('/settings/rbac/roles/detail/')}{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
+                        Check the created role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Rbac/customRoleUpdatedEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/customRoleUpdatedEmailBody.html
@@ -37,7 +37,7 @@
                         <br>
                         A custom role has been updated by {action.events[0].payload.username}.
                         <br>
-                        Check the updated role <a class="rh-url" href="{environment.url('/settings/rbac/roles/detail/')}{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
+                        Check the updated role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Rbac/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/insightsEmailBody.html
@@ -561,7 +561,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="{environment.url('/')}" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}/" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>
@@ -592,7 +592,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        This email was sent by Red Hat Insights |<a href="{environment.url('/user-preferences/notifications/rhel')}" target="_blank">&nbsp;Manage notification preferences</a>
+                                        This email was sent by Red Hat Insights |<a href="{environment.url}/user-preferences/notifications/rhel" target="_blank">&nbsp;Manage notification preferences</a>
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/Rbac/nonPlatformRoleUpdatedEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/nonPlatformRoleUpdatedEmailBody.html
@@ -35,7 +35,7 @@
                         Hi,
                         <br>
                         <br>
-                        Red Hat has updated the role <a class="rh-url" href="{environment.url('/settings/rbac/roles/detail/')}{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>.
+                        Red Hat has updated the role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>.
                         <br>
                         The role does not belong to the platform default access group.
                     </p>

--- a/engine/src/main/resources/templates/Rbac/platformGroupToCustomEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/platformGroupToCustomEmailBody.html
@@ -37,7 +37,7 @@
                         <br>
                         Platform default group is modified by {action.events[0].payload.username} and the Red Hat will not be responsible for managing it from now on.
                         <br>
-                        Check the custom platform default group here: <a class="rh-url" href="{environment.url('/settings/rbac/groups/detail/')}{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
+                        Check the custom platform default group here: <a class="rh-url" href="{environment.url}/settings/rbac/groups/detail/{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Rbac/platformRoleUpdatedEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/platformRoleUpdatedEmailBody.html
@@ -35,10 +35,10 @@
                         Hi,
                         <br>
                         <br>
-                        Red Hat has updated the role <a class="rh-url" href="{environment.url('/settings/rbac/roles/detail/')}{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>.
+                        Red Hat has updated the role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>.
                         <br>
                         The role belongs to the platform default access group and
-                        will be inherited by all users within your account. 
+                        will be inherited by all users within your account.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Rbac/roleAddedToPlatformGroupEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/roleAddedToPlatformGroupEmailBody.html
@@ -35,7 +35,7 @@
                         Hi,
                         <br>
                         <br>
-                        Red Hat added a role <a class="rh-url" href="{environment.url('/settings/rbac/roles/detail/')}{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> to platform default access group.
+                        Red Hat added a role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> to platform default access group.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Rbac/roleRemovedFromPlatformGroupEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/roleRemovedFromPlatformGroupEmailBody.html
@@ -37,7 +37,7 @@
                         <br>
                         Red Hat removed a role from platform default access group.
                         <br>
-                        The removed role is: <a class="rh-url" href="{environment.url('/settings/rbac/roles/detail/')}{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a>
+                        The removed role is: <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a>
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Rbac/systemRoleAvailableEmailBody.html
+++ b/engine/src/main/resources/templates/Rbac/systemRoleAvailableEmailBody.html
@@ -37,7 +37,7 @@
                         <br>
                         Red Hat now provides a new role.
                         <br>
-                        Check the new available role <a class="rh-url" href="{environment.url('/settings/rbac/roles/detail/')}{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
+                        Check the new available role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}"><b>{action.events[0].payload.name}</b></a>
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Sources/availabilityStatusEmailBody.html
+++ b/engine/src/main/resources/templates/Sources/availabilityStatusEmailBody.html
@@ -32,12 +32,12 @@
             <tr>
                 <td class="rh-content__block">
                     <p>
-                        {action.context.resource_display_name}'s availability status was changed from <b>{action.context.previous_availability_status}</b> to 
+                        {action.context.resource_display_name}'s availability status was changed from <b>{action.context.previous_availability_status}</b> to
                         <b>{action.context.current_availability_status}</b>.
                     </p>
                     <p>
                         {#if action.context.source_id > 0}
-                        For more information please check summary page of <a class="rh-url" href="{environment.url('/settings/sources/detail/')}{action.context.source_id}">{action.context.source_name} source</a>.
+                        For more information please check summary page of <a class="rh-url" href="{environment.url}/settings/sources/detail/{action.context.source_id}">{action.context.source_name} source</a>.
                         {/if}
                     </p>
                 </td>

--- a/engine/src/main/resources/templates/Vulnerability/anyCveKnownExploitBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/anyCveKnownExploitBody.html
@@ -26,7 +26,7 @@
             <tr>
                 <td class="rh-content__block">
                     <p>
-                        Red Hat Insights has just identified a CVE with the Known exploit label. Please review the details of this <a href="{environment.url()}insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a>. The “Known Exploit” flag is added to any CVE that is determined to have been exploited in the “wild” by Red Hat Product Security. This flag does not reflect your environment.
+                        Red Hat Insights has just identified a CVE with the Known exploit label. Please review the details of this <a href="{environment.url()}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a>. The “Known Exploit” flag is added to any CVE that is determined to have been exploited in the “wild” by Red Hat Product Security. This flag does not reflect your environment.
                         <br><br>
                         Please review the details of this CVE and affected systems to determine risk and exposure for your organization. Red Hat recommends treating this issue with high priority to protect your organization.
                     </p>

--- a/engine/src/main/resources/templates/Vulnerability/anyCveKnownExploitBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/anyCveKnownExploitBody.html
@@ -26,7 +26,7 @@
             <tr>
                 <td class="rh-content__block">
                     <p>
-                        Red Hat Insights has just identified a CVE with the Known exploit label. Please review the details of this <a href="{environment.url()}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a>. The “Known Exploit” flag is added to any CVE that is determined to have been exploited in the “wild” by Red Hat Product Security. This flag does not reflect your environment.
+                        Red Hat Insights has just identified a CVE with the Known exploit label. Please review the details of this <a href="{environment.url}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a>. The “Known Exploit” flag is added to any CVE that is determined to have been exploited in the “wild” by Red Hat Product Security. This flag does not reflect your environment.
                         <br><br>
                         Please review the details of this CVE and affected systems to determine risk and exposure for your organization. Red Hat recommends treating this issue with high priority to protect your organization.
                     </p>

--- a/engine/src/main/resources/templates/Vulnerability/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/dailyEmailBody.html
@@ -30,7 +30,7 @@
                         These are the identified CVEs.
                         <ul>
                             {#for cve in action.context.vulnerability.reported_cves}
-                            <li><a href="{environment.url()}/insights/vulnerability/cves/{cve}">{cve}</a></li>
+                            <li><a href="{environment.url}/insights/vulnerability/cves/{cve}">{cve}</a></li>
                             {/for}
                         </ul>
                     </p>

--- a/engine/src/main/resources/templates/Vulnerability/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/dailyEmailBody.html
@@ -30,7 +30,7 @@
                         These are the identified CVEs.
                         <ul>
                             {#for cve in action.context.vulnerability.reported_cves}
-                            <li><a href="{environment.url()}insights/vulnerability/cves/{cve}">{cve}</a></li>
+                            <li><a href="{environment.url()}/insights/vulnerability/cves/{cve}">{cve}</a></li>
                             {/for}
                         </ul>
                     </p>

--- a/engine/src/main/resources/templates/Vulnerability/newCveCritSeverityEmailBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/newCveCritSeverityEmailBody.html
@@ -26,7 +26,7 @@
             <tr>
                 <td class="rh-content__block">
                     <p>
-                        Red Hat Insights has just identified a CVE with a Severity of Critical. Please review the details of this <a href="{environment.url()}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
+                        Red Hat Insights has just identified a CVE with a Severity of Critical. Please review the details of this <a href="{environment.url}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Vulnerability/newCveCritSeverityEmailBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/newCveCritSeverityEmailBody.html
@@ -26,7 +26,7 @@
             <tr>
                 <td class="rh-content__block">
                     <p>
-                        Red Hat Insights has just identified a CVE with a Severity of Critical. Please review the details of this <a href="{environment.url()}insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
+                        Red Hat Insights has just identified a CVE with a Severity of Critical. Please review the details of this <a href="{environment.url()}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Vulnerability/newCveHighCvssEmailBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/newCveHighCvssEmailBody.html
@@ -26,7 +26,7 @@
             <tr>
                 <td class="rh-content__block">
                     <p>
-                        Red Hat Insights has just identified a CVE with a CVSS score of >= 7. Please review the details of this <a href="{environment.url()}insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
+                        Red Hat Insights has just identified a CVE with a CVSS score of >= 7. Please review the details of this <a href="{environment.url()}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Vulnerability/newCveHighCvssEmailBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/newCveHighCvssEmailBody.html
@@ -26,7 +26,7 @@
             <tr>
                 <td class="rh-content__block">
                     <p>
-                        Red Hat Insights has just identified a CVE with a CVSS score of >= 7. Please review the details of this <a href="{environment.url()}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
+                        Red Hat Insights has just identified a CVE with a CVSS score of >= 7. Please review the details of this <a href="{environment.url}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Vulnerability/newCveSecurityRuleBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/newCveSecurityRuleBody.html
@@ -26,7 +26,7 @@
             <tr>
                 <td class="rh-content__block">
                     <p>
-                        Red Hat Insights has just identified a newly published CVE with the Security rule label. Please review the details of this <a href="{environment.url()}insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization. Red Hat recommends treating this issue with high priority to protect your organization.
+                        Red Hat Insights has just identified a newly published CVE with the Security rule label. Please review the details of this <a href="{environment.url()}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization. Red Hat recommends treating this issue with high priority to protect your organization.
                     </p>
                 </td>
             </tr>

--- a/engine/src/main/resources/templates/Vulnerability/newCveSecurityRuleBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/newCveSecurityRuleBody.html
@@ -26,7 +26,7 @@
             <tr>
                 <td class="rh-content__block">
                     <p>
-                        Red Hat Insights has just identified a newly published CVE with the Security rule label. Please review the details of this <a href="{environment.url()}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization. Red Hat recommends treating this issue with high priority to protect your organization.
+                        Red Hat Insights has just identified a newly published CVE with the Security rule label. Please review the details of this <a href="{environment.url}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization. Red Hat recommends treating this issue with high priority to protect your organization.
                     </p>
                 </td>
             </tr>

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/models/EnvironmentTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/models/EnvironmentTest.java
@@ -14,7 +14,8 @@ public class EnvironmentTest {
         assertEquals("https://console.redhat.com/foobar", environment.url("/foobar"));
         // Adds slash if path does not start with it
         assertEquals("https://console.redhat.com/foobar", environment.url("foobar"));
-        assertEquals("https://console.redhat.com/", environment.url());
+        // No slash is added to base
+        assertEquals("https://console.redhat.com", environment.url());
         assertEquals("prod", environment.name());
 
         environment.environment = "stage";

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/models/EnvironmentTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/models/EnvironmentTest.java
@@ -11,24 +11,19 @@ public class EnvironmentTest {
         Environment environment = new Environment();
 
         environment.environment = "prod";
-        assertEquals("https://console.redhat.com/foobar", environment.url("/foobar"));
-        // Adds slash if path does not start with it
-        assertEquals("https://console.redhat.com/foobar", environment.url("foobar"));
-        // No slash is added to base
         assertEquals("https://console.redhat.com", environment.url());
         assertEquals("prod", environment.name());
 
         environment.environment = "stage";
-        assertEquals("https://console.stage.redhat.com/blabla/etc", environment.url("/blabla/etc"));
+        assertEquals("https://console.stage.redhat.com", environment.url());
         assertEquals("stage", environment.name());
 
         environment.environment = "ephemeral";
-        assertEquals("/nothing-to-see-here", environment.url("/nothing-to-see-here"));
+        assertEquals("/", environment.url());
         assertEquals("ephemeral", environment.name());
 
         environment.environment = "anything-else";
-        assertEquals("/anything-else", environment.url("/anything-else"));
-        assertEquals("/anything-else", environment.url("anything-else"));
+        assertEquals("/", environment.url());
         assertEquals("anything-else", environment.name());
     }
 }


### PR DESCRIPTION
- environment.url() no longer adds a trailing slash
- environment.url(string) no longer exists
- Updates all the templates to take into account the new usage.

These changes make it easier to read the templates (IMO).
A major problem with `environment.url(string)` is that it didn't allow to concatenate strings inside the method, thus:
`{environment.url('stuff/' + variable)}` would yield: `https://console.redhat.com/stuff/ + variable` (yes, literally that)

Users had to do: `{environment.url("stuff/")}{variable}` to get the desired output, which is harder to read and defeats the purpose of the argument anyway.

With the latest changes it can to be now: `{environment.url}/stuff/{variable}` which feels more natural.

This change was motivated by the review of https://github.com/RedHatInsights/notifications-backend/pull/1273