### PR TITLE
Reduce RBAC failures noise in Sentry

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProvider.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProvider.java
@@ -119,8 +119,7 @@ public class ConsoleIdentityProvider implements IdentityProvider<ConsoleAuthenti
                                                 .atMost(maxRetryAttempts)
                                                 // After we're done retrying, an RBAC server call failure will cause an authentication failure
                                                 .onFailure().transform(failure -> {
-                                                    Log.warnf("RBAC authentication call failed: %s", failure.getMessage());
-                                                    throw new AuthenticationFailedException(failure.getMessage());
+                                                    throw new AuthenticationFailedException("RBAC authentication call failed", failure);
                                                 })
                                                 // Otherwise, we can finish building the QuarkusSecurityIdentity and return the result
                                                 .onItem().transform(rbacRaw -> {

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
@@ -18,7 +18,9 @@ public class RbacClientResponseFilter implements ClientResponseFilter {
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
         Response.StatusType statusInfo = responseContext.getStatusInfo();
         int status = statusInfo.getStatusCode();
-        if (status != 200) {
+        if (status == 0) {
+            Log.infof("Call to the Rbac server failed with code %d, %s", status, statusInfo.getReasonPhrase());
+        } else if (status != 200) {
             Log.warnf("Call to the Rbac server failed with code %d, %s", status, statusInfo.getReasonPhrase());
         }
     }


### PR DESCRIPTION
This PR reduces the Sentry alerts from 3 to 1 when the RBAC calls fail because of a timeout or a closed connection.