### PR TITLE
Revert "Bump Quarkus to 2.10.0.Final (#1312)"

### DIFF
--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
@@ -88,7 +88,7 @@ public class DbQuteEngineTest {
                 templateService.compileTemplate(outerTemplate.getData(), outerTemplate.getName()).render();
             });
         });
-        assertEquals("Rendering error in template [outer-template] line 1: included template [inner-template] not found", e.getMessage());
+        assertEquals("Included template [inner-template] not found in template [outer-template] on line 1", e.getMessage());
     }
 
     @Test
@@ -99,7 +99,7 @@ public class DbQuteEngineTest {
                 templateService.compileTemplate(outerTemplate.getData(), outerTemplate.getName()).render();
             });
         });
-        assertEquals("Rendering error in template [other-outer-template] line 1: included template [unknown-inner-template] not found", e.getMessage());
+        assertEquals("Included template [unknown-inner-template] not found in template [other-outer-template] on line 1", e.getMessage());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.10.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.9.2.Final</quarkus.platform.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
IQE tests are very unstable on stage. I'll deploy this to determine if the unstability came from the latest Quarkus bump.