### PR TITLE
Roll back clowder config source to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <mockserver-netty-no-dependencies.version>5.13.2</mockserver-netty-no-dependencies.version>
 
         <insights-notification-schemas-java.version>0.13</insights-notification-schemas-java.version>
-        <clowder-quarkus-config-source.version>1.0.1</clowder-quarkus-config-source.version>
+        <clowder-quarkus-config-source.version>1.0.0</clowder-quarkus-config-source.version>
 
         <quarkus-logging-cloudwatch.version>4.3.0</quarkus-logging-cloudwatch.version>
         <quarkus-logging-sentry.version>1.1.1</quarkus-logging-sentry.version>


### PR DESCRIPTION
1.0.1 has some issues - especially the log.type field is not populated in the provided config files and thus makes the evaluation of cloudwatch entries fail.