### PR TITLE
NOTIF-603 Add dedicated orgId feature flag for /events

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.db.repositories;
 
-import com.redhat.cloud.notifications.OrgIdHelper;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
@@ -28,7 +28,7 @@ public class EventRepository {
     EntityManager entityManager;
 
     @Inject
-    OrgIdHelper orgIdHelper;
+    FeatureFlipper featureFlipper;
 
     public List<Event> getEvents(String accountId, String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
@@ -55,7 +55,7 @@ public class EventRepository {
                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes,
                       Set<CompositeEndpointType> compositeEndpointTypes, Set<Boolean> invocationResults) {
         String hql = "SELECT COUNT(*) FROM Event e WHERE ";
-        if (orgIdHelper.useOrgId(orgId)) {
+        if (featureFlipper.isUseOrgIdInEvents()) {
             hql += "e.orgId = :orgId";
         } else {
             hql += "e.accountId = :accountId";
@@ -92,7 +92,7 @@ public class EventRepository {
                                         LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                         Set<Boolean> invocationResults, Integer limit, Integer offset, Optional<String> orderByCondition) {
         String hql = "SELECT e.id FROM Event e WHERE ";
-        if (orgIdHelper.useOrgId(orgId)) {
+        if (featureFlipper.isUseOrgIdInEvents()) {
             hql += "e.orgId = :orgId";
         } else {
             hql += "e.accountId = :accountId";
@@ -174,7 +174,7 @@ public class EventRepository {
     private void setQueryParams(TypedQuery<?> query, String accountId, String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeName,
                                        LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                        Set<Boolean> invocationResults) {
-        if (orgIdHelper.useOrgId(orgId)) {
+        if (featureFlipper.isUseOrgIdInEvents()) {
             query.setParameter("orgId", orgId);
         } else {
             query.setParameter("accountId", accountId);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
@@ -78,15 +78,15 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @Test
     void shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly_AccountId() {
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
         shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly();
     }
 
     @Test
     void shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly_OrgId() {
-        featureFlipper.setUseOrgId(true);
+        featureFlipper.setUseOrgIdInEvents(true);
         shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly();
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
     }
 
     void shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly() {
@@ -100,15 +100,15 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @Test
     void testAllQueryParams_AccountId() {
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
         testAllQueryParams();
     }
 
     @Test
     void testAllQueryParams_OrgId() {
-        featureFlipper.setUseOrgId(true);
+        featureFlipper.setUseOrgIdInEvents(true);
         testAllQueryParams();
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
     }
 
     void testAllQueryParams() {
@@ -471,15 +471,15 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @Test
     void testInsufficientPrivileges_AccountId() {
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
         testInsufficientPrivileges();
     }
 
     @Test
     void testInsufficientPrivileges_OrgId() {
-        featureFlipper.setUseOrgId(true);
+        featureFlipper.setUseOrgIdInEvents(true);
         testInsufficientPrivileges();
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
     }
 
     void testInsufficientPrivileges() {
@@ -493,15 +493,15 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @Test
     void testInvalidSortBy_AccountId() {
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
         testInvalidSortBy();
     }
 
     @Test
     void testInvalidSortBy_OrgId() {
-        featureFlipper.setUseOrgId(true);
+        featureFlipper.setUseOrgIdInEvents(true);
         testInvalidSortBy();
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
     }
 
     void testInvalidSortBy() {
@@ -517,15 +517,15 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @Test
     void testInvalidLimit_AccountId() {
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
         testInvalidLimit();
     }
 
     @Test
     void testInvalidLimit_OrgId() {
-        featureFlipper.setUseOrgId(true);
+        featureFlipper.setUseOrgIdInEvents(true);
         testInvalidLimit();
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
     }
 
     void testInvalidLimit() {
@@ -548,15 +548,15 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @Test
     void shouldBeAllowedToGetEventLogs_AccountId() {
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
         shouldBeAllowedToGetEventLogs();
     }
 
     @Test
     void shouldBeAllowedToGetEventLogs_OrgId() {
-        featureFlipper.setUseOrgId(true);
+        featureFlipper.setUseOrgIdInEvents(true);
         shouldBeAllowedToGetEventLogs();
-        featureFlipper.setUseOrgId(false);
+        featureFlipper.setUseOrgIdInEvents(false);
     }
 
     void shouldBeAllowedToGetEventLogs() {

--- a/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
@@ -54,6 +54,9 @@ public class FeatureFlipper {
     @ConfigProperty(name = "notifications.use-org-id", defaultValue = "false")
     boolean useOrgId;
 
+    @ConfigProperty(name = "notifications.events.use-org-id", defaultValue = "false")
+    boolean useOrgIdInEvents;
+
     void logFeaturesStatusAtStartup(@Observes StartupEvent event) {
         Log.infof("=== %s startup status ===", FeatureFlipper.class.getSimpleName());
         Log.infof("The behavior groups unique name constraint is %s", enforceBehaviorGroupNameUnicity ? "enabled" : "disabled");
@@ -61,6 +64,7 @@ public class FeatureFlipper {
         Log.infof("The actions reinjection in case of Camel integration error is %s", enableReInject ? "enabled" : "disabled");
         Log.infof("The Kafka outage detector is %s", kafkaConsumedTotalCheckerEnabled ? "enabled" : "disabled");
         Log.infof("The org ID migration is %s", useOrgId ? "enabled" : "disabled");
+        Log.infof("The org ID migration is %s in the events API", useOrgIdInEvents ? "enabled" : "disabled");
     }
 
     public boolean isEnforceBehaviorGroupNameUnicity() {
@@ -83,6 +87,15 @@ public class FeatureFlipper {
     public void setUseOrgId(boolean useOrgId) {
         checkTestLaunchMode();
         this.useOrgId = useOrgId;
+    }
+
+    public boolean isUseOrgIdInEvents() {
+        return useOrgIdInEvents;
+    }
+
+    public void setUseOrgIdInEvents(boolean useOrgIdInEvents) {
+        checkTestLaunchMode();
+        this.useOrgIdInEvents = useOrgIdInEvents;
     }
 
     public boolean isEnableReInject() {


### PR DESCRIPTION
`GET /events` cannot rely on the `org_id` that comes from the user authentication headers yet because some onboarded apps still send Kafka messages without an `org_id` value. If we want these messages to be returned by `/events`, then we need to retrieve all events from the DB using the `account_id` for now.

`notifications.use-org-id` will be set to `true` shortly on stage and prod.
`notifications.events.use-org-id` will be set to `true` a bit later when all the Kafka messages we receive will contain an `org_id`.