### PR TITLE
Log orgId in access_log

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProvider.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProvider.java
@@ -17,12 +17,15 @@ import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.Json;
+import io.vertx.ext.web.RoutingContext;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.security.Principal;
@@ -67,6 +70,8 @@ public class ConsoleIdentityProvider implements IdentityProvider<ConsoleAuthenti
     @ConfigProperty(name = "rbac.retry.back-off.max-value", defaultValue = "1S")
     Duration maxBackOff;
 
+    CurrentVertxRequest currentVertxRequest;
+
     @Override
     public Class<ConsoleAuthenticationRequest> getRequestType() {
         return ConsoleAuthenticationRequest.class;
@@ -74,6 +79,9 @@ public class ConsoleIdentityProvider implements IdentityProvider<ConsoleAuthenti
 
     @Override
     public Uni<SecurityIdentity> authenticate(ConsoleAuthenticationRequest rhAuthReq, AuthenticationRequestContext authenticationRequestContext) {
+
+        RoutingContext routingContext = request().getCurrent();
+
         if (!isRbacEnabled) {
             Principal principal;
             String xH = rhAuthReq.getAttribute(X_RH_IDENTITY_HEADER);
@@ -84,6 +92,7 @@ public class ConsoleIdentityProvider implements IdentityProvider<ConsoleAuthenti
                 } catch (IllegalIdentityHeaderException e) {
                     return Uni.createFrom().failure(() -> new AuthenticationFailedException(e));
                 }
+                routingContext.put("x-rh-rbac-org-id", ((RhIdentity) identity).getOrgId());
             } else {
                 principal = ConsolePrincipal.noIdentity();
             }
@@ -146,6 +155,7 @@ public class ConsoleIdentityProvider implements IdentityProvider<ConsoleAuthenti
                                                     if (rbacRaw.canWrite("integrations", "endpoints")) {
                                                         builder.addRole(RBAC_WRITE_INTEGRATIONS_ENDPOINTS);
                                                     }
+                                                    routingContext.put("x-rh-rbac-org-id", ((RhIdentity) identity).getOrgId());
                                                     return builder.build();
                                                 });
                                     } else if (identity instanceof TurnpikeSamlIdentity) {
@@ -178,5 +188,12 @@ public class ConsoleIdentityProvider implements IdentityProvider<ConsoleAuthenti
         ConsoleIdentity identity = Json.decodeValue(xRhDecoded, ConsoleIdentityWrapper.class).getIdentity();
         identity.rawIdentity = xRhIdHeader;
         return identity;
+    }
+
+    private CurrentVertxRequest request() {
+        if (currentVertxRequest == null) {
+            currentVertxRequest = CDI.current().select(CurrentVertxRequest.class).get();
+        }
+        return currentVertxRequest;
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -24,7 +24,7 @@ mp.openapi.extensions.smallrye.operationIdStrategy=CLASS_METHOD
 
 quarkus.http.access-log.enabled=true
 quarkus.http.access-log.category=access_log
-quarkus.http.access-log.pattern="%h %l %u %t \"%r\" %s %b orgId=%{d,x-rh-rbac-org-id}"
+quarkus.http.access-log.pattern=%h %l %u %t "%r" %s %b "%{i,Referer}" "%{i,User-Agent}" orgId=%{d,x-rh-rbac-org-id}
 quarkus.log.category."com.redhat.cloud.notifications".level=INFO
 
 %test.quarkus.http.access-log.category=info

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -24,7 +24,7 @@ mp.openapi.extensions.smallrye.operationIdStrategy=CLASS_METHOD
 
 quarkus.http.access-log.enabled=true
 quarkus.http.access-log.category=access_log
-quarkus.http.access-log.pattern=combined
+quarkus.http.access-log.pattern="%h %l %u %t \"%r\" %s %b orgId=%{d,x-rh-rbac-org-id}"
 quarkus.log.category."com.redhat.cloud.notifications".level=INFO
 
 %test.quarkus.http.access-log.category=info

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -40,7 +40,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
     }
 
     void setupPostgres(Map<String, String> props) throws SQLException {
-        postgreSQLContainer = new PostgreSQLContainer<>("postgres:12");
+        postgreSQLContainer = new PostgreSQLContainer<>("postgres:11");
         postgreSQLContainer.start();
         // Now that postgres is started, we need to get its URL and tell Quarkus
         // quarkus.datasource.driver=io.opentracing.contrib.jdbc.TracingDriver

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -40,7 +40,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
     }
 
     void setupPostgres(Map<String, String> props) throws SQLException {
-        postgreSQLContainer = new PostgreSQLContainer<>("postgres");
+        postgreSQLContainer = new PostgreSQLContainer<>("postgres:12");
         postgreSQLContainer.start();
         // Now that postgres is started, we need to get its URL and tell Quarkus
         // quarkus.datasource.driver=io.opentracing.contrib.jdbc.TracingDriver
@@ -52,7 +52,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
         props.put("quarkus.datasource.db-kind", "postgresql");
 
         // Install the pgcrypto extension
-        // Could perhas be done by a migration with a lower number than the 'live' ones.
+        // Could perhaps be done by a migration with a lower number than the 'live' ones.
         PGSimpleDataSource ds = new PGSimpleDataSource();
         ds.setURL(jdbcUrl);
         Connection connection = ds.getConnection("test", "test");

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -212,7 +212,7 @@ public class ResourceHelpers {
     }
 
     public List<Endpoint> findEndpointsByBehaviorGroupId(String orgId, UUID behaviorGroupId) {
-        String query = "SELECT bga.endpoint FROM BehaviorGroupAction bga WHERE bga.endpoint.orgId = :orgId AND bga.behaviorGroup.id = :behaviorGroupId";
+        String query = "SELECT bga.endpoint FROM BehaviorGroupAction bga WHERE bga.endpoint.orgId = :orgId AND bga.behaviorGroup.id = :behaviorGroupId ORDER BY bga.endpoint.created";
         return entityManager.createQuery(query, Endpoint.class)
                 .setParameter("orgId", orgId)
                 .setParameter("behaviorGroupId", behaviorGroupId)

--- a/common/src/test/java/com/redhat/cloud/notifications/MockServerLifecycleManager.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/MockServerLifecycleManager.java
@@ -29,6 +29,8 @@ public class MockServerLifecycleManager {
     }
 
     public static void stop() {
-        mockServer.stop();
+        if (mockServer != null) {
+            mockServer.stop();
+        }
     }
 }


### PR DESCRIPTION
Requires Quarkus 2.11

Unfortunately it looks like the underlying VertX.Web imp has changed, so that engine would not compile. 

And on top there seem to be changes in the authentication, as the tests work in Quarkus 2.10.2, but fail in 2.11

The backend code works though (with -Drbac.enabled=false) and then shows the right log:

`2022-07-26 15:21:32,622 INFO  [access_log] (executor-thread-1) "127.0.0.1 - hrupp 26/Jul/2022:15:21:32 +0200 "GET /api/integrations/v1.0/endpoints HTTP/1.1" 200 622 orgId=1234567"`