### PR TITLE
use clowder_smoke env

### DIFF
--- a/.rhcicd/stage-post-deployment-tests.yaml
+++ b/.rhcicd/stage-post-deployment-tests.yaml
@@ -13,7 +13,7 @@ objects:
     testing:
       iqe:
         debug: false
-        dynaconfEnvName: 'stage_post_deploy'
+        dynaconfEnvName: clowder_smoke
         filter: ''
         marker: 'notification_smoke and api'
 parameters:


### PR DESCRIPTION
For now, let's use clowder smoke env.
We need further investigation into why in ephemeral env we are not able to authenticate with stage user and now changes for default user iqe-core need to apply in all other dependent plugins.
