### PR TITLE
SPM-1485 Handle advisories uniquely per account in Patch aggregator

### DIFF
--- a/engine/src/main/resources/templates/Patch/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Patch/dailyEmailBody.html
@@ -1,168 +1,12 @@
 {#include Patch/insightsEmailBody}
 {#content-title}Patch Advisories Daily Report - {action.context.start_time.toStringFormat()}{/content-title}
 {#content-body}
-<tr>
-  <td class="rh-body rh-multi-column">
-    <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" width="100%">
-      <tbody>
-        <!-- Content block -->
-        <tr>
-          <td>
-            <div class="container" style="display: table;">
-              <div class="rh-card" style="margin-right: 5px; width: 48%;">
-                <div class="rh-card__header">
-                  <h2>
-                    New Enhancement Advisories
-                  </h2>
-                </div>
-                <div>
-                  <span class="rh-metric__count">{action.context.patch.enhancement.advisories.size()}</span>
-                </div>
-              </div>
-              <div style="display: table-cell; padding-right: 12px"></div>
-              <div class="rh-card" style="margin-left: 12px; width: 48%; height: 100%;">
-                <div class="rh-card__header">
-                  <h2>
-                    New Security Advisories
-                  </h2>
-                </div>
-                <div>
-                  <span class="rh-metric__count">{action.context.patch.security.advisories.size()}</span>
-                </div>
-              </div>
-            </div>
-            <!-- end 50 col -->
-            <!--[if (gte mso 9)|(IE)]>
-                    </td>
-                    </tr>
-                    </table>
-                    <![endif]-->
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <br>
-            <div class="container" style="display: table;">
-              <div class="rh-card" style="margin-right: 5px; width: 48%;">
-                <div class="rh-card__header">
-                  <h2>
-                    New Bugfix Advisories
-                  </h2>
-                </div>
-                <div>
-                  <span class="rh-metric__count">{action.context.patch.bugfix.advisories.size()}</span>
-                </div>
-              </div>
-              <div style="display: table-cell; padding-right: 12px"></div>
-              <div class="rh-card" style="margin-left: 12px; width: 48%; height: 100%;">
-                <div class="rh-card__header">
-                  <h2>
-                    New Unspecified Advisories
-                  </h2>
-                </div>
-                <div>
-                  <span class="rh-metric__count">{action.context.patch.unspecified.advisories.size()}</span>
-                </div>
-              </div>
-            </div>
-            <!-- end 50 col -->
-            <!--[if (gte mso 9)|(IE)]>
-                    </td>
-                    </tr>
-                    </table>
-                    <![endif]-->
-          </td>
-        </tr>
-        <!-- end content block -->
-      </tbody>
-    </table>
-    <br>
-    <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" width="100%">
-      <tbody>
-        <!-- Content block -->
-        <tr>
-          <td>
-            <div class="container" style="display: table;">
-              <div class="rh-card" style="margin-right: 5px; width: 48%;">
-                <div class="rh-card__header">
-                  <h2>
-                    Systems affected by Enhancement Advisories
-                  </h2>
-                </div>
-                <div>
-                  <span class="rh-metric__count">{action.context.patch.enhancement.unique_system_count ?: 0}</span>
-                </div>
-              </div>
-              <div style="display: table-cell; padding-right: 12px"></div>
-              <div class="rh-card" style="margin-left: 12px; width: 48%; height: 100%;">
-                <div class="rh-card__header">
-                  <h2>
-                    Systems affected by Security Advisories
-                  </h2>
-                </div>
-                <div>
-                  <span class="rh-metric__count">{action.context.patch.security.unique_system_count ?: 0}</span>
-                </div>
-              </div>
-            </div>
-            <!-- end 50 col -->
-            <!--[if (gte mso 9)|(IE)]>
-                    </td>
-                    </tr>
-                    </table>
-                    <![endif]-->
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <br>
-            <div class="container" style="display: table;">
-              <div class="rh-card" style="margin-right: 5px; width: 48%;">
-                <div class="rh-card__header">
-                  <h2>
-                    Systems affected by Bugfix Advisories
-                  </h2>
-                </div>
-                <div>
-                  <span class="rh-metric__count">{action.context.patch.bugfix.unique_system_count ?: 0}</span>
-                </div>
-              </div>
-              <div style="display: table-cell; padding-right: 12px"></div>
-              <div class="rh-card" style="margin-left: 12px; width: 48%; height: 100%;">
-                <div class="rh-card__header">
-                  <h2>
-                    Systems affected in Total
-                  </h2>
-                </div>
-                <div>
-                  <p></p>
-                  <span class="rh-metric__count">{action.context.unique_system_count ?: 0}</span>
-                </div>
-              </div>
-            </div>
-            <!-- end 50 col -->
-            <!--[if (gte mso 9)|(IE)]>
-                    </td>
-                    </tr>
-                    </table>
-                    <![endif]-->
-          </td>
-        </tr>
-        <!-- end content block -->
-      </tbody>
-    </table>
-    <br>
-  </td>
-</tr>
-<!-- end body section -->
-
 <!-- Body section -->
 <tr>
   <td class="rh-body">
     <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0"
       width="100%">
       <tbody>
-        <!-- Content block -->
         <tr>
           <td class="rh-content__block">
             <p>
@@ -173,9 +17,6 @@
             </p>
           </td>
         </tr>
-        <!-- end content block -->
-
-        <!-- Content block -->
         <tr>
           <td class="rh-content__block">
             <table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center"
@@ -192,22 +33,17 @@
             </table>
           </td>
         </tr>
-        <!-- end content block -->
       </tbody>
     </table>
   </td>
 </tr>
-<!-- end body section -->
-
-<!-- Body section -->
 <tr>
   <td class="rh-body">
     {#for key in action.context.patch.keySet()}
-    {#if action.context.patch.get(key).get("advisories").size() > 0}
+    {#if action.context.patch.get(key).size() > 0}
     <table class="rh-content rh-m-plain" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0"
       width="100%">
       <tbody>
-        <!-- Content block -->
         <tr>
           <td class="rh-content__block">
             <table width:="" 100%;="" class="rh-data-table rh-m-bordered">
@@ -217,7 +53,7 @@
                 </tr>
               </thead>
               <tbody>
-                {#for advisory in action.context.patch.get(key).get("advisories").keySet()}
+                {#for advisory in action.context.patch.get(key)}
                 <tr>
                   <td>
                     <a class="rh-url" href="{environment.url}/insights/patch/advisories/{advisory}">{advisory}</a>
@@ -228,7 +64,6 @@
             </table>
           </td>
         </tr>
-        <!-- end content block -->
       </tbody>
     </table>
     <br>
@@ -236,5 +71,6 @@
     {/for}
   </td>
 </tr>
+<!-- end body section -->
 {/content-body}
 {/include}

--- a/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
@@ -11,9 +11,9 @@ import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.vertx.core.json.JsonObject;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class PatchTestHelpers {
 
@@ -113,18 +113,8 @@ public class PatchTestHelpers {
         return aggregation;
     }
 
-    public static Integer getUniqueHostForAdvisoryType(PatchEmailPayloadAggregator aggregator, String advisoryType) {
-        Map<String, Map> patch = (Map<String, Map>) aggregator.getContext().get("patch");
-        return (Integer) patch.get(advisoryType).get(UNIQUE_HOSTS_CNT);
-    }
-
-    public static Integer getUniqueHost(PatchEmailPayloadAggregator aggregator) {
-        return (Integer) aggregator.getContext().get(UNIQUE_HOSTS_CNT);
-    }
-
-    public static Set<String> getAdvisoriesByType(PatchEmailPayloadAggregator aggregator, String advisoryType) {
+    public static ArrayList<String> getAdvisoriesByType(PatchEmailPayloadAggregator aggregator, String advisoryType) {
         Map<String, Object> patch = (Map<String, Object>) ((Map<String, Object>) aggregator.getContext()).get("patch");
-        Map<String, Object> advisories = (Map<String, Object>) ((Map<String, Object>) patch.get(advisoryType)).get(ADVISORIES_KEY);
-        return advisories.keySet();
+        return (ArrayList<String>) patch.get(advisoryType);
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregatorTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Map;
-import java.util.Set;
 
 public class PatchEmailPayloadAggregatorTest {
 
@@ -41,26 +41,22 @@ public class PatchEmailPayloadAggregatorTest {
         LocalDateTime endTime = LocalDateTime.of(2021, 4, 22, 14, 15, 33);
 
         aggregator.aggregate(PatchTestHelpers.createEmailAggregation(tenant, bundle, application, "advisory_1", security, "host-01"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(tenant, bundle, application, "advisory_1", security, "host-01"));
         aggregator.aggregate(PatchTestHelpers.createEmailAggregation(tenant, bundle, application, "advisory_2", enhancement, "host-01"));
         aggregator.aggregate(PatchTestHelpers.createEmailAggregation(tenant, bundle, application, "advisory_3", enhancement, "host-02"));
         aggregator.aggregate(PatchTestHelpers.createEmailAggregation(tenant, bundle, application, "advisory_4", bugfix, "host-03"));
-        Assertions.assertEquals(PatchTestHelpers.getUniqueHostForAdvisoryType(aggregator, security), 1);
-        Assertions.assertEquals(PatchTestHelpers.getUniqueHostForAdvisoryType(aggregator, enhancement), 2);
-        Assertions.assertEquals(PatchTestHelpers.getUniqueHostForAdvisoryType(aggregator, bugfix), 1);
-        Assertions.assertEquals(PatchTestHelpers.getUniqueHost(aggregator), 3);
 
-        Set<String> secAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, security);
-        Assertions.assertEquals(secAdvs.size(), 1);
-        Assertions.assertTrue(secAdvs.iterator().next().equals("advisory_1"));
+        ArrayList<String> secAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, security);
+        Assertions.assertEquals(1, secAdvs.size());
+        Assertions.assertTrue(secAdvs.get(0).equals("advisory_1"));
 
-        Set<String> enhAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, enhancement);
-        Assertions.assertEquals(enhAdvs.size(), 2);
-        Assertions.assertTrue(enhAdvs.iterator().next().equals("advisory_2"));
+        ArrayList<String> enhAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, enhancement);
+        Assertions.assertEquals(2, enhAdvs.size());
+        Assertions.assertTrue(enhAdvs.get(0).equals("advisory_2"));
+        Assertions.assertTrue(enhAdvs.get(1).equals("advisory_3"));
 
-        Set<String> fixAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, bugfix);
-        Assertions.assertEquals(fixAdvs.size(), 1);
-        Assertions.assertTrue(fixAdvs.iterator().next().equals("advisory_4"));
+        ArrayList<String> fixAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, bugfix);
+        Assertions.assertEquals(1, fixAdvs.size());
+        Assertions.assertTrue(fixAdvs.get(0).equals("advisory_4"));
 
         Map<String, Object> patch = aggregator.getContext();
         patch.put("start_time", startTime.toString());
@@ -70,9 +66,9 @@ public class PatchEmailPayloadAggregatorTest {
     @Test
     void validatePayloadMultipleEvents() {
         aggregator.aggregate(PatchTestHelpers.createEmailAggregationMultipleEvents(tenant, bundle, application));
-        Set<String> enhAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, enhancement);
-        Assertions.assertTrue(enhAdvs.iterator().next().equals("RH-1"));
-        Set<String> fixAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, bugfix);
-        Assertions.assertTrue(fixAdvs.iterator().next().equals("RH-2"));
+        ArrayList<String> enhAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, enhancement);
+        Assertions.assertTrue(enhAdvs.get(0).equals("RH-1"));
+        ArrayList<String> fixAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, bugfix);
+        Assertions.assertTrue(fixAdvs.get(0).equals("RH-2"));
     }
 }


### PR DESCRIPTION
Patch was sending too much notifications and now is going to notify only once for each new advisory per account instead of system.