### PR TITLE
NOTIF-707 Introduce orgId in the Camel integration

### DIFF
--- a/engine/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
@@ -3,13 +3,16 @@ package com.redhat.cloud.notifications;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,7 +45,12 @@ public class MicrometerAssertionHelper {
                     .counters();
         for (Counter counter : counters) {
             Meter.Id id = counter.getId();
-            counterValuesBeforeTest.put(counterName, registry.counter(counterName, id.getTags()).count());
+            List<String> tags = new ArrayList<>();
+            for (Tag tag : id.getTags()) {
+                tags.add(tag.getKey());
+                tags.add(tag.getValue());
+            }
+            counterValuesBeforeTest.put(counterName + tags, registry.counter(counterName, id.getTags()).count());
         }
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -152,4 +152,11 @@ public class ResourceHelpers {
         entityManager.createQuery("DELETE FROM InstantEmailTemplate").executeUpdate();
         entityManager.createQuery("DELETE FROM AggregationEmailTemplate").executeUpdate();
     }
+
+    @Transactional
+    public void deleteEndpoint(UUID id) {
+        entityManager.createQuery("DELETE FROM Endpoint WHERE id = :id")
+                .setParameter("id", id)
+                .executeUpdate();
+    }
 }


### PR DESCRIPTION
This PR adds a new `rh-org-id` header to the Kafka messages sent on the `tocamel` topic when the orgId is enabled.