### PR TITLE
NOTIF-603 Introduce orgId in engine repositories

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/OrgIdHelper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/OrgIdHelper.java
@@ -1,0 +1,17 @@
+package com.redhat.cloud.notifications;
+
+import com.redhat.cloud.notifications.config.FeatureFlipper;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class OrgIdHelper {
+
+    @Inject
+    FeatureFlipper featureFlipper;
+
+    public boolean useOrgId(String orgId) {
+        return featureFlipper.isUseOrgId() && orgId != null && !orgId.isBlank();
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.OrgIdHelper;
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 
@@ -13,14 +14,28 @@ public class EmailSubscriptionRepository {
     @Inject
     StatelessSessionFactory statelessSessionFactory;
 
-    public List<String> getEmailSubscribersUserId(String accountNumber, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
-        String query = "SELECT es.id.userId FROM EmailSubscription es WHERE id.accountId = :accountId AND application.bundle.name = :bundleName " +
-                "AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
-        return statelessSessionFactory.getCurrentSession().createQuery(query, String.class)
-                .setParameter("accountId", accountNumber)
-                .setParameter("bundleName", bundleName)
-                .setParameter("applicationName", applicationName)
-                .setParameter("subscriptionType", subscriptionType)
-                .getResultList();
+    @Inject
+    OrgIdHelper orgIdHelper;
+
+    public List<String> getEmailSubscribersUserId(String accountId, String orgId, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT es.id.userId FROM EmailSubscription es WHERE id.orgId = :orgId AND application.bundle.name = :bundleName " +
+                    "AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
+            return statelessSessionFactory.getCurrentSession().createQuery(query, String.class)
+                    .setParameter("orgId", orgId)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("applicationName", applicationName)
+                    .setParameter("subscriptionType", subscriptionType)
+                    .getResultList();
+        } else {
+            String query = "SELECT es.id.userId FROM EmailSubscription es WHERE id.accountId = :accountId AND application.bundle.name = :bundleName " +
+                    "AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
+            return statelessSessionFactory.getCurrentSession().createQuery(query, String.class)
+                    .setParameter("accountId", accountId)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("applicationName", applicationName)
+                    .setParameter("subscriptionType", subscriptionType)
+                    .getResultList();
+        }
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.OrgIdHelper;
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
@@ -31,6 +32,9 @@ public class EndpointRepository {
     @Inject
     StatelessSessionFactory statelessSessionFactory;
 
+    @Inject
+    OrgIdHelper orgIdHelper;
+
     /**
      * The purpose of this method is to find or create an EMAIL_SUBSCRIPTION endpoint with empty properties. This
      * endpoint is used to aggregate and store in the DB the email actions outcome, which will be used later by the
@@ -38,12 +42,21 @@ public class EndpointRepository {
      * multiple endpoints and recipients settings. The properties created below have no impact on the resolution of the
      * action recipients.
      */
-    public Endpoint getOrCreateDefaultEmailSubscription(String accountId) {
-        String query = "FROM Endpoint WHERE accountId = :accountId AND compositeType.type = :endpointType";
-        List<Endpoint> emailEndpoints = statelessSessionFactory.getCurrentSession().createQuery(query, Endpoint.class)
-                .setParameter("accountId", accountId)
-                .setParameter("endpointType", EMAIL_SUBSCRIPTION)
-                .getResultList();
+    public Endpoint getOrCreateDefaultEmailSubscription(String accountId, String orgId) {
+        List<Endpoint> emailEndpoints;
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "FROM Endpoint WHERE orgId = :orgId AND compositeType.type = :endpointType";
+            emailEndpoints = statelessSessionFactory.getCurrentSession().createQuery(query, Endpoint.class)
+                    .setParameter("orgId", orgId)
+                    .setParameter("endpointType", EMAIL_SUBSCRIPTION)
+                    .getResultList();
+        } else {
+            String query = "FROM Endpoint WHERE accountId = :accountId AND compositeType.type = :endpointType";
+            emailEndpoints = statelessSessionFactory.getCurrentSession().createQuery(query, Endpoint.class)
+                    .setParameter("accountId", accountId)
+                    .setParameter("endpointType", EMAIL_SUBSCRIPTION)
+                    .getResultList();
+        }
         loadProperties(emailEndpoints);
 
         EmailSubscriptionProperties properties = new EmailSubscriptionProperties();
@@ -58,6 +71,7 @@ public class EndpointRepository {
         Endpoint endpoint = new Endpoint();
         endpoint.setProperties(properties);
         endpoint.setAccountId(accountId);
+        endpoint.setOrgId(orgId);
         endpoint.setEnabled(true);
         endpoint.setDescription("System email endpoint");
         endpoint.setName("Email endpoint");
@@ -70,40 +84,76 @@ public class EndpointRepository {
         return endpoint;
     }
 
-    public List<Endpoint> getTargetEndpoints(String tenant, EventType eventType) {
-        String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
-                "WHERE e.enabled IS TRUE AND b.eventType = :eventType AND (bga.behaviorGroup.accountId = :accountId OR bga.behaviorGroup.accountId IS NULL)";
+    public List<Endpoint> getTargetEndpoints(String accountId, String orgId, EventType eventType) {
+        List<Endpoint> endpoints;
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
+                    "WHERE e.enabled IS TRUE AND b.eventType = :eventType AND (bga.behaviorGroup.orgId = :orgId OR bga.behaviorGroup.orgId IS NULL)";
 
-        List<Endpoint> endpoints = statelessSessionFactory.getCurrentSession().createQuery(query, Endpoint.class)
-                .setParameter("eventType", eventType)
-                .setParameter("accountId", tenant)
-                .getResultList();
+            endpoints = statelessSessionFactory.getCurrentSession().createQuery(query, Endpoint.class)
+                    .setParameter("eventType", eventType)
+                    .setParameter("orgId", orgId)
+                    .getResultList();
+        } else {
+            String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
+                    "WHERE e.enabled IS TRUE AND b.eventType = :eventType AND (bga.behaviorGroup.accountId = :accountId OR bga.behaviorGroup.accountId IS NULL)";
+            endpoints = statelessSessionFactory.getCurrentSession().createQuery(query, Endpoint.class)
+                    .setParameter("eventType", eventType)
+                    .setParameter("accountId", accountId)
+                    .getResultList();
+        }
         loadProperties(endpoints);
         for (Endpoint endpoint : endpoints) {
-            if (endpoint.getAccountId() == null) {
-                if (endpoint.getType() == EMAIL_SUBSCRIPTION) {
-                    endpoint.setAccountId(tenant);
-                } else {
-                    Log.warnf("Invalid endpoint configured in default behavior group: %s", endpoint.getId());
+            if (orgIdHelper.useOrgId(orgId)) {
+                if (endpoint.getOrgId() == null) {
+                    if (endpoint.getType() == EMAIL_SUBSCRIPTION) {
+                        endpoint.setOrgId(orgId);
+                    } else {
+                        Log.warnf("Invalid endpoint configured in default behavior group: %s", endpoint.getId());
+                    }
+                }
+            } else {
+                if (endpoint.getAccountId() == null) {
+                    if (endpoint.getType() == EMAIL_SUBSCRIPTION) {
+                        endpoint.setAccountId(accountId);
+                    } else {
+                        Log.warnf("Invalid endpoint configured in default behavior group: %s", endpoint.getId());
+                    }
                 }
             }
         }
         return endpoints;
     }
 
-    public List<Endpoint> getTargetEmailSubscriptionEndpoints(String tenant, String bundleName, String applicationName, String eventTypeName) {
-        String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
-                "WHERE e.enabled IS TRUE AND b.eventType.name = :eventTypeName AND (bga.behaviorGroup.accountId = :accountId OR bga.behaviorGroup.accountId IS NULL) " +
-                "AND b.eventType.application.name = :applicationName AND b.eventType.application.bundle.name = :bundleName " +
-                "AND e.compositeType.type = :endpointType";
+    public List<Endpoint> getTargetEmailSubscriptionEndpoints(String accountId, String orgId, String bundleName, String applicationName, String eventTypeName) {
+        List<Endpoint> endpoints;
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
+                    "WHERE e.enabled IS TRUE AND b.eventType.name = :eventTypeName AND (bga.behaviorGroup.orgId = :orgId OR bga.behaviorGroup.orgId IS NULL) " +
+                    "AND b.eventType.application.name = :applicationName AND b.eventType.application.bundle.name = :bundleName " +
+                    "AND e.compositeType.type = :endpointType";
 
-        List<Endpoint> endpoints = statelessSessionFactory.getCurrentSession().createQuery(query, Endpoint.class)
-                .setParameter("applicationName", applicationName)
-                .setParameter("eventTypeName", eventTypeName)
-                .setParameter("accountId", tenant)
-                .setParameter("bundleName", bundleName)
-                .setParameter("endpointType", EMAIL_SUBSCRIPTION)
-                .getResultList();
+            endpoints = statelessSessionFactory.getCurrentSession().createQuery(query, Endpoint.class)
+                    .setParameter("applicationName", applicationName)
+                    .setParameter("eventTypeName", eventTypeName)
+                    .setParameter("orgId", orgId)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("endpointType", EMAIL_SUBSCRIPTION)
+                    .getResultList();
+        } else {
+            String query = "SELECT DISTINCT e FROM Endpoint e JOIN e.behaviorGroupActions bga JOIN bga.behaviorGroup.behaviors b " +
+                    "WHERE e.enabled IS TRUE AND b.eventType.name = :eventTypeName AND (bga.behaviorGroup.accountId = :accountId OR bga.behaviorGroup.accountId IS NULL) " +
+                    "AND b.eventType.application.name = :applicationName AND b.eventType.application.bundle.name = :bundleName " +
+                    "AND e.compositeType.type = :endpointType";
+
+            endpoints = statelessSessionFactory.getCurrentSession().createQuery(query, Endpoint.class)
+                    .setParameter("applicationName", applicationName)
+                    .setParameter("eventTypeName", eventTypeName)
+                    .setParameter("accountId", accountId)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("endpointType", EMAIL_SUBSCRIPTION)
+                    .getResultList();
+        }
         loadProperties(endpoints);
         return endpoints;
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -57,7 +57,7 @@ public class EndpointProcessor {
 
     public void process(Event event) {
         processedItems.increment();
-        List<Endpoint> endpoints = endpointRepository.getTargetEndpoints(event.getAccountId(), event.getEventType());
+        List<Endpoint> endpoints = endpointRepository.getTargetEndpoints(event.getAccountId(), event.getOrgId(), event.getEventType());
 
         // Target endpoints are grouped by endpoint type.
         endpointTargeted.increment(endpoints.size());

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -48,7 +48,7 @@ public class EmailAggregator {
 
     private Set<String> getEmailSubscribers(EmailAggregationKey aggregationKey, EmailSubscriptionType emailSubscriptionType) {
         return Set.copyOf(emailSubscriptionRepository
-                .getEmailSubscribersUserId(aggregationKey.getAccountId(), aggregationKey.getBundle(), aggregationKey.getApplication(), emailSubscriptionType));
+                .getEmailSubscribersUserId(aggregationKey.getAccountId(), aggregationKey.getOrgId(), aggregationKey.getBundle(), aggregationKey.getApplication(), emailSubscriptionType));
     }
 
     public Map<User, Map<String, Object>> getAggregated(EmailAggregationKey aggregationKey, EmailSubscriptionType emailSubscriptionType, LocalDateTime start, LocalDateTime end) {
@@ -62,7 +62,7 @@ public class EmailAggregator {
             String eventType = getEventType(aggregation);
             // Let's retrieve these targets.
             Set<Endpoint> endpoints = Set.copyOf(endpointRepository
-                    .getTargetEmailSubscriptionEndpoints(aggregationKey.getAccountId(), aggregationKey.getBundle(), aggregationKey.getApplication(), eventType));
+                    .getTargetEmailSubscriptionEndpoints(aggregationKey.getAccountId(), aggregationKey.getOrgId(), aggregationKey.getBundle(), aggregationKey.getApplication(), eventType));
 
             // Now we want to determine who will actually receive the aggregation email.
             // All users who subscribed to the current application and subscription type combination are recipients candidates.

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
@@ -90,7 +90,7 @@ public class EmailSender {
 
         // uses canonical EmailSubscription
         try {
-            Endpoint endpoint = endpointRepository.getOrCreateDefaultEmailSubscription(action.getAccountId());
+            Endpoint endpoint = endpointRepository.getOrCreateDefaultEmailSubscription(action.getAccountId(), action.getOrgId());
             Notification notification = new Notification(event, endpoint);
 
             // TODO Add recipients processing from policies-notifications processing (failed recipients)

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -189,7 +189,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
         ).collect(Collectors.toSet());
 
         Set<String> subscribers = Set.copyOf(emailSubscriptionRepository
-                .getEmailSubscribersUserId(action.getAccountId(), action.getBundle(), action.getApplication(), emailSubscriptionType));
+                .getEmailSubscribersUserId(action.getAccountId(), action.getOrgId(), action.getBundle(), action.getApplication(), emailSubscriptionType));
 
         return recipientResolver.recipientUsers(action.getAccountId(), action.getOrgId(), requests, subscribers)
                 .stream()

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepositoryTest.java
@@ -115,7 +115,7 @@ public class EmailAggregationRepositoryTest {
             clearEmailAggregations();
             resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD1);
             resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
-            resourceHelpers.addEmailAggregation("other-account", ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
+            resourceHelpers.addEmailAggregation("other-account", "other-org-id", BUNDLE_NAME, APP_NAME, PAYLOAD2);
             resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, "other-bundle", APP_NAME, PAYLOAD2);
             resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, "other-app", PAYLOAD2);
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -158,7 +158,7 @@ public class LifecycleITest {
 
         // Get the account canonical email endpoint
         Endpoint emailEndpoint = statelessSessionFactory.withSession(statelessSession -> {
-            return getAccountCanonicalEmailEndpoint(accountId);
+            return getAccountCanonicalEmailEndpoint(accountId, orgId);
         });
 
         // Pushing a new message should trigger two webhook calls.
@@ -256,8 +256,8 @@ public class LifecycleITest {
                 .executeUpdate();
     }
 
-    Endpoint getAccountCanonicalEmailEndpoint(String accountId) {
-        return endpointRepository.getOrCreateDefaultEmailSubscription(accountId);
+    Endpoint getAccountCanonicalEmailEndpoint(String accountId, String orgId) {
+        return endpointRepository.getOrCreateDefaultEmailSubscription(accountId, orgId);
     }
 
     private Endpoint createWebhookEndpoint(String accountId, String secretToken) {


### PR DESCRIPTION
#1271 is too big and hard to rebase, so I'm breaking it down into smaller PRs.

This is step 3: introducing `orgId` in all notifications-engine repositories.