### PR TITLE
[NOTIF-716] Revert stage post deployment env

### DIFF
--- a/.rhcicd/stage-post-deployment-tests.yaml
+++ b/.rhcicd/stage-post-deployment-tests.yaml
@@ -13,7 +13,7 @@ objects:
     testing:
       iqe:
         debug: false
-        dynaconfEnvName: clowder_smoke
+        dynaconfEnvName: stage_post_deploy
         filter: ''
         marker: 'notification_smoke and api'
 parameters:


### PR DESCRIPTION
reverting my changes: https://github.com/RedHatInsights/notifications-backend/pull/1368

clowder smoke env user not applicable for stage env so lets try to fix stage_post_deploy env only