### PR TITLE
Use the new Quarkus Log API

### DIFF
--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -8,10 +8,10 @@ import com.redhat.cloud.notifications.models.CronJobRun;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.exporter.PushGateway;
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
-import org.jboss.logging.Logger;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.control.ActivateRequestContext;
 import javax.inject.Inject;
@@ -31,8 +31,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 public class DailyEmailAggregationJob {
 
     public static final String AGGREGATION_CHANNEL = "aggregation";
-
-    private static final Logger LOG = Logger.getLogger(DailyEmailAggregationJob.class);
 
     private final EmailAggregationResources emailAggregationResources;
     private final ObjectMapper objectMapper;
@@ -71,14 +69,14 @@ public class DailyEmailAggregationJob {
                     final String payload = objectMapper.writeValueAsString(aggregationCommand);
                     futures.add(emitter.send(payload).toCompletableFuture());
                 } catch (JsonProcessingException e) {
-                    LOG.warn("Could not transform AggregationCommand to JSON object.", e);
+                    Log.warn("Could not transform AggregationCommand to JSON object.", e);
                 }
 
                 // resolve completable futures so the Quarkus main thread doesn't stop before everything has been sent
                 try {
                     CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
                 } catch (InterruptedException | ExecutionException ie) {
-                    LOG.error("Writing AggregationCommands failed", ie);
+                    Log.error("Writing AggregationCommands failed", ie);
                 }
             }
 
@@ -96,7 +94,7 @@ public class DailyEmailAggregationJob {
             try {
                 pg.pushAdd(registry, "aggregator_job");
             } catch (IOException e) {
-                LOG.warn("Could not push metrics to Prometheus Pushgateway.", e);
+                Log.warn("Could not push metrics to Prometheus Pushgateway.", e);
             }
         }
     }
@@ -105,7 +103,7 @@ public class DailyEmailAggregationJob {
         final CronJobRun lastCronJobRun = emailAggregationResources.getLastCronJobRun();
         LocalDateTime startTime = lastCronJobRun.getLastRun();
 
-        LOG.infof("Collecting email aggregation for period (%s, %s) and type %s", startTime, endTime, DAILY);
+        Log.infof("Collecting email aggregation for period (%s, %s) and type %s", startTime, endTime, DAILY);
 
         final List<AggregationCommand> pendingAggregationCommands =
                 emailAggregationResources.getApplicationsWithPendingAggregation(startTime, endTime)
@@ -113,7 +111,7 @@ public class DailyEmailAggregationJob {
                         .map(aggregationKey -> new AggregationCommand(aggregationKey, startTime, endTime, DAILY))
                         .collect(Collectors.toList());
 
-        LOG.infof(
+        Log.infof(
                 "Finished collecting email aggregations for period (%s, %s) and type %s after %d seconds. %d (accountIds, applications) pairs were processed",
                 startTime,
                 endTime,

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/NotificationsApp.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.notifications;
 
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
-import org.jboss.logging.Logger;
 import javax.inject.Inject;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -12,14 +12,12 @@ import java.io.InputStreamReader;
 @QuarkusMain
 public class NotificationsApp implements QuarkusApplication {
 
-    private static final Logger LOG = Logger.getLogger(NotificationsApp.class);
-
     @Inject
     DailyEmailAggregationJob dailyEmailAggregationJob;
 
     @Override
     public int run(String... args) {
-        LOG.info(readGitProperties());
+        Log.info(readGitProperties());
 
         dailyEmailAggregationJob.processDailyEmail();
 
@@ -31,7 +29,7 @@ public class NotificationsApp implements QuarkusApplication {
         try (InputStream inputStream = classLoader.getResourceAsStream("git.properties")) {
             return readFromInputStream(inputStream);
         } catch (IOException e) {
-            LOG.error("Could not read git.properties.", e);
+            Log.error("Could not read git.properties.", e);
             return "Version information could not be retrieved";
         }
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.auth.rbac;
 
-import org.jboss.logging.Logger;
+import io.quarkus.logging.Log;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
@@ -14,14 +14,12 @@ import java.io.IOException;
  */
 public class RbacClientResponseFilter implements ClientResponseFilter {
 
-    private static final Logger log = Logger.getLogger(RbacClientResponseFilter.class);
-
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
         Response.StatusType statusInfo = responseContext.getStatusInfo();
         int status = statusInfo.getStatusCode();
         if (status != 200) {
-            log.warnf("Call to the Rbac server failed with code %d, %s", status, statusInfo.getReasonPhrase());
+            Log.warnf("Call to the Rbac server failed with code %d, %s", status, statusInfo.getReasonPhrase());
         }
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -10,7 +10,7 @@ import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.WebhookProperties;
-import org.jboss.logging.Logger;
+import io.quarkus.logging.Log;
 
 import javax.annotation.Nullable;
 import javax.enterprise.context.ApplicationScoped;
@@ -33,8 +33,6 @@ import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class EndpointRepository {
-
-    private static final Logger LOGGER = Logger.getLogger(EndpointRepository.class);
 
     @Inject
     EntityManager entityManager;
@@ -335,7 +333,7 @@ public class EndpointRepository {
 
     public Endpoint loadProperties(Endpoint endpoint) {
         if (endpoint == null) {
-            LOGGER.warn("Endpoint properties loading attempt with a null endpoint. It should never happen, this is a bug.");
+            Log.warn("Endpoint properties loading attempt with a null endpoint. It should never happen, this is a bug.");
             return null;
         }
         loadProperties(Collections.singletonList(endpoint));

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
@@ -2,8 +2,8 @@ package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.models.NotificationHistory;
+import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonObject;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -19,8 +19,6 @@ import java.util.UUID;
 public class NotificationRepository {
 
     public static final int MAX_NOTIFICATION_HISTORY_RESULTS = 500;
-
-    private static final Logger LOGGER = Logger.getLogger(NotificationRepository.class);
 
     @Inject
     EntityManager entityManager;
@@ -44,7 +42,7 @@ public class NotificationRepository {
 
         if (limiter != null && limiter.getLimit() != null && limiter.getLimit().getLimit() > 0) {
             if (limiter.getLimit().getLimit() > MAX_NOTIFICATION_HISTORY_RESULTS) {
-                LOGGER.debugf("Too many notification history entries requested (%d), the default max limit (%d) will be enforced",
+                Log.debugf("Too many notification history entries requested (%d), the default max limit (%d) will be enforced",
                         limiter.getLimit().getLimit(), MAX_NOTIFICATION_HISTORY_RESULTS);
             } else {
                 historyQuery = historyQuery.setMaxResults(limiter.getLimit().getLimit())

--- a/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/EphemeralDataInitializer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/ephemeral/EphemeralDataInitializer.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
@@ -22,7 +22,6 @@ public class EphemeralDataInitializer {
 
     public static final String EPHEMERAL_DATA_KEY = "NOTIFICATIONS_EPHEMERAL_DATA";
 
-    private static final Logger LOGGER = Logger.getLogger(EphemeralDataInitializer.class);
     private static final String ENV_NAME_KEY = "ENV_NAME";
     private static final String ENV_EPHEMERAL_PREFIX = "env-ephemeral";
 
@@ -46,26 +45,26 @@ public class EphemeralDataInitializer {
                 if (inputStream != null) {
                     String rawData = new String(inputStream.readAllBytes(), UTF_8);
                     if (!rawData.isBlank()) {
-                        LOGGER.info("Loading ephemeral data from file");
+                        Log.info("Loading ephemeral data from file");
                         EphemeralData data = objectMapper.readValue(rawData, EphemeralData.class);
                         persist(data);
                     }
                 }
             }
         } catch (Exception e) {
-            LOGGER.error("Ephemeral data loading from file failed", e);
+            Log.error("Ephemeral data loading from file failed", e);
         }
     }
 
     private void loadFromEnvVar() {
         String rawData = System.getenv(EPHEMERAL_DATA_KEY);
         if (rawData != null && !rawData.isBlank()) {
-            LOGGER.info("Loading ephemeral data from environment variable");
+            Log.info("Loading ephemeral data from environment variable");
             try {
                 EphemeralData data = objectMapper.readValue(rawData, EphemeralData.class);
                 persist(data);
             } catch (Exception e) {
-                LOGGER.error("Ephemeral data loading from environment variable failed", e);
+                Log.error("Ephemeral data loading from environment variable failed", e);
             }
         }
     }
@@ -80,7 +79,7 @@ public class EphemeralDataInitializer {
                     bundle = entityManager.createQuery(selectBundleQuery, Bundle.class)
                             .setParameter("bundleName", b.name)
                             .getSingleResult();
-                    LOGGER.infof("Bundle with name '%s' already exists, it won't be created from the ephemeral data", b.name);
+                    Log.infof("Bundle with name '%s' already exists, it won't be created from the ephemeral data", b.name);
                 } catch (NoResultException e) {
                     bundle = new Bundle();
                     bundle.setName(b.name);
@@ -97,7 +96,7 @@ public class EphemeralDataInitializer {
                                     .setParameter("bundleName", b.name)
                                     .setParameter("appName", a.name)
                                     .getSingleResult();
-                            LOGGER.infof("Application with name '%s' already exists, it won't be created from the ephemeral data", a.name);
+                            Log.infof("Application with name '%s' already exists, it won't be created from the ephemeral data", a.name);
                         } catch (NoResultException e) {
                             app = new Application();
                             app.setName(a.name);
@@ -117,7 +116,7 @@ public class EphemeralDataInitializer {
                                             .setParameter("appName", a.name)
                                             .setParameter("eventTypeName", et.name)
                                             .getSingleResult();
-                                    LOGGER.infof("Event type with name '%s' already exists, it won't be created from the ephemeral data", et.name);
+                                    Log.infof("Event type with name '%s' already exists, it won't be created from the ephemeral data", et.name);
                                 } catch (NoResultException e) {
                                     eventType = new EventType();
                                     eventType.setName(et.name);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -24,6 +24,7 @@ import com.redhat.cloud.notifications.openbridge.BridgeAuth;
 import com.redhat.cloud.notifications.routers.models.EndpointPage;
 import com.redhat.cloud.notifications.routers.models.Meta;
 import com.redhat.cloud.notifications.routers.models.RequestEmailSubscriptionProperties;
+import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonObject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
@@ -34,7 +35,6 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
@@ -77,8 +77,6 @@ public class EndpointResource {
     public static final String OB_PROCESSOR_ID = "processorId";
     public static final String OB_PROCESSOR_NAME = "processorname"; // Must be all lower for the filter.
     public static final String SLACK = "slack_sink_0.1";
-
-    private static final Logger LOGGER = Logger.getLogger(EndpointResource.class);
 
     private static final List<EndpointType> systemEndpointType = List.of(
             EndpointType.EMAIL_SUBSCRIPTION
@@ -196,7 +194,7 @@ public class EndpointResource {
                 try {
                     processorId = setupOpenBridgeProcessor(endpoint, properties, processorName);
                 } catch (Exception e) {
-                    LOGGER.warn("Processor setup failed: " + e.getMessage());
+                    Log.warn("Processor setup failed: " + e.getMessage());
                     throw new InternalServerErrorException("Can't set up the endpoint");
                 }
 
@@ -276,11 +274,11 @@ public class EndpointResource {
                             try {
                                 bridgeApiService.deleteProcessor(bridge.getId(), processorId, bridgeAuth.getToken());
                             } catch (Exception ex) {
-                                LOGGER.warn("Removal of OB processor failed:" + ex.getMessage());
+                                Log.warn("Removal of OB processor failed:" + ex.getMessage());
                                 // Nothing more we can do
                             }
                         } else {
-                            LOGGER.warn("ProcessorId was null for endpoint " + id.toString());
+                            Log.warn("ProcessorId was null for endpoint " + id.toString());
                         }
                     }
                 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/RouteRedirector.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/RouteRedirector.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.notifications.routers;
 
+import io.quarkus.logging.Log;
 import io.quarkus.vertx.web.RouteFilter;
 import io.vertx.ext.web.RoutingContext;
-import org.jboss.logging.Logger;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -19,8 +19,6 @@ public class RouteRedirector {
 
     Pattern p = Pattern.compile("/api/(integrations|notifications)/v1/(.*)");
 
-    private static final Logger log = Logger.getLogger(RouteRedirector.class);
-
     /**
      * If the requested route is the one with major version only,
      * we rewrite it on the fly.
@@ -32,14 +30,14 @@ public class RouteRedirector {
     @RouteFilter(400)
     void myRedirector(RoutingContext rc) {
         String uri = rc.request().uri();
-        if (log.isTraceEnabled()) {
+        if (Log.isTraceEnabled()) {
             String sanitizedUri = ANTI_INJECTION_PATTERN.matcher(uri).replaceAll("");
-            log.tracef("Incoming uri: %s", sanitizedUri);
+            Log.tracef("Incoming uri: %s", sanitizedUri);
         }
         Matcher m = p.matcher(uri);
         if (m.matches()) {
             String newTarget = "/api/" + m.group(1) + "/v1.0/" + m.group(2);
-            log.tracef("Rerouting to: %s", newTarget);
+            Log.tracef("Rerouting to: %s", newTarget);
 
             rc.reroute(newTarget);
             return;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/filters/MaintenanceModeRequestFilter.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/filters/MaintenanceModeRequestFilter.java
@@ -2,7 +2,7 @@ package com.redhat.cloud.notifications.routers.filters;
 
 import com.redhat.cloud.notifications.db.repositories.StatusRepository;
 import io.quarkus.cache.CacheResult;
-import org.jboss.logging.Logger;
+import io.quarkus.logging.Log;
 import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -20,8 +20,6 @@ import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 @ApplicationScoped
 public class MaintenanceModeRequestFilter {
 
-    private static final Logger LOGGER = Logger.getLogger(MaintenanceModeRequestFilter.class);
-
     // This list contains all request paths that should never be affected by the maintenance mode.
     private static final List<String> NO_MAINTENANCE_REQUEST_PATHS = List.of(
             API_INTERNAL,
@@ -38,7 +36,7 @@ public class MaintenanceModeRequestFilter {
     @ServerRequestFilter
     public Response filter(ContainerRequestContext requestContext) {
         String requestPath = requestContext.getUriInfo().getRequestUri().getPath();
-        LOGGER.tracef("Filtering request to %s", requestPath);
+        Log.tracef("Filtering request to %s", requestPath);
 
         if (!isAffectedByMaintenanceMode(requestPath)) {
             return null;
@@ -49,7 +47,7 @@ public class MaintenanceModeRequestFilter {
          * Let's check if maintenance is on in the database.
          */
         if (isMaintenance()) {
-            LOGGER.trace("Maintenance mode is enabled in the database, aborting request and returning HTTP status 503");
+            Log.trace("Maintenance mode is enabled in the database, aborting request and returning HTTP status 503");
             return MAINTENANCE_IN_PROGRESS;
         } else {
             // This filter work is done. The request will be processed normally.
@@ -61,7 +59,7 @@ public class MaintenanceModeRequestFilter {
         // First, we check if the request path should be affected by the maintenance mode.
         for (String noMaintenanceRequestPath : NO_MAINTENANCE_REQUEST_PATHS) {
             if (requestPath.startsWith(noMaintenanceRequestPath)) {
-                LOGGER.trace("Request path shouldn't be affected by the maintenance mode, database check will be skipped");
+                Log.trace("Request path shouldn't be affected by the maintenance mode, database check will be skipped");
                 // This filter work is done. The request will be processed normally.
                 return false;
             }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -21,12 +21,12 @@ import com.redhat.cloud.notifications.routers.SecurityContextUtil;
 import com.redhat.cloud.notifications.routers.internal.models.AddApplicationRequest;
 import com.redhat.cloud.notifications.routers.internal.models.RequestDefaultBehaviorGroupPropertyList;
 import com.redhat.cloud.notifications.routers.internal.models.ServerInfo;
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
-import org.jboss.logging.Logger;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
@@ -65,7 +65,6 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 @Path(API_INTERNAL)
 public class InternalResource {
 
-    private static final Logger LOGGER = Logger.getLogger(InternalResource.class);
     private static final Pattern GIT_COMMIT_ID_PATTERN = Pattern.compile("git.commit.id.abbrev=([0-9a-f]{7})");
 
     @Inject
@@ -105,7 +104,7 @@ public class InternalResource {
         if (m.matches()) {
             return m.group(1);
         } else {
-            LOGGER.infof("Git commit hash not found: %s", gitProperties);
+            Log.infof("Git commit hash not found: %s", gitProperties);
             return "Git commit hash not found";
         }
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/filters/MaintenanceModeRequestFilterTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/filters/MaintenanceModeRequestFilterTest.java
@@ -1,24 +1,29 @@
 package com.redhat.cloud.notifications.routers.filters;
 
+import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@QuarkusTest
 class MaintenanceModeRequestFilterTest {
 
-    private final MaintenanceModeRequestFilter testee = new MaintenanceModeRequestFilter();
+    @Inject
+    MaintenanceModeRequestFilter requestFilter;
 
     @ParameterizedTest
     @ValueSource(strings = {"/blabla", "/api/notifications/v1.0/notifications/eventTypes"})
     void shouldBeAffectedByMaintenanceMode(String requestPath) {
-        assertTrue(testee.isAffectedByMaintenanceMode(requestPath));
+        assertTrue(requestFilter.isAffectedByMaintenanceMode(requestPath));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"/health", "/metrics", "/internal", "/internal/admin/status", "/api/notifications/v1.0/status"})
     void shouldNotBeAffectedByMaintenanceModeWhenPathIsHealth(String requestPath) {
-        assertFalse(testee.isAffectedByMaintenanceMode(requestPath));
+        assertFalse(requestFilter.isAffectedByMaintenanceMode(requestPath));
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/StartupUtils.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/StartupUtils.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.notifications;
 
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.io.BufferedReader;
@@ -17,8 +17,6 @@ public class StartupUtils {
 
     public static final Pattern ACCESS_LOG_FILTER_PATTERN = Pattern.compile(".*(/health(/\\w+)?|/metrics) HTTP/[0-9].[0-9]\" 200.*\\n?");
 
-    private static final Logger LOG = Logger.getLogger(StartupUtils.class);
-
     @ConfigProperty(name = "quarkus.http.access-log.category")
     String accessLogCategory;
 
@@ -30,9 +28,9 @@ public class StartupUtils {
 
     public void logGitProperties() {
         try {
-            LOG.info(readGitProperties());
+            Log.info(readGitProperties());
         } catch (Exception e) {
-            LOG.error("Could not read git.properties", e);
+            Log.error("Could not read git.properties", e);
         }
     }
 
@@ -58,7 +56,7 @@ public class StartupUtils {
     }
 
     public void logExternalServiceUrl(String configKey) {
-        LOG.infof("%s=%s", configKey, ConfigProvider.getConfig().getValue(configKey, String.class));
+        Log.infof("%s=%s", configKey, ConfigProvider.getConfig().getValue(configKey, String.class));
     }
 
     public void disableRestClientContextualErrors() {

--- a/common/src/main/java/com/redhat/cloud/notifications/models/filter/ApiResponseFilter.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/filter/ApiResponseFilter.java
@@ -8,7 +8,7 @@ import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.InstantEmailTemplate;
-import org.jboss.logging.Logger;
+import io.quarkus.logging.Log;
 
 /**
  * This filter can be used to dynamically filter out properties from a REST response at serialization time. Each class
@@ -18,8 +18,6 @@ import org.jboss.logging.Logger;
 public class ApiResponseFilter extends SimpleBeanPropertyFilter {
 
     public static final String NAME = "ApiResponseFilter";
-
-    private static final Logger LOGGER = Logger.getLogger(ApiResponseFilter.class);
 
     @Override
     public void serializeAsField(Object pojo, JsonGenerator jgen, SerializerProvider provider, PropertyWriter writer) throws Exception {
@@ -114,6 +112,6 @@ public class ApiResponseFilter extends SimpleBeanPropertyFilter {
     }
 
     private void logFilterOut(String className, String fieldName) {
-        LOGGER.tracef("Filtering out %s#%s from a JSON response", className, fieldName);
+        Log.tracef("Filtering out %s#%s from a JSON response", className, fieldName);
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/openbridge/BridgeHelper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/openbridge/BridgeHelper.java
@@ -1,9 +1,9 @@
 package com.redhat.cloud.notifications.openbridge;
 
 import io.quarkus.cache.CacheResult;
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
@@ -38,8 +38,6 @@ public class BridgeHelper {
 
     private Bridge bridgeInstance;
 
-    private static final Logger LOGGER = Logger.getLogger(BridgeHelper.class);
-
     @ApplicationScoped
     @Produces
     public Bridge getBridgeIfNeeded() {
@@ -57,7 +55,7 @@ public class BridgeHelper {
         try {
             token = getAuthTokenInternal();
         } catch (Exception e) {
-            LOGGER.errorf("Failed to get an auth token: %s", e.getMessage());
+            Log.errorf("Failed to get an auth token: %s", e.getMessage());
             throw e;
         }
 
@@ -66,7 +64,7 @@ public class BridgeHelper {
             bridgeMap = apiService.getBridgeById(ourBridge, token);
         } catch (WebApplicationException e) {
             if (e.getResponse().getStatus() == 404) {
-                LOGGER.errorf("Bridge with id %s not found in the OpenBridge instance. Did you create it?", ourBridge);
+                Log.errorf("Bridge with id %s not found in the OpenBridge instance. Did you create it?", ourBridge);
             }
             throw e;
         }
@@ -91,13 +89,13 @@ public class BridgeHelper {
             return new BridgeAuth("- OB not enabled token -");
         }
 
-        LOGGER.debug("In getAuthToken()");
+        Log.debug("In getAuthToken()");
 
         BridgeAuth ba = null;
         try {
             ba = new BridgeAuth(getAuthTokenInternal());
         } catch (Exception e) {
-            LOGGER.warn("Failed to get an auth token: " + e.getMessage());
+            Log.warn("Failed to get an auth token: " + e.getMessage());
             ba = new BridgeAuth("- No token - obtained -");
         }
         return ba;
@@ -108,7 +106,7 @@ public class BridgeHelper {
     @CacheResult(cacheName = "kc-cache")
     String getAuthTokenInternal() {
 
-        LOGGER.debug("Fetching a new token from SSO");
+        Log.debug("Fetching a new token from SSO");
 
         String body = "client_id=" + clientId
                     + "&client_secret=" + clientSecret

--- a/engine/src/main/java/com/redhat/cloud/notifications/clowder/KafkaSaslInitializer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/clowder/KafkaSaslInitializer.java
@@ -1,9 +1,9 @@
 package com.redhat.cloud.notifications.clowder;
 
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 
 import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
@@ -19,7 +19,6 @@ import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
 @ApplicationScoped
 public class KafkaSaslInitializer {
 
-    private static final Logger LOGGER = Logger.getLogger(KafkaSaslInitializer.class);
     private static final String KAFKA_SASL_JAAS_CONFIG = "kafka.sasl.jaas.config";
     private static final String KAFKA_SASL_MECHANISM = "kafka.sasl.mechanism";
     private static final String KAFKA_SECURITY_PROTOCOL = "kafka.security.protocol";
@@ -35,7 +34,7 @@ public class KafkaSaslInitializer {
         Optional<String> kafkaSslTruststoreType = config.getOptionalValue(KAFKA_SSL_TRUSTSTORE_TYPE, String.class);
 
         if (kafkaSaslJaasConfig.isPresent() || kafkaSaslMechanism.isPresent() || kafkaSecurityProtocol.isPresent() || kafkaSslTruststoreLocation.isPresent() || kafkaSslTruststoreType.isPresent()) {
-            LOGGER.info("Initializing Kafka SASL configuration...");
+            Log.info("Initializing Kafka SASL configuration...");
             setValue(KAFKA_SASL_JAAS_CONFIG, kafkaSaslJaasConfig);
             setValue(KAFKA_SASL_MECHANISM, kafkaSaslMechanism);
             setValue(KAFKA_SECURITY_PROTOCOL, kafkaSecurityProtocol);
@@ -47,7 +46,7 @@ public class KafkaSaslInitializer {
     private static void setValue(String configKey, Optional<String> configValue) {
         configValue.ifPresent(value -> {
             System.setProperty(configKey, value);
-            LOGGER.infof("%s has been set", configKey);
+            Log.infof("%s has been set", configKey);
         });
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/StatelessSessionFactory.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/StatelessSessionFactory.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.notifications.db;
 
+import io.quarkus.logging.Log;
 import org.hibernate.Session;
 import org.hibernate.StatelessSession;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -12,8 +12,6 @@ import java.util.function.Function;
 
 @ApplicationScoped
 public class StatelessSessionFactory {
-
-    private static final Logger LOGGER = Logger.getLogger(StatelessSessionFactory.class);
 
     @Inject
     EntityManager entityManager;
@@ -71,7 +69,7 @@ public class StatelessSessionFactory {
         if (threadLocalSession.get() != null) {
             throw new IllegalStateException("Stateless session already bound to the current thread. Did you use nested StatelessSessionFactory#withSession calls?");
         } else {
-            LOGGER.trace("Creating a new stateless session");
+            Log.trace("Creating a new stateless session");
             StatelessSession session = entityManager.unwrap(Session.class).getSessionFactory().openStatelessSession();
             /*
              * We're not using ThreadLocal#withInitial because StatelessSessionFactory#close needs to call ThreadLocal#get
@@ -86,10 +84,10 @@ public class StatelessSessionFactory {
         StatelessSession session = threadLocalSession.get();
         if (session != null) {
             if (session.isOpen()) {
-                LOGGER.trace("Closing the current stateless session");
+                Log.trace("Closing the current stateless session");
                 session.close();
             }
-            LOGGER.trace("Removing the current stateless session from ThreadLocal field");
+            Log.trace("Removing the current stateless session from ThreadLocal field");
             threadLocalSession.remove();
         }
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepository.java
@@ -3,8 +3,8 @@ package com.redhat.cloud.notifications.db.repositories;
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.models.EmailAggregationKey;
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -16,8 +16,6 @@ import java.util.List;
 public class EmailAggregationRepository {
 
     public static final String USE_ORG_ID = "notifications.use-org-id";
-
-    private static final Logger LOGGER = Logger.getLogger(EmailAggregationRepository.class);
 
     @ConfigProperty(name = USE_ORG_ID, defaultValue = "false")
     public boolean useOrgId;
@@ -31,7 +29,7 @@ public class EmailAggregationRepository {
             statelessSessionFactory.getCurrentSession().insert(aggregation);
             return true;
         } catch (Exception e) {
-            LOGGER.warn("Email aggregation persisting failed", e);
+            Log.warn("Email aggregation persisting failed", e);
             return false;
         }
     }
@@ -48,7 +46,7 @@ public class EmailAggregationRepository {
                     .setParameter("end", end)
                     .getResultList();
 
-            LOGGER.info("getEmailAggregation resultlist" + resultList);
+            Log.info("getEmailAggregation resultlist" + resultList);
             return resultList;
         } else {
             String query = "FROM EmailAggregation WHERE accountId = :accountId AND bundleName = :bundleName AND applicationName = :applicationName AND created > :start AND created <= :end ORDER BY created";

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -8,7 +8,7 @@ import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.WebhookProperties;
-import org.jboss.logging.Logger;
+import io.quarkus.logging.Log;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -27,8 +27,6 @@ import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
 
 @ApplicationScoped
 public class EndpointRepository {
-
-    private static final Logger LOGGER = Logger.getLogger(EndpointRepository.class);
 
     @Inject
     StatelessSessionFactory statelessSessionFactory;
@@ -86,7 +84,7 @@ public class EndpointRepository {
                 if (endpoint.getType() == EMAIL_SUBSCRIPTION) {
                     endpoint.setAccountId(tenant);
                 } else {
-                    LOGGER.warnf("Invalid endpoint configured in default behavior group: %s", endpoint.getId());
+                    Log.warnf("Invalid endpoint configured in default behavior group: %s", endpoint.getId());
                 }
             }
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -12,7 +12,7 @@ import com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProc
 import com.redhat.cloud.notifications.processors.webhooks.WebhookTypeProcessor;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.jboss.logging.Logger;
+import io.quarkus.logging.Log;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -27,8 +27,6 @@ public class EndpointProcessor {
 
     public static final String PROCESSED_MESSAGES_COUNTER_NAME = "processor.input.processed";
     public static final String PROCESSED_ENDPOINTS_COUNTER_NAME = "processor.input.endpoint.processed";
-
-    private static final Logger LOGGER = Logger.getLogger(EndpointProcessor.class);
 
     @Inject
     EndpointRepository endpointRepository;
@@ -80,7 +78,7 @@ public class EndpointProcessor {
                 try {
                     notificationHistoryRepository.createNotificationHistory(history);
                 } catch (Exception e) {
-                    LOGGER.errorf("Notification history creation failed for %s", history.getEndpoint());
+                    Log.errorf("Notification history creation failed for %s", history.getEndpoint());
                 }
             }
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -10,11 +10,11 @@ import com.redhat.cloud.notifications.utils.ActionParser;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.quarkus.logging.Log;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.jboss.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -36,7 +36,6 @@ public class EventConsumer {
     public static final String DUPLICATE_COUNTER_NAME = "input.duplicate";
     public static final String CONSUMED_TIMER_NAME = "input.consumed";
 
-    private static final Logger LOGGER = Logger.getLogger(EventConsumer.class);
     private static final String EVENT_TYPE_NOT_FOUND_MSG = "No event type found for [bundleName=%s, applicationName=%s, eventTypeName=%s]";
 
     @Inject
@@ -106,7 +105,7 @@ public class EventConsumer {
             bundleName[0] = action.getBundle();
             appName[0] = action.getApplication();
             String eventTypeName = action.getEventType();
-            LOGGER.infof("Processing received action: (%s) %s/%s/%s", action.getAccountId(), bundleName[0], appName[0], eventTypeName);
+            Log.infof("Processing received action: (%s) %s/%s/%s", action.getAccountId(), bundleName[0], appName[0], eventTypeName);
             /*
              * Step 2
              * The message ID is extracted from the Kafka message headers. It can be null for now to give the onboarded
@@ -159,7 +158,7 @@ public class EventConsumer {
                         if (messageId != null) {
                             event.setId(messageId);
                         } else {
-                            LOGGER.infof("NOID: Event with %s/%s/%s did not have an incoming id or messageId ",
+                            Log.infof("NOID: Event with %s/%s/%s did not have an incoming id or messageId ",
                                     bundleName[0], appName[0], eventTypeName);
                             event.setId(UUID.randomUUID());
                         }
@@ -186,7 +185,7 @@ public class EventConsumer {
              * it is logged and added to the exception counter metric.
              */
             processingExceptionCounter.increment();
-            LOGGER.infof(e, "Could not process the payload: %s", payload);
+            Log.infof(e, "Could not process the payload: %s", payload);
         } finally {
             // bundleName[0] and appName[0] are null when the action parsing failed.
             String bundle = bundleName[0] == null ? "" : bundleName[0];

--- a/engine/src/main/java/com/redhat/cloud/notifications/health/KafkaConsumedTotalChecker.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/health/KafkaConsumedTotalChecker.java
@@ -2,9 +2,9 @@ package com.redhat.cloud.notifications.health;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -13,7 +13,6 @@ import javax.inject.Inject;
 @ApplicationScoped
 public class KafkaConsumedTotalChecker {
 
-    private static final Logger LOGGER = Logger.getLogger(KafkaConsumedTotalChecker.class);
     private static final String COUNTER_NAME = "kafka.consumer.fetch.manager.records.consumed.total";
     private static final String INGRESS_TOPIC = "platform.notifications.ingress";
 
@@ -34,7 +33,7 @@ public class KafkaConsumedTotalChecker {
                 .functionCounter();
         if (consumedTotalCounter == null) {
             // This will help prevent a NPE throw if the metrics happens to change in our dependency.
-            LOGGER.warnf("%s counter not found, %s is disabled", COUNTER_NAME, KafkaConsumedTotalChecker.class.getSimpleName());
+            Log.warnf("%s counter not found, %s is disabled", COUNTER_NAME, KafkaConsumedTotalChecker.class.getSimpleName());
             enabled = false;
         }
     }
@@ -44,7 +43,7 @@ public class KafkaConsumedTotalChecker {
         if (enabled) {
             double currentTotal = consumedTotalCounter.count();
             if (currentTotal == previousTotal) {
-                LOGGER.debugf("Kafka records consumed total check failed for topic '%s'", INGRESS_TOPIC);
+                Log.debugf("Kafka records consumed total check failed for topic '%s'", INGRESS_TOPIC);
                 down = true;
             }
             previousTotal = currentTotal;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -16,6 +16,7 @@ import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.context.Context;
+import io.quarkus.logging.Log;
 import io.smallrye.reactive.messaging.TracingMetadata;
 import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
@@ -26,7 +27,6 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -62,8 +62,6 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
     @Inject
     @Channel(TOCAMEL_CHANNEL)
     Emitter<String> emitter;
-
-    private static final Logger LOGGER = Logger.getLogger(CamelTypeProcessor.class);
 
     @Inject
     MeterRegistry registry;
@@ -152,7 +150,7 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
                 Map<String, Object> details = new HashMap<>();
                 details.put("failure", e.getMessage());
                 history.setDetails(details);
-                LOGGER.infof("SE: Sending event with historyId=%s and originalId=%s failed: %s ",
+                Log.infof("SE: Sending event with historyId=%s and originalId=%s failed: %s ",
                         historyId, originalEventId, e.getMessage());
             } finally {
                 endTime = System.currentTimeMillis();
@@ -185,7 +183,7 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
                 .build()
         );
         msg = msg.addMetadata(tracingMetadata);
-        LOGGER.infof("CA Sending for account=%s, historyId=%s, integration=%s, origId=%s",
+        Log.infof("CA Sending for account=%s, historyId=%s, integration=%s, origId=%s",
                 accountId, historyId, integrationName, originalEventId);
         emitter.send(msg);
 
@@ -206,7 +204,7 @@ public class CamelTypeProcessor implements EndpointTypeProcessor {
         ce.put("originaleventid", originalEventId);
         // TODO add dataschema
 
-        LOGGER.infof("SE: Sending Event with historyId=%s, processorName=%s, processorId=%s, integration=%s, origId=%s",
+        Log.infof("SE: Sending Event with historyId=%s, processorName=%s, processorId=%s, integration=%s, origId=%s",
                 id.toString(), extras.get(PROCESSORNAME), extras.get("processorId"), integrationName, originalEventId);
 
         body.remove(NOTIF_METADATA_KEY); // Not needed on OB

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
@@ -13,13 +13,13 @@ import com.redhat.cloud.notifications.templates.TemplateService;
 import com.redhat.cloud.notifications.utils.LineBreakCleaner;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.quarkus.logging.Log;
 import io.quarkus.qute.TemplateInstance;
 import io.vertx.core.json.JsonObject;
 import io.vertx.mutiny.core.buffer.Buffer;
 import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.WebClient;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -32,8 +32,6 @@ import java.util.Set;
 
 @ApplicationScoped
 public class EmailSender {
-
-    private static final Logger logger = Logger.getLogger(EmailSender.class);
 
     static final String BOP_APITOKEN_HEADER = "x-rh-apitoken";
     static final String BOP_CLIENT_ID_HEADER = "x-rh-clientid";
@@ -112,7 +110,7 @@ public class EmailSender {
 
             return Optional.of(history);
         } catch (Exception e) {
-            logger.info("Email sending failed", e);
+            Log.info("Email sending failed", e);
             return Optional.empty();
         }
     }
@@ -125,7 +123,7 @@ public class EmailSender {
             renderedSubject = templateService.renderTemplate(user, action, subject);
             renderedBody = templateService.renderTemplate(user, action, body);
         } catch (Exception e) {
-            logger.warnf(e,
+            Log.warnf(e,
                     "Unable to render template for bundle: [%s] application: [%s], eventType: [%s].",
                     action.getBundle(),
                     action.getApplication(),

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -29,13 +29,13 @@ import com.redhat.cloud.notifications.templates.TemplateService;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.logging.Log;
 import io.quarkus.qute.TemplateInstance;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.vertx.core.json.JsonObject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.jboss.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -61,8 +61,6 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
     public static final String AGGREGATION_COMMAND_REJECTED_COUNTER_NAME = "aggregation.command.rejected";
     public static final String AGGREGATION_COMMAND_PROCESSED_COUNTER_NAME = "aggregation.command.processed";
     public static final String AGGREGATION_COMMAND_ERROR_COUNTER_NAME = "aggregation.command.error";
-
-    private static final Logger LOGGER = Logger.getLogger(EmailSubscriptionTypeProcessor.class);
 
     private static final List<EmailSubscriptionType> NON_INSTANT_SUBSCRIPTION_TYPES = Arrays.stream(EmailSubscriptionType.values())
             .filter(emailSubscriptionType -> emailSubscriptionType != EmailSubscriptionType.INSTANT)
@@ -111,8 +109,6 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
     private Counter rejectedAggregationCommandCount;
     private Counter processedAggregationCommandCount;
     private Counter failedAggregationCommandCount;
-
-    private static final Logger LOG = Logger.getLogger(EmailSubscriptionTypeProcessor.class);
 
     @PostConstruct
     void postConstruct() {
@@ -195,7 +191,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
         Set<String> subscribers = Set.copyOf(emailSubscriptionRepository
                 .getEmailSubscribersUserId(action.getAccountId(), action.getBundle(), action.getApplication(), emailSubscriptionType));
 
-        LOG.info("sending email for event: " + event);
+        Log.info("sending email for event: " + event);
         return recipientResolver.recipientUsers(action.getAccountId(), action.getOrgId(), requests, subscribers)
                 .stream()
                 .map(user -> emailSender.sendEmail(user, event, subject, body))
@@ -213,12 +209,12 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
         try {
             aggregationCommand = objectMapper.readValue(aggregationCommandJson, AggregationCommand.class);
         } catch (JsonProcessingException e) {
-            LOGGER.error("Kafka aggregation payload parsing failed", e);
+            Log.error("Kafka aggregation payload parsing failed", e);
             rejectedAggregationCommandCount.increment();
             return;
         }
 
-        LOGGER.infof("Processing received aggregation command: %s", aggregationCommand);
+        Log.infof("Processing received aggregation command: %s", aggregationCommand);
         processedAggregationCommandCount.increment();
 
         try {
@@ -232,7 +228,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
                         aggregationCommand.getSubscriptionType().equals(EmailSubscriptionType.DAILY));
             });
         } catch (Exception e) {
-            LOGGER.info("Error while processing aggregation", e);
+            Log.info("Error while processing aggregation", e);
             failedAggregationCommandCount.increment();
         }
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webclient/WebClientProducer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webclient/WebClientProducer.java
@@ -1,10 +1,10 @@
 package com.redhat.cloud.notifications.processors.webclient;
 
+import io.quarkus.logging.Log;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.ext.web.client.WebClient;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
@@ -14,8 +14,6 @@ import java.util.Optional;
 
 @ApplicationScoped
 public class WebClientProducer {
-
-    private static final Logger LOGGER = Logger.getLogger(WebClientProducer.class);
 
     @Inject
     Vertx vertx;
@@ -49,7 +47,7 @@ public class WebClientProducer {
                 .setTrustAll(trustAll)
                 .setConnectTimeout(3000); // TODO Should this be configurable by the system? We need a maximum in any case
         if (maxPoolSize.isPresent()) {
-            LOGGER.debugf("Producing a WebClient with a configured max pool size: %d", maxPoolSize.get());
+            Log.debugf("Producing a WebClient with a configured max pool size: %d", maxPoolSize.get());
             options = options.setMaxPoolSize(maxPoolSize.get());
         }
         return options;

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
@@ -2,7 +2,7 @@ package com.redhat.cloud.notifications.recipients;
 
 import com.redhat.cloud.notifications.recipients.rbac.RbacRecipientUsersProvider;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.jboss.logging.Logger;
+import io.quarkus.logging.Log;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -16,8 +16,6 @@ import java.util.stream.Collectors;
 public class RecipientResolver {
 
     private final AtomicInteger usersCount = new AtomicInteger(0);
-
-    private static final Logger LOG = Logger.getLogger(RecipientResolver.class);
 
     @Inject
     RbacRecipientUsersProvider rbacRecipientUsersProvider;
@@ -43,7 +41,7 @@ public class RecipientResolver {
         } else {
             rbacUsers = rbacRecipientUsersProvider.getGroupUsers(accountId, orgId, request.isOnlyAdmins(), request.getGroupId());
         }
-        LOG.info("recipientUsers: " + rbacUsers);
+        Log.info("recipientUsers: " + rbacUsers);
 
         // The base list of recipients comes from RBAC.
         Set<User> users = Set.copyOf(rbacUsers);

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/AuthRequestFilter.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/AuthRequestFilter.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.Base64Utils;
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
@@ -34,8 +34,6 @@ public class AuthRequestFilter implements ClientRequestFilter {
     private final String secret;
     private final String application;
 
-    private static final Logger log = Logger.getLogger(AuthRequestFilter.class);
-
     AuthRequestFilter() {
         Config config = ConfigProvider.getConfig();
 
@@ -49,13 +47,13 @@ public class AuthRequestFilter implements ClientRequestFilter {
                     new TypeReference<>() { }
             );
         } catch (JsonProcessingException jsonProcessingException) {
-            log.error("Unable to load Rbac service to service secret map, defaulting to empty map", jsonProcessingException);
+            Log.error("Unable to load Rbac service to service secret map, defaulting to empty map", jsonProcessingException);
             rbacServiceToServiceSecretMap = Map.of();
         }
 
         secret = rbacServiceToServiceSecretMap.getOrDefault(application, new Secret()).secret;
         if (secret == null) {
-            log.error("Unable to load Rbac service to service secret key");
+            Log.error("Unable to load Rbac service to service secret key");
         }
 
         String tmp = System.getProperty(RBAC_SERVICE_TO_SERVICE_DEV_EXCEPTIONAL_AUTH_KEY);

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
@@ -16,9 +16,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.ConnectTimeoutException;
 import io.quarkus.cache.CacheResult;
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.ClientWebApplicationException;
 
 import javax.annotation.PostConstruct;
@@ -36,8 +36,6 @@ import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class RbacRecipientUsersProvider {
-
-    private static final Logger LOGGER = Logger.getLogger(RbacRecipientUsersProvider.class);
 
     public static final String ORG_ADMIN_PERMISSION = "admin:org:all";
 
@@ -103,7 +101,7 @@ public class RbacRecipientUsersProvider {
                 .withMaxAttempts(maxRetryAttempts)
                 .onRetriesExceeded(event -> {
                     // All retry attempts failed, let's log a warning about the failure.
-                    LOGGER.warnf("RBAC S2S call failed", event.getException().getMessage());
+                    Log.warnf("RBAC S2S call failed", event.getException().getMessage());
                 })
                 .build();
 
@@ -116,7 +114,7 @@ public class RbacRecipientUsersProvider {
                 .withMaxAttempts(maxRetryAttemptsIt)
                 .onRetriesExceeded(event -> {
                     // All retry attempts failed, let's log a warning about the failure.
-                    LOGGER.warnf("IT User Service call failed", event.getException().getMessage());
+                    Log.warnf("IT User Service call failed", event.getException().getMessage());
                 })
                 .build();
     }
@@ -139,7 +137,7 @@ public class RbacRecipientUsersProvider {
             firstResult += maxResultsPerPage;
         } while (usersPaging.size() == maxResultsPerPage);
 
-        LOGGER.info("usersTotal: " + usersTotal);
+        Log.info("usersTotal: " + usersTotal);
 
         users = transformToUser(usersTotal);
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/DbTemplateLocator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/DbTemplateLocator.java
@@ -2,9 +2,9 @@ package com.redhat.cloud.notifications.templates;
 
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.models.Template;
+import io.quarkus.logging.Log;
 import io.quarkus.qute.TemplateLocator;
 import io.quarkus.qute.Variant;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -16,8 +16,6 @@ import java.util.Optional;
 @ApplicationScoped
 public class DbTemplateLocator implements TemplateLocator {
 
-    private static Logger LOGGER = Logger.getLogger(DbTemplateLocator.class);
-
     @Inject
     StatelessSessionFactory statelessSessionFactory;
 
@@ -28,10 +26,10 @@ public class DbTemplateLocator implements TemplateLocator {
             Template template = statelessSessionFactory.getCurrentSession().createQuery(hql, Template.class)
                     .setParameter("name", name)
                     .getSingleResult();
-            LOGGER.tracef("Template with [name=%s] found in the database", name);
+            Log.tracef("Template with [name=%s] found in the database", name);
             return Optional.of(buildTemplateLocation(template.getData()));
         } catch (NoResultException e) {
-            LOGGER.tracef("Template with [name=%s] not found in the database", name);
+            Log.tracef("Template with [name=%s] not found in the database", name);
             return Optional.empty();
         }
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -5,7 +5,7 @@ import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.InstantEmailTemplate;
 import com.redhat.cloud.notifications.models.Template;
-import org.jboss.logging.Logger;
+import io.quarkus.logging.Log;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -32,8 +32,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 @Path(API_INTERNAL + "/template-engine/migrate")
 public class EmailTemplateMigrationService {
 
-    private static final Logger LOGGER = Logger.getLogger(EmailTemplateMigrationService.class);
-
     @Inject
     EntityManager entityManager;
 
@@ -56,7 +54,7 @@ public class EmailTemplateMigrationService {
     public List<String> migrate() {
         List<String> warnings = new ArrayList<>();
 
-        LOGGER.debug("Migration starting");
+        Log.debug("Migration starting");
 
         /*
          * Former src/main/resources/templates/Advisor folder.
@@ -332,7 +330,7 @@ public class EmailTemplateMigrationService {
                 "Vulnerability/dailyEmailBody", "html", "Vulnerability daily email body"
         );
 
-        LOGGER.debug("Migration ended");
+        Log.debug("Migration ended");
 
         return warnings;
     }
@@ -349,7 +347,7 @@ public class EmailTemplateMigrationService {
             warnings.add(String.format("Template found in DB: %s", name));
             return template;
         } catch (NoResultException e) {
-            LOGGER.infof("Creating template: %s", name);
+            Log.infof("Creating template: %s", name);
             Template template = new Template();
             template.setName(name);
             template.setDescription(description);
@@ -391,7 +389,7 @@ public class EmailTemplateMigrationService {
                     Template subjectTemplate = getOrCreateTemplate(warnings, subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
                     Template bodyTemplate = getOrCreateTemplate(warnings, bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
 
-                    LOGGER.infof("Creating instant email template for event type: %s/%s/%s", bundleName, appName, eventTypeName);
+                    Log.infof("Creating instant email template for event type: %s/%s/%s", bundleName, appName, eventTypeName);
 
                     InstantEmailTemplate emailTemplate = new InstantEmailTemplate();
                     emailTemplate.setEventType(eventType.get());
@@ -448,7 +446,7 @@ public class EmailTemplateMigrationService {
                 Template subjectTemplate = getOrCreateTemplate(warnings, subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
                 Template bodyTemplate = getOrCreateTemplate(warnings, bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
 
-                LOGGER.infof("Creating daily email template for application: %s/%s", bundleName, appName);
+                Log.infof("Creating daily email template for application: %s/%s", bundleName, appName);
 
                 AggregationEmailTemplate emailTemplate = new AggregationEmailTemplate();
                 emailTemplate.setApplication(app.get());

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateService.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.recipients.User;
 import com.redhat.cloud.notifications.templates.extensions.ActionExtension;
 import com.redhat.cloud.notifications.templates.extensions.LocalDateTimeExtension;
 import com.redhat.cloud.notifications.templates.models.Environment;
+import io.quarkus.logging.Log;
 import io.quarkus.qute.Engine;
 import io.quarkus.qute.EvalContext;
 import io.quarkus.qute.ReflectionValueResolver;
@@ -14,7 +15,6 @@ import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.ValueResolver;
 import io.quarkus.scheduler.Scheduled;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -27,8 +27,6 @@ import java.util.function.Function;
 public class TemplateService {
 
     public static final String USE_TEMPLATES_FROM_DB_KEY = "notifications.use-templates-from-db";
-
-    private static final Logger LOGGER = Logger.getLogger(TemplateService.class);
 
     @Inject
     Engine engine;
@@ -44,7 +42,7 @@ public class TemplateService {
     @PostConstruct
     void postConstruct() {
         if (ConfigProvider.getConfig().getValue(USE_TEMPLATES_FROM_DB_KEY, Boolean.class)) {
-            LOGGER.info("Using templates from the database");
+            Log.info("Using templates from the database");
         }
         dbEngine = Engine.builder()
                 .addDefaults()


### PR DESCRIPTION
Quarkus recently introduced a new `Log` API which delegates all its invocations to `org.jboss.logging.Logger`. Building the logger is no longer needed.