### PR TITLE
Saving behavior group actions and linked event types in a single call

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -7,8 +7,6 @@ import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EventType;
-import com.redhat.cloud.notifications.models.EventTypeBehavior;
-import com.redhat.cloud.notifications.models.EventTypeBehaviorId;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -15,7 +15,6 @@ import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.time.LocalDateTime;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -7,6 +7,8 @@ import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.EventTypeBehavior;
+import com.redhat.cloud.notifications.models.EventTypeBehaviorId;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -15,6 +17,7 @@ import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import java.time.LocalDateTime;
@@ -40,6 +43,26 @@ public class BehaviorGroupRepository {
 
     @Inject
     OrgIdHelper orgIdHelper;
+
+    public BehaviorGroup get(@NotNull UUID behaviorGroupId) {
+        return entityManager.find(BehaviorGroup.class, behaviorGroupId);
+    }
+
+    public BehaviorGroup createFull(String accountId, String orgId, @Valid BehaviorGroup behaviorGroup, List<UUID> endpoints, Set<UUID> eventTypes) {
+        BehaviorGroup saved = create(accountId, orgId, behaviorGroup);
+        if (endpoints != null) {
+            updateBehaviorGroupActions(accountId, orgId, saved.getId(), endpoints);
+        }
+
+        if (eventTypes != null) {
+            updateBehaviorEventTypes(accountId, orgId, saved.getId(), eventTypes);
+        }
+
+        entityManager.flush();
+        entityManager.refresh(saved);
+
+        return saved;
+    }
 
     public BehaviorGroup create(String accountId, String orgId, @Valid BehaviorGroup behaviorGroup) {
         return this.create(accountId, orgId, behaviorGroup, false);
@@ -289,6 +312,80 @@ public class BehaviorGroupRepository {
                 .setParameter("behaviorGroupId", behaviorGroupId)
                 .executeUpdate();
         return true;
+    }
+
+    /**
+     * Sets the event types of a behavior group
+     * @param accountId Account id of the behavior group
+     * @param behaviorGroupId Id of the behavior group
+     * @param eventTypeIds List of the event type ids that we want to set
+     */
+    @Transactional
+    public void updateBehaviorEventTypes(String accountId, String orgId, UUID behaviorGroupId, Set<UUID> eventTypeIds) {
+        BehaviorGroup behaviorGroup = entityManager.find(BehaviorGroup.class, behaviorGroupId);
+        if (featureFlipper.isUseOrgId()) {
+            if (behaviorGroup == null || !behaviorGroup.getOrgId().equals(orgId)) {
+                throw new NotFoundException("Behavior group not found in the org");
+            }
+        } else {
+            if (behaviorGroup == null || !behaviorGroup.getAccountId().equals(accountId)) {
+                throw new NotFoundException("Behavior group not found in the account");
+            }
+        }
+
+        if (!eventTypeIds.isEmpty()) {
+            // Behavior group can only be linked to event types in the same bundle
+            String integrityCheckHql = "SELECT id from EventType WHERE id IN (:eventTypeIds) "
+                    + "AND application.bundle.id != :bundleId";
+            List<UUID> differentBundle = entityManager.createQuery(integrityCheckHql, UUID.class)
+                    .setParameter("eventTypeIds", eventTypeIds)
+                    .setParameter("bundleId", behaviorGroup.getBundleId())
+                    .getResultList();
+            if (!differentBundle.isEmpty()) {
+                throw new BadRequestException("Some event types can't be linked to the behavior group because they " +
+                        "belong to a different bundle: " + differentBundle);
+            }
+        }
+
+        /*
+         * Lock related rows to avoid deadlocks
+         */
+        String lockQuery = "SELECT id.eventTypeId FROM EventTypeBehavior " +
+                "WHERE id.behaviorGroupId = :behaviorGroupId";
+        List<UUID> eventTypesFromDb = entityManager.createQuery(lockQuery, UUID.class)
+                .setParameter("behaviorGroupId", behaviorGroupId)
+                .setLockMode(PESSIMISTIC_WRITE)
+                .getResultList();
+
+        /*
+        * Delete the event type links that were not provided
+        */
+        List<UUID> eventTypesToDelete = new ArrayList<>(eventTypesFromDb);
+        eventTypesToDelete.removeAll(eventTypeIds);
+
+        if (!eventTypesToDelete.isEmpty()) {
+            String deleteQuery = "DELETE FROM EventTypeBehavior " +
+                    "WHERE id.eventTypeId IN (:eventTypeIds) AND id.behaviorGroupId = :behaviorGroupId";
+            entityManager.createQuery(deleteQuery)
+                    .setParameter("eventTypeIds", eventTypesToDelete)
+                    .setParameter("behaviorGroupId", behaviorGroupId)
+                    .executeUpdate();
+        }
+
+        List<UUID> eventTypesToAdd = new ArrayList<>(eventTypeIds);
+        eventTypesToAdd.removeAll(eventTypesFromDb);
+
+        if (!eventTypesToAdd.isEmpty()) {
+            for (UUID eventTypeId : eventTypesToAdd) {
+                String insertQuery = "INSERT INTO event_type_behavior (event_type_id, behavior_group_id, created) " +
+                        "SELECT :eventTypeId, :behaviorGroupId, :created";
+                entityManager.createNativeQuery(insertQuery)
+                        .setParameter("eventTypeId", eventTypeId)
+                        .setParameter("behaviorGroupId", behaviorGroupId)
+                        .setParameter("created", LocalDateTime.now(UTC))
+                        .executeUpdate();
+            }
+        }
     }
 
     @Transactional

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -51,6 +51,8 @@ public class BehaviorGroupRepository {
             updateBehaviorEventTypes(accountId, orgId, saved.getId(), eventTypes);
         }
 
+        // The previous updates execute native SQL - hibernate is not aware of the changes it made on the behavior group
+        // so we need to refresh to ensure we have the actions and event types.
         entityManager.flush();
         entityManager.refresh(saved);
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -42,10 +42,6 @@ public class BehaviorGroupRepository {
     @Inject
     OrgIdHelper orgIdHelper;
 
-    public BehaviorGroup get(@NotNull UUID behaviorGroupId) {
-        return entityManager.find(BehaviorGroup.class, behaviorGroupId);
-    }
-
     public BehaviorGroup createFull(String accountId, String orgId, @Valid BehaviorGroup behaviorGroup, List<UUID> endpoints, Set<UUID> eventTypes) {
         BehaviorGroup saved = create(accountId, orgId, behaviorGroup);
         if (endpoints != null) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -27,6 +27,8 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
@@ -178,7 +180,7 @@ public class NotificationResource {
     })
     @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @Transactional
-    public CreateBehaviorGroupResponse createBehaviorGroup(@Context SecurityContext sec, CreateBehaviorGroupRequest request) {
+    public CreateBehaviorGroupResponse createBehaviorGroup(@Context SecurityContext sec, @Valid @NotNull CreateBehaviorGroupRequest request) {
         String accountId = getAccountId(sec);
         String orgId = getOrgId(sec);
 
@@ -197,8 +199,6 @@ public class NotificationResource {
         CreateBehaviorGroupResponse response = new CreateBehaviorGroupResponse();
 
         response.id = behaviorGroup.getId();
-        response.accountId = behaviorGroup.getAccountId();
-        response.orgId = null;
         response.bundleId = behaviorGroup.getBundleId();
         response.displayName = behaviorGroup.getDisplayName();
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -173,7 +173,7 @@ public class NotificationResource {
     @Consumes(APPLICATION_JSON)
     @Operation(summary = "Create a behavior group - assigning actions and linking to event types as requested")
     @APIResponses(value = {
-            @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = BehaviorGroup.class))),
+            @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = CreateBehaviorGroupResponse.class))),
             @APIResponse(responseCode = "400", content = @Content(mediaType = TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING)))
     })
     @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -220,7 +220,7 @@ public class NotificationResource {
     @Operation(summary = "Update a behavior group.")
     @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @Transactional
-    public Response updateBehaviorGroup(@Context SecurityContext sec, @PathParam("id") UUID id, UpdateBehaviorGroupRequest request) {
+    public Response updateBehaviorGroup(@Context SecurityContext sec, @PathParam("id") UUID id, @NotNull UpdateBehaviorGroupRequest request) {
         String accountId = getAccountId(sec);
         String orgId = getOrgId(sec);
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -197,10 +197,15 @@ public class NotificationResource {
         CreateBehaviorGroupResponse response = new CreateBehaviorGroupResponse();
 
         response.id = behaviorGroup.getId();
+        response.accountId = behaviorGroup.getAccountId();
+        response.orgId = null;
         response.bundleId = behaviorGroup.getBundleId();
         response.displayName = behaviorGroup.getDisplayName();
+
         response.endpoints = behaviorGroup.getActions().stream().map(action -> action.getId().endpointId).collect(Collectors.toList());
         response.eventTypes = behaviorGroup.getBehaviors().stream().map(b -> b.getId().eventTypeId).collect(Collectors.toSet());
+
+        response.created = behaviorGroup.getCreated();
 
         return response;
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -215,7 +215,8 @@ public class NotificationResource {
     @Consumes(APPLICATION_JSON)
     @APIResponses(value = {
             @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(type = SchemaType.BOOLEAN))),
-            @APIResponse(responseCode = "400", content = @Content(mediaType = TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING)))
+            @APIResponse(responseCode = "400", content = @Content(mediaType = TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING))),
+            @APIResponse(responseCode = "404", content = @Content(mediaType = TEXT_PLAIN,  schema = @Schema(type = SchemaType.STRING)))
     })
     @Operation(summary = "Update a behavior group.")
     @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -237,7 +237,7 @@ public class NotificationResource {
             behaviorGroupRepository.updateBehaviorEventTypes(accountId, orgId, id, request.eventTypeIds);
         }
 
-            return Response.status(200).type(APPLICATION_JSON).entity(true).build();
+        return Response.status(200).type(APPLICATION_JSON).entity(true).build();
     }
 
     @DELETE

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
@@ -18,21 +18,18 @@ public class CreateBehaviorGroupRequest {
     /**
      * BundleId the behavior group will be created for.
      */
-    @Valid
     @NotNull
     public UUID bundleId;
 
     /**
      * Display name the behavior group will have.
      */
-    @Valid
     @NotNull
     public String displayName;
 
     /**
      * If not null, the behavior group will have the relations to the endpoints (i.e. actions within a behavior group).
      */
-    @Valid
     // Allow this list to be null to be backwards compatible with the previous CreateBehaviorGroupRequest
     public List<UUID> endpointIds;
 
@@ -40,6 +37,5 @@ public class CreateBehaviorGroupRequest {
      * If not null, the behavior group will have the relations to the event types (i.e. the event type is linked with
      * the behavior group).
      */
-    @Valid
     public Set<UUID> eventTypeIds;
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
@@ -4,14 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-@Valid
-@NotNull
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateBehaviorGroupRequest {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
@@ -1,0 +1,45 @@
+package com.redhat.cloud.notifications.routers.models.behaviorgroup;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Valid
+@NotNull
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CreateBehaviorGroupRequest {
+    /**
+     * BundleId the behavior group will be created for.
+     */
+    @Valid
+    @NotNull
+    public UUID bundleId;
+
+    /**
+     * Display name the behavior group will have.
+     */
+    @Valid
+    @NotNull
+    public String displayName;
+
+    /**
+     * If not null, the behavior group will have the relations to the endpoints (i.e. actions within a behavior group).
+     */
+    @Valid
+    // Allow this list to be null to be backwards compatible with the previous CreateBehaviorGroupRequest
+    public List<UUID> endpointIds;
+
+    /**
+     * If not null, the behavior group will have the relations to the event types (i.e. the event type is linked with
+     * the behavior group).
+     */
+    @Valid
+    public Set<UUID> eventTypeIds;
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.routers.models.behaviorgroup;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -17,41 +18,48 @@ public class CreateBehaviorGroupResponse {
     /**
      * Id of the newly created behavior group.
      */
+    @NotNull
     public UUID id;
 
     /**
      * Account id the behavior group belongs to.
      */
     @Deprecated
+    @NotNull
     public String accountId;
 
     /**
      * Org id the behavior group belongs to.
      */
-    public String orgId;
+    public String orgId; // Should add @NotNull when have fully migrated to org id.
 
     /**
      * Bundle if of the newly created behavior group.
      */
+    @NotNull
     public UUID bundleId;
 
     /**
      * Display name of the newly created behavior group.
      */
+    @NotNull
     public String displayName;
 
     /**
      * Endpoints linked to the newly created behavior group.
      */
+    @NotNull
     public List<UUID> endpoints;
 
     /**
      * Event types linked to the newly created behavior group.
      */
+    @NotNull
     public Set<UUID> eventTypes;
 
     /**
      * Creation time of the behavior group
      */
+    @NotNull
     public LocalDateTime created;
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
@@ -1,0 +1,40 @@
+package com.redhat.cloud.notifications.routers.models.behaviorgroup;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Response to the create behavior group request.
+ * Has information about how the behavior group was created.
+ */
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CreateBehaviorGroupResponse {
+    /**
+     * Id of the newly created behavior group.
+     */
+    public UUID id;
+
+    /**
+     * Bundle if of the newly created behavior group.
+     */
+    public UUID bundleId;
+
+    /**
+     * Display name of the newly created behavior group.
+     */
+    public String displayName;
+
+    /**
+     * Endpoints linked to the newly created behavior group.
+     */
+    public List<UUID> endpoints;
+
+    /**
+     * Event types linked to the newly created behavior group.
+     */
+    public Set<UUID> eventTypes;
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.routers.models.behaviorgroup;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -17,6 +18,17 @@ public class CreateBehaviorGroupResponse {
      * Id of the newly created behavior group.
      */
     public UUID id;
+
+    /**
+     * Account id the behavior group belongs to.
+     */
+    @Deprecated
+    public String accountId;
+
+    /**
+     * Org id the behavior group belongs to.
+     */
+    public String orgId;
 
     /**
      * Bundle if of the newly created behavior group.
@@ -37,4 +49,9 @@ public class CreateBehaviorGroupResponse {
      * Event types linked to the newly created behavior group.
      */
     public Set<UUID> eventTypes;
+
+    /**
+     * Creation time of the behavior group
+     */
+    public LocalDateTime created;
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
@@ -22,18 +22,6 @@ public class CreateBehaviorGroupResponse {
     public UUID id;
 
     /**
-     * Account id the behavior group belongs to.
-     */
-    @Deprecated
-    @NotNull
-    public String accountId;
-
-    /**
-     * Org id the behavior group belongs to.
-     */
-    public String orgId; // Should add @NotNull when have fully migrated to org id.
-
-    /**
      * Bundle if of the newly created behavior group.
      */
     @NotNull

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupResponse.java
@@ -22,7 +22,7 @@ public class CreateBehaviorGroupResponse {
     public UUID id;
 
     /**
-     * Bundle if of the newly created behavior group.
+     * Bundle id of the newly created behavior group.
      */
     @NotNull
     public UUID bundleId;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
@@ -11,6 +11,13 @@ import java.util.UUID;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class UpdateBehaviorGroupRequest {
+
+    /**
+     * Remove: Only used to make QA tests happy
+     */
+    @Deprecated
+    public UUID bundleId;
+
     /**
      * If not null, changes the display name of the behavior group to this value.
      */

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-import javax.validation.Valid;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
@@ -15,14 +15,12 @@ public class UpdateBehaviorGroupRequest {
     /**
      * If not null, changes the display name of the behavior group to this value.
      */
-    @Valid
     public String displayName;
 
     /**
      * If not null, changes the list of associated endpoints.
      * This will effectively set the linked endpoints..
      */
-    @Valid
     // Allow this list to be null to be backwards compatible with the previous CreateBehaviorGroupRequest
     public List<UUID> endpointIds;
 
@@ -30,6 +28,5 @@ public class UpdateBehaviorGroupRequest {
      * If not null, changes the list of associated event types..
      * This will effectively set the linked event types..
      */
-    @Valid
     public Set<UUID> eventTypeIds;
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
@@ -1,0 +1,35 @@
+package com.redhat.cloud.notifications.routers.models.behaviorgroup;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UpdateBehaviorGroupRequest {
+    /**
+     * If not null, changes the display name of the behavior group to this value.
+     */
+    @Valid
+    public String displayName;
+
+    /**
+     * If not null, changes the list of associated endpoints.
+     * This will effectively set the linked endpoints..
+     */
+    @Valid
+    // Allow this list to be null to be backwards compatible with the previous CreateBehaviorGroupRequest
+    public List<UUID> endpointIds;
+
+    /**
+     * If not null, changes the list of associated event types..
+     * This will effectively set the linked event types..
+     */
+    @Valid
+    public Set<UUID> eventTypeIds;
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
@@ -20,7 +20,7 @@ public class UpdateBehaviorGroupRequest {
      * If not null, changes the list of associated endpoints.
      * This will effectively set the linked endpoints..
      */
-    // Allow this list to be null to be backwards compatible with the previous CreateBehaviorGroupRequest
+    // Allow this list to be null to be backwards compatible with the previous UpdateBehaviorGroupRequest
     public List<UUID> endpointIds;
 
     /**

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -15,14 +15,12 @@ import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.WebhookProperties;
-import com.redhat.cloud.notifications.routers.models.behaviorgroup.CreateBehaviorGroupResponse;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -15,12 +15,14 @@ import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.routers.models.behaviorgroup.CreateBehaviorGroupResponse;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
@@ -186,6 +188,10 @@ public class ResourceHelpers {
         return history;
     }
 
+    public BehaviorGroup getBehaviorGroup(UUID behaviorGroupId) {
+        return behaviorGroupRepository.get(behaviorGroupId);
+    }
+
     public BehaviorGroup createBehaviorGroup(String accountId, String orgId, String displayName, UUID bundleId) {
         BehaviorGroup behaviorGroup = new BehaviorGroup();
         behaviorGroup.setDisplayName(displayName);
@@ -202,6 +208,14 @@ public class ResourceHelpers {
 
     public List<EventType> findEventTypesByBehaviorGroupId(UUID behaviorGroupId) {
         return behaviorGroupRepository.findEventTypesByBehaviorGroupId(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, behaviorGroupId);
+    }
+
+    public List<Endpoint> findEndpointsByBehaviorGroupId(String accountId, UUID behaviorGroupId) {
+        String query = "SELECT bga.endpoint FROM BehaviorGroupAction bga WHERE bga.endpoint.accountId = :accountId AND bga.behaviorGroup.id = :behaviorGroupId";
+        return entityManager.createQuery(query, Endpoint.class)
+                .setParameter("accountId", accountId)
+                .setParameter("behaviorGroupId", behaviorGroupId)
+                .getResultList();
     }
 
     public List<BehaviorGroup> findBehaviorGroupsByEventTypeId(UUID eventTypeId) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -204,8 +204,12 @@ public class ResourceHelpers {
         return behaviorGroupRepository.createDefault(behaviorGroup);
     }
 
+    public List<EventType> findEventTypesByBehaviorGroupId(String accountId, String orgId, UUID behaviorGroupId) {
+        return behaviorGroupRepository.findEventTypesByBehaviorGroupId(accountId, orgId, behaviorGroupId);
+    }
+
     public List<EventType> findEventTypesByBehaviorGroupId(UUID behaviorGroupId) {
-        return behaviorGroupRepository.findEventTypesByBehaviorGroupId(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, behaviorGroupId);
+        return findEventTypesByBehaviorGroupId(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, behaviorGroupId);
     }
 
     public List<Endpoint> findEndpointsByBehaviorGroupId(String accountId, UUID behaviorGroupId) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -187,7 +187,7 @@ public class ResourceHelpers {
     }
 
     public BehaviorGroup getBehaviorGroup(UUID behaviorGroupId) {
-        return behaviorGroupRepository.get(behaviorGroupId);
+        return entityManager.find(BehaviorGroup.class, behaviorGroupId);
     }
 
     public BehaviorGroup createBehaviorGroup(String accountId, String orgId, String displayName, UUID bundleId) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -13,7 +13,6 @@ import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.db.repositories.BehaviorGroupRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
-import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.EventType;
@@ -24,7 +23,6 @@ import com.redhat.cloud.notifications.routers.models.behaviorgroup.UpdateBehavio
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
 import io.vertx.core.json.JsonArray;

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -577,18 +577,19 @@ public class NotificationResourceTest extends DbIsolatedTest {
     @Test
     void testCreateFullBehaviorGroup() {
         String tenant = "tenant-bg-create-full";
+        String orgId = "org-bg-create-full";
 
-        Header identityHeader = initRbacMock(tenant, "orgId", "user", FULL_ACCESS);
+        Header identityHeader = initRbacMock(tenant, orgId, "user", FULL_ACCESS);
 
         helpers.createTestAppAndEventTypes();
         List<Application> apps = applicationRepository.getApplications(TEST_BUNDLE_NAME);
         UUID myBundleId = apps.stream().findFirst().get().getBundleId();
 
         List<UUID> endpoints = Stream.of(
-                helpers.createEndpoint(tenant, EndpointType.EMAIL_SUBSCRIPTION),
-                helpers.createEndpoint(tenant, EndpointType.EMAIL_SUBSCRIPTION),
-                helpers.createEndpoint(tenant, EndpointType.CAMEL),
-                helpers.createEndpoint(tenant, EndpointType.CAMEL)
+                helpers.createEndpoint(tenant, orgId, EndpointType.EMAIL_SUBSCRIPTION),
+                helpers.createEndpoint(tenant, orgId, EndpointType.EMAIL_SUBSCRIPTION),
+                helpers.createEndpoint(tenant, orgId, EndpointType.CAMEL),
+                helpers.createEndpoint(tenant, orgId, EndpointType.CAMEL)
         ).map(Endpoint::getId).collect(Collectors.toList());
         Set<UUID> eventTypes = apps.stream().findFirst().get().getEventTypes().stream().map(EventType::getId).collect(Collectors.toSet());
 
@@ -642,20 +643,21 @@ public class NotificationResourceTest extends DbIsolatedTest {
     @Test
     void testUpdateFullBehaviorGroup() {
         String tenant = "tenant-bg-update-full";
-        Header identityHeader = initRbacMock(tenant, "orgId", "user", FULL_ACCESS);
+        String orgId = "orgId-bg-update-full";
+        Header identityHeader = initRbacMock(tenant, orgId, "user", FULL_ACCESS);
 
         helpers.createTestAppAndEventTypes();
         List<Application> apps = applicationRepository.getApplications(TEST_BUNDLE_NAME);
         UUID myBundleId = apps.stream().findFirst().get().getBundleId();
 
-        UUID behaviorGroupId = helpers.createBehaviorGroup(tenant, "My behavior group 1", myBundleId).getId();
-        UUID behaviorGroupIdOtherTenant = helpers.createBehaviorGroup(tenant + "-other", "My behavior", myBundleId).getId();
+        UUID behaviorGroupId = helpers.createBehaviorGroup(tenant, orgId, "My behavior group 1", myBundleId).getId();
+        UUID behaviorGroupIdOtherTenant = helpers.createBehaviorGroup(tenant + "-other", orgId + "-other", "My behavior", myBundleId).getId();
 
         List<UUID> endpoints = Stream.of(
-                helpers.createEndpoint(tenant, EndpointType.EMAIL_SUBSCRIPTION),
-                helpers.createEndpoint(tenant, EndpointType.EMAIL_SUBSCRIPTION),
-                helpers.createEndpoint(tenant, EndpointType.CAMEL),
-                helpers.createEndpoint(tenant, EndpointType.CAMEL)
+                helpers.createEndpoint(tenant, orgId, EndpointType.EMAIL_SUBSCRIPTION),
+                helpers.createEndpoint(tenant, orgId, EndpointType.EMAIL_SUBSCRIPTION),
+                helpers.createEndpoint(tenant, orgId, EndpointType.CAMEL),
+                helpers.createEndpoint(tenant, orgId, EndpointType.CAMEL)
         ).map(Endpoint::getId).collect(Collectors.toList());
 
         Set<UUID> eventTypes = apps.stream().findFirst().get().getEventTypes().stream().map(EventType::getId).collect(Collectors.toSet());
@@ -690,7 +692,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
         behaviorGroup = helpers.getBehaviorGroup(behaviorGroupId);
         assertEquals("My behavior group 2.0", behaviorGroup.getDisplayName());
         assertEquals(endpoints, getEndpointsIds(tenant, behaviorGroupId));
-        assertEquals(Set.of(), getEventTypeIds(tenant, behaviorGroupId));
+        assertEquals(Set.of(), getEventTypeIds(tenant, orgId, behaviorGroupId));
 
         // Updating only event types (endpoints remain the same)
         behaviorGroupRequest.displayName = "My behavior group 3.0";
@@ -701,7 +703,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
         behaviorGroup = helpers.getBehaviorGroup(behaviorGroupId);
         assertEquals("My behavior group 3.0", behaviorGroup.getDisplayName());
         assertEquals(endpoints, getEndpointsIds(tenant, behaviorGroupId));
-        assertEquals(eventTypes, getEventTypeIds(tenant, behaviorGroupId));
+        assertEquals(eventTypes, getEventTypeIds(tenant, orgId, behaviorGroupId));
 
         // Updating both to empty
         behaviorGroupRequest.displayName = "My behavior group 4.0";
@@ -712,7 +714,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
         behaviorGroup = helpers.getBehaviorGroup(behaviorGroupId);
         assertEquals("My behavior group 4.0", behaviorGroup.getDisplayName());
         assertEquals(List.of(), getEndpointsIds(tenant, behaviorGroupId));
-        assertEquals(Set.of(), getEventTypeIds(tenant, behaviorGroupId));
+        assertEquals(Set.of(), getEventTypeIds(tenant, orgId, behaviorGroupId));
     }
 
     @Test
@@ -1001,9 +1003,9 @@ public class NotificationResourceTest extends DbIsolatedTest {
                 .collect(Collectors.toList());
     }
 
-    private Set<UUID> getEventTypeIds(String tenant, UUID behaviorGroupId) {
+    private Set<UUID> getEventTypeIds(String tenant, String orgId, UUID behaviorGroupId) {
         return helpers
-                .findEventTypesByBehaviorGroupId(tenant, behaviorGroupId)
+                .findEventTypesByBehaviorGroupId(tenant, orgId, behaviorGroupId)
                 .stream()
                 .map(EventType::getId)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
The create behavior group (and the update) will now accept the eventTypes(ids) and endpoints(ids) properties.

If these are provided (not null) the create event will create all the required relations.

For the update, it will act as a "set" and the backend will remove current relations that were not specified in the current request and add those that were not currently set.

New request objects were created to make the request explicit on what is expecting, instead of relaying on guessing if the attributes of the BehaviorGroup are used in the request or not.