### PR TITLE
NOTIF-603 Add orgId to DB repositories and REST resources

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/rhid/RhIdPrincipal.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/rhid/RhIdPrincipal.java
@@ -11,4 +11,8 @@ public class RhIdPrincipal extends ConsolePrincipal<RhIdentity> {
     public String getAccount() {
         return getIdentity().getAccountNumber();
     }
+
+    public String getOrgId() {
+        return getIdentity().getOrgId();
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.OrgIdHelper;
 import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
@@ -37,19 +38,23 @@ public class BehaviorGroupRepository {
     @Inject
     FeatureFlipper featureFlipper;
 
-    public BehaviorGroup create(String accountId, @Valid BehaviorGroup behaviorGroup) {
-        return this.create(accountId, behaviorGroup, false);
+    @Inject
+    OrgIdHelper orgIdHelper;
+
+    public BehaviorGroup create(String accountId, String orgId, @Valid BehaviorGroup behaviorGroup) {
+        return this.create(accountId, orgId, behaviorGroup, false);
     }
 
     public BehaviorGroup createDefault(BehaviorGroup behaviorGroup) {
-        return this.create(null, behaviorGroup, true);
+        return this.create(null, null, behaviorGroup, true);
     }
 
     @Transactional
-    BehaviorGroup create(String accountId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {
-        checkBehaviorGroupDisplayNameDuplicate(accountId, behaviorGroup, isDefaultBehaviorGroup);
+    BehaviorGroup create(String accountId, String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {
+        checkBehaviorGroupDisplayNameDuplicate(accountId, orgId, behaviorGroup, isDefaultBehaviorGroup);
 
         behaviorGroup.setAccountId(accountId);
+        behaviorGroup.setOrgId(orgId);
         if (isDefaultBehaviorGroup != behaviorGroup.isDefaultBehavior()) {
             throw new BadRequestException(String.format(
                     "Unexpected default behavior group status: Expected [%s] found: [%s]",
@@ -69,9 +74,16 @@ public class BehaviorGroupRepository {
     }
 
     public List<BehaviorGroup> findDefaults() {
-        final String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
-                "WHERE b.accountId IS NULL " +
-                "ORDER BY b.created DESC, a.position ASC";
+        String query;
+        if (featureFlipper.isUseOrgId()) {
+            query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+                    "WHERE b.orgId IS NULL " +
+                    "ORDER BY b.created DESC, a.position ASC";
+        } else {
+            query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+                    "WHERE b.accountId IS NULL " +
+                    "ORDER BY b.created DESC, a.position ASC";
+        }
 
         List<BehaviorGroup> behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
                 .getResultList();
@@ -81,7 +93,7 @@ public class BehaviorGroupRepository {
         return behaviorGroups;
     }
 
-    public List<BehaviorGroup> findByBundleId(String accountId, UUID bundleId) {
+    public List<BehaviorGroup> findByBundleId(String accountId, String orgId, UUID bundleId) {
         Bundle bundle = entityManager.find(Bundle.class, bundleId);
         if (bundle == null) {
             throw new NotFoundException("Bundle not found");
@@ -94,53 +106,79 @@ public class BehaviorGroupRepository {
          * DISTINCT keyword to the DBMS. This is better for performances.
          * See https://in.relation.to/2016/08/04/introducing-distinct-pass-through-query-hint/ for more details about that hint.
          */
-        String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
-                "WHERE (b.accountId = :accountId OR b.accountId IS NULL) AND b.bundle.id = :bundleId " +
-                "ORDER BY b.created DESC, a.position ASC";
-        List<BehaviorGroup> behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
-                .setParameter("accountId", accountId)
-                .setParameter("bundleId", bundleId)
-                .setHint(HINT_PASS_DISTINCT_THROUGH, false)
-                .getResultList();
+        List<BehaviorGroup> behaviorGroups;
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+                    "WHERE (b.orgId = :orgId OR b.orgId IS NULL) AND b.bundle.id = :bundleId " +
+                    "ORDER BY b.created DESC, a.position ASC";
+            behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
+                    .setParameter("orgId", orgId)
+                    .setParameter("bundleId", bundleId)
+                    .setHint(HINT_PASS_DISTINCT_THROUGH, false)
+                    .getResultList();
+        } else {
+            String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+                    "WHERE (b.accountId = :accountId OR b.accountId IS NULL) AND b.bundle.id = :bundleId " +
+                    "ORDER BY b.created DESC, a.position ASC";
+            behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
+                    .setParameter("accountId", accountId)
+                    .setParameter("bundleId", bundleId)
+                    .setHint(HINT_PASS_DISTINCT_THROUGH, false)
+                    .getResultList();
+        }
         for (BehaviorGroup behaviorGroup : behaviorGroups) {
             behaviorGroup.filterOutBundle();
         }
         return behaviorGroups;
     }
 
-    public boolean update(String accountId, BehaviorGroup behaviorGroup) {
-        return this.update(accountId, behaviorGroup, false);
+    public boolean update(String accountId, String orgId, BehaviorGroup behaviorGroup) {
+        return this.update(accountId, orgId, behaviorGroup, false);
     }
 
     public boolean updateDefault(BehaviorGroup behaviorGroup) {
-        return this.update(null, behaviorGroup, true);
+        return this.update(null, null, behaviorGroup, true);
     }
 
     @Transactional
-    boolean update(String accountId, BehaviorGroup behaviorGroup, boolean isDefaultBehavior) {
-        checkBehaviorGroupDisplayNameDuplicate(accountId, behaviorGroup, isDefaultBehavior);
+    boolean update(String accountId, String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehavior) {
+        checkBehaviorGroupDisplayNameDuplicate(accountId, orgId, behaviorGroup, isDefaultBehavior);
 
         checkBehaviorGroup(behaviorGroup.getId(), isDefaultBehavior);
         String query = "UPDATE BehaviorGroup SET displayName = :displayName WHERE id = :id";
 
-        if (accountId == null) {
-            query += " AND accountId IS NULL";
+        if (featureFlipper.isUseOrgId()) {
+            if (orgId == null) {
+                query += " AND orgId IS NULL";
+            } else {
+                query += " AND orgId = :orgId";
+            }
         } else {
-            query += " AND accountId = :accountId";
+            if (accountId == null) {
+                query += " AND accountId IS NULL";
+            } else {
+                query += " AND accountId = :accountId";
+            }
         }
 
         javax.persistence.Query q = entityManager.createQuery(query)
                 .setParameter("displayName", behaviorGroup.getDisplayName())
                 .setParameter("id", behaviorGroup.getId());
 
-        if (accountId != null) {
-            q = q.setParameter("accountId", accountId);
+        if (featureFlipper.isUseOrgId()) {
+            if (orgId != null) {
+                q = q.setParameter("orgId", orgId);
+            }
+        } else {
+            if (accountId != null) {
+                q = q.setParameter("accountId", accountId);
+            }
         }
 
         return q.executeUpdate() > 0;
     }
 
-    private void checkBehaviorGroupDisplayNameDuplicate(String accountId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {
+    private void checkBehaviorGroupDisplayNameDuplicate(String accountId, String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {
         if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
             // The check is disabled from configuration.
             return;
@@ -150,10 +188,18 @@ public class BehaviorGroupRepository {
         if (behaviorGroup.getId() != null) { // The behavior group already exists in the DB, it's being updated.
             hql += " AND id != :behaviorGroupId";
         }
-        if (isDefaultBehaviorGroup) {
-            hql += " AND accountId IS NULL";
+        if (featureFlipper.isUseOrgId()) {
+            if (isDefaultBehaviorGroup) {
+                hql += " AND orgId IS NULL";
+            } else {
+                hql += " AND orgId = :orgId";
+            }
         } else {
-            hql += " AND accountId = :accountId";
+            if (isDefaultBehaviorGroup) {
+                hql += " AND accountId IS NULL";
+            } else {
+                hql += " AND accountId = :accountId";
+            }
         }
 
         TypedQuery<Long> query = entityManager.createQuery(hql, Long.class)
@@ -161,38 +207,58 @@ public class BehaviorGroupRepository {
         if (behaviorGroup.getId() != null) {
             query.setParameter("behaviorGroupId", behaviorGroup.getId());
         }
-        if (!isDefaultBehaviorGroup) {
-            query.setParameter("accountId", accountId);
+        if (featureFlipper.isUseOrgId()) {
+            if (!isDefaultBehaviorGroup) {
+                query.setParameter("orgId", orgId);
+            }
+        } else {
+            if (!isDefaultBehaviorGroup) {
+                query.setParameter("accountId", accountId);
+            }
         }
         if (query.getSingleResult() > 0) {
             throw new BadRequestException("A behavior group with display name [" + behaviorGroup.getDisplayName() + "] already exists");
         }
     }
 
-    public boolean delete(String accountId, UUID behaviorGroupId) {
-        return this.delete(accountId, behaviorGroupId, false);
+    public boolean delete(String accountId, String orgId, UUID behaviorGroupId) {
+        return this.delete(accountId, orgId, behaviorGroupId, false);
     }
 
     public boolean deleteDefault(UUID behaviorGroupId) {
-        return this.delete(null, behaviorGroupId, true);
+        return this.delete(null, null, behaviorGroupId, true);
     }
 
     @Transactional
-    public boolean delete(String accountId, UUID behaviorGroupId, boolean isDefaultBehavior) {
+    public boolean delete(String accountId, String orgId, UUID behaviorGroupId, boolean isDefaultBehavior) {
         checkBehaviorGroup(behaviorGroupId, isDefaultBehavior);
         String query = "DELETE FROM BehaviorGroup WHERE id = :id";
 
-        if (accountId == null) {
-            query += " AND accountId IS NULL";
+        if (featureFlipper.isUseOrgId()) {
+            if (orgId == null) {
+                query += " AND orgId IS NULL";
+            } else {
+                query += " AND orgId = :orgId";
+            }
         } else {
-            query += " AND accountId = :accountId";
+            if (accountId == null) {
+                query += " AND accountId IS NULL";
+            } else {
+                query += " AND accountId = :accountId";
+            }
         }
 
         javax.persistence.Query q = entityManager.createQuery(query)
                 .setParameter("id", behaviorGroupId);
 
-        if (accountId != null) {
-            q = q.setParameter("accountId", accountId);
+        if (featureFlipper.isUseOrgId()) {
+            if (orgId != null) {
+                q = q.setParameter("orgId", orgId);
+            }
+        } else {
+            if (accountId != null) {
+                q = q.setParameter("accountId", accountId);
+            }
         }
 
         return q.executeUpdate() > 0;
@@ -215,7 +281,7 @@ public class BehaviorGroupRepository {
     @Transactional
     public boolean unlinkEventTypeDefaultBehavior(UUID eventTypeId, UUID behaviorGroupId) {
         checkBehaviorGroup(behaviorGroupId, true);
-        String deleteQuery = "DELETE FROM EventTypeBehavior b " +
+        String deleteQuery = "DELETE FROM EventTypeBehavior " +
                 "WHERE eventType.id = :eventTypeId " +
                 "AND id.behaviorGroupId = :behaviorGroupId";
         entityManager.createQuery(deleteQuery)
@@ -226,7 +292,7 @@ public class BehaviorGroupRepository {
     }
 
     @Transactional
-    public void updateEventTypeBehaviors(String accountId, UUID eventTypeId, Set<UUID> behaviorGroupIds) {
+    public void updateEventTypeBehaviors(String accountId, String orgId, UUID eventTypeId, Set<UUID> behaviorGroupIds) {
         // First, let's make sure the event type exists.
         EventType eventType = entityManager.find(EventType.class, eventTypeId);
         if (eventType == null) {
@@ -251,13 +317,24 @@ public class BehaviorGroupRepository {
              * Before changing the DB data, we need to lock the existing rows "for update" to prevent them
              * from being modified or deleted by other transactions. Otherwise, DB deadlocks could happen.
              */
-            String lockQuery = "SELECT behaviorGroup.id FROM EventTypeBehavior " +
-                    "WHERE behaviorGroup.accountId = :accountId AND eventType.id = :eventTypeId";
-            List<UUID> behaviorsFromDb = entityManager.createQuery(lockQuery, UUID.class)
-                    .setParameter("accountId", accountId)
-                    .setParameter("eventTypeId", eventTypeId)
-                    .setLockMode(PESSIMISTIC_WRITE)
-                    .getResultList();
+            List<UUID> behaviorsFromDb;
+            if (orgIdHelper.useOrgId(orgId)) {
+                String lockQuery = "SELECT behaviorGroup.id FROM EventTypeBehavior " +
+                        "WHERE behaviorGroup.orgId = :orgId AND eventType.id = :eventTypeId";
+                behaviorsFromDb = entityManager.createQuery(lockQuery, UUID.class)
+                        .setParameter("orgId", orgId)
+                        .setParameter("eventTypeId", eventTypeId)
+                        .setLockMode(PESSIMISTIC_WRITE)
+                        .getResultList();
+            } else {
+                String lockQuery = "SELECT behaviorGroup.id FROM EventTypeBehavior " +
+                        "WHERE behaviorGroup.accountId = :accountId AND eventType.id = :eventTypeId";
+                behaviorsFromDb = entityManager.createQuery(lockQuery, UUID.class)
+                        .setParameter("accountId", accountId)
+                        .setParameter("eventTypeId", eventTypeId)
+                        .setLockMode(PESSIMISTIC_WRITE)
+                        .getResultList();
+            }
 
             /*
              * All event type behaviors that should no longer exist must be deleted.
@@ -281,50 +358,85 @@ public class BehaviorGroupRepository {
                 List<UUID> behaviorsToInsert = new ArrayList<>(behaviorGroupIds);
                 behaviorsToInsert.removeAll(behaviorsFromDb);
                 for (UUID behaviorGroupId : behaviorsToInsert) {
-                    String insertQuery = "INSERT INTO event_type_behavior (event_type_id, behavior_group_id, created) " +
-                            "SELECT :eventTypeId, :behaviorGroupId, :created " +
-                            "WHERE EXISTS (SELECT 1 FROM behavior_group WHERE account_id = :accountId AND id = :behaviorGroupId) " +
-                            "ON CONFLICT (event_type_id, behavior_group_id) DO NOTHING";
-                    entityManager.createNativeQuery(insertQuery)
-                            .setParameter("eventTypeId", eventTypeId)
-                            .setParameter("behaviorGroupId", behaviorGroupId)
-                            .setParameter("created", LocalDateTime.now(UTC))
-                            .setParameter("accountId", accountId)
-                            .executeUpdate();
+                    if (orgIdHelper.useOrgId(orgId)) {
+                        String insertQuery = "INSERT INTO event_type_behavior (event_type_id, behavior_group_id, created) " +
+                                "SELECT :eventTypeId, :behaviorGroupId, :created " +
+                                "WHERE EXISTS (SELECT 1 FROM behavior_group WHERE org_id = :orgId AND id = :behaviorGroupId) " +
+                                "ON CONFLICT (event_type_id, behavior_group_id) DO NOTHING";
+                        entityManager.createNativeQuery(insertQuery)
+                                .setParameter("eventTypeId", eventTypeId)
+                                .setParameter("behaviorGroupId", behaviorGroupId)
+                                .setParameter("created", LocalDateTime.now(UTC))
+                                .setParameter("orgId", orgId)
+                                .executeUpdate();
+                    } else {
+                        String insertQuery = "INSERT INTO event_type_behavior (event_type_id, behavior_group_id, created) " +
+                                "SELECT :eventTypeId, :behaviorGroupId, :created " +
+                                "WHERE EXISTS (SELECT 1 FROM behavior_group WHERE account_id = :accountId AND id = :behaviorGroupId) " +
+                                "ON CONFLICT (event_type_id, behavior_group_id) DO NOTHING";
+                        entityManager.createNativeQuery(insertQuery)
+                                .setParameter("eventTypeId", eventTypeId)
+                                .setParameter("behaviorGroupId", behaviorGroupId)
+                                .setParameter("created", LocalDateTime.now(UTC))
+                                .setParameter("accountId", accountId)
+                                .executeUpdate();
+                    }
                 }
             }
         }
     }
 
-    public List<EventType> findEventTypesByBehaviorGroupId(String accountId, UUID behaviorGroupId) {
+    public List<EventType> findEventTypesByBehaviorGroupId(String accountId, String orgId, UUID behaviorGroupId) {
         BehaviorGroup behaviorGroup = entityManager.find(BehaviorGroup.class, behaviorGroupId);
         if (behaviorGroup == null) {
             throw new NotFoundException("Behavior group not found");
         }
 
-        String query = "SELECT e FROM EventType e LEFT JOIN FETCH e.application JOIN e.behaviors b " +
-                "WHERE (b.behaviorGroup.accountId = :accountId OR b.behaviorGroup.accountId IS NULL) AND b.behaviorGroup.id = :behaviorGroupId";
-        return entityManager.createQuery(query, EventType.class)
-                .setParameter("accountId", accountId)
-                .setParameter("behaviorGroupId", behaviorGroupId)
-                .getResultList();
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT e FROM EventType e LEFT JOIN FETCH e.application JOIN e.behaviors b " +
+                    "WHERE (b.behaviorGroup.orgId = :orgId OR b.behaviorGroup.orgId IS NULL) AND b.behaviorGroup.id = :behaviorGroupId";
+            return entityManager.createQuery(query, EventType.class)
+                    .setParameter("orgId", orgId)
+                    .setParameter("behaviorGroupId", behaviorGroupId)
+                    .getResultList();
+        } else {
+            String query = "SELECT e FROM EventType e LEFT JOIN FETCH e.application JOIN e.behaviors b " +
+                    "WHERE (b.behaviorGroup.accountId = :accountId OR b.behaviorGroup.accountId IS NULL) AND b.behaviorGroup.id = :behaviorGroupId";
+            return entityManager.createQuery(query, EventType.class)
+                    .setParameter("accountId", accountId)
+                    .setParameter("behaviorGroupId", behaviorGroupId)
+                    .getResultList();
+        }
     }
 
-    public List<BehaviorGroup> findBehaviorGroupsByEventTypeId(String accountId, UUID eventTypeId, Query limiter) {
+    public List<BehaviorGroup> findBehaviorGroupsByEventTypeId(String accountId, String orgId, UUID eventTypeId, Query limiter) {
         EventType eventType = entityManager.find(EventType.class, eventTypeId);
         if (eventType == null) {
             throw new NotFoundException("Event type not found");
         }
 
-        String query = "SELECT bg FROM BehaviorGroup bg JOIN bg.behaviors b WHERE (bg.accountId = :accountId OR bg.accountId IS NULL) AND b.eventType.id = :eventTypeId";
+        TypedQuery<BehaviorGroup> typedQuery;
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT bg FROM BehaviorGroup bg JOIN bg.behaviors b WHERE (bg.orgId = :orgId OR bg.orgId IS NULL) AND b.eventType.id = :eventTypeId";
 
-        if (limiter != null) {
-            query = limiter.getModifiedQuery(query);
+            if (limiter != null) {
+                query = limiter.getModifiedQuery(query);
+            }
+
+            typedQuery = entityManager.createQuery(query, BehaviorGroup.class)
+                    .setParameter("orgId", orgId)
+                    .setParameter("eventTypeId", eventTypeId);
+        } else {
+            String query = "SELECT bg FROM BehaviorGroup bg JOIN bg.behaviors b WHERE (bg.accountId = :accountId OR bg.accountId IS NULL) AND b.eventType.id = :eventTypeId";
+
+            if (limiter != null) {
+                query = limiter.getModifiedQuery(query);
+            }
+
+            typedQuery = entityManager.createQuery(query, BehaviorGroup.class)
+                    .setParameter("accountId", accountId)
+                    .setParameter("eventTypeId", eventTypeId);
         }
-
-        TypedQuery<BehaviorGroup> typedQuery = entityManager.createQuery(query, BehaviorGroup.class)
-                .setParameter("accountId", accountId)
-                .setParameter("eventTypeId", eventTypeId);
 
         if (limiter != null && limiter.getLimit() != null && limiter.getLimit().getLimit() > 0) {
             typedQuery = typedQuery.setMaxResults(limiter.getLimit().getLimit())
@@ -339,21 +451,35 @@ public class BehaviorGroupRepository {
     }
 
     @Transactional
-    public void updateBehaviorGroupActions(String accountId, UUID behaviorGroupId, List<UUID> endpointIds) {
+    public void updateBehaviorGroupActions(String accountId, String orgId, UUID behaviorGroupId, List<UUID> endpointIds) {
 
         // First, let's make sure the behavior group exists and is owned by the current account.
-        String checkBehaviorGroupQuery = "SELECT 1 FROM BehaviorGroup WHERE id = :id AND accountId ";
-        if (accountId == null) {
-            checkBehaviorGroupQuery += "IS NULL";
+        String checkBehaviorGroupQuery = "SELECT 1 FROM BehaviorGroup WHERE id = :id AND ";
+        if (featureFlipper.isUseOrgId()) {
+            if (orgId == null) {
+                checkBehaviorGroupQuery += "orgId IS NULL";
+            } else {
+                checkBehaviorGroupQuery += "orgId = :orgId";
+            }
         } else {
-            checkBehaviorGroupQuery += "= :accountId";
+            if (accountId == null) {
+                checkBehaviorGroupQuery += "accountId IS NULL";
+            } else {
+                checkBehaviorGroupQuery += "accountId = :accountId";
+            }
         }
 
         TypedQuery<Integer> query = entityManager.createQuery(checkBehaviorGroupQuery, Integer.class)
                 .setParameter("id", behaviorGroupId);
 
-        if (accountId != null) {
-            query = query.setParameter("accountId", accountId);
+        if (featureFlipper.isUseOrgId()) {
+            if (orgId != null) {
+                query = query.setParameter("orgId", orgId);
+            }
+        } else {
+            if (accountId != null) {
+                query = query.setParameter("accountId", accountId);
+            }
         }
 
         try {
@@ -366,13 +492,27 @@ public class BehaviorGroupRepository {
          * Before changing the DB data, we need to lock the existing rows "for update" to prevent them
          * from being modified or deleted by other transactions. Otherwise, DB deadlocks could happen.
          */
-        String lockQuery = "SELECT endpoint.id FROM BehaviorGroupAction " +
-                "WHERE behaviorGroup.accountId = :accountId AND behaviorGroup.id = :behaviorGroupId";
-        List<UUID> actionsFromDb = entityManager.createQuery(lockQuery, UUID.class)
-                .setParameter("accountId", accountId)
-                .setParameter("behaviorGroupId", behaviorGroupId)
-                .setLockMode(PESSIMISTIC_WRITE)
-                .getResultList();
+        TypedQuery<UUID> lockQuery;
+        if (featureFlipper.isUseOrgId()) {
+            String lockHql = "SELECT endpoint.id FROM BehaviorGroupAction " +
+                    "WHERE behaviorGroup.orgId " + (orgId == null ? "IS NULL" : "= :orgId") + " AND behaviorGroup.id = :behaviorGroupId";
+            lockQuery = entityManager.createQuery(lockHql, UUID.class)
+                    .setParameter("behaviorGroupId", behaviorGroupId)
+                    .setLockMode(PESSIMISTIC_WRITE);
+            if (orgId != null) {
+                lockQuery = lockQuery.setParameter("orgId", orgId);
+            }
+        } else {
+            String lockHql = "SELECT endpoint.id FROM BehaviorGroupAction " +
+                    "WHERE behaviorGroup.accountId " + (accountId == null ? "IS NULL" : "= :accountId") + " AND behaviorGroup.id = :behaviorGroupId";
+            lockQuery = entityManager.createQuery(lockHql, UUID.class)
+                    .setParameter("behaviorGroupId", behaviorGroupId)
+                    .setLockMode(PESSIMISTIC_WRITE);
+            if (accountId != null) {
+                lockQuery = lockQuery.setParameter("accountId", accountId);
+            }
+        }
+        List<UUID> actionsFromDb = lockQuery.getResultList();
 
         /*
          * All behavior group actions that should no longer exist must be deleted.
@@ -395,12 +535,22 @@ public class BehaviorGroupRepository {
              * - otherwise, the action will be inserted into the database
              * In the end, all inserted or updated actions will have the same position than the endpointIds list order.
              */
-            String upsertQuery = "INSERT INTO behavior_group_action (behavior_group_id, endpoint_id, position, created) " +
-                    "SELECT :behaviorGroupId, :endpointId, :position, :created " +
-                    "WHERE EXISTS (SELECT 1 FROM endpoints WHERE account_id " +
-                    (accountId == null ? "IS NULL" : "= :accountId") +
-                    " AND id = :endpointId) " +
-                    "ON CONFLICT (behavior_group_id, endpoint_id) DO UPDATE SET position = :position";
+            String upsertQuery;
+            if (featureFlipper.isUseOrgId()) {
+                upsertQuery = "INSERT INTO behavior_group_action (behavior_group_id, endpoint_id, position, created) " +
+                        "SELECT :behaviorGroupId, :endpointId, :position, :created " +
+                        "WHERE EXISTS (SELECT 1 FROM endpoints WHERE orgId " +
+                        (orgId == null ? "IS NULL" : "= :orgId") +
+                        " AND id = :endpointId) " +
+                        "ON CONFLICT (behavior_group_id, endpoint_id) DO UPDATE SET position = :position";
+            } else {
+                upsertQuery = "INSERT INTO behavior_group_action (behavior_group_id, endpoint_id, position, created) " +
+                        "SELECT :behaviorGroupId, :endpointId, :position, :created " +
+                        "WHERE EXISTS (SELECT 1 FROM endpoints WHERE account_id " +
+                        (accountId == null ? "IS NULL" : "= :accountId") +
+                        " AND id = :endpointId) " +
+                        "ON CONFLICT (behavior_group_id, endpoint_id) DO UPDATE SET position = :position";
+            }
 
             var sessionQuery = entityManager.createNativeQuery(upsertQuery)
                     .setParameter("behaviorGroupId", behaviorGroupId)
@@ -408,8 +558,14 @@ public class BehaviorGroupRepository {
                     .setParameter("position", endpointIds.indexOf(endpointId))
                     .setParameter("created", LocalDateTime.now(UTC));
 
-            if (accountId != null) {
-                sessionQuery = sessionQuery.setParameter("accountId", accountId);
+            if (featureFlipper.isUseOrgId()) {
+                if (orgId != null) {
+                    sessionQuery = sessionQuery.setParameter("orgId", orgId);
+                }
+            } else {
+                if (accountId != null) {
+                    sessionQuery = sessionQuery.setParameter("accountId", accountId);
+                }
             }
 
             sessionQuery.executeUpdate();
@@ -417,20 +573,29 @@ public class BehaviorGroupRepository {
     }
 
     public void updateDefaultBehaviorGroupActions(UUID behaviorGroupId, List<UUID> endpointIds) {
-        updateBehaviorGroupActions(null, behaviorGroupId, endpointIds);
+        updateBehaviorGroupActions(null, null, behaviorGroupId, endpointIds);
     }
 
-    public List<BehaviorGroup> findBehaviorGroupsByEndpointId(String accountId, UUID endpointId) {
+    public List<BehaviorGroup> findBehaviorGroupsByEndpointId(String accountId, String orgId, UUID endpointId) {
         Endpoint endpoint = entityManager.find(Endpoint.class, endpointId);
         if (endpoint == null) {
             throw new NotFoundException("Endpoint not found");
         }
 
-        String query = "SELECT bg FROM BehaviorGroup bg LEFT JOIN FETCH bg.bundle JOIN bg.actions a WHERE bg.accountId = :accountId AND a.endpoint.id = :endpointId";
-        List<BehaviorGroup> behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
-                .setParameter("accountId", accountId)
-                .setParameter("endpointId", endpointId)
-                .getResultList();
+        List<BehaviorGroup> behaviorGroups;
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT bg FROM BehaviorGroup bg LEFT JOIN FETCH bg.bundle JOIN bg.actions a WHERE bg.orgId = :orgId AND a.endpoint.id = :endpointId";
+            behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
+                    .setParameter("orgId", orgId)
+                    .setParameter("endpointId", endpointId)
+                    .getResultList();
+        } else {
+            String query = "SELECT bg FROM BehaviorGroup bg LEFT JOIN FETCH bg.bundle JOIN bg.actions a WHERE bg.accountId = :accountId AND a.endpoint.id = :endpointId";
+            behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
+                    .setParameter("accountId", accountId)
+                    .setParameter("endpointId", endpointId)
+                    .getResultList();
+        }
         for (BehaviorGroup behaviorGroup : behaviorGroups) {
             behaviorGroup.filterOutActions();
         }
@@ -442,13 +607,25 @@ public class BehaviorGroupRepository {
         if (behaviorGroup == null) {
             throw new NotFoundException("Behavior group not found");
         } else {
-            if (isDefaultBehaviorGroup) {
-                if (behaviorGroup.getAccountId() != null) {
-                    throw new BadRequestException("Default behavior groups must have a null accountId");
+            if (featureFlipper.isUseOrgId()) {
+                if (isDefaultBehaviorGroup) {
+                    if (behaviorGroup.getOrgId() != null) {
+                        throw new BadRequestException("Default behavior groups must have a null accountId");
+                    }
+                } else {
+                    if (behaviorGroup.getOrgId() == null) {
+                        throw new BadRequestException("Only default behavior groups have a null accountId");
+                    }
                 }
             } else {
-                if (behaviorGroup.getAccountId() == null) {
-                    throw new BadRequestException("Only default behavior groups have a null accountId");
+                if (isDefaultBehaviorGroup) {
+                    if (behaviorGroup.getAccountId() != null) {
+                        throw new BadRequestException("Default behavior groups must have a null accountId");
+                    }
+                } else {
+                    if (behaviorGroup.getAccountId() == null) {
+                        throw new BadRequestException("Only default behavior groups have a null accountId");
+                    }
                 }
             }
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.OrgIdHelper;
 import com.redhat.cloud.notifications.models.EmailSubscription;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 
@@ -16,15 +17,19 @@ public class EmailSubscriptionRepository {
     @Inject
     EntityManager entityManager;
 
+    @Inject
+    OrgIdHelper orgIdHelper;
+
     @Transactional
-    public boolean subscribe(String accountNumber, String username, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
-        String query = "INSERT INTO endpoint_email_subscriptions(account_id, user_id, application_id, subscription_type) " +
-                "SELECT :accountId, :userId, a.id, :subscriptionType " +
+    public boolean subscribe(String accountNumber, String orgId, String username, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
+        String query = "INSERT INTO endpoint_email_subscriptions(account_id, org_id, user_id, application_id, subscription_type) " +
+                "SELECT :accountId, :orgId, :userId, a.id, :subscriptionType " +
                 "FROM applications a, bundles b WHERE a.bundle_id = b.id AND a.name = :applicationName AND b.name = :bundleName " +
                 "ON CONFLICT (account_id, org_id, user_id, application_id, subscription_type) DO NOTHING"; // The value is already on the database, this is OK
         // HQL does not support the ON CONFLICT clause so we need a native query here
         entityManager.createNativeQuery(query)
                 .setParameter("accountId", accountNumber)
+                .setParameter("orgId", orgId)
                 .setParameter("userId", username)
                 .setParameter("bundleName", bundleName)
                 .setParameter("applicationName", applicationName)
@@ -34,43 +39,82 @@ public class EmailSubscriptionRepository {
     }
 
     @Transactional
-    public boolean unsubscribe(String accountNumber, String username, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
-        String query = "DELETE FROM EmailSubscription WHERE id.accountId = :accountId AND id.userId = :userId " +
-                "AND id.applicationId = (SELECT a.id FROM Application a, Bundle b WHERE a.bundle.id = b.id " +
-                "AND b.name = :bundleName AND a.name = :applicationName) AND id.subscriptionType = :subscriptionType";
-        entityManager.createQuery(query)
-                .setParameter("accountId", accountNumber)
-                .setParameter("userId", username)
-                .setParameter("bundleName", bundleName)
-                .setParameter("applicationName", applicationName)
-                .setParameter("subscriptionType", subscriptionType)
-                .executeUpdate();
-        return true;
-    }
-
-    public EmailSubscription getEmailSubscription(String accountNumber, String username, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
-        String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
-                "WHERE es.id.accountId = :accountId AND es.id.userId = :userId " +
-                "AND b.name = :bundleName AND a.name = :applicationName AND es.id.subscriptionType = :subscriptionType";
-        try {
-            return entityManager.createQuery(query, EmailSubscription.class)
+    public boolean unsubscribe(String accountNumber, String orgId, String username, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "DELETE FROM EmailSubscription WHERE id.orgId = :orgId AND id.userId = :userId " +
+                    "AND id.applicationId = (SELECT a.id FROM Application a, Bundle b WHERE a.bundle.id = b.id " +
+                    "AND b.name = :bundleName AND a.name = :applicationName) AND id.subscriptionType = :subscriptionType";
+            entityManager.createQuery(query)
+                    .setParameter("orgId", orgId)
+                    .setParameter("userId", username)
+                    .setParameter("bundleName", bundleName)
+                    .setParameter("applicationName", applicationName)
+                    .setParameter("subscriptionType", subscriptionType)
+                    .executeUpdate();
+        } else {
+            String query = "DELETE FROM EmailSubscription WHERE id.accountId = :accountId AND id.userId = :userId " +
+                    "AND id.applicationId = (SELECT a.id FROM Application a, Bundle b WHERE a.bundle.id = b.id " +
+                    "AND b.name = :bundleName AND a.name = :applicationName) AND id.subscriptionType = :subscriptionType";
+            entityManager.createQuery(query)
                     .setParameter("accountId", accountNumber)
                     .setParameter("userId", username)
                     .setParameter("bundleName", bundleName)
                     .setParameter("applicationName", applicationName)
                     .setParameter("subscriptionType", subscriptionType)
-                    .getSingleResult();
-        } catch (NoResultException e) {
-            return null;
+                    .executeUpdate();
+        }
+        return true;
+    }
+
+    public EmailSubscription getEmailSubscription(String accountNumber, String orgId, String username, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
+                    "WHERE es.id.orgId = :orgId AND es.id.userId = :userId " +
+                    "AND b.name = :bundleName AND a.name = :applicationName AND es.id.subscriptionType = :subscriptionType";
+            try {
+                return entityManager.createQuery(query, EmailSubscription.class)
+                        .setParameter("orgId", orgId)
+                        .setParameter("userId", username)
+                        .setParameter("bundleName", bundleName)
+                        .setParameter("applicationName", applicationName)
+                        .setParameter("subscriptionType", subscriptionType)
+                        .getSingleResult();
+            } catch (NoResultException e) {
+                return null;
+            }
+        } else {
+            String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
+                    "WHERE es.id.accountId = :accountId AND es.id.userId = :userId " +
+                    "AND b.name = :bundleName AND a.name = :applicationName AND es.id.subscriptionType = :subscriptionType";
+            try {
+                return entityManager.createQuery(query, EmailSubscription.class)
+                        .setParameter("accountId", accountNumber)
+                        .setParameter("userId", username)
+                        .setParameter("bundleName", bundleName)
+                        .setParameter("applicationName", applicationName)
+                        .setParameter("subscriptionType", subscriptionType)
+                        .getSingleResult();
+            } catch (NoResultException e) {
+                return null;
+            }
         }
     }
 
-    public List<EmailSubscription> getEmailSubscriptionsForUser(String accountNumber, String username) {
-        String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
-                "WHERE es.id.accountId = :accountId AND es.id.userId = :userId";
-        return entityManager.createQuery(query, EmailSubscription.class)
-                .setParameter("accountId", accountNumber)
-                .setParameter("userId", username)
-                .getResultList();
+    public List<EmailSubscription> getEmailSubscriptionsForUser(String accountNumber, String orgId, String username) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
+                    "WHERE es.id.orgId = :orgId AND es.id.userId = :userId";
+            return entityManager.createQuery(query, EmailSubscription.class)
+                    .setParameter("orgId", orgId)
+                    .setParameter("userId", username)
+                    .getResultList();
+        } else {
+            String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
+                    "WHERE es.id.accountId = :accountId AND es.id.userId = :userId";
+            return entityManager.createQuery(query, EmailSubscription.class)
+                    .setParameter("accountId", accountNumber)
+                    .setParameter("userId", username)
+                    .getResultList();
+        }
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.OrgIdHelper;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.builder.QueryBuilder;
 import com.redhat.cloud.notifications.db.builder.WhereBuilder;
@@ -36,6 +38,12 @@ public class EndpointRepository {
 
     @Inject
     EntityManager entityManager;
+
+    @Inject
+    OrgIdHelper orgIdHelper;
+
+    @Inject
+    FeatureFlipper featureFlipper;
 
     @Transactional
     public Endpoint createEndpoint(Endpoint endpoint) {
@@ -79,11 +87,11 @@ public class EndpointRepository {
         return endpoint;
     }
 
-    public List<Endpoint> getEndpointsPerCompositeType(String accountId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly, Query limiter) {
+    public List<Endpoint> getEndpointsPerCompositeType(String accountId, String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly, Query limiter) {
 
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Query.Sort sort = limiter == null ? null : limiter.getSort();
-        List<Endpoint> endpoints = EndpointRepository.queryBuilderEndpointsPerType(accountId, name, type, activeOnly)
+        List<Endpoint> endpoints = EndpointRepository.queryBuilderEndpointsPerType(accountId, orgId, featureFlipper.isUseOrgId(), name, type, activeOnly)
                 .limit(limit)
                 .sort(sort)
                 .build(entityManager::createQuery)
@@ -92,21 +100,33 @@ public class EndpointRepository {
         return endpoints;
     }
 
-    public EndpointType getEndpointTypeById(String accountId, UUID endpointId) {
-        String query = "Select e.compositeType.type from Endpoint e WHERE e.accountId = :accountId AND e.id = :endpointId";
-        try {
-            return entityManager.createQuery(query, EndpointType.class)
-                    .setParameter("accountId", accountId)
-                    .setParameter("endpointId", endpointId)
-                    .getSingleResult();
-        } catch (NoResultException e) {
-            throw new NotFoundException("Endpoint not found");
+    public EndpointType getEndpointTypeById(String accountId, String orgId, UUID endpointId) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "Select e.compositeType.type from Endpoint e WHERE e.orgId = :orgId AND e.id = :endpointId";
+            try {
+                return entityManager.createQuery(query, EndpointType.class)
+                        .setParameter("orgId", orgId)
+                        .setParameter("endpointId", endpointId)
+                        .getSingleResult();
+            } catch (NoResultException e) {
+                throw new NotFoundException("Endpoint not found");
+            }
+        } else {
+            String query = "Select e.compositeType.type from Endpoint e WHERE e.accountId = :accountId AND e.id = :endpointId";
+            try {
+                return entityManager.createQuery(query, EndpointType.class)
+                        .setParameter("accountId", accountId)
+                        .setParameter("endpointId", endpointId)
+                        .getSingleResult();
+            } catch (NoResultException e) {
+                throw new NotFoundException("Endpoint not found");
+            }
         }
     }
 
     @Transactional
-    public Endpoint getOrCreateEmailSubscriptionEndpoint(String accountId, EmailSubscriptionProperties properties) {
-        List<Endpoint> emailEndpoints = getEndpointsPerCompositeType(accountId, null, Set.of(new CompositeEndpointType(EndpointType.EMAIL_SUBSCRIPTION)), null, null);
+    public Endpoint getOrCreateEmailSubscriptionEndpoint(String accountId, String orgId, EmailSubscriptionProperties properties) {
+        List<Endpoint> emailEndpoints = getEndpointsPerCompositeType(accountId, orgId, null, Set.of(new CompositeEndpointType(EndpointType.EMAIL_SUBSCRIPTION)), null, null);
         loadProperties(emailEndpoints);
         Optional<Endpoint> endpointOptional = emailEndpoints
                 .stream()
@@ -118,6 +138,7 @@ public class EndpointRepository {
         Endpoint endpoint = new Endpoint();
         endpoint.setProperties(properties);
         endpoint.setAccountId(accountId);
+        endpoint.setOrgId(orgId);
         endpoint.setEnabled(true);
         endpoint.setDescription("System email endpoint");
         endpoint.setName("Email endpoint");
@@ -126,33 +147,47 @@ public class EndpointRepository {
         return createEndpoint(endpoint);
     }
 
-    public Long getEndpointsCountPerCompositeType(String tenant, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly) {
-        return EndpointRepository.queryBuilderEndpointsPerType(tenant, name, type, activeOnly)
+    public Long getEndpointsCountPerCompositeType(String tenant, String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly) {
+        return EndpointRepository.queryBuilderEndpointsPerType(tenant, orgId, featureFlipper.isUseOrgId(), name, type, activeOnly)
                 .buildCount(entityManager::createQuery)
                 .getSingleResult();
     }
 
-    public QueryBuilder<Endpoint> getEndpointsQuery(String tenant, @Nullable String name) {
-        return QueryBuilder.builder(Endpoint.class)
-                .alias("e")
-                .where(
-                        WhereBuilder.builder()
-                                .and("e.accountId = :accountId", "accountId", tenant)
-                                .ifAnd(
-                                        name != null && !name.isEmpty(),
-                                        "LOWER(e.name) LIKE :name",
-                                        "name", (Supplier<String>) () -> "%" + name.toLowerCase() + "%"
-                                )
-                );
+    public QueryBuilder<Endpoint> getEndpointsQuery(String tenant, String orgId, @Nullable String name) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            return QueryBuilder.builder(Endpoint.class)
+                    .alias("e")
+                    .where(
+                            WhereBuilder.builder()
+                                    .and("e.orgId = :orgId", "orgId", orgId)
+                                    .ifAnd(
+                                            name != null && !name.isEmpty(),
+                                            "LOWER(e.name) LIKE :name",
+                                            "name", (Supplier<String>) () -> "%" + name.toLowerCase() + "%"
+                                    )
+                    );
+        } else {
+            return QueryBuilder.builder(Endpoint.class)
+                    .alias("e")
+                    .where(
+                            WhereBuilder.builder()
+                                    .and("e.accountId = :accountId", "accountId", tenant)
+                                    .ifAnd(
+                                            name != null && !name.isEmpty(),
+                                            "LOWER(e.name) LIKE :name",
+                                            "name", (Supplier<String>) () -> "%" + name.toLowerCase() + "%"
+                                    )
+                    );
+        }
     }
 
-    public List<Endpoint> getEndpoints(String tenant, @Nullable String name, Query limiter) {
+    public List<Endpoint> getEndpoints(String tenant, String orgId, @Nullable String name, Query limiter) {
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Query.Sort sort = limiter == null ? null : limiter.getSort();
 
         // TODO Add the ability to modify the getEndpoints to return also with JOIN to application_eventtypes_endpoints link table
         //      or should I just create a new method for it?
-        List<Endpoint> endpoints = getEndpointsQuery(tenant, name)
+        List<Endpoint> endpoints = getEndpointsQuery(tenant, orgId, name)
                 .limit(limit)
                 .sort(sort)
                 .build(entityManager::createQuery)
@@ -161,63 +196,101 @@ public class EndpointRepository {
         return endpoints;
     }
 
-    public Long getEndpointsCount(String tenant, @Nullable String name) {
-        return getEndpointsQuery(tenant, name)
+    public Long getEndpointsCount(String tenant, String orgId, @Nullable String name) {
+        return getEndpointsQuery(tenant, orgId, name)
                 .buildCount(entityManager::createQuery)
                 .getSingleResult();
     }
 
-    public Endpoint getEndpoint(String tenant, UUID id) {
-        String query = "SELECT e FROM Endpoint e WHERE e.accountId = :accountId AND e.id = :id";
-        try {
-            Endpoint endpoint = entityManager.createQuery(query, Endpoint.class)
-                    .setParameter("id", id)
-                    .setParameter("accountId", tenant)
-                    .getSingleResult();
-            loadProperties(endpoint);
-            return endpoint;
-        } catch (NoResultException e) {
-            return null;
+    public Endpoint getEndpoint(String tenant, String orgId, UUID id) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT e FROM Endpoint e WHERE e.orgId = :orgId AND e.id = :id";
+            try {
+                Endpoint endpoint = entityManager.createQuery(query, Endpoint.class)
+                        .setParameter("id", id)
+                        .setParameter("orgId", orgId)
+                        .getSingleResult();
+                loadProperties(endpoint);
+                return endpoint;
+            } catch (NoResultException e) {
+                return null;
+            }
+        } else {
+            String query = "SELECT e FROM Endpoint e WHERE e.accountId = :accountId AND e.id = :id";
+            try {
+                Endpoint endpoint = entityManager.createQuery(query, Endpoint.class)
+                        .setParameter("id", id)
+                        .setParameter("accountId", tenant)
+                        .getSingleResult();
+                loadProperties(endpoint);
+                return endpoint;
+            } catch (NoResultException e) {
+                return null;
+            }
         }
     }
 
     @Transactional
-    public boolean deleteEndpoint(String tenant, UUID id) {
-
-        String query = "DELETE FROM Endpoint WHERE accountId = :accountId AND id = :id";
-        int rowCount = entityManager.createQuery(query)
-                .setParameter("id", id)
-                .setParameter("accountId", tenant)
-                .executeUpdate();
-        return rowCount > 0;
+    public boolean deleteEndpoint(String tenant, String orgId, UUID id) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "DELETE FROM Endpoint WHERE orgId = :orgId AND id = :id";
+            int rowCount = entityManager.createQuery(query)
+                    .setParameter("id", id)
+                    .setParameter("orgId", orgId)
+                    .executeUpdate();
+            return rowCount > 0;
+        } else {
+            String query = "DELETE FROM Endpoint WHERE accountId = :accountId AND id = :id";
+            int rowCount = entityManager.createQuery(query)
+                    .setParameter("id", id)
+                    .setParameter("accountId", tenant)
+                    .executeUpdate();
+            return rowCount > 0;
+        }
         // Actually, the endpoint targeting this should be repeatable
     }
 
-    public boolean disableEndpoint(String tenant, UUID id) {
-        return modifyEndpointStatus(tenant, id, false);
+    public boolean disableEndpoint(String tenant, String orgId, UUID id) {
+        return modifyEndpointStatus(tenant, orgId, id, false);
     }
 
-    public boolean enableEndpoint(String tenant, UUID id) {
-        return modifyEndpointStatus(tenant, id, true);
+    public boolean enableEndpoint(String tenant, String orgId, UUID id) {
+        return modifyEndpointStatus(tenant, orgId, id, true);
     }
 
     @Transactional
-    boolean modifyEndpointStatus(String tenant, UUID id, boolean enabled) {
-        String query = "UPDATE Endpoint SET enabled = :enabled WHERE accountId = :accountId AND id = :id";
-        int rowCount = entityManager.createQuery(query)
-                .setParameter("id", id)
-                .setParameter("accountId", tenant)
-                .setParameter("enabled", enabled)
-                .executeUpdate();
-        return rowCount > 0;
+    boolean modifyEndpointStatus(String tenant, String orgId, UUID id, boolean enabled) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "UPDATE Endpoint SET enabled = :enabled WHERE orgId = :orgId AND id = :id";
+            int rowCount = entityManager.createQuery(query)
+                    .setParameter("id", id)
+                    .setParameter("orgId", orgId)
+                    .setParameter("enabled", enabled)
+                    .executeUpdate();
+            return rowCount > 0;
+        } else {
+            String query = "UPDATE Endpoint SET enabled = :enabled WHERE accountId = :accountId AND id = :id";
+            int rowCount = entityManager.createQuery(query)
+                    .setParameter("id", id)
+                    .setParameter("accountId", tenant)
+                    .setParameter("enabled", enabled)
+                    .executeUpdate();
+            return rowCount > 0;
+        }
     }
 
     @Transactional
     public boolean updateEndpoint(Endpoint endpoint) {
         // TODO Update could fail because the item did not exist, throw 404 in that case?
         // TODO Fix transaction so that we don't end up with half the updates applied
-        String endpointQuery = "UPDATE Endpoint SET name = :name, description = :description, enabled = :enabled " +
-                "WHERE accountId = :accountId AND id = :id";
+        String endpointQuery;
+        if (orgIdHelper.useOrgId(endpoint.getOrgId())) {
+            endpointQuery = "UPDATE Endpoint SET name = :name, description = :description, enabled = :enabled " +
+                    "WHERE orgId = :orgId AND id = :id";
+        } else {
+            endpointQuery = "UPDATE Endpoint SET name = :name, description = :description, enabled = :enabled " +
+                    "WHERE accountId = :accountId AND id = :id";
+        }
         String webhookQuery = "UPDATE WebhookProperties SET url = :url, method = :method, " +
                 "disableSslVerification = :disableSslVerification, secretToken = :secretToken WHERE endpoint.id = :endpointId";
         String camelQuery = "UPDATE CamelProperties SET url = :url, extras = :extras, " +
@@ -228,13 +301,24 @@ public class EndpointRepository {
             throw new RuntimeException("Unable to update an endpoint of type EMAIL_SUBSCRIPTION");
         }
 
-        int endpointRowCount = entityManager.createQuery(endpointQuery)
-                .setParameter("name", endpoint.getName())
-                .setParameter("description", endpoint.getDescription())
-                .setParameter("enabled", endpoint.isEnabled())
-                .setParameter("accountId", endpoint.getAccountId())
-                .setParameter("id", endpoint.getId())
-                .executeUpdate();
+        int endpointRowCount;
+        if (orgIdHelper.useOrgId(endpoint.getOrgId())) {
+            endpointRowCount = entityManager.createQuery(endpointQuery)
+                    .setParameter("name", endpoint.getName())
+                    .setParameter("description", endpoint.getDescription())
+                    .setParameter("enabled", endpoint.isEnabled())
+                    .setParameter("orgId", endpoint.getOrgId())
+                    .setParameter("id", endpoint.getId())
+                    .executeUpdate();
+        } else {
+            endpointRowCount = entityManager.createQuery(endpointQuery)
+                    .setParameter("name", endpoint.getName())
+                    .setParameter("description", endpoint.getDescription())
+                    .setParameter("enabled", endpoint.isEnabled())
+                    .setParameter("accountId", endpoint.getAccountId())
+                    .setParameter("id", endpoint.getId())
+                    .executeUpdate();
+        }
 
         if (endpointRowCount == 0) {
             return false;
@@ -304,31 +388,56 @@ public class EndpointRepository {
         }
     }
 
-    static QueryBuilder<Endpoint> queryBuilderEndpointsPerType(String accountId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly) {
+    static QueryBuilder<Endpoint> queryBuilderEndpointsPerType(String accountId, String orgId, boolean useOrgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly) {
         Set<EndpointType> basicTypes = type.stream().filter(c -> c.getSubType() == null).map(CompositeEndpointType::getType).collect(Collectors.toSet());
         Set<CompositeEndpointType> compositeTypes = type.stream().filter(c -> c.getSubType() != null).collect(Collectors.toSet());
-        return QueryBuilder
-                .builder(Endpoint.class)
-                .alias("e")
-                .where(
-                        WhereBuilder.builder()
-                            .ifElse(
-                                    accountId == null,
-                                    WhereBuilder.builder().and("e.accountId IS NULL"),
-                                    WhereBuilder.builder().and("e.accountId = :accountId", "accountId", accountId)
-                            )
-                            .and(
-                                    WhereBuilder.builder()
-                                            .ifOr(basicTypes.size() > 0, "e.compositeType.type IN (:endpointType)", "endpointType", basicTypes)
-                                            .ifOr(compositeTypes.size() > 0, "e.compositeType IN (:compositeTypes)", "compositeTypes", compositeTypes)
-                            )
-                            .ifAnd(activeOnly != null, "e.enabled = :enabled", "enabled", activeOnly)
-                            .ifAnd(
-                                    name != null && !name.isEmpty(),
-                                    "LOWER(e.name) LIKE :name",
-                                    "name", (Supplier<String>) () -> "%" + name.toLowerCase() + "%"
-                            )
-                );
+        if (useOrgId) {
+            return QueryBuilder
+                    .builder(Endpoint.class)
+                    .alias("e")
+                    .where(
+                            WhereBuilder.builder()
+                                    .ifElse(
+                                            orgId == null,
+                                            WhereBuilder.builder().and("e.orgId IS NULL"),
+                                            WhereBuilder.builder().and("e.orgId = :orgId", "orgId", orgId)
+                                    )
+                                    .and(
+                                            WhereBuilder.builder()
+                                                    .ifOr(basicTypes.size() > 0, "e.compositeType.type IN (:endpointType)", "endpointType", basicTypes)
+                                                    .ifOr(compositeTypes.size() > 0, "e.compositeType IN (:compositeTypes)", "compositeTypes", compositeTypes)
+                                    )
+                                    .ifAnd(activeOnly != null, "e.enabled = :enabled", "enabled", activeOnly)
+                                    .ifAnd(
+                                            name != null && !name.isEmpty(),
+                                            "LOWER(e.name) LIKE :name",
+                                            "name", (Supplier<String>) () -> "%" + name.toLowerCase() + "%"
+                                    )
+                    );
+        } else {
+            return QueryBuilder
+                    .builder(Endpoint.class)
+                    .alias("e")
+                    .where(
+                            WhereBuilder.builder()
+                                    .ifElse(
+                                            accountId == null,
+                                            WhereBuilder.builder().and("e.accountId IS NULL"),
+                                            WhereBuilder.builder().and("e.accountId = :accountId", "accountId", accountId)
+                                    )
+                                    .and(
+                                            WhereBuilder.builder()
+                                                    .ifOr(basicTypes.size() > 0, "e.compositeType.type IN (:endpointType)", "endpointType", basicTypes)
+                                                    .ifOr(compositeTypes.size() > 0, "e.compositeType IN (:compositeTypes)", "compositeTypes", compositeTypes)
+                                    )
+                                    .ifAnd(activeOnly != null, "e.enabled = :enabled", "enabled", activeOnly)
+                                    .ifAnd(
+                                            name != null && !name.isEmpty(),
+                                            "LOWER(e.name) LIKE :name",
+                                            "name", (Supplier<String>) () -> "%" + name.toLowerCase() + "%"
+                                    )
+                    );
+        }
     }
 
     public Endpoint loadProperties(Endpoint endpoint) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.OrgIdHelper;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
@@ -26,11 +27,14 @@ public class EventRepository {
     @Inject
     EntityManager entityManager;
 
-    public List<Event> getEvents(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
+    @Inject
+    OrgIdHelper orgIdHelper;
+
+    public List<Event> getEvents(String accountId, String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                       Set<Boolean> invocationResults, boolean fetchNotificationHistory, Integer limit, Integer offset, String sortBy) {
         Optional<String> orderByCondition = getOrderByCondition(sortBy);
-        List<UUID> eventIds = getEventIds(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, limit, offset, orderByCondition);
+        List<UUID> eventIds = getEventIds(accountId, orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, limit, offset, orderByCondition);
         String hql;
         if (fetchNotificationHistory) {
             hql = "SELECT DISTINCT e FROM Event e LEFT JOIN FETCH e.historyEntries he WHERE e.id IN (:eventIds)";
@@ -47,15 +51,20 @@ public class EventRepository {
                 .getResultList();
     }
 
-    public Long count(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
+    public Long count(String accountId, String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes,
                       Set<CompositeEndpointType> compositeEndpointTypes, Set<Boolean> invocationResults) {
-        String hql = "SELECT COUNT(*) FROM Event e WHERE e.accountId = :accountId";
+        String hql = "SELECT COUNT(*) FROM Event e WHERE ";
+        if (orgIdHelper.useOrgId(orgId)) {
+            hql += "e.orgId = :orgId";
+        } else {
+            hql += "e.accountId = :accountId";
+        }
 
         hql = addHqlConditions(hql, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults);
 
         TypedQuery<Long> query = entityManager.createQuery(hql, Long.class);
-        setQueryParams(query, accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults);
+        setQueryParams(query, accountId, orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults);
 
         return query.getSingleResult();
     }
@@ -79,10 +88,15 @@ public class EventRepository {
         }
     }
 
-    private List<UUID> getEventIds(String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
+    private List<UUID> getEventIds(String accountId, String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                         LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                         Set<Boolean> invocationResults, Integer limit, Integer offset, Optional<String> orderByCondition) {
-        String hql = "SELECT e.id FROM Event e WHERE e.accountId = :accountId";
+        String hql = "SELECT e.id FROM Event e WHERE ";
+        if (orgIdHelper.useOrgId(orgId)) {
+            hql += "e.orgId = :orgId";
+        } else {
+            hql += "e.accountId = :accountId";
+        }
 
         hql = addHqlConditions(hql, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults);
 
@@ -91,7 +105,7 @@ public class EventRepository {
         }
 
         TypedQuery<UUID> query = entityManager.createQuery(hql, UUID.class);
-        setQueryParams(query, accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults);
+        setQueryParams(query, accountId, orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults);
 
         if (limit != null) {
             query.setMaxResults(limit);
@@ -157,10 +171,14 @@ public class EventRepository {
         return hql;
     }
 
-    private static void setQueryParams(TypedQuery<?> query, String accountId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeName,
+    private void setQueryParams(TypedQuery<?> query, String accountId, String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeName,
                                        LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                        Set<Boolean> invocationResults) {
-        query.setParameter("accountId", accountId);
+        if (orgIdHelper.useOrgId(orgId)) {
+            query.setParameter("orgId", orgId);
+        } else {
+            query.setParameter("accountId", accountId);
+        }
         if (bundleIds != null && !bundleIds.isEmpty()) {
             query.setParameter("bundleIds", bundleIds);
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.OrgIdHelper;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import io.quarkus.logging.Log;
@@ -23,22 +24,39 @@ public class NotificationRepository {
     @Inject
     EntityManager entityManager;
 
-    public List<NotificationHistory> getNotificationHistory(String tenant, UUID endpoint, boolean includeDetails, Query limiter) {
+    @Inject
+    OrgIdHelper orgIdHelper;
+
+    public List<NotificationHistory> getNotificationHistory(String tenant, String orgId, UUID endpoint, boolean includeDetails, Query limiter) {
         String query = "SELECT NEW NotificationHistory(nh.id, nh.invocationTime, nh.invocationResult, nh.endpoint, nh.created";
         if (includeDetails) {
             query += ", nh.details";
         }
-        query += ") FROM NotificationHistory nh WHERE nh.event.accountId = :accountId AND nh.endpoint.id = :endpointId";
+        query += ") FROM NotificationHistory nh WHERE nh.endpoint.id = :endpointId AND ";
+        if (orgIdHelper.useOrgId(orgId)) {
+            query += "nh.event.orgId = :orgId";
+        } else {
+            query += "nh.event.accountId = :accountId";
+        }
 
         if (limiter != null) {
             query = limiter.getModifiedQuery(query);
         }
 
-        TypedQuery<NotificationHistory> historyQuery = entityManager.createQuery(query, NotificationHistory.class)
-                .setParameter("accountId", tenant)
-                .setParameter("endpointId", endpoint)
-                // Default limit to prevent OutOfMemoryError, it may be overridden below.
-                .setMaxResults(MAX_NOTIFICATION_HISTORY_RESULTS);
+        TypedQuery<NotificationHistory> historyQuery;
+        if (orgIdHelper.useOrgId(orgId)) {
+            historyQuery = entityManager.createQuery(query, NotificationHistory.class)
+                    .setParameter("orgId", orgId)
+                    .setParameter("endpointId", endpoint)
+                    // Default limit to prevent OutOfMemoryError, it may be overridden below.
+                    .setMaxResults(MAX_NOTIFICATION_HISTORY_RESULTS);
+        } else {
+            historyQuery = entityManager.createQuery(query, NotificationHistory.class)
+                    .setParameter("accountId", tenant)
+                    .setParameter("endpointId", endpoint)
+                    // Default limit to prevent OutOfMemoryError, it may be overridden below.
+                    .setMaxResults(MAX_NOTIFICATION_HISTORY_RESULTS);
+        }
 
         if (limiter != null && limiter.getLimit() != null && limiter.getLimit().getLimit() > 0) {
             if (limiter.getLimit().getLimit() > MAX_NOTIFICATION_HISTORY_RESULTS) {
@@ -54,21 +72,39 @@ public class NotificationRepository {
                 .getResultList();
     }
 
-    public JsonObject getNotificationDetails(String tenant, UUID endpoint, UUID historyId) {
-        String query = "SELECT details FROM NotificationHistory WHERE event.accountId = :accountId AND endpoint.id = :endpointId AND id = :historyId";
-        try {
-            Map<String, Object> map = entityManager.createQuery(query, Map.class)
-                    .setParameter("accountId", tenant)
-                    .setParameter("endpointId", endpoint)
-                    .setParameter("historyId", historyId)
-                    .getSingleResult();
-            if (map == null) {
+    public JsonObject getNotificationDetails(String tenant, String orgId, UUID endpoint, UUID historyId) {
+        if (orgIdHelper.useOrgId(orgId)) {
+            String query = "SELECT details FROM NotificationHistory WHERE event.orgId = :orgId AND endpoint.id = :endpointId AND id = :historyId";
+            try {
+                Map<String, Object> map = entityManager.createQuery(query, Map.class)
+                        .setParameter("orgId", orgId)
+                        .setParameter("endpointId", endpoint)
+                        .setParameter("historyId", historyId)
+                        .getSingleResult();
+                if (map == null) {
+                    return null;
+                } else {
+                    return new JsonObject(map);
+                }
+            } catch (NoResultException e) {
                 return null;
-            } else {
-                return new JsonObject(map);
             }
-        } catch (NoResultException e) {
-            return null;
+        } else {
+            String query = "SELECT details FROM NotificationHistory WHERE event.accountId = :accountId AND endpoint.id = :endpointId AND id = :historyId";
+            try {
+                Map<String, Object> map = entityManager.createQuery(query, Map.class)
+                        .setParameter("accountId", tenant)
+                        .setParameter("endpointId", endpoint)
+                        .setParameter("historyId", historyId)
+                        .getSingleResult();
+                if (map == null) {
+                    return null;
+                } else {
+                    return new JsonObject(map);
+                }
+            } catch (NoResultException e) {
+                return null;
+            }
         }
     }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
@@ -35,6 +35,7 @@ import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
 import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS;
 import static com.redhat.cloud.notifications.routers.EventResource.PATH;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getAccountId;
+import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -85,7 +86,8 @@ public class EventResource {
         }
 
         String accountId = getAccountId(securityContext);
-        List<Event> events = eventRepository.getEvents(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, limit, offset, sortBy);
+        String orgId = getOrgId(securityContext);
+        List<Event> events = eventRepository.getEvents(accountId, orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, limit, offset, sortBy);
         List<EventLogEntry> eventLogEntries = events.stream().map(event -> {
             List<EventLogEntryAction> actions;
             if (!includeActions) {
@@ -117,7 +119,7 @@ public class EventResource {
             }
             return entry;
         }).collect(Collectors.toList());
-        Long count = eventRepository.count(accountId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults);
+        Long count = eventRepository.count(accountId, orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults);
 
         Meta meta = new Meta();
         meta.setCount(count);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/SecurityContextUtil.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/SecurityContextUtil.java
@@ -27,6 +27,11 @@ public class SecurityContextUtil {
         return principal.getAccount();
     }
 
+    public static String getOrgId(SecurityContext securityContext) {
+        RhIdPrincipal principal = (RhIdPrincipal) securityContext.getUserPrincipal();
+        return principal.getOrgId();
+    }
+
     public void hasPermissionForRole(SecurityContext securityContext, String role) {
         if (securityContext.isUserInRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
             return;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -380,7 +380,7 @@ public class InternalResource {
             EmailSubscriptionProperties properties = new EmailSubscriptionProperties();
             properties.setOnlyAdmins(p.isOnlyAdmins());
             properties.setIgnorePreferences(p.isIgnorePreferences());
-            return endpointRepository.getOrCreateEmailSubscriptionEndpoint(null, properties);
+            return endpointRepository.getOrCreateEmailSubscriptionEndpoint(null, null, properties);
         }).collect(Collectors.toList());
         behaviorGroupRepository.updateDefaultBehaviorGroupActions(
                 behaviorGroupId,

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -111,26 +112,27 @@ public class ResourceHelpers {
         return bundle.getId();
     }
 
-    public Endpoint createEndpoint(String accountId, EndpointType type) {
-        return createEndpoint(accountId, type, null);
+    public Endpoint createEndpoint(String accountId, String orgId, EndpointType type) {
+        return createEndpoint(accountId, orgId, type, null);
     }
 
-    public Endpoint createEndpoint(String accountId, EndpointType type, String subType) {
-        return createEndpoint(accountId, type, subType, "name", "description", null, FALSE);
+    public Endpoint createEndpoint(String accountId, String orgId, EndpointType type, String subType) {
+        return createEndpoint(accountId, orgId, type, subType, "name", "description", null, FALSE);
     }
 
-    public UUID createWebhookEndpoint(String accountId) {
+    public UUID createWebhookEndpoint(String accountId, String orgId) {
         WebhookProperties properties = new WebhookProperties();
         properties.setMethod(HttpType.POST);
         properties.setUrl("https://localhost");
         String name = "Endpoint " + UUID.randomUUID();
-        return createEndpoint(accountId, WEBHOOK, null, name, "Automatically generated", properties, TRUE)
+        return createEndpoint(accountId, orgId, WEBHOOK, null, name, "Automatically generated", properties, TRUE)
                 .getId();
     }
 
-    public Endpoint createEndpoint(String accountId, EndpointType type, String subType, String name, String description, EndpointProperties properties, Boolean enabled) {
+    public Endpoint createEndpoint(String accountId, String orgId, EndpointType type, String subType, String name, String description, EndpointProperties properties, Boolean enabled) {
         Endpoint endpoint = new Endpoint();
         endpoint.setAccountId(accountId);
+        endpoint.setOrgId(orgId);
         endpoint.setType(type);
         endpoint.setSubType(subType);
         endpoint.setName(name);
@@ -140,7 +142,7 @@ public class ResourceHelpers {
         return endpointRepository.createEndpoint(endpoint);
     }
 
-    public int[] createTestEndpoints(String tenant, int count) {
+    public int[] createTestEndpoints(String tenant, String orgId, int count) {
         int[] statsValues = new int[3];
         statsValues[0] = count;
         for (int i = 0; i < count; i++) {
@@ -164,6 +166,7 @@ public class ResourceHelpers {
             }
 
             ep.setAccountId(tenant);
+            ep.setOrgId(orgId);
             endpointRepository.createEndpoint(ep);
         }
         return statsValues;
@@ -183,11 +186,11 @@ public class ResourceHelpers {
         return history;
     }
 
-    public BehaviorGroup createBehaviorGroup(String accountId, String displayName, UUID bundleId) {
+    public BehaviorGroup createBehaviorGroup(String accountId, String orgId, String displayName, UUID bundleId) {
         BehaviorGroup behaviorGroup = new BehaviorGroup();
         behaviorGroup.setDisplayName(displayName);
         behaviorGroup.setBundleId(bundleId);
-        return behaviorGroupRepository.create(accountId, behaviorGroup);
+        return behaviorGroupRepository.create(accountId, orgId, behaviorGroup);
     }
 
     public BehaviorGroup createDefaultBehaviorGroup(String displayName, UUID bundleId) {
@@ -198,23 +201,23 @@ public class ResourceHelpers {
     }
 
     public List<EventType> findEventTypesByBehaviorGroupId(UUID behaviorGroupId) {
-        return behaviorGroupRepository.findEventTypesByBehaviorGroupId(DEFAULT_ACCOUNT_ID, behaviorGroupId);
+        return behaviorGroupRepository.findEventTypesByBehaviorGroupId(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, behaviorGroupId);
     }
 
     public List<BehaviorGroup> findBehaviorGroupsByEventTypeId(UUID eventTypeId) {
-        return behaviorGroupRepository.findBehaviorGroupsByEventTypeId(DEFAULT_ACCOUNT_ID, eventTypeId, new Query());
+        return behaviorGroupRepository.findBehaviorGroupsByEventTypeId(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, eventTypeId, new Query());
     }
 
     public List<BehaviorGroup> findBehaviorGroupsByEndpointId(UUID endpointId) {
-        return behaviorGroupRepository.findBehaviorGroupsByEndpointId(DEFAULT_ACCOUNT_ID, endpointId);
+        return behaviorGroupRepository.findBehaviorGroupsByEndpointId(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, endpointId);
     }
 
     public Boolean updateBehaviorGroup(BehaviorGroup behaviorGroup) {
-        return behaviorGroupRepository.update(DEFAULT_ACCOUNT_ID, behaviorGroup);
+        return behaviorGroupRepository.update(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, behaviorGroup);
     }
 
     public Boolean deleteBehaviorGroup(UUID behaviorGroupId) {
-        return behaviorGroupRepository.delete(DEFAULT_ACCOUNT_ID, behaviorGroupId);
+        return behaviorGroupRepository.delete(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, behaviorGroupId);
     }
 
     public Boolean updateDefaultBehaviorGroup(BehaviorGroup behaviorGroup) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -26,6 +26,8 @@ public class EndpointRepositoryTest {
         EndpointRepository.queryBuilderEndpointsPerType(
                 null,
                 null,
+                false,
+                null,
                 Set.of(
                         new CompositeEndpointType(EndpointType.WEBHOOK),
                         new CompositeEndpointType(EndpointType.CAMEL, "splunk")
@@ -44,6 +46,8 @@ public class EndpointRepositoryTest {
         EndpointRepository.queryBuilderEndpointsPerType(
                 null,
                 null,
+                false,
+                null,
                 Set.of(
                         new CompositeEndpointType(EndpointType.WEBHOOK)
                 ),
@@ -60,6 +64,8 @@ public class EndpointRepositoryTest {
         // with sub-types
         EndpointRepository.queryBuilderEndpointsPerType(
                 null,
+                null,
+                false,
                 null,
                 Set.of(
                         new CompositeEndpointType(EndpointType.CAMEL, "splunk")

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/IntegrationTemplateRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/IntegrationTemplateRepositoryTest.java
@@ -42,14 +42,14 @@ public class IntegrationTemplateRepositoryTest extends DbIsolatedTest {
         Template genericSlack = createTemplate(GENERIC_SLACK, "The default", "The default");
         createIntegrationTemplate(genericSlack, IntegrationTemplate.TemplateKind.DEFAULT, SLACK);
 
-        Optional<IntegrationTemplate> ito = templateRepository.findIntegrationTemplate(null, null, IntegrationTemplate.TemplateKind.APPLICATION, SLACK);
+        Optional<IntegrationTemplate> ito = templateRepository.findIntegrationTemplate(null, null, null, IntegrationTemplate.TemplateKind.APPLICATION, SLACK);
         assertTrue(ito.isPresent());
         IntegrationTemplate it = ito.get();
         assertEquals(it.getTemplateKind(), IntegrationTemplate.TemplateKind.APPLICATION);
         assertEquals(it.getTheTemplate().getName(), SPECIFIC_SLACK);
 
         // This should be the default
-        ito = templateRepository.findIntegrationTemplate(null, null, IntegrationTemplate.TemplateKind.DEFAULT, SLACK);
+        ito = templateRepository.findIntegrationTemplate(null, null, null, IntegrationTemplate.TemplateKind.DEFAULT, SLACK);
         assertTrue(ito.isPresent());
         it = ito.get();
         assertEquals(it.getTemplateKind(), IntegrationTemplate.TemplateKind.DEFAULT);
@@ -61,19 +61,19 @@ public class IntegrationTemplateRepositoryTest extends DbIsolatedTest {
     void testUserFallback() {
 
         Template specificSlack = createTemplate(SPECIFIC_SLACK, "Just a test", "Li la lu");
-        createIntegrationTemplate(specificSlack, IntegrationTemplate.TemplateKind.ORG, SLACK, "user-123");
+        createIntegrationTemplate(specificSlack, IntegrationTemplate.TemplateKind.ORG, SLACK, "user-123", "org-id-123");
         Template genericSlack = createTemplate(GENERIC_SLACK, "The default", "The default");
         createIntegrationTemplate(genericSlack, IntegrationTemplate.TemplateKind.DEFAULT, SLACK);
 
         Optional<IntegrationTemplate> ito = templateRepository.findIntegrationTemplate(null, "user-123",
-                IntegrationTemplate.TemplateKind.ORG, SLACK);
+                "org-id-123", IntegrationTemplate.TemplateKind.ORG, SLACK);
         assertTrue(ito.isPresent());
         IntegrationTemplate it = ito.get();
         assertEquals(IntegrationTemplate.TemplateKind.ORG, it.getTemplateKind());
         assertEquals(SPECIFIC_SLACK, it.getTheTemplate().getName());
 
         // This should be the default
-        ito = templateRepository.findIntegrationTemplate(null, null, IntegrationTemplate.TemplateKind.DEFAULT, SLACK);
+        ito = templateRepository.findIntegrationTemplate(null, null, null, IntegrationTemplate.TemplateKind.DEFAULT, SLACK);
         assertTrue(ito.isPresent());
         it = ito.get();
         assertEquals(IntegrationTemplate.TemplateKind.DEFAULT, it.getTemplateKind());
@@ -81,7 +81,7 @@ public class IntegrationTemplateRepositoryTest extends DbIsolatedTest {
 
         // Now see if we fall back to default if the user has no template
         ito = templateRepository.findIntegrationTemplate(null, "unknown-user",
-                IntegrationTemplate.TemplateKind.ORG, SLACK);
+                "unknown-org-id", IntegrationTemplate.TemplateKind.ORG, SLACK);
         assertTrue(ito.isPresent());
         it = ito.get();
         assertEquals(IntegrationTemplate.TemplateKind.DEFAULT, it.getTemplateKind());
@@ -100,7 +100,7 @@ public class IntegrationTemplateRepositoryTest extends DbIsolatedTest {
     }
 
     @Transactional
-    IntegrationTemplate createIntegrationTemplate(Template template, IntegrationTemplate.TemplateKind kind, String iType, String account) {
+    IntegrationTemplate createIntegrationTemplate(Template template, IntegrationTemplate.TemplateKind kind, String iType, String account, String orgId) {
         IntegrationTemplate gt = new IntegrationTemplate();
         gt.setTemplateKind(kind);
         gt.setIntegrationType(iType);
@@ -108,12 +108,15 @@ public class IntegrationTemplateRepositoryTest extends DbIsolatedTest {
         if (account != null) {
             gt.setAccountId(account);
         }
+        if (orgId != null) {
+            gt.setOrgId(orgId);
+        }
         entityManager.persist(gt);
         return gt;
     }
 
     IntegrationTemplate createIntegrationTemplate(Template template, IntegrationTemplate.TemplateKind kind, String iType) {
-        return createIntegrationTemplate(template, kind, iType, null);
+        return createIntegrationTemplate(template, kind, iType, null, null);
     }
 
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -820,7 +820,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
 
         // Create 50 test-ones with sanely sortable name & enabled & disabled & type
-        int[] stats = helpers.createTestEndpoints(tenant, 50);
+        int[] stats = helpers.createTestEndpoints(tenant, orgId, 50);
         int disableCount = stats[1];
         int webhookCount = stats[2];
 
@@ -1176,7 +1176,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
     @Test
     void testEmailSubscription() {
         String tenant = "test-subscription";
-        String orgId = "test-subscription2";
+        String orgId = "test-subscription-org-id";
         String username = "test-user";
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(tenant, orgId, username);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -1251,10 +1251,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .then().statusCode(200)
                 .contentType(JSON);
 
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Enable instant on rhel.policies
         given()
@@ -1263,10 +1263,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/rhel/policies/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Enable daily on rhel.policies
         given()
@@ -1275,10 +1275,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/rhel/policies/daily")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", INSTANT));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Enable instant on TEST_BUNDLE_NAME.TEST_APP_NAME
         given()
@@ -1287,10 +1287,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .put("/endpoints/email/subscription/" + TEST_BUNDLE_NAME + "/" + TEST_APP_NAME + "/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", INSTANT));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Disable daily on rhel.policies
         given()
@@ -1299,10 +1299,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .delete("/endpoints/email/subscription/rhel/policies/daily")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
 
         // Disable instant on rhel.policies
         given()
@@ -1311,10 +1311,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .delete("/endpoints/email/subscription/rhel/policies/instant")
                 .then().statusCode(200).contentType(JSON);
 
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "rhel", "policies", DAILY));
-        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "rhel", "policies", DAILY));
+        assertNotNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, TEST_BUNDLE_NAME, TEST_APP_NAME, DAILY));
     }
 
     @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
@@ -59,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class EventResourceTest extends DbIsolatedTest {
 
     private static final String OTHER_ACCOUNT_ID = "other-account-id";
+    private static final String OTHER_ORG_ID = "other-org-id";
     private static final LocalDateTime NOW = LocalDateTime.now(UTC);
     private static final String PAYLOAD = "payload";
 
@@ -98,21 +99,21 @@ public class EventResourceTest extends DbIsolatedTest {
         Application app2 = resourceHelpers.createApplication(bundle2.getId(), "app-2", "Application 2");
         EventType eventType1 = resourceHelpers.createEventType(app1.getId(), "event-type-1", "Event type 1", "Event type 1");
         EventType eventType2 = resourceHelpers.createEventType(app2.getId(), "event-type-2", "Event type 2", "Event type 2");
-        Event event1 = createEvent(DEFAULT_ACCOUNT_ID, bundle1, app1, eventType1, NOW.minusDays(5L));
-        Event event2 = createEvent(DEFAULT_ACCOUNT_ID, bundle2, app2, eventType2, NOW);
-        Event event3 = createEvent(DEFAULT_ACCOUNT_ID, bundle2, app2, eventType2, NOW.minusDays(2L));
-        Event event4 = createEvent(OTHER_ACCOUNT_ID, bundle2, app2, eventType2, NOW.minusDays(10L));
-        Endpoint endpoint1 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, WEBHOOK);
-        Endpoint endpoint2 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, EMAIL_SUBSCRIPTION);
-        Endpoint endpoint3 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, CAMEL, "SlAcK");
+        Event event1 = createEvent(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, bundle1, app1, eventType1, NOW.minusDays(5L));
+        Event event2 = createEvent(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, bundle2, app2, eventType2, NOW);
+        Event event3 = createEvent(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, bundle2, app2, eventType2, NOW.minusDays(2L));
+        Event event4 = createEvent(OTHER_ACCOUNT_ID, OTHER_ORG_ID, bundle2, app2, eventType2, NOW.minusDays(10L));
+        Endpoint endpoint1 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, WEBHOOK);
+        Endpoint endpoint2 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, EMAIL_SUBSCRIPTION);
+        Endpoint endpoint3 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, CAMEL, "SlAcK");
         NotificationHistory history1 = resourceHelpers.createNotificationHistory(event1, endpoint1, TRUE);
         NotificationHistory history2 = resourceHelpers.createNotificationHistory(event1, endpoint2, FALSE);
         NotificationHistory history3 = resourceHelpers.createNotificationHistory(event2, endpoint1, TRUE);
         NotificationHistory history4 = resourceHelpers.createNotificationHistory(event3, endpoint2, TRUE);
         NotificationHistory history5 = resourceHelpers.createNotificationHistory(event3, endpoint3, TRUE);
-        endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint1.getId());
-        endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint2.getId());
-        endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, endpoint3.getId());
+        endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, endpoint1.getId());
+        endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, endpoint2.getId());
+        endpointRepository.deleteEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, endpoint3.getId());
 
         /*
          * Test #1
@@ -493,10 +494,11 @@ public class EventResourceTest extends DbIsolatedTest {
     }
 
     @Transactional
-    Event createEvent(String accountId, Bundle bundle, Application app, EventType eventType, LocalDateTime created) {
+    Event createEvent(String accountId, String orgId, Bundle bundle, Application app, EventType eventType, LocalDateTime created) {
         Event event = new Event();
         event.setId(UUID.randomUUID());
         event.setAccountId(accountId);
+        event.setOrgId(orgId);
         event.setBundleId(bundle.getId());
         event.setBundleDisplayName(bundle.getDisplayName());
         event.setApplicationId(app.getId());

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -311,17 +311,17 @@ public class NotificationResourceTest extends DbIsolatedTest {
         String orgId = "testGetEventTypesAffectedByEndpointOrgId";
         Header identityHeader = initRbacMock(tenant, orgId, "user", FULL_ACCESS);
         UUID bundleId = helpers.createTestAppAndEventTypes();
-        UUID behaviorGroupId1 = helpers.createBehaviorGroup(tenant, "behavior-group-1", bundleId).getId();
-        UUID behaviorGroupId2 = helpers.createBehaviorGroup(tenant, "behavior-group-2", bundleId).getId();
+        UUID behaviorGroupId1 = helpers.createBehaviorGroup(tenant, orgId, "behavior-group-1", bundleId).getId();
+        UUID behaviorGroupId2 = helpers.createBehaviorGroup(tenant, orgId, "behavior-group-2", bundleId).getId();
         UUID appId = applicationRepository.getApplications(TEST_BUNDLE_NAME).stream()
                 .filter(a -> a.getName().equals(TEST_APP_NAME_2))
                 .findFirst().get().getId();
-        UUID endpointId1 = helpers.createWebhookEndpoint(tenant);
-        UUID endpointId2 = helpers.createWebhookEndpoint(tenant);
+        UUID endpointId1 = helpers.createWebhookEndpoint(tenant, orgId);
+        UUID endpointId2 = helpers.createWebhookEndpoint(tenant, orgId);
         List<EventType> eventTypes = applicationRepository.getEventTypes(appId);
         // ep1 assigned to ev0; ep2 not assigned.
-        behaviorGroupRepository.updateEventTypeBehaviors(tenant, eventTypes.get(0).getId(), Set.of(behaviorGroupId1));
-        behaviorGroupRepository.updateBehaviorGroupActions(tenant, behaviorGroupId1, List.of(endpointId1));
+        behaviorGroupRepository.updateEventTypeBehaviors(tenant, orgId, eventTypes.get(0).getId(), Set.of(behaviorGroupId1));
+        behaviorGroupRepository.updateBehaviorGroupActions(tenant, orgId, behaviorGroupId1, List.of(endpointId1));
 
         String responseBody = given()
                 .header(identityHeader)
@@ -352,8 +352,8 @@ public class NotificationResourceTest extends DbIsolatedTest {
         assertEquals(0, behaviorGroups.size());
 
         // ep1 assigned to event ev0; ep2 assigned to event ev1
-        behaviorGroupRepository.updateEventTypeBehaviors(tenant, eventTypes.get(0).getId(), Set.of(behaviorGroupId2));
-        behaviorGroupRepository.updateBehaviorGroupActions(tenant, behaviorGroupId2, List.of(endpointId2));
+        behaviorGroupRepository.updateEventTypeBehaviors(tenant, orgId, eventTypes.get(0).getId(), Set.of(behaviorGroupId2));
+        behaviorGroupRepository.updateBehaviorGroupActions(tenant, orgId, behaviorGroupId2, List.of(endpointId2));
 
         responseBody = given()
                 .header(identityHeader)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
@@ -254,7 +254,7 @@ public class UserConfigResourceTest extends DbIsolatedTest {
         assertEquals(true, preferences.getInstantEmail());
 
         // does not fail if we have unknown apps in our bundle's settings
-        emailSubscriptionRepository.subscribe(tenant, username, bundle, "not-found-app", DAILY);
+        emailSubscriptionRepository.subscribe(tenant, orgId, username, bundle, "not-found-app", DAILY);
 
         given()
                 .header(identityHeader)
@@ -265,7 +265,7 @@ public class UserConfigResourceTest extends DbIsolatedTest {
                 .statusCode(200)
                 .contentType(JSON);
 
-        emailSubscriptionRepository.unsubscribe(tenant, username, "not-found-bundle", "not-found-app", DAILY);
+        emailSubscriptionRepository.unsubscribe(tenant, orgId, username, "not-found-bundle", "not-found-app", DAILY);
 
         // Fails if we don't specify the bundleName
         given()
@@ -287,8 +287,8 @@ public class UserConfigResourceTest extends DbIsolatedTest {
                 .then()
                 .statusCode(200)
                 .contentType(TEXT);
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "not-found-bundle-2", "not-found-app-2", DAILY));
-        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, username, "not-found-bundle", "not-found-app", INSTANT));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "not-found-bundle-2", "not-found-app-2", DAILY));
+        assertNull(emailSubscriptionRepository.getEmailSubscription(tenant, orgId, username, "not-found-bundle", "not-found-app", INSTANT));
 
         // Does not add event type if is not supported by the templates
         when(templateEngineClient.isSubscriptionTypeSupported(bundle, application, DAILY)).thenReturn(FALSE);

--- a/common/src/main/java/com/redhat/cloud/notifications/models/IntegrationTemplate.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/IntegrationTemplate.java
@@ -48,6 +48,8 @@ public class IntegrationTemplate extends CreationUpdateTimestamped {
 
     private String accountId;
 
+    private String orgId;
+
     @ManyToOne(optional = false)
     @JsonProperty(access = READ_ONLY)
     private Template theTemplate;
@@ -82,6 +84,14 @@ public class IntegrationTemplate extends CreationUpdateTimestamped {
 
     public void setAccountId(String accountId) {
         this.accountId = accountId;
+    }
+
+    public String getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
     }
 
     /*

--- a/database/src/main/resources/db/migration/V1.54.0__NOTIF-603_integration_template_org_id.sql
+++ b/database/src/main/resources/db/migration/V1.54.0__NOTIF-603_integration_template_org_id.sql
@@ -1,0 +1,4 @@
+ALTER TABLE integration_template
+    ADD COLUMN org_id TEXT;
+
+CREATE INDEX ix_integration_template_org_id ON integration_template (org_id);


### PR DESCRIPTION
All the `backend` tests still rely on the `accountId`. I'm not sure of the most reasonable approach regarding the `orgId` integration into tests. This is gonna be painful.

Anyway the `orgId` is disabled for now so let's move forward and start by merging this.