### PR TITLE
Bump Quarkus to 2.10.0.Final (again)

### DIFF
--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
@@ -88,7 +88,7 @@ public class DbQuteEngineTest {
                 templateService.compileTemplate(outerTemplate.getData(), outerTemplate.getName()).render();
             });
         });
-        assertEquals("Included template [inner-template] not found in template [outer-template] on line 1", e.getMessage());
+        assertEquals("Rendering error in template [outer-template] line 1: included template [inner-template] not found", e.getMessage());
     }
 
     @Test
@@ -99,7 +99,7 @@ public class DbQuteEngineTest {
                 templateService.compileTemplate(outerTemplate.getData(), outerTemplate.getName()).render();
             });
         });
-        assertEquals("Included template [unknown-inner-template] not found in template [other-outer-template] on line 1", e.getMessage());
+        assertEquals("Rendering error in template [other-outer-template] line 1: included template [unknown-inner-template] not found", e.getMessage());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.9.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.10.0.Final</quarkus.platform.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Quarkus 2.10 wasn't the cause of the IQE tests instability on stage.