### PR TITLE
Add bundle and app to the input.missing.orgid metric

### DIFF
--- a/engine/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/MicrometerAssertionHelper.java
@@ -39,7 +39,7 @@ public class MicrometerAssertionHelper {
         }
     }
 
-    public void saveCounterValueWithTagsBeforeTest(String counterName, String tagKeys) {
+    public void saveCounterValueWithTagsBeforeTest(String counterName, String... tagKeys) {
         Collection<Counter> counters = registry.find(counterName)
             .tagKeys(tagKeys)
                     .counters();

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -101,9 +101,9 @@ public class EventConsumerTest {
                 DUPLICATE_COUNTER_NAME,
                 MESSAGE_ID_VALID_COUNTER_NAME,
                 MESSAGE_ID_INVALID_COUNTER_NAME,
-                MESSAGE_ID_MISSING_COUNTER_NAME,
-                MISSING_ORG_ID
+                MESSAGE_ID_MISSING_COUNTER_NAME
         );
+        micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(MISSING_ORG_ID, "application", "bundle");
         micrometerAssertionHelper.removeDynamicTimer(CONSUMED_TIMER_NAME);
     }
 
@@ -177,7 +177,7 @@ public class EventConsumerTest {
         micrometerAssertionHelper.awaitAndAssertTimerIncrement(CONSUMED_TIMER_NAME, 1);
         assertEquals(1L, registry.timer(CONSUMED_TIMER_NAME, "bundle", action.getBundle(), "application", action.getApplication()).count());
         micrometerAssertionHelper.assertCounterIncrement(MESSAGE_ID_VALID_COUNTER_NAME, 1);
-        micrometerAssertionHelper.assertCounterIncrement(MISSING_ORG_ID, 1);
+        micrometerAssertionHelper.assertCounterIncrement(MISSING_ORG_ID, 1, "application", APP, "bundle", BUNDLE);
         assertNoCounterIncrement(
                 REJECTED_COUNTER_NAME,
                 PROCESSING_ERROR_COUNTER_NAME,


### PR DESCRIPTION
This PR should help us identify which onboarded apps do not send the `org_id` field yet.

The counter is now incremented even if the org ID is disabled.