### PR TITLE
Remove QA workaround for the Update behavior group endpoint

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
@@ -13,12 +13,6 @@ import java.util.UUID;
 public class UpdateBehaviorGroupRequest {
 
     /**
-     * Remove: Only used to make QA tests happy
-     */
-    @Deprecated
-    public UUID bundleId;
-
-    /**
      * If not null, changes the display name of the behavior group to this value.
      */
     public String displayName;


### PR DESCRIPTION
This removes the workaround that was added to the Update behavior group.

The `bundle_id` was never used, but there are QA tests checking that the value has to be a valid UUID.