### PR TITLE
NOTIF-603 Polish the orgId migration in engine

### DIFF
--- a/aggregator/src/test/java/com/redhat/cloud/notifications/helpers/TestHelpers.java
+++ b/aggregator/src/test/java/com/redhat/cloud/notifications/helpers/TestHelpers.java
@@ -55,6 +55,7 @@ public class TestHelpers {
         ));
 
         emailActionMessage.setAccountId(tenant);
+        emailActionMessage.setOrgId(orgId);
 
         JsonObject payload = baseTransformer.transform(emailActionMessage);
         aggregation.setPayload(payload);

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/FromCamelHistoryFiller.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/FromCamelHistoryFiller.java
@@ -124,6 +124,7 @@ public class FromCamelHistoryFiller {
                 .withApplication("notifications")
                 .withEventType("integration-failed")
                 .withAccountId(ep != null ? ep.getAccountId() : "")
+                .withOrgId(ep != null && ep.getOrgId() != null ? ep.getOrgId() : "")
                 .withContext(contextBuilder.build())
                 .withTimestamp(LocalDateTime.now(ZoneOffset.UTC))
                 .withEvents(Collections.singletonList(event))

--- a/engine/src/main/java/com/redhat/cloud/notifications/models/EmailAggregationKey.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/models/EmailAggregationKey.java
@@ -51,20 +51,22 @@ public class EmailAggregationKey {
 
         EmailAggregationKey that = (EmailAggregationKey) o;
 
-        // TODO NOTIF-603 Add orgId
-        return Objects.equals(accountId, that.accountId) && Objects.equals(bundle, that.bundle) && Objects.equals(application, that.application);
+        return Objects.equals(accountId, that.accountId) &&
+                Objects.equals(orgId, that.orgId) &&
+                Objects.equals(bundle, that.bundle) &&
+                Objects.equals(application, that.application);
     }
 
     @Override
     public int hashCode() {
-        // TODO NOTIF-603 Add orgId
-        return Objects.hash(accountId, bundle, application);
+        return Objects.hash(accountId, orgId, bundle, application);
     }
 
     @Override
     public String toString() {
         return "EmailAggregationKey{" +
                 "accountId='" + accountId + '\'' +
+                ", orgId='" + orgId + '\'' +
                 ", bundle='" + bundle + '\'' +
                 ", application='" + application + '\'' +
                 '}';

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -41,6 +41,7 @@ import static com.redhat.cloud.notifications.events.KafkaMessageDeduplicator.MES
 import static com.redhat.cloud.notifications.models.NotificationHistory.getHistoryStub;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+// TODO NOTIF-603 Migrate to orgId (not started in this class)
 @ApplicationScoped
 public class CamelTypeProcessor implements EndpointTypeProcessor {
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.processors.email;
 
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
 import com.redhat.cloud.notifications.db.repositories.EmailSubscriptionRepository;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
@@ -41,6 +42,9 @@ public class EmailAggregator {
 
     @Inject
     EmailSubscriptionRepository emailSubscriptionRepository;
+
+    @Inject
+    FeatureFlipper featureFlipper;
 
     // This is manually used from the JSON payload instead of converting it to an Action and using getEventType()
     private static final String EVENT_TYPE_KEY = "event_type";
@@ -110,7 +114,7 @@ public class EmailAggregator {
 
     private void fillUsers(EmailAggregationKey aggregationKey, User user, Map<User, AbstractEmailPayloadAggregator> aggregated, EmailAggregation emailAggregation) {
         AbstractEmailPayloadAggregator aggregator = aggregated.computeIfAbsent(user, ignored -> EmailPayloadAggregatorFactory.by(aggregationKey));
-        aggregator.aggregate(emailAggregation);
+        aggregator.aggregate(emailAggregation, featureFlipper.isUseOrgId());
     }
 
     private String getEventType(EmailAggregation aggregation) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -136,6 +136,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
             if (shouldSaveAggregation) {
                 EmailAggregation aggregation = new EmailAggregation();
                 aggregation.setAccountId(action.getAccountId());
+                aggregation.setOrgId(action.getOrgId());
                 aggregation.setApplicationName(action.getApplication());
                 aggregation.setBundleName(action.getBundle());
 
@@ -281,6 +282,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
                 action.setContext(contextBuilder.build());
                 action.setEvents(List.of());
                 action.setAccountId(aggregationKey.getAccountId());
+                action.setOrgId(aggregationKey.getOrgId());
                 action.setApplication(aggregationKey.getApplication());
                 action.setBundle(aggregationKey.getBundle());
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AbstractEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AbstractEmailPayloadAggregator.java
@@ -14,6 +14,7 @@ public abstract class AbstractEmailPayloadAggregator {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private String accountId;
+    private String orgId;
     private int processedAggregations;
 
     JsonObject context = new JsonObject();
@@ -21,10 +22,19 @@ public abstract class AbstractEmailPayloadAggregator {
     abstract void processEmailAggregation(EmailAggregation aggregation);
 
     public void aggregate(EmailAggregation aggregation) {
+        aggregate(aggregation, false);
+    }
+
+    public void aggregate(EmailAggregation aggregation, boolean useOrgId) {
         if (accountId == null) {
             accountId = aggregation.getAccountId();
         } else if (!accountId.equals(aggregation.getAccountId())) {
             throw new RuntimeException("Invalid aggregation using different accountIds");
+        }
+        if (orgId == null) {
+            orgId = aggregation.getOrgId();
+        } else if (useOrgId && !orgId.equals(aggregation.getOrgId())) {
+            throw new RuntimeException("Invalid aggregation using different orgIds");
         }
 
         processEmailAggregation(aggregation);
@@ -52,6 +62,10 @@ public abstract class AbstractEmailPayloadAggregator {
 
     String getAccountId() {
         return accountId;
+    }
+
+    String getOrgId() {
+        return orgId;
     }
 
     public int getProcessedAggregations() {

--- a/engine/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
@@ -21,6 +21,7 @@ public class BaseTransformer {
         message.put("application", action.getApplication());
         message.put("event_type", action.getEventType());
         message.put("account_id", action.getAccountId());
+        message.put("org_id", action.getOrgId());
         message.put("timestamp", action.getTimestamp().toString());
         message.put("events", new JsonArray(action.getEvents().stream().map(event -> Map.of(
                 "metadata", JsonObject.mapFrom(event.getMetadata()),

--- a/engine/src/test/java/com/redhat/cloud/notifications/ComplianceTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ComplianceTestHelpers.java
@@ -12,6 +12,7 @@ import io.vertx.core.json.JsonObject;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static java.time.ZoneOffset.UTC;
 
 public class ComplianceTestHelpers {
@@ -23,6 +24,7 @@ public class ComplianceTestHelpers {
         aggregation.setBundleName(bundle);
         aggregation.setApplicationName(application);
         aggregation.setAccountId(tenant);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
         aggregation.setCreated(LocalDateTime.now(UTC).minusHours(5L));
 
         Action emailActionMessage = new Action();
@@ -54,6 +56,7 @@ public class ComplianceTestHelpers {
         ));
 
         emailActionMessage.setAccountId(tenant);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         JsonObject payload = baseTransformer.transform(emailActionMessage);
         aggregation.setPayload(payload);

--- a/engine/src/test/java/com/redhat/cloud/notifications/DriftTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/DriftTestHelpers.java
@@ -12,6 +12,8 @@ import io.vertx.core.json.JsonObject;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
 public class DriftTestHelpers {
 
     public static BaseTransformer baseTransformer = new BaseTransformer();
@@ -21,6 +23,7 @@ public class DriftTestHelpers {
         aggregation.setBundleName(bundle);
         aggregation.setApplicationName(application);
         aggregation.setAccountId(tenant);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
 
         Action emailActionMessage = new Action();
         emailActionMessage.setBundle(bundle);
@@ -49,6 +52,7 @@ public class DriftTestHelpers {
         ));
 
         emailActionMessage.setAccountId(tenant);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         JsonObject payload = baseTransformer.transform(emailActionMessage);
         aggregation.setPayload(payload);
@@ -93,6 +97,7 @@ public class DriftTestHelpers {
         ));
 
         emailActionMessage.setAccountId(tenant);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         return emailActionMessage;
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
 public class PatchTestHelpers {
 
     public static BaseTransformer baseTransformer = new BaseTransformer();
@@ -29,6 +31,7 @@ public class PatchTestHelpers {
         aggregation.setBundleName(bundle);
         aggregation.setApplicationName(application);
         aggregation.setAccountId(tenant);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
 
         Action emailActionMessage = new Action();
         emailActionMessage.setBundle(bundle);
@@ -52,6 +55,7 @@ public class PatchTestHelpers {
                         .build()
         ));
         emailActionMessage.setAccountId(tenant);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         JsonObject payload = baseTransformer.transform(emailActionMessage);
         aggregation.setPayload(payload);
@@ -64,6 +68,7 @@ public class PatchTestHelpers {
         aggregation.setBundleName(bundle);
         aggregation.setApplicationName(application);
         aggregation.setAccountId(tenant);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
 
         Action emailActionMessage = new Action();
         emailActionMessage = new Action();
@@ -106,6 +111,7 @@ public class PatchTestHelpers {
                 .build()
         ));
         emailActionMessage.setAccountId(tenant);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         JsonObject payload = baseTransformer.transform(emailActionMessage);
         aggregation.setPayload(payload);

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -13,6 +13,8 @@ import io.vertx.core.json.JsonObject;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
 public class TestHelpers {
 
     public static BaseTransformer baseTransformer = new BaseTransformer();
@@ -27,6 +29,7 @@ public class TestHelpers {
         aggregation.setBundleName(bundle);
         aggregation.setApplicationName(application);
         aggregation.setAccountId(tenant);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
 
         Action emailActionMessage = new Action();
         emailActionMessage.setBundle(bundle);
@@ -57,6 +60,7 @@ public class TestHelpers {
         ));
 
         emailActionMessage.setAccountId(tenant);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         JsonObject payload = baseTransformer.transform(emailActionMessage);
         aggregation.setPayload(payload);
@@ -110,6 +114,7 @@ public class TestHelpers {
         ));
 
         emailActionMessage.setAccountId(accountId);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         return emailActionMessage;
     }
@@ -121,6 +126,7 @@ public class TestHelpers {
         emailActionMessage.setTimestamp(LocalDateTime.of(2020, 10, 3, 15, 22, 13, 25));
         emailActionMessage.setEventType(eventType);
         emailActionMessage.setAccountId(accountId);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         if (eventType.equals("deactivated-recommendation")) {
             emailActionMessage.setContext(new Context.ContextBuilder().build());
@@ -225,6 +231,7 @@ public class TestHelpers {
         emailActionMessage.setTimestamp(LocalDateTime.of(2021, 5, 20, 15, 22, 13, 25));
         emailActionMessage.setEventType(eventType);
         emailActionMessage.setAccountId(accountId);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         if (eventType.equals("new-recommendation")) {
             emailActionMessage.setContext(

--- a/engine/src/test/java/com/redhat/cloud/notifications/VulnerabilityTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/VulnerabilityTestHelpers.java
@@ -13,6 +13,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
 public class VulnerabilityTestHelpers {
 
     public static BaseTransformer baseTransformer = new BaseTransformer();
@@ -20,11 +22,13 @@ public class VulnerabilityTestHelpers {
     public static EmailAggregation createEmailAggregation(String tenant, String bundle, String application, String eventType, String cve) {
         EmailAggregation aggregation = new EmailAggregation();
         aggregation.setAccountId(tenant);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
         aggregation.setBundleName(bundle);
         aggregation.setApplicationName(application);
 
         Action emailActionMessage = new Action();
         emailActionMessage.setAccountId(tenant);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
         emailActionMessage.setApplication(application);
         emailActionMessage.setBundle(bundle);
         emailActionMessage.setTimestamp(LocalDateTime.now());

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -21,6 +21,7 @@ import javax.transaction.Transactional;
 import java.security.SecureRandom;
 import java.util.UUID;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
 import static java.lang.Boolean.TRUE;
 
@@ -88,6 +89,7 @@ public class ResourceHelpers {
         Event event = new Event();
         event.setId(UUID.randomUUID());
         event.setAccountId("account-id");
+        event.setOrgId(DEFAULT_ORG_ID);
         event.setEventType(eventType);
         event.setEventTypeDisplayName(eventType.getDisplayName());
         event.setApplicationId(eventType.getApplication().getId());

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.events.KafkaMessageDeduplicator.MESSAGE_ID_HEADER;
 import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.processors.camel.CamelTypeProcessor.CAMEL_SUBTYPE_HEADER;
@@ -153,6 +154,7 @@ public class CamelTypeProcessorTest {
         // We need input data for the test.
         Event event = buildEvent();
         event.setAccountId("rhid123");
+        event.setOrgId(DEFAULT_ORG_ID);
         Endpoint endpoint = buildCamelEndpoint(event.getAction().getAccountId());
         endpoint.setSubType("slack");
 
@@ -213,6 +215,7 @@ public class CamelTypeProcessorTest {
 
         // Now try again, but the remote throws an error
         event.getAction().setAccountId("something-random");
+        event.getAction().setOrgId(DEFAULT_ORG_ID);
         result = processor.process(event, List.of(endpoint));
         assertEquals(1, result.size());
         // Metrics should report the same thing.
@@ -242,6 +245,7 @@ public class CamelTypeProcessorTest {
         action.setEventType("event-type");
         action.setTimestamp(LocalDateTime.now());
         action.setAccountId("account-id");
+        action.setOrgId(DEFAULT_ORG_ID);
         action.setRecipients(List.of());
         action.setContext(new Context.ContextBuilder().build());
         action.setEvents(
@@ -278,6 +282,7 @@ public class CamelTypeProcessorTest {
 
         Endpoint endpoint = new Endpoint();
         endpoint.setAccountId(accountId);
+        endpoint.setOrgId(DEFAULT_ORG_ID);
         endpoint.setType(CAMEL);
         endpoint.setSubType(SUB_TYPE);
         endpoint.setProperties(properties);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ComplianceEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ComplianceEmailAggregatorTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
 class ComplianceEmailAggregatorTest {
 
     private ComplianceEmailAggregator aggregator;
@@ -18,14 +20,16 @@ class ComplianceEmailAggregatorTest {
     }
 
     @Test
-    void emptyAggregatorHasNoAccountId() {
+    void emptyAggregatorHasNoAccountIdOrOrgId() {
         Assertions.assertNull(aggregator.getAccountId(), "Empty aggregator has no accountId");
+        Assertions.assertNull(aggregator.getOrgId(), "Empty aggregator has no orgId");
     }
 
     @Test
-    void shouldSetAccountNumber() {
+    void shouldSetAccountNumberAndOrgId() {
         aggregator.aggregate(ComplianceTestHelpers.createEmailAggregation("tenant", "rhel", "compliance", "report-upload-failed", "policyId", "inventoryId"));
         Assertions.assertEquals("tenant", aggregator.getAccountId());
+        Assertions.assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/DriftEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/DriftEmailPayloadAggregatorTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
 class DriftEmailPayloadAggregatorTest {
 
     private DriftEmailPayloadAggregator aggregator;
@@ -19,14 +21,16 @@ class DriftEmailPayloadAggregatorTest {
     }
 
     @Test
-    void emptyAggregatorHasNoAccountId() {
+    void emptyAggregatorHasNoAccountIdOrOrgId() {
         Assertions.assertNull(aggregator.getAccountId(), "Empty aggregator has no accountId");
+        Assertions.assertNull(aggregator.getOrgId(), "Empty aggregator has no orgId");
     }
 
     @Test
     void shouldHaveOneSingleHost() {
         aggregator.aggregate(DriftTestHelpers.createEmailAggregation("tenant", "rhel", "drift", "baseline_01", "baseline_1", "host-01", "Machine 1"));
         Assertions.assertEquals("tenant", aggregator.getAccountId());
+        Assertions.assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
 
         // 1 host
         Assertions.assertEquals(1, aggregator.getUniqueHostCount());

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregatorTest.java
@@ -9,6 +9,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
 public class PatchEmailPayloadAggregatorTest {
 
     private PatchEmailPayloadAggregator aggregator;
@@ -25,14 +27,16 @@ public class PatchEmailPayloadAggregatorTest {
     }
 
     @Test
-    void emptyAggregatorHasNoAccountId() {
+    void emptyAggregatorHasNoAccountIdOrOrgId() {
         Assertions.assertNull(aggregator.getAccountId(), "Empty aggregator has no accountId");
+        Assertions.assertNull(aggregator.getOrgId(), "Empty aggregator has no orgId");
     }
 
     @Test
-    void shouldSetAccountNumber() {
+    void shouldSetAccountNumberAndOrgId() {
         aggregator.aggregate(PatchTestHelpers.createEmailAggregation(tenant, bundle, application, "advisory", bugfix, "inventoryId"));
         Assertions.assertEquals("tenant", aggregator.getAccountId());
+        Assertions.assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PoliciesEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PoliciesEmailPayloadAggregatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -17,9 +18,10 @@ public class PoliciesEmailPayloadAggregatorTest {
     }
 
     @Test
-    void emptyAggregatorHasNoAccountId() {
+    void emptyAggregatorHasNoAccountIdOrOrgId() {
         PoliciesEmailPayloadAggregator aggregator = new PoliciesEmailPayloadAggregator();
         assertNull(aggregator.getAccountId(), "Empty aggregator has no accountId");
+        assertNull(aggregator.getOrgId(), "Empty aggregator has no orgId");
     }
 
     @Test
@@ -27,6 +29,7 @@ public class PoliciesEmailPayloadAggregatorTest {
         PoliciesEmailPayloadAggregator aggregator = new PoliciesEmailPayloadAggregator();
         aggregator.aggregate(TestHelpers.createEmailAggregation("tenant", "insights", "policies", "policy-01", "host-01"));
         assertEquals("tenant", aggregator.getAccountId());
+        assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
 
         // 1 host
         assertEquals(1, aggregator.getUniqueHostCount());

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/RhosakEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/RhosakEmailAggregatorTest.java
@@ -18,6 +18,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestHelpers.baseTransformer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,8 +49,9 @@ class RhosakEmailAggregatorTest {
     }
 
     @Test
-    void emptyAggregatorHasNoAccountId() {
+    void emptyAggregatorHasNoAccountIdOrOrgId() {
         assertNull(aggregator.getAccountId(), "Empty aggregator has no accountId");
+        assertNull(aggregator.getOrgId(), "Empty aggregator has no orgId");
     }
 
     @Test
@@ -202,6 +204,7 @@ class RhosakEmailAggregatorTest {
         aggregation.setBundleName(APPLICATION_SERVICES);
         aggregation.setApplicationName(RHOSAK);
         aggregation.setAccountId(ACCOUNT_ID);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
 
         Action emailActionMessage = new Action();
         emailActionMessage.setBundle(APPLICATION_SERVICES);
@@ -227,6 +230,7 @@ class RhosakEmailAggregatorTest {
         ));
 
         emailActionMessage.setAccountId(ACCOUNT_ID);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         JsonObject payload = baseTransformer.transform(emailActionMessage);
         aggregation.setPayload(payload);
@@ -239,6 +243,7 @@ class RhosakEmailAggregatorTest {
         aggregation.setBundleName(APPLICATION_SERVICES);
         aggregation.setApplicationName(RHOSAK);
         aggregation.setAccountId(ACCOUNT_ID);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
 
         Action emailActionMessage = new Action();
         emailActionMessage.setBundle(APPLICATION_SERVICES);
@@ -265,6 +270,7 @@ class RhosakEmailAggregatorTest {
         ));
 
         emailActionMessage.setAccountId(ACCOUNT_ID);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         JsonObject payload = baseTransformer.transform(emailActionMessage);
         aggregation.setPayload(payload);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregatorTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
 public class VulnerabilityEmailPayloadAggregatorTest {
 
     private VulnerabilityEmailPayloadAggregator aggregator;
@@ -26,14 +28,16 @@ public class VulnerabilityEmailPayloadAggregatorTest {
     }
 
     @Test
-    void emptyAggregatorHasNoAccountId() {
+    void emptyAggregatorHasNoAccountIdOrOrgId() {
         Assertions.assertNull(aggregator.getAccountId(), "Empty aggregator has no accountId");
+        Assertions.assertNull(aggregator.getOrgId(), "Empty aggregator has no orgId");
     }
 
     @Test
-    void shouldSetAccountNumber() {
+    void shouldSetAccountNumberAndOrgId() {
         aggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(tenant, bundle, application, CVSS_EVENT, "CVE-2021-0001"));
         Assertions.assertEquals(tenant, aggregator.getAccountId());
+        Assertions.assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -89,6 +90,7 @@ public class WebhookTest {
         assertEquals("WebhookTest", webhookInput.getString("application"));
         assertEquals("testWebhook", webhookInput.getString("event_type"));
         assertEquals("tenant", webhookInput.getString("account_id"));
+        assertEquals(DEFAULT_ORG_ID, webhookInput.getString("org_id"));
 
         JsonObject webhookInputContext = webhookInput.getJsonObject("context");
         assertEquals("more", webhookInputContext.getString("free"));
@@ -151,6 +153,7 @@ public class WebhookTest {
         webhookActionMessage.setTimestamp(LocalDateTime.of(2020, 10, 3, 15, 22, 13, 25));
         webhookActionMessage.setEventType("testWebhook");
         webhookActionMessage.setAccountId("tenant");
+        webhookActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         Payload payload1 = new Payload.PayloadBuilder()
                 .withAdditionalProperty("any", "thing")

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
@@ -1,0 +1,36 @@
+package com.redhat.cloud.notifications.transformers;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BaseTransformerTest {
+
+    private final BaseTransformer testee = new BaseTransformer();
+
+    @Test
+    void shouldContainOrgId() {
+        Action action = new Action();
+        action.setOrgId("someOrgId");
+        action.setTimestamp(LocalDateTime.of(2022, 12, 24, 12, 0));
+
+        final JsonObject jsonObject = testee.toJsonObject(action);
+
+        assertEquals("someOrgId", jsonObject.getString("org_id"));
+    }
+
+    @Test
+    void shouldNotRaiseAnExceptionWhenOrgIdIsMissing() {
+        Action action = new Action();
+        action.setTimestamp(LocalDateTime.of(2022, 12, 24, 12, 0));
+
+        final JsonObject jsonObject = testee.toJsonObject(action);
+
+        assertNull(jsonObject.getString("org_id"));
+    }
+}


### PR DESCRIPTION
This PR adds the `orgId` in most places where it was missing in `notifications-engine`.

After that, `CamelTypeProcessor` should be the only class where the `orgId` is missing. As explained below, it will be updated separately.