### PR TITLE
NOTIF-603 Add orgId to DB entities

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
@@ -21,7 +21,7 @@ public class EmailSubscriptionRepository {
         String query = "INSERT INTO endpoint_email_subscriptions(account_id, user_id, application_id, subscription_type) " +
                 "SELECT :accountId, :userId, a.id, :subscriptionType " +
                 "FROM applications a, bundles b WHERE a.bundle_id = b.id AND a.name = :applicationName AND b.name = :bundleName " +
-                "ON CONFLICT (account_id, user_id, application_id, subscription_type) DO NOTHING"; // The value is already on the database, this is OK
+                "ON CONFLICT (account_id, org_id, user_id, application_id, subscription_type) DO NOTHING"; // The value is already on the database, this is OK
         // HQL does not support the ON CONFLICT clause so we need a native query here
         entityManager.createNativeQuery(query)
                 .setParameter("accountId", accountNumber)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -44,6 +44,10 @@ public class BehaviorGroup extends CreationUpdateTimestamped {
     @JsonIgnore
     private String accountId;
 
+    @Size(max = 50)
+    @JsonIgnore
+    private String orgId;
+
     @NotNull
     @NotBlank
     private String displayName;
@@ -76,7 +80,7 @@ public class BehaviorGroup extends CreationUpdateTimestamped {
     @JsonInclude
     @JsonProperty(access = READ_ONLY, value = "default_behavior")
     public boolean isDefaultBehavior() {
-        return accountId == null;
+        return accountId == null && orgId == null;
     }
 
     public UUID getId() {
@@ -93,6 +97,14 @@ public class BehaviorGroup extends CreationUpdateTimestamped {
 
     public void setAccountId(String accountId) {
         this.accountId = accountId;
+    }
+
+    public String getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
     }
 
     public String getDisplayName() {

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EmailSubscription.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EmailSubscription.java
@@ -32,6 +32,14 @@ public class EmailSubscription {
         id.accountId = accountId;
     }
 
+    public String getOrgId() {
+        return id.orgId;
+    }
+
+    public void setOrgId(String orgId) {
+        id.orgId = orgId;
+    }
+
     public String getUserId() {
         return id.userId;
     }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionId.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionId.java
@@ -17,6 +17,9 @@ public class EmailSubscriptionId implements Serializable {
     @Size(max = 50)
     public String accountId;
 
+    @Size(max = 50)
+    public String orgId;
+
     @NotNull
     @Size(max = 50)
     public String userId;
@@ -37,6 +40,7 @@ public class EmailSubscriptionId implements Serializable {
         if (o instanceof EmailSubscriptionId) {
             EmailSubscriptionId other = (EmailSubscriptionId) o;
             return Objects.equals(accountId, other.accountId) &&
+                    Objects.equals(orgId, other.orgId) &&
                     Objects.equals(userId, other.userId) &&
                     Objects.equals(subscriptionType, other.subscriptionType) &&
                     Objects.equals(applicationId, other.applicationId);
@@ -46,6 +50,6 @@ public class EmailSubscriptionId implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountId, userId, subscriptionType, applicationId);
+        return Objects.hash(accountId, orgId, userId, subscriptionType, applicationId);
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -42,6 +42,10 @@ public class Endpoint extends CreationUpdateTimestamped {
     @JsonIgnore
     private String accountId;
 
+    @Size(max = 50)
+    @JsonIgnore
+    private String orgId;
+
     @NotNull
     @Size(max = 255)
     private String name;
@@ -104,6 +108,14 @@ public class Endpoint extends CreationUpdateTimestamped {
 
     public void setAccountId(String accountId) {
         this.accountId = accountId;
+    }
+
+    public String getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
     }
 
     public String getName() {
@@ -210,6 +222,7 @@ public class Endpoint extends CreationUpdateTimestamped {
         return "Endpoint{" +
                 "id=" + id +
                 ", accountId='" + accountId + '\'' +
+                ", orgId='" + orgId + '\'' +
                 ", name='" + name + '\'' +
                 ", description='" + description + '\'' +
                 ", enabled=" + enabled +

--- a/database/src/main/resources/db/migration/V1.52.0__NOTIF-603_org_id.sql
+++ b/database/src/main/resources/db/migration/V1.52.0__NOTIF-603_org_id.sql
@@ -1,0 +1,22 @@
+ALTER TABLE behavior_group
+    ADD COLUMN org_id TEXT;
+CREATE INDEX ix_behavior_group_org_id ON behavior_group (org_id);
+
+ALTER TABLE endpoint_email_subscriptions
+    -- Hibernate is unable to load an @EmbeddedId (EmailSubscriptionId) if one of its fields is null.
+    -- As a consequence, the org_id DB column must always be non-null.
+    -- TODO NOTIF-603 Remove the default value from the following column after the org ID migration is done.
+    ADD COLUMN org_id TEXT DEFAULT 'PLACEHOLDER',
+    DROP CONSTRAINT pk_endpoint_email_subscriptions,
+    ADD CONSTRAINT pk_endpoint_email_subscriptions PRIMARY KEY (account_id, org_id, user_id, subscription_type, application_id);
+CREATE INDEX ix_endpoint_email_subscriptions_org_id ON endpoint_email_subscriptions (org_id);
+
+-- Hibernate is unable to load an @EmbeddedId (EmailSubscriptionId) if one of its fields is null.
+-- As a consequence, the org_id DB column must always be non-null.
+UPDATE endpoint_email_subscriptions
+    SET org_id = 'PLACEHOLDER'
+    WHERE org_id IS NULL;
+
+ALTER TABLE endpoints
+    ADD COLUMN org_id TEXT;
+CREATE INDEX ix_endpoints_org_id ON endpoints (org_id);

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -494,6 +494,8 @@ public class LifecycleITest {
         EmailSubscription subscription = new EmailSubscription();
         subscription.setId(new EmailSubscriptionId());
         subscription.setAccountId(accountId);
+        // TODO NOTIF-603 Replace the placeholder with the real org ID.
+        subscription.setOrgId("PLACEHOLDER");
         subscription.setUserId(userId);
         subscription.setApplication(application);
         subscription.setType(INSTANT);


### PR DESCRIPTION
#1271 is too big and hard to rebase, so I'm breaking it down into smaller PRs.

This is step 1: adding the `orgId` field to all  DB entities where it was missing.