### PR TITLE
NOTIF-603 Add orgId tests

### DIFF
--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -112,7 +112,7 @@ public class DailyEmailAggregationJob {
                         .collect(Collectors.toList());
 
         Log.infof(
-                "Finished collecting email aggregations for period (%s, %s) and type %s after %d seconds. %d (accountIds, applications) pairs were processed",
+                "Finished collecting email aggregations for period (%s, %s) and type %s after %d seconds. %d (accountIds/orgIds, applications) pairs were processed",
                 startTime,
                 endTime,
                 DAILY,
@@ -120,6 +120,7 @@ public class DailyEmailAggregationJob {
                 pendingAggregationCommands.size()
         );
 
+        // TODO NOTIF-603 Rename the gauge after the migration to orgId is done.
         pairsProcessed = Gauge
                 .build()
                 .name("aggregator_job_accountid_application_pairs_processed")

--- a/aggregator/src/test/java/com/redhat/cloud/notifications/helpers/BaseTransformer.java
+++ b/aggregator/src/test/java/com/redhat/cloud/notifications/helpers/BaseTransformer.java
@@ -21,6 +21,7 @@ class BaseTransformer {
         message.put("application", action.getApplication());
         message.put("event_type", action.getEventType());
         message.put("account_id", action.getAccountId());
+        message.put("org_id", action.getOrgId());
         message.put("timestamp", action.getTimestamp().toString());
         message.put("events", new JsonArray(action.getEvents().stream().map(event -> Map.of(
                 "metadata", JsonObject.mapFrom(event.getMetadata()),

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -539,7 +539,7 @@ public class BehaviorGroupRepository {
             if (featureFlipper.isUseOrgId()) {
                 upsertQuery = "INSERT INTO behavior_group_action (behavior_group_id, endpoint_id, position, created) " +
                         "SELECT :behaviorGroupId, :endpointId, :position, :created " +
-                        "WHERE EXISTS (SELECT 1 FROM endpoints WHERE orgId " +
+                        "WHERE EXISTS (SELECT 1 FROM endpoints WHERE org_id " +
                         (orgId == null ? "IS NULL" : "= :orgId") +
                         " AND id = :endpointId) " +
                         "ON CONFLICT (behavior_group_id, endpoint_id) DO UPDATE SET position = :position";

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -54,6 +54,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     FeatureFlipper featureFlipper;
 
     @Test
+    void shouldThrowExceptionWhenCreatingWithExistingDisplayNameAndSameAccount_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldThrowExceptionWhenCreatingWithExistingDisplayNameAndSameAccount();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingWithExistingDisplayNameAndSameAccount_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldThrowExceptionWhenCreatingWithExistingDisplayNameAndSameAccount();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldThrowExceptionWhenCreatingWithExistingDisplayNameAndSameAccount() {
         if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
             // The check is disabled from configuration.
@@ -76,6 +88,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void shouldThrowExceptionWhenCreatingDefaultWithExistingDisplayName_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldThrowExceptionWhenCreatingDefaultWithExistingDisplayName();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingDefaultWithExistingDisplayName_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldThrowExceptionWhenCreatingDefaultWithExistingDisplayName();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldThrowExceptionWhenCreatingDefaultWithExistingDisplayName() {
         if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
             // The check is disabled from configuration.
@@ -96,6 +120,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void shouldNotThrowExceptionWhenCreatingWithExistingDisplayNameButDifferentAccount_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldNotThrowExceptionWhenCreatingWithExistingDisplayNameButDifferentAccount();
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenCreatingWithExistingDisplayNameButDifferentAccount_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldNotThrowExceptionWhenCreatingWithExistingDisplayNameButDifferentAccount();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldNotThrowExceptionWhenCreatingWithExistingDisplayNameButDifferentAccount() {
         Bundle bundle = resourceHelpers.createBundle();
         BehaviorGroup behaviorGroup1 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName", bundle.getId());
@@ -110,6 +146,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void shouldThrowExceptionWhenUpdatingToExistingDisplayNameAndSameAccount_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldThrowExceptionWhenUpdatingToExistingDisplayNameAndSameAccount();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUpdatingToExistingDisplayNameAndSameAccount_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldThrowExceptionWhenUpdatingToExistingDisplayNameAndSameAccount();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldThrowExceptionWhenUpdatingToExistingDisplayNameAndSameAccount() {
         if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
             // The check is disabled from configuration.
@@ -128,6 +176,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void shouldThrowExceptionWhenUpdatingDefaultToExistingDisplayName_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldThrowExceptionWhenUpdatingDefaultToExistingDisplayName();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUpdatingDefaultToExistingDisplayName_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldThrowExceptionWhenUpdatingDefaultToExistingDisplayName();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldThrowExceptionWhenUpdatingDefaultToExistingDisplayName() {
         if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
             // The check is disabled from configuration.
@@ -146,6 +206,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void shouldNotThrowExceptionWhenUpdatingToExistingDisplayNameButDifferentAccount_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldNotThrowExceptionWhenUpdatingToExistingDisplayNameButDifferentAccount();
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenUpdatingToExistingDisplayNameButDifferentAccount_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldNotThrowExceptionWhenUpdatingToExistingDisplayNameButDifferentAccount();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldNotThrowExceptionWhenUpdatingToExistingDisplayNameButDifferentAccount() {
         Bundle bundle = resourceHelpers.createBundle("name", "displayName");
         BehaviorGroup behaviorGroup1 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName1", bundle.getId());
@@ -155,6 +227,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void shouldNotThrowExceptionWhenSelfUpdatingWithSameDisplayName_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldNotThrowExceptionWhenSelfUpdatingWithSameDisplayName();
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenSelfUpdatingWithSameDisplayName_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldNotThrowExceptionWhenSelfUpdatingWithSameDisplayName();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldNotThrowExceptionWhenSelfUpdatingWithSameDisplayName() {
         Bundle bundle = resourceHelpers.createBundle("name", "displayName");
         BehaviorGroup behaviorGroup = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName1", bundle.getId());
@@ -162,6 +246,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void shouldNotThrowExceptionWhenSelfUpdatingDefaultWithSameDisplayName_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldNotThrowExceptionWhenSelfUpdatingDefaultWithSameDisplayName();
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenSelfUpdatingDefaultWithSameDisplayName_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldNotThrowExceptionWhenSelfUpdatingDefaultWithSameDisplayName();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldNotThrowExceptionWhenSelfUpdatingDefaultWithSameDisplayName() {
         Bundle bundle = resourceHelpers.createBundle("name", "displayName");
         BehaviorGroup behaviorGroup = resourceHelpers.createDefaultBehaviorGroup("displayName1", bundle.getId());
@@ -169,6 +265,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testCreateAndUpdateAndDeleteBehaviorGroup_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateAndUpdateAndDeleteBehaviorGroup();
+    }
+
+    @Test
+    void testCreateAndUpdateAndDeleteBehaviorGroup_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateAndUpdateAndDeleteBehaviorGroup();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateAndUpdateAndDeleteBehaviorGroup() {
         String newDisplayName = "newDisplayName";
 
@@ -201,6 +309,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testCreateAndUpdateAndDeleteDefaultBehaviorGroup_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateAndUpdateAndDeleteDefaultBehaviorGroup();
+    }
+
+    @Test
+    void testCreateAndUpdateAndDeleteDefaultBehaviorGroup_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateAndUpdateAndDeleteDefaultBehaviorGroup();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateAndUpdateAndDeleteDefaultBehaviorGroup() {
         String newDisplayName = "newDisplayName";
 
@@ -234,21 +354,69 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testCreateBehaviorGroupWithNullDisplayName_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateBehaviorGroupWithNullDisplayName();
+    }
+
+    @Test
+    void testCreateBehaviorGroupWithNullDisplayName_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateBehaviorGroupWithNullDisplayName();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateBehaviorGroupWithNullDisplayName() {
         createBehaviorGroupWithIllegalDisplayName(null);
     }
 
     @Test
+    void testCreateBehaviorGroupWithEmptyDisplayName_AccountId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateBehaviorGroupWithEmptyDisplayName();
+        featureFlipper.setUseOrgId(false);
+    }
+
+    @Test
+    void testCreateBehaviorGroupWithEmptyDisplayName_OrgId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateBehaviorGroupWithEmptyDisplayName();
+    }
+
     void testCreateBehaviorGroupWithEmptyDisplayName() {
         createBehaviorGroupWithIllegalDisplayName("");
     }
 
     @Test
+    void testCreateBehaviorGroupWithBlankDisplayName_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateBehaviorGroupWithBlankDisplayName();
+    }
+
+    @Test
+    void testCreateBehaviorGroupWithBlankDisplayName_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateBehaviorGroupWithBlankDisplayName();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateBehaviorGroupWithBlankDisplayName() {
         createBehaviorGroupWithIllegalDisplayName(" ");
     }
 
     @Test
+    void testCreateBehaviorGroupWithNullBundleId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateBehaviorGroupWithNullBundleId();
+    }
+
+    @Test
+    void testCreateBehaviorGroupWithNullBundleId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateBehaviorGroupWithNullBundleId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateBehaviorGroupWithNullBundleId() {
         ConstraintViolationException e = assertThrows(ConstraintViolationException.class, () -> {
             resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName", null);
@@ -257,6 +425,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testCreateBehaviorGroupWithUnknownBundleId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateBehaviorGroupWithUnknownBundleId();
+    }
+
+    @Test
+    void testCreateBehaviorGroupWithUnknownBundleId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateBehaviorGroupWithUnknownBundleId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateBehaviorGroupWithUnknownBundleId() {
         NotFoundException e = assertThrows(NotFoundException.class, () -> {
             resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName", UUID.randomUUID());
@@ -265,6 +445,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testfindByBundleIdOrdering_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testfindByBundleIdOrdering();
+    }
+
+    @Test
+    void testfindByBundleIdOrdering_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testfindByBundleIdOrdering();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testfindByBundleIdOrdering() {
         Bundle bundle = resourceHelpers.createBundle();
         BehaviorGroup behaviorGroup1 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName1", bundle.getId());
@@ -279,6 +471,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAddAndDeleteEventTypeBehavior_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAddAndDeleteEventTypeBehavior();
+    }
+
+    @Test
+    void testAddAndDeleteEventTypeBehavior_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAddAndDeleteEventTypeBehavior();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAddAndDeleteEventTypeBehavior() {
         Bundle bundle = resourceHelpers.createBundle();
         Application app = resourceHelpers.createApplication(bundle.getId());
@@ -295,6 +499,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAddEventTypeBehaviorWithBundleIntegrityCheckFailure_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAddEventTypeBehaviorWithBundleIntegrityCheckFailure();
+    }
+
+    @Test
+    void testAddEventTypeBehaviorWithBundleIntegrityCheckFailure_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAddEventTypeBehaviorWithBundleIntegrityCheckFailure();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAddEventTypeBehaviorWithBundleIntegrityCheckFailure() {
         /*
          * Bundle 1 objects hierarchy.
@@ -321,6 +537,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testFindEventTypesByBehaviorGroupId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testFindEventTypesByBehaviorGroupId();
+    }
+
+    @Test
+    void testFindEventTypesByBehaviorGroupId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testFindEventTypesByBehaviorGroupId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testFindEventTypesByBehaviorGroupId() {
         Bundle bundle = resourceHelpers.createBundle();
         Application app = resourceHelpers.createApplication(bundle.getId());
@@ -333,6 +561,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testFindBehaviorGroupsByEventTypeId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testFindBehaviorGroupsByEventTypeId();
+    }
+
+    @Test
+    void testFindBehaviorGroupsByEventTypeId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testFindBehaviorGroupsByEventTypeId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testFindBehaviorGroupsByEventTypeId() {
         Bundle bundle = resourceHelpers.createBundle();
         Application app = resourceHelpers.createApplication(bundle.getId());
@@ -345,6 +585,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAddAndDeleteBehaviorGroupAction_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAddAndDeleteBehaviorGroupAction();
+    }
+
+    @Test
+    void testAddAndDeleteBehaviorGroupAction_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAddAndDeleteBehaviorGroupAction();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAddAndDeleteBehaviorGroupAction() {
         Bundle bundle = resourceHelpers.createBundle();
         BehaviorGroup behaviorGroup1 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "Behavior group 1", bundle.getId());
@@ -374,6 +626,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAddMultipleEmailSubscriptionBehaviorGroupActions_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAddMultipleEmailSubscriptionBehaviorGroupActions();
+    }
+
+    @Test
+    void testAddMultipleEmailSubscriptionBehaviorGroupActions_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAddMultipleEmailSubscriptionBehaviorGroupActions();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAddMultipleEmailSubscriptionBehaviorGroupActions() {
         Bundle bundle = resourceHelpers.createBundle();
         BehaviorGroup behaviorGroup = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName", bundle.getId());
@@ -383,6 +647,18 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testUpdateBehaviorGroupActionsWithWrongAccountId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUpdateBehaviorGroupActionsWithWrongAccountId();
+    }
+
+    @Test
+    void testUpdateBehaviorGroupActionsWithWrongAccountId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUpdateBehaviorGroupActionsWithWrongAccountId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUpdateBehaviorGroupActionsWithWrongAccountId() {
         Bundle bundle = resourceHelpers.createBundle();
         BehaviorGroup behaviorGroup = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName", bundle.getId());

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/IntegrationTemplateRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/IntegrationTemplateRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.models.IntegrationTemplate;
 import com.redhat.cloud.notifications.models.Template;
@@ -16,10 +17,6 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
-/**
- *
- */
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
 public class IntegrationTemplateRepositoryTest extends DbIsolatedTest {
@@ -27,14 +24,29 @@ public class IntegrationTemplateRepositoryTest extends DbIsolatedTest {
     public static final String SPECIFIC_SLACK = "specific-slack";
     public static final String SLACK = "slack";
     public static final String GENERIC_SLACK = "generic-slack";
+
     @Inject
     EntityManager entityManager;
 
     @Inject
     TemplateRepository templateRepository;
 
+    @Inject
+    FeatureFlipper featureFlipper;
 
     @Test
+    void testMostSpecificOneIsUsed_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testMostSpecificOneIsUsed();
+    }
+
+    @Test
+    void testMostSpecificOneIsUsed_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testMostSpecificOneIsUsed();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testMostSpecificOneIsUsed() {
 
         Template specificSlack = createTemplate(SPECIFIC_SLACK, "Just a test", "Li la lu");
@@ -58,6 +70,18 @@ public class IntegrationTemplateRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testUserFallback_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUserFallback();
+    }
+
+    @Test
+    void testUserFallback_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUserFallback();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUserFallback() {
 
         Template specificSlack = createTemplate(SPECIFIC_SLACK, "Just a test", "Li la lu");

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -89,6 +89,18 @@ public class LifecycleITest extends DbIsolatedTest {
     }
 
     @Test
+    void shouldReturn400AndBadRequestExceptionWhenDisplayNameIsAlreadyPresent_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldReturn400AndBadRequestExceptionWhenDisplayNameIsAlreadyPresent();
+    }
+
+    @Test
+    void shouldReturn400AndBadRequestExceptionWhenDisplayNameIsAlreadyPresent_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldReturn400AndBadRequestExceptionWhenDisplayNameIsAlreadyPresent();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldReturn400AndBadRequestExceptionWhenDisplayNameIsAlreadyPresent() {
         if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
             // The check is disabled from configuration.
@@ -129,6 +141,18 @@ public class LifecycleITest extends DbIsolatedTest {
     }
 
     @Test
+    void test_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        test();
+    }
+
+    @Test
+    void test_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        test();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void test() {
         /*
          * TODO

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/AuthenticationTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/AuthenticationTest.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import io.quarkus.cache.Cache;
 import io.quarkus.cache.CacheName;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -12,6 +13,8 @@ import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
 
 import static io.restassured.RestAssured.given;
 
@@ -27,8 +30,25 @@ public class AuthenticationTest {
     @CacheName("rbac-cache")
     Cache cache;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @Test
+    void testEndpointRoles_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEndpointRoles();
+    }
+
+    @Test
+    void testEndpointRoles_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEndpointRoles();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEndpointRoles() {
+        MockServerConfig.clearRbac();
+
         String tenant = "empty";
         String orgId = "empty";
         String userName = "testEndpointRoles";

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -9,7 +9,6 @@ import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.EmailSubscriptionRepository;
-import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
 import com.redhat.cloud.notifications.models.BasicAuthentication;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
@@ -87,12 +86,6 @@ public class EndpointResourceTest extends DbIsolatedTest {
     EmailSubscriptionRepository emailSubscriptionRepository;
 
     @Inject
-    EndpointResource endpointResource;
-
-    @Inject
-    TemplateRepository templateRepository;
-
-    @Inject
     EntityManager entityManager;
 
     @Inject
@@ -102,6 +95,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     FeatureFlipper featureFlipper;
 
     @Test
+    void testEndpointAdding_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEndpointAdding();
+    }
+
+    @Test
+    void testEndpointAdding_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEndpointAdding();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEndpointAdding() {
         String tenant = "empty";
         String orgId = "empty";
@@ -243,6 +248,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEndpointValidation_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEndpointValidation();
+    }
+
+    @Test
+    void testEndpointValidation_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEndpointValidation();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEndpointValidation() {
         String tenant = "validation";
         String orgId = "validation2";
@@ -303,6 +320,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void addCamelEndpoint_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        addCamelEndpoint();
+    }
+
+    @Test
+    void addCamelEndpoint_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        addCamelEndpoint();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void addCamelEndpoint() {
 
         String tenant = "empty";
@@ -377,6 +406,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void addBogusCamelEndpoint_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        addBogusCamelEndpoint();
+    }
+
+    @Test
+    void addBogusCamelEndpoint_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        addBogusCamelEndpoint();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void addBogusCamelEndpoint() {
 
         String tenant = "empty";
@@ -428,6 +469,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void addOpenBridgeEndpoint_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        addOpenBridgeEndpoint();
+    }
+
+    @Test
+    void addOpenBridgeEndpoint_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        addOpenBridgeEndpoint();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void addOpenBridgeEndpoint() {
 
         String tenant = "empty";
@@ -548,6 +601,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEndpointUpdates_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEndpointUpdates();
+    }
+
+    @Test
+    void testEndpointUpdates_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEndpointUpdates();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEndpointUpdates() {
         String tenant = "updates";
         String orgId = "updates2";
@@ -650,7 +715,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         assertEquals("not-so-secret-anymore", attrSingleUpdated.getString("secret_token"));
     }
 
-    private static Stream<Arguments> testEndpointTypeQuery() {
+    private static Stream<Arguments> testEndpointTypeQuery_AccountId() {
         return Stream.of(
                 Arguments.of(Set.of(EndpointType.WEBHOOK)),
                 Arguments.of(Set.of(EndpointType.CAMEL)),
@@ -658,8 +723,29 @@ public class EndpointResourceTest extends DbIsolatedTest {
         );
     }
 
+    private static Stream<Arguments> testEndpointTypeQuery_OrgId() {
+        return Stream.of(
+                Arguments.of(Set.of(EndpointType.WEBHOOK)),
+                Arguments.of(Set.of(EndpointType.CAMEL)),
+                Arguments.of(Set.of(EndpointType.WEBHOOK, EndpointType.CAMEL))
+        );
+    }
+
     @ParameterizedTest
     @MethodSource
+    void testEndpointTypeQuery_AccountId(Set<EndpointType> types) {
+        featureFlipper.setUseOrgId(false);
+        testEndpointTypeQuery(types);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testEndpointTypeQuery_OrgId(Set<EndpointType> types) {
+        featureFlipper.setUseOrgId(true);
+        testEndpointTypeQuery(types);
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEndpointTypeQuery(Set<EndpointType> types) {
         String tenant = "limiter";
         String orgId = "limiter2";
@@ -764,6 +850,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEndpointLimiter_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEndpointLimiter();
+    }
+
+    @Test
+    void testEndpointLimiter_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEndpointLimiter();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEndpointLimiter() {
         String tenant = "limiter";
         String orgId = "limiter2";
@@ -810,6 +908,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testSortingOrder_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testSortingOrder();
+    }
+
+    @Test
+    void testSortingOrder_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testSortingOrder();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testSortingOrder() {
         String tenant = "testSortingOrder";
         String orgId = "testSortingOrder2";
@@ -875,6 +985,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testWebhookAttributes_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testWebhookAttributes();
+    }
+
+    @Test
+    void testWebhookAttributes_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testWebhookAttributes();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testWebhookAttributes() {
         String tenant = "testWebhookAttributes";
         String orgId = "testWebhookAttributes2";
@@ -929,6 +1051,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAddEndpointEmailSubscription_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAddEndpointEmailSubscription();
+    }
+
+    @Test
+    void testAddEndpointEmailSubscription_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAddEndpointEmailSubscription();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAddEndpointEmailSubscription() {
         String tenant = "adding-email-subscription";
         String orgId = "adding-email-subscription2";
@@ -1095,6 +1229,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAddEndpointEmailSubscriptionRbac_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAddEndpointEmailSubscriptionRbac();
+    }
+
+    @Test
+    void testAddEndpointEmailSubscriptionRbac_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAddEndpointEmailSubscriptionRbac();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAddEndpointEmailSubscriptionRbac() {
         String tenant = "adding-email-subscription";
         String orgId = "adding-email-subscription2";
@@ -1174,6 +1320,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEmailSubscription_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEmailSubscription();
+    }
+
+    @Test
+    void testEmailSubscription_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEmailSubscription();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEmailSubscription() {
         String tenant = "test-subscription";
         String orgId = "test-subscription-org-id";
@@ -1318,6 +1476,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testUnknownEndpointTypes_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUnknownEndpointTypes();
+    }
+
+    @Test
+    void testUnknownEndpointTypes_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUnknownEndpointTypes();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUnknownEndpointTypes() {
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("test-tenant", "test-orgid", "test-user");
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -1342,6 +1512,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testConnectionCount_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testConnectionCount();
+    }
+
+    @Test
+    void testConnectionCount_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testConnectionCount();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testConnectionCount() {
         String tenant = "count";
         String orgId = "count2";
@@ -1404,6 +1586,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testSearch_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testSearch();
+    }
+
+    @Test
+    void testSearch_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testSearch();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testSearch() {
         String tenant = "search";
         String orgId = "search2";
@@ -1448,6 +1642,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testSearchWithType_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testSearchWithType();
+    }
+
+    @Test
+    void testSearchWithType_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testSearchWithType();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testSearchWithType() {
         String tenant = "search-type";
         String orgId = "search-type2";

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.routers;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
@@ -72,7 +73,22 @@ public class EventResourceTest extends DbIsolatedTest {
     @Inject
     EndpointRepository endpointRepository;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @Test
+    void shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly();
+    }
+
+    @Test
+    void shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly() {
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "user2", NOTIFICATIONS_ACCESS_ONLY);
         given()
@@ -83,6 +99,18 @@ public class EventResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAllQueryParams_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAllQueryParams();
+    }
+
+    @Test
+    void testAllQueryParams_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAllQueryParams();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAllQueryParams() {
         /*
          * This method is very long, but splitting it into several smaller ones would mean we have to recreate lots of
@@ -91,7 +119,7 @@ public class EventResourceTest extends DbIsolatedTest {
          */
 
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "user", FULL_ACCESS);
-        Header otherIdentityHeader = mockRbac(OTHER_ACCOUNT_ID, DEFAULT_ORG_ID, "other-username", FULL_ACCESS);
+        Header otherIdentityHeader = mockRbac(OTHER_ACCOUNT_ID, OTHER_ORG_ID, "other-username", FULL_ACCESS);
 
         Bundle bundle1 = resourceHelpers.createBundle("bundle-1", "Bundle 1");
         Bundle bundle2 = resourceHelpers.createBundle("bundle-2", "Bundle 2");
@@ -442,6 +470,18 @@ public class EventResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testInsufficientPrivileges_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testInsufficientPrivileges();
+    }
+
+    @Test
+    void testInsufficientPrivileges_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testInsufficientPrivileges();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testInsufficientPrivileges() {
         Header noAccessIdentityHeader = mockRbac("tenant", DEFAULT_ORG_ID, "noAccess", NO_ACCESS);
         given()
@@ -452,6 +492,18 @@ public class EventResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testInvalidSortBy_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testInvalidSortBy();
+    }
+
+    @Test
+    void testInvalidSortBy_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testInvalidSortBy();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testInvalidSortBy() {
         Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "user", FULL_ACCESS);
         given()
@@ -464,6 +516,18 @@ public class EventResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testInvalidLimit_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testInvalidLimit();
+    }
+
+    @Test
+    void testInvalidLimit_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testInvalidLimit();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testInvalidLimit() {
         Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "user", FULL_ACCESS);
         given()
@@ -483,6 +547,18 @@ public class EventResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void shouldBeAllowedToGetEventLogs_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldBeAllowedToGetEventLogs();
+    }
+
+    @Test
+    void shouldBeAllowedToGetEventLogs_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldBeAllowedToGetEventLogs();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldBeAllowedToGetEventLogs() {
         Header readAccessIdentityHeader = mockRbac("tenant", DEFAULT_ORG_ID, "user-read-access", NOTIFICATIONS_READ_ACCESS_ONLY);
         given()

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/InternalResourceTest.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -11,6 +12,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -63,25 +65,76 @@ public class InternalResourceTest extends DbIsolatedTest {
     @ConfigProperty(name = "internal.admin-role")
     String adminRole;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @Test
+    void testCreateNullBundle_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateNullBundle();
+    }
+
+    @Test
+    void testCreateNullBundle_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateNullBundle();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateNullBundle() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         createBundle(identity, null, BAD_REQUEST);
     }
 
     @Test
+    void testCreateNullApp_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateNullApp();
+    }
+
+    @Test
+    void testCreateNullApp_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateNullApp();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateNullApp() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         createApp(identity, null, null, BAD_REQUEST);
     }
 
     @Test
+    void testCreateNullEventType_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateNullEventType();
+    }
+
+    @Test
+    void testCreateNullEventType_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateNullEventType();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateNullEventType() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         createEventType(identity, null, BAD_REQUEST);
     }
 
     @Test
+    void testCreateInvalidBundle_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateInvalidBundle();
+    }
+
+    @Test
+    void testCreateInvalidBundle_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateInvalidBundle();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateInvalidBundle() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         createBundle(identity, buildBundle(null, "I am valid"), BAD_REQUEST);
@@ -90,6 +143,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testCreateInvalidApp_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateInvalidApp();
+    }
+
+    @Test
+    void testCreateInvalidApp_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateInvalidApp();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateInvalidApp() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String bundleId = createBundle(identity, "bundle-name", "Bundle", OK).get();
@@ -100,6 +165,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testCreateInvalidEventType_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateInvalidEventType();
+    }
+
+    @Test
+    void testCreateInvalidEventType_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateInvalidEventType();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateInvalidEventType() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String bundleId = createBundle(identity, "bundle-name", "Bundle", OK).get();
@@ -111,6 +188,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testBundleNameUniqueSqlConstraint_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testBundleNameUniqueSqlConstraint();
+    }
+
+    @Test
+    void testBundleNameUniqueSqlConstraint_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testBundleNameUniqueSqlConstraint();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testBundleNameUniqueSqlConstraint() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         // Double bundle creation with the same name.
@@ -123,6 +212,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAppNameUniqueSqlConstraint_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAppNameUniqueSqlConstraint();
+    }
+
+    @Test
+    void testAppNameUniqueSqlConstraint_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAppNameUniqueSqlConstraint();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAppNameUniqueSqlConstraint() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String bundleId = createBundle(identity, "bundle-name", "Bundle", OK).get();
@@ -136,6 +237,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEventTypeNameUniqueSqlConstraint_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEventTypeNameUniqueSqlConstraint();
+    }
+
+    @Test
+    void testEventTypeNameUniqueSqlConstraint_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEventTypeNameUniqueSqlConstraint();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEventTypeNameUniqueSqlConstraint() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String bundleId = createBundle(identity, "bundle-name", "Bundle", OK).get();
@@ -147,6 +260,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testGetUnknownBundle_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testGetUnknownBundle();
+    }
+
+    @Test
+    void testGetUnknownBundle_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testGetUnknownBundle();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testGetUnknownBundle() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String unknownBundleId = UUID.randomUUID().toString();
@@ -154,6 +279,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testGetUnknownApp_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testGetUnknownApp();
+    }
+
+    @Test
+    void testGetUnknownApp_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testGetUnknownApp();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testGetUnknownApp() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String unknownAppId = UUID.randomUUID().toString();
@@ -161,6 +298,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testUpdateNullBundle_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUpdateNullBundle();
+    }
+
+    @Test
+    void testUpdateNullBundle_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUpdateNullBundle();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUpdateNullBundle() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String bundleId = createBundle(identity, "bundle-name", "Bundle", OK).get();
@@ -168,6 +317,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testUpdateNullApp_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUpdateNullApp();
+    }
+
+    @Test
+    void testUpdateNullApp_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUpdateNullApp();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUpdateNullApp() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String bundleId = createBundle(identity, "bundle-name", "Bundle", OK).get();
@@ -176,6 +337,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testUpdateUnknownBundle_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUpdateUnknownBundle();
+    }
+
+    @Test
+    void testUpdateUnknownBundle_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUpdateUnknownBundle();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUpdateUnknownBundle() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String unknownBundleId = UUID.randomUUID().toString();
@@ -183,6 +356,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testUpdateUnknownApp_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUpdateUnknownApp();
+    }
+
+    @Test
+    void testUpdateUnknownApp_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUpdateUnknownApp();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUpdateUnknownApp() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String bundleId = createBundle(identity, "bundle-name", "Bundle", OK).get();
@@ -191,6 +376,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAddAppToUnknownBundle_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAddAppToUnknownBundle();
+    }
+
+    @Test
+    void testAddAppToUnknownBundle_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAddAppToUnknownBundle();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAddAppToUnknownBundle() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String unknownBundleId = UUID.randomUUID().toString();
@@ -198,6 +395,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAddEventTypeToUnknownApp_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAddEventTypeToUnknownApp();
+    }
+
+    @Test
+    void testAddEventTypeToUnknownApp_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAddEventTypeToUnknownApp();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAddEventTypeToUnknownApp() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String unknownAppId = UUID.randomUUID().toString();
@@ -205,6 +414,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testGetAppsFromUnknownBundle_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testGetAppsFromUnknownBundle();
+    }
+
+    @Test
+    void testGetAppsFromUnknownBundle_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testGetAppsFromUnknownBundle();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testGetAppsFromUnknownBundle() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String unknownBundleId = UUID.randomUUID().toString();
@@ -212,6 +433,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testGetEventTypesFromUnknownApp_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testGetEventTypesFromUnknownApp();
+    }
+
+    @Test
+    void testGetEventTypesFromUnknownApp_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testGetEventTypesFromUnknownApp();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testGetEventTypesFromUnknownApp() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         String unknownAppId = UUID.randomUUID().toString();
@@ -219,6 +452,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testCreateAndGetAndUpdateAndDeleteBundle_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateAndGetAndUpdateAndDeleteBundle();
+    }
+
+    @Test
+    void testCreateAndGetAndUpdateAndDeleteBundle_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateAndGetAndUpdateAndDeleteBundle();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateAndGetAndUpdateAndDeleteBundle() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         // First, we create two bundles with different names. Only the second one will be used after that.
@@ -238,6 +483,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testCreateAndGetAndUpdateAndDeleteApp_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateAndGetAndUpdateAndDeleteApp();
+    }
+
+    @Test
+    void testCreateAndGetAndUpdateAndDeleteApp_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateAndGetAndUpdateAndDeleteApp();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateAndGetAndUpdateAndDeleteApp() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         // We need to persist a bundle for this test.
@@ -266,6 +523,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testCreateAndGetAndUpdateAndDeleteEventType_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testCreateAndGetAndUpdateAndDeleteEventType();
+    }
+
+    @Test
+    void testCreateAndGetAndUpdateAndDeleteEventType_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testCreateAndGetAndUpdateAndDeleteEventType();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testCreateAndGetAndUpdateAndDeleteEventType() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         // We need to persist a bundle and an app for this test.
@@ -293,6 +562,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testDefaultBehaviorGroupCRUD_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testDefaultBehaviorGroupCRUD();
+    }
+
+    @Test
+    void testDefaultBehaviorGroupCRUD_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testDefaultBehaviorGroupCRUD();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testDefaultBehaviorGroupCRUD() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         // We need to persist a bundle.
@@ -353,6 +634,18 @@ public class InternalResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void appUserAccessTest_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        appUserAccessTest();
+    }
+
+    @Test
+    void appUserAccessTest_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        appUserAccessTest();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void appUserAccessTest() {
         String appRole = "app-admin";
         Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("admin", adminRole);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -6,6 +6,7 @@ import com.redhat.cloud.notifications.MockServerConfig.RbacAccess;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
@@ -66,6 +67,9 @@ public class NotificationResourceTest extends DbIsolatedTest {
     @Inject
     BehaviorGroupRepository behaviorGroupRepository;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @BeforeEach
     void beforeEach() {
         RestAssured.basePath = TestConstants.API_NOTIFICATIONS_V_1_0;
@@ -79,6 +83,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEventTypeFetching_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEventTypeFetching();
+    }
+
+    @Test
+    void testEventTypeFetching_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEventTypeFetching();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEventTypeFetching() {
         helpers.createTestAppAndEventTypes();
         Header identityHeader = initRbacMock(TENANT, ORG_ID, USERNAME, RbacAccess.FULL_ACCESS);
@@ -152,6 +168,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEventTypeFetchingByApplication_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEventTypeFetchingByApplication();
+    }
+
+    @Test
+    void testEventTypeFetchingByApplication_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEventTypeFetchingByApplication();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEventTypeFetchingByApplication() {
         helpers.createTestAppAndEventTypes();
         List<Application> apps = applicationRepository.getApplications(TEST_BUNDLE_NAME);
@@ -181,6 +209,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEventTypeFetchingByBundle_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEventTypeFetchingByBundle();
+    }
+
+    @Test
+    void testEventTypeFetchingByBundle_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEventTypeFetchingByBundle();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEventTypeFetchingByBundle() {
         helpers.createTestAppAndEventTypes();
         List<Application> apps = applicationRepository.getApplications(TEST_BUNDLE_NAME);
@@ -211,6 +251,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEventTypeFetchingByBundleAndApplicationId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEventTypeFetchingByBundleAndApplicationId();
+    }
+
+    @Test
+    void testEventTypeFetchingByBundleAndApplicationId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEventTypeFetchingByBundleAndApplicationId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEventTypeFetchingByBundleAndApplicationId() {
         helpers.createTestAppAndEventTypes();
         List<Application> apps = applicationRepository.getApplications(TEST_BUNDLE_NAME);
@@ -244,6 +296,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEventTypeFetchingByEventTypeName_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEventTypeFetchingByEventTypeName();
+    }
+
+    @Test
+    void testEventTypeFetchingByEventTypeName_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEventTypeFetchingByEventTypeName();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEventTypeFetchingByEventTypeName() {
         helpers.createTestAppAndEventTypes();
         Header identityHeader = initRbacMock(TENANT, ORG_ID, USERNAME, RbacAccess.FULL_ACCESS);
@@ -271,6 +335,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testEventTypeFetchingByBundleApplicationAndEventTypeName_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testEventTypeFetchingByBundleApplicationAndEventTypeName();
+    }
+
+    @Test
+    void testEventTypeFetchingByBundleApplicationAndEventTypeName_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testEventTypeFetchingByBundleApplicationAndEventTypeName();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testEventTypeFetchingByBundleApplicationAndEventTypeName() {
         helpers.createTestAppAndEventTypes();
         List<Application> apps = applicationRepository.getApplications(TEST_BUNDLE_NAME);
@@ -306,6 +382,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testGetEventTypesAffectedByEndpoint_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testGetEventTypesAffectedByEndpoint();
+    }
+
+    @Test
+    void testGetEventTypesAffectedByEndpoint_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testGetEventTypesAffectedByEndpoint();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testGetEventTypesAffectedByEndpoint() {
         String tenant = "testGetEventTypesAffectedByEndpoint";
         String orgId = "testGetEventTypesAffectedByEndpointOrgId";
@@ -387,6 +475,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testGetApplicationFacets_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testGetApplicationFacets();
+    }
+
+    @Test
+    void testGetApplicationFacets_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testGetApplicationFacets();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testGetApplicationFacets() {
         Header identityHeader = initRbacMock("test", "test2", "user", READ_ACCESS);
         List<Facet> applications = given()
@@ -416,6 +516,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testGetBundlesFacets_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testGetBundlesFacets();
+    }
+
+    @Test
+    void testGetBundlesFacets_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testGetBundlesFacets();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testGetBundlesFacets() {
         // no children by default
         Header identityHeader = initRbacMock("test", "test2", "user", READ_ACCESS);
@@ -455,6 +567,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testInsufficientPrivileges_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testInsufficientPrivileges();
+    }
+
+    @Test
+    void testInsufficientPrivileges_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testInsufficientPrivileges();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testInsufficientPrivileges() {
         Header noAccessIdentityHeader = initRbacMock("tenant", "orgId", "noAccess", NO_ACCESS);
         Header readAccessIdentityHeader = initRbacMock("tenant", "orgId", "readAccess", READ_ACCESS);
@@ -545,6 +669,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testUpdateUnknownBehaviorGroupId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUpdateUnknownBehaviorGroupId();
+    }
+
+    @Test
+    void testUpdateUnknownBehaviorGroupId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUpdateUnknownBehaviorGroupId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUpdateUnknownBehaviorGroupId() {
         Header identityHeader = initRbacMock("tenant", "orgId", "user", FULL_ACCESS);
 
@@ -564,6 +700,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testDeleteUnknownBehaviorGroupId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testDeleteUnknownBehaviorGroupId();
+    }
+
+    @Test
+    void testDeleteUnknownBehaviorGroupId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testDeleteUnknownBehaviorGroupId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testDeleteUnknownBehaviorGroupId() {
         Header identityHeader = initRbacMock("tenant", "orgId", "user", FULL_ACCESS);
         given()
@@ -576,6 +724,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testFindBehaviorGroupsByUnknownBundleId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testFindBehaviorGroupsByUnknownBundleId();
+    }
+
+    @Test
+    void testFindBehaviorGroupsByUnknownBundleId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testFindBehaviorGroupsByUnknownBundleId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testFindBehaviorGroupsByUnknownBundleId() {
         Header identityHeader = initRbacMock("tenant", "orgId", "user", FULL_ACCESS);
         given()
@@ -588,6 +748,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testFindEventTypesAffectedByRemovalOfUnknownBehaviorGroupId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testFindEventTypesAffectedByRemovalOfUnknownBehaviorGroupId();
+    }
+
+    @Test
+    void testFindEventTypesAffectedByRemovalOfUnknownBehaviorGroupId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testFindEventTypesAffectedByRemovalOfUnknownBehaviorGroupId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testFindEventTypesAffectedByRemovalOfUnknownBehaviorGroupId() {
         Header identityHeader = initRbacMock("tenant", "orgId", "user", FULL_ACCESS);
         given()
@@ -600,6 +772,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testFindBehaviorGroupsByUnknownEventTypeId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testFindBehaviorGroupsByUnknownEventTypeId();
+    }
+
+    @Test
+    void testFindBehaviorGroupsByUnknownEventTypeId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testFindBehaviorGroupsByUnknownEventTypeId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testFindBehaviorGroupsByUnknownEventTypeId() {
         Header identityHeader = initRbacMock("tenant", "orgId", "user", FULL_ACCESS);
         given()
@@ -612,6 +796,18 @@ public class NotificationResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testBehaviorGroupsAffectedByRemovalOfUnknownEndpointId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testBehaviorGroupsAffectedByRemovalOfUnknownEndpointId();
+    }
+
+    @Test
+    void testBehaviorGroupsAffectedByRemovalOfUnknownEndpointId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testBehaviorGroupsAffectedByRemovalOfUnknownEndpointId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testBehaviorGroupsAffectedByRemovalOfUnknownEndpointId() {
         Header identityHeader = initRbacMock("tenant", "someOrgId", "user", FULL_ACCESS);
         given()

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.repositories.EmailSubscriptionRepository;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
@@ -54,6 +55,9 @@ public class UserConfigResourceTest extends DbIsolatedTest {
     @InjectMock
     TemplateEngineClient templateEngineClient;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     private Field rhelPolicyForm(SettingsValueJsonForm jsonForm) {
         for (Field section : jsonForm.fields.get(0).sections) {
             if (section.name.equals("policies")) {
@@ -92,6 +96,18 @@ public class UserConfigResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testSettings_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testSettings();
+    }
+
+    @Test
+    void testSettings_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testSettings();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testSettings() {
         String tenant = "empty";
         String orgId = "empty";

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/ValidationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/ValidationResourceTest.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.models.EventType;
 import io.quarkus.test.junit.QuarkusTest;
@@ -9,6 +10,7 @@ import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.http.Header;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import javax.persistence.NoResultException;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
@@ -24,7 +26,22 @@ class ValidationResourceTest {
     @InjectMock
     ApplicationRepository applicationRepository;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @Test
+    void shouldReturnNotFoundWhenTripleIsInvalid_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldReturnNotFoundWhenTripleIsInvalid();
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenTripleIsInvalid_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldReturnNotFoundWhenTripleIsInvalid();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldReturnNotFoundWhenTripleIsInvalid() {
         when(applicationRepository.getEventType(eq("blabla"), eq("Notifications"), eq("Any"))).thenThrow(new NoResultException());
 
@@ -48,6 +65,18 @@ class ValidationResourceTest {
     }
 
     @Test
+    void shouldReturnStatusOkWhenTripleExists_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldReturnStatusOkWhenTripleExists();
+    }
+
+    @Test
+    void shouldReturnStatusOkWhenTripleExists_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldReturnStatusOkWhenTripleExists();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldReturnStatusOkWhenTripleExists() {
         EventType eventType = new EventType();
         when(applicationRepository.getEventType(eq("my-bundle"), eq("Policies"), eq("Any"))).thenReturn(eventType);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionsServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionsServiceTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.routers.internal;
 import com.redhat.cloud.notifications.CrudTestHelpers;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.routers.internal.models.InternalApplicationUserPermission;
 import com.redhat.cloud.notifications.routers.internal.models.InternalUserPermissions;
@@ -12,6 +13,7 @@ import io.restassured.http.Header;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -31,10 +33,25 @@ public class InternalPermissionsServiceTest extends DbIsolatedTest {
     @ConfigProperty(name = "internal.admin-role")
     String adminRole;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     private static final int OK = 200;
     private static final int FORBIDDEN = 403;
 
     @Test
+    void userAccess_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        userAccess();
+    }
+
+    @Test
+    void userAccess_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        userAccess();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void userAccess() {
         String appRole = "crc-app-team";
         String otherRole = "other-role";
@@ -120,6 +137,18 @@ public class InternalPermissionsServiceTest extends DbIsolatedTest {
     }
 
     @Test
+    void createAppWithPermissions_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        createAppWithPermissions();
+    }
+
+    @Test
+    void createAppWithPermissions_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        createAppWithPermissions();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void createAppWithPermissions() {
         String appRole = "crc-app-team";
         Header turnpikeAdminHeader = TestHelpers.createTurnpikeIdentityHeader("admin", adminRole);
@@ -193,6 +222,18 @@ public class InternalPermissionsServiceTest extends DbIsolatedTest {
     }
 
     @Test
+    void accessListTest_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        accessListTest();
+    }
+
+    @Test
+    void accessListTest_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        accessListTest();
+        featureFlipper.setUseOrgId(false);
+    }
+
     public void accessListTest() {
         String appRole = "Acrc-app-team";
         String otherRole = "Bcrc-other-team-role";

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/TemplateResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/TemplateResourceTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.routers.internal;
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
 import com.redhat.cloud.notifications.models.InstantEmailTemplate;
@@ -19,6 +20,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 
 import java.util.UUID;
@@ -60,7 +62,22 @@ public class TemplateResourceTest extends DbIsolatedTest {
     @InjectMock
     TemplateEngineClient templateEngineClient;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @Test
+    void testAllTemplateEndpoints_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAllTemplateEndpoints();
+    }
+
+    @Test
+    void testAllTemplateEndpoints_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAllTemplateEndpoints();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAllTemplateEndpoints() {
         Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
 
@@ -92,6 +109,18 @@ public class TemplateResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAllInstantEmailTemplateEndpoints_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAllInstantEmailTemplateEndpoints();
+    }
+
+    @Test
+    void testAllInstantEmailTemplateEndpoints_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAllInstantEmailTemplateEndpoints();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAllInstantEmailTemplateEndpoints() {
         Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
 
@@ -167,6 +196,18 @@ public class TemplateResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testAllAggregationEmailTemplateEndpoints_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testAllAggregationEmailTemplateEndpoints();
+    }
+
+    @Test
+    void testAllAggregationEmailTemplateEndpoints_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testAllAggregationEmailTemplateEndpoints();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testAllAggregationEmailTemplateEndpoints() {
         Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
 
@@ -223,6 +264,18 @@ public class TemplateResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testTemplateIncludeCheckBeforeDelete_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testTemplateIncludeCheckBeforeDelete();
+    }
+
+    @Test
+    void testTemplateIncludeCheckBeforeDelete_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testTemplateIncludeCheckBeforeDelete();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testTemplateIncludeCheckBeforeDelete() {
         Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
 
@@ -255,6 +308,18 @@ public class TemplateResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testUnauthorizedHttpStatus_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUnauthorizedHttpStatus();
+    }
+
+    @Test
+    void testUnauthorizedHttpStatus_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUnauthorizedHttpStatus();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUnauthorizedHttpStatus() {
         UUID notUsed = UUID.randomUUID();
 
@@ -361,6 +426,18 @@ public class TemplateResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testInvalidEmailTemplateRendering_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testInvalidEmailTemplateRendering();
+    }
+
+    @Test
+    void testInvalidEmailTemplateRendering_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testInvalidEmailTemplateRendering();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testInvalidEmailTemplateRendering() {
         Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
         RenderEmailTemplateRequest request = new RenderEmailTemplateRequest();

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -114,6 +114,18 @@ public class EventConsumerTest {
     }
 
     @Test
+    void testValidPayloadWithMessageId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testValidPayloadWithMessageId();
+    }
+
+    @Test
+    void testValidPayloadWithMessageId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testValidPayloadWithMessageId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testValidPayloadWithMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction();
@@ -139,6 +151,18 @@ public class EventConsumerTest {
     }
 
     @Test
+    void testValidPayloadWithoutOrgId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testValidPayloadWithoutOrgId();
+    }
+
+    @Test
+    void testValidPayloadWithoutOrgId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testValidPayloadWithoutOrgId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testValidPayloadWithoutOrgId() {
         featureFlipper.setUseOrgId(true);
 
@@ -169,6 +193,18 @@ public class EventConsumerTest {
     }
 
     @Test
+    void testValidPayloadWithoutMessageId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testValidPayloadWithoutMessageId();
+    }
+
+    @Test
+    void testValidPayloadWithoutMessageId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testValidPayloadWithoutMessageId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testValidPayloadWithoutMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction();
@@ -192,6 +228,18 @@ public class EventConsumerTest {
     }
 
     @Test
+    void testInvalidPayloadWithMessageId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testInvalidPayloadWithMessageId();
+    }
+
+    @Test
+    void testInvalidPayloadWithMessageId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testInvalidPayloadWithMessageId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testInvalidPayloadWithMessageId() {
         Message<String> message = buildMessageWithId(UUID.randomUUID().toString().getBytes(UTF_8), "I am not a valid payload!");
         inMemoryConnector.source(INGRESS_CHANNEL).send(message);
@@ -213,6 +261,18 @@ public class EventConsumerTest {
     }
 
     @Test
+    void testUnknownEventTypeWithoutMessageId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testUnknownEventTypeWithoutMessageId();
+    }
+
+    @Test
+    void testUnknownEventTypeWithoutMessageId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testUnknownEventTypeWithoutMessageId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testUnknownEventTypeWithoutMessageId() {
         mockGetUnknownEventType();
         Action action = buildValidAction();
@@ -236,6 +296,18 @@ public class EventConsumerTest {
     }
 
     @Test
+    void testProcessingErrorWithoutMessageId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testProcessingErrorWithoutMessageId();
+    }
+
+    @Test
+    void testProcessingErrorWithoutMessageId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testProcessingErrorWithoutMessageId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testProcessingErrorWithoutMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         mockProcessingFailure();
@@ -259,6 +331,18 @@ public class EventConsumerTest {
     }
 
     @Test
+    void testDuplicatePayload_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testDuplicatePayload();
+    }
+
+    @Test
+    void testDuplicatePayload_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testDuplicatePayload();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testDuplicatePayload() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction();
@@ -285,6 +369,18 @@ public class EventConsumerTest {
     }
 
     @Test
+    void testNullMessageId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testNullMessageId();
+    }
+
+    @Test
+    void testNullMessageId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testNullMessageId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testNullMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction();
@@ -309,6 +405,18 @@ public class EventConsumerTest {
     }
 
     @Test
+    void testInvalidMessageId_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testInvalidMessageId();
+    }
+
+    @Test
+    void testInvalidMessageId_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testInvalidMessageId();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testInvalidMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction();

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/FromCamelHistoryFillerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/FromCamelHistoryFillerTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.events;
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -41,6 +42,9 @@ public class FromCamelHistoryFillerTest {
     @Inject
     MicrometerAssertionHelper micrometerAssertionHelper;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @BeforeEach
     void beforeEach() {
         micrometerAssertionHelper.saveCounterValuesBeforeTest(
@@ -55,6 +59,18 @@ public class FromCamelHistoryFillerTest {
     }
 
     @Test
+    void testInvalidPayload_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testInvalidPayload();
+    }
+
+    @Test
+    void testInvalidPayload_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testInvalidPayload();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testInvalidPayload() {
         inMemoryConnector.source(FROMCAMEL_CHANNEL).send("I am not valid!");
 
@@ -65,6 +81,18 @@ public class FromCamelHistoryFillerTest {
     }
 
     @Test
+    void testValidPayload_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testValidPayload();
+    }
+
+    @Test
+    void testValidPayload_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testValidPayload();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testValidPayload() {
         String expectedHistoryId = "e3c90a94-751b-4ce1-b345-b85d825795a4";
         int expectedDuration = 67549274;

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.events;
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
 import com.redhat.cloud.notifications.MockServerLifecycleManager;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
@@ -121,7 +122,22 @@ public class LifecycleITest {
     @Inject
     ResourceHelpers resourceHelpers;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @Test
+    void test_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        test();
+    }
+
+    @Test
+    void test_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        test();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void test() {
         final String accountId = "tenant";
         final String username = "user";

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -101,6 +101,7 @@ public class CamelTypeProcessorTest {
 
     @Test
     void testCamelEndpointProcessingWithoutOrgId() {
+        featureFlipper.setUseOrgId(false);
         // The assertions will vary depending on the orgId feature flag.
         testCamelEndpointProcessing();
     }
@@ -110,6 +111,7 @@ public class CamelTypeProcessorTest {
         featureFlipper.setUseOrgId(true);
         // The assertions will vary depending on the orgId feature flag.
         testCamelEndpointProcessing();
+        featureFlipper.setUseOrgId(false);
     }
 
     private void testCamelEndpointProcessing() {

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.processors.email;
 
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
 import com.redhat.cloud.notifications.models.AggregationCommand;
 import com.redhat.cloud.notifications.models.EmailAggregationKey;
@@ -51,6 +52,9 @@ class EmailSubscriptionTypeProcessorTest {
     @Inject
     MicrometerAssertionHelper micrometerAssertionHelper;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @Test
     void shouldNotProcessWhenEndpointsAreNull() {
         assertTrue(testee.process(new Event(), null).isEmpty());
@@ -62,6 +66,18 @@ class EmailSubscriptionTypeProcessorTest {
     }
 
     @Test
+    void shouldSuccessfullySendEmail_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        shouldSuccessfullySendEmail();
+    }
+
+    @Test
+    void shouldSuccessfullySendEmail_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        shouldSuccessfullySendEmail();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void shouldSuccessfullySendEmail() {
         micrometerAssertionHelper.saveCounterValuesBeforeTest(AGGREGATION_COMMAND_REJECTED_COUNTER_NAME, AGGREGATION_COMMAND_PROCESSED_COUNTER_NAME, AGGREGATION_COMMAND_ERROR_COUNTER_NAME);
 
@@ -113,6 +129,18 @@ class EmailSubscriptionTypeProcessorTest {
     }
 
     @Test
+    void consumeEmailAggregationsShouldNotThrowInCaseOfInvalidPayload_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        consumeEmailAggregationsShouldNotThrowInCaseOfInvalidPayload();
+    }
+
+    @Test
+    void consumeEmailAggregationsShouldNotThrowInCaseOfInvalidPayload_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        consumeEmailAggregationsShouldNotThrowInCaseOfInvalidPayload();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void consumeEmailAggregationsShouldNotThrowInCaseOfInvalidPayload() {
         micrometerAssertionHelper.saveCounterValuesBeforeTest(AGGREGATION_COMMAND_REJECTED_COUNTER_NAME, AGGREGATION_COMMAND_PROCESSED_COUNTER_NAME, AGGREGATION_COMMAND_ERROR_COUNTER_NAME);
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.processors.webhook;
 
 import com.redhat.cloud.notifications.MockServerLifecycleManager;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Metadata;
@@ -43,6 +44,9 @@ public class WebhookTest {
     @Inject
     WebhookTypeProcessor webhookTypeProcessor;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     private HttpRequest getMockHttpRequest(ExpectationResponseCallback verifyEmptyRequest) {
         HttpRequest postReq = new HttpRequest()
                 .withPath("/foobar")
@@ -55,6 +59,18 @@ public class WebhookTest {
     }
 
     @Test
+    void testWebhook_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testWebhook();
+    }
+
+    @Test
+    void testWebhook_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testWebhook();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testWebhook() {
         String url = getMockServerUrl() + "/foobar";
 
@@ -108,11 +124,35 @@ public class WebhookTest {
     }
 
     @Test
+    void testRetryWithFinalSuccess_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testRetryWithFinalSuccess();
+    }
+
+    @Test
+    void testRetryWithFinalSuccess_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testRetryWithFinalSuccess();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testRetryWithFinalSuccess() {
         testRetry(true);
     }
 
     @Test
+    void testRetryWithFinalFailure_AccountId() {
+        featureFlipper.setUseOrgId(false);
+        testRetryWithFinalFailure();
+    }
+
+    @Test
+    void testRetryWithFinalFailure_OrgId() {
+        featureFlipper.setUseOrgId(true);
+        testRetryWithFinalFailure();
+        featureFlipper.setUseOrgId(false);
+    }
+
     void testRetryWithFinalFailure() {
         testRetry(false);
     }


### PR DESCRIPTION
After this PR, most of the notifications tests will be run twice:
- with `notifications.use-org-id=false`
- with `notifications.use-org-id=true`

The test code is almost unchanged and there is only one runtime code change highlighted below.