### PR TITLE
Clowdappizing the cronjob

### DIFF
--- a/.rhcicd/clowdapp-aggregator.yaml
+++ b/.rhcicd/clowdapp-aggregator.yaml
@@ -44,26 +44,6 @@ objects:
         volumeMounts:
         - name: rds-client-ca
           mountPath: /tmp
-        readinessProbe:
-          httpGet:
-            path: /health/ready
-            port: 8000
-            scheme: HTTP
-          initialDelaySeconds: 1
-          periodSeconds: 1
-          timeoutSeconds: 1
-          successThreshold: 1
-          failureThreshold: 3
-        livenessProbe:
-          httpGet:
-            path: /health/live
-            port: 8000
-            scheme: HTTP
-          initialDelaySeconds: 1
-          periodSeconds: 1
-          timeoutSeconds: 1
-          successThreshold: 1
-          failureThreshold: 3
         env:
         - name: ENV_NAME
           value: ${ENV_NAME}

--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -135,6 +135,47 @@ objects:
           requests:
             cpu: 50m
             memory: 512Mi
+    - name: notifications-db-cleaner-cronjob
+      podSpec:
+        image: quay.io/cloudservices/postgresql-rds:12-1
+        schedule: ${DB_CLEANER_SCHEDULE}
+        suspend: ${{DISABLE_DB_CLEANER}}
+        concurrencyPolicy: Forbid
+        restartPolicy: Never
+        volumes:
+          - name: notifications-db-cleaner-volume
+            configMap:
+              name: notifications-db-cleaner-config
+              restartPolicy: Never
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 100Mi
+                limits:
+                  cpu: 200m
+                  memory: 200Mi
+              volumeMounts:
+          - name: notifications-db-cleaner-volume
+            mountPath: /notifications-db-cleaner
+        command: ['sh', '/notifications-db-cleaner/clean.sh']
+        env:
+        - name: PGHOST
+          valueFrom:
+            secretKeyRef:
+              name: notifications-backend-db
+              key: ${DB_SECRET_HOSTNAME_KEY}
+        - name: PGDATABASE
+          value: ${DB_NAME}
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: notifications-backend-db
+              key: ${DB_SECRET_USERNAME_KEY}
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: notifications-backend-db
+              key: ${DB_SECRET_PASSWORD_KEY}
     deployments:
     - name: service
       minReplicas: ${{MIN_REPLICAS}}
@@ -234,59 +275,6 @@ objects:
       VACUUM notification_history;
       CALL cleanKafkaMessagesIds();
       VACUUM kafka_message;
-- apiVersion: batch/v1
-  kind: CronJob
-  metadata:
-    name: notifications-db-cleaner-cronjob
-    annotations: 
-      ignore-check.kube-linter.io/no-liveness-probe: "short lived cronjob doesn't need probes"
-      ignore-check.kube-linter.io/no-readiness-probe: "short lived cronjob doesn't need probes"
-  spec:
-    schedule: ${DB_CLEANER_SCHEDULE}
-    suspend: ${{DISABLE_DB_CLEANER}}
-    concurrencyPolicy: Forbid
-    jobTemplate:
-      spec:
-        template:
-          spec:
-            restartPolicy: Never
-            volumes:
-            - name: notifications-db-cleaner-volume
-              configMap:
-                name: notifications-db-cleaner-config
-            containers:
-            - name: notifications-db-cleaner
-              image: quay.io/cloudservices/postgresql-rds:12-1
-              restartPolicy: Never
-              resources:
-                requests:
-                  cpu: 100m
-                  memory: 100Mi
-                limits:
-                  cpu: 200m
-                  memory: 200Mi
-              volumeMounts:
-              - name: notifications-db-cleaner-volume
-                mountPath: /notifications-db-cleaner
-              command: ['sh', '/notifications-db-cleaner/clean.sh']
-              env:
-              - name: PGHOST
-                valueFrom:
-                  secretKeyRef:
-                    name: notifications-backend-db
-                    key: ${DB_SECRET_HOSTNAME_KEY}
-              - name: PGDATABASE
-                value: ${DB_NAME}
-              - name: PGUSER
-                valueFrom:
-                  secretKeyRef:
-                    name: notifications-backend-db
-                    key: ${DB_SECRET_USERNAME_KEY}
-              - name: PGPASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: notifications-backend-db
-                    key: ${DB_SECRET_PASSWORD_KEY}
 - apiVersion: v1
   kind: ConfigMap
   metadata:


### PR DESCRIPTION
This will finally ensure that both cronjobs meet the serviceaccount and annotation requirement (now managed by clowder), so the alerts will clean up in dashdb, and onboarding can progress