### PR TITLE
Prevent NPE in UserConfigResource

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -65,7 +66,7 @@ public class UserConfigResource {
     @Produces(TEXT_PLAIN)
     @Operation(hidden = true)
     @Transactional
-    public Response saveSettings(@Context SecurityContext sec, @Valid SettingsValues values) {
+    public Response saveSettings(@Context SecurityContext sec, @NotNull @Valid SettingsValues values) {
 
         final RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         final String account = principal.getAccount();


### PR DESCRIPTION
Someone called `POST /api/notifications/v1.0/user-config/notification-preference?bundleName=rhel` on stage will a `null` request body which caused a NPE and an HTTP 500 status. After this PR, the returned HTTP status will be 400.