### PR TITLE
Fixes the names on the log when using org id

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -702,11 +702,11 @@ public class BehaviorGroupRepository {
             if (featureFlipper.isUseOrgId()) {
                 if (isDefaultBehaviorGroup) {
                     if (behaviorGroup.getOrgId() != null) {
-                        throw new BadRequestException("Default behavior groups must have a null accountId");
+                        throw new BadRequestException("Default behavior groups must have a null org id");
                     }
                 } else {
                     if (behaviorGroup.getOrgId() == null) {
-                        throw new BadRequestException("Only default behavior groups have a null accountId");
+                        throw new BadRequestException("Only default behavior groups have a null org id");
                     }
                 }
             } else {


### PR DESCRIPTION
No other effect than letting us know that we are using org ids and not account ids.