### PR TITLE
NOTIF-744 Translate account_id to org_id using BOP

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -103,6 +103,8 @@ objects:
           value: ${KAFKA_CONSUMED_TOTAL_CHECKER_PERIOD}
         - name: NOTIFICATIONS_USE_ORG_ID
           value: ${NOTIFICATIONS_USE_ORG_ID}
+        - name: NOTIFICATIONS_TRANSLATE_ACCOUNT_ID_TO_ORG_ID
+          value: ${NOTIFICATIONS_TRANSLATE_ACCOUNT_ID_TO_ORG_ID}
         - name: PROCESSOR_EMAIL_BOP_APITOKEN
           valueFrom:
             secretKeyRef:
@@ -280,4 +282,6 @@ parameters:
   description: Enable Sentry (or not)
   value: "false"
 - name: NOTIFICATIONS_USE_ORG_ID
+  value: "false"
+- name: NOTIFICATIONS_TRANSLATE_ACCOUNT_ID_TO_ORG_ID
   value: "false"

--- a/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
@@ -57,6 +57,10 @@ public class FeatureFlipper {
     @ConfigProperty(name = "notifications.events.use-org-id", defaultValue = "false")
     boolean useOrgIdInEvents;
 
+    // TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
+    @ConfigProperty(name = "notifications.translate-account-id-to-org-id", defaultValue = "false")
+    boolean translateAccountIdToOrgId;
+
     void logFeaturesStatusAtStartup(@Observes StartupEvent event) {
         Log.infof("=== %s startup status ===", FeatureFlipper.class.getSimpleName());
         Log.infof("The behavior groups unique name constraint is %s", enforceBehaviorGroupNameUnicity ? "enabled" : "disabled");
@@ -65,6 +69,7 @@ public class FeatureFlipper {
         Log.infof("The Kafka outage detector is %s", kafkaConsumedTotalCheckerEnabled ? "enabled" : "disabled");
         Log.infof("The org ID migration is %s", useOrgId ? "enabled" : "disabled");
         Log.infof("The org ID migration is %s in the events API", useOrgIdInEvents ? "enabled" : "disabled");
+        Log.infof("The account ID translation to org ID is %s", translateAccountIdToOrgId ? "enabled" : "disabled");
     }
 
     public boolean isEnforceBehaviorGroupNameUnicity() {
@@ -109,6 +114,15 @@ public class FeatureFlipper {
     public void setKafkaConsumedTotalCheckerEnabled(boolean kafkaConsumedTotalCheckerEnabled) {
         // It's ok to override this config value at runtime.
         this.kafkaConsumedTotalCheckerEnabled = kafkaConsumedTotalCheckerEnabled;
+    }
+
+    public boolean isTranslateAccountIdToOrgId() {
+        return translateAccountIdToOrgId;
+    }
+
+    public void setTranslateAccountIdToOrgId(boolean translateAccountIdToOrgId) {
+        checkTestLaunchMode();
+        this.translateAccountIdToOrgId = translateAccountIdToOrgId;
     }
 
     /**

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/Bop.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/Bop.java
@@ -1,0 +1,29 @@
+package com.redhat.cloud.notifications.events.orgid;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.util.List;
+import java.util.Map;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+// TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
+@RegisterRestClient(configKey = "bop")
+public interface Bop {
+
+    @POST
+    @Path("/v2/accountMapping/orgIds")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    Map<String, String> translateAccountIdsToOrgIds(
+            @HeaderParam("x-rh-apitoken") String apiToken,
+            @HeaderParam("x-rh-clientid") String clientId,
+            @HeaderParam("x-rh-insights-env") String insightsEnv,
+            List<String> accountIds
+    );
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdTranslator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdTranslator.java
@@ -1,0 +1,43 @@
+package com.redhat.cloud.notifications.events.orgid;
+
+import io.quarkus.cache.CacheResult;
+import io.quarkus.logging.Log;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+
+// TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
+@ApplicationScoped
+public class OrgIdTranslator {
+
+    @ConfigProperty(name = "processor.email.bop_apitoken")
+    String bopApiToken;
+
+    @ConfigProperty(name = "processor.email.bop_client_id")
+    String bopClientId;
+
+    @ConfigProperty(name = "processor.email.bop_env")
+    String bopEnv;
+
+    @Inject
+    @RestClient
+    Bop bop;
+
+    @CacheResult(cacheName = "account-id-to-org-id")
+    public String translate(String accountId) {
+        Log.debugf("Calling BOP to translate EAN %s to an org ID", accountId);
+        Map<String, String> result = bop.translateAccountIdsToOrgIds(bopApiToken, bopClientId, bopEnv, List.of(accountId));
+        if (result != null && !result.isEmpty()) {
+            String orgId = result.get(accountId);
+            Log.debugf("EAN %s translated to org ID %s", accountId, orgId);
+            return orgId;
+        } else {
+            Log.debugf("BOP did not know EAN %s", accountId);
+            return null;
+        }
+    }
+}

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -97,6 +97,9 @@ processor.email.bop_client_id=policies
 processor.email.bop_env=qa
 processor.email.no_reply=no-reply@redhat.com
 
+# TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
+quarkus.rest-client.bop.url=${processor.email.bop_url}
+
 # qute
 quarkus.qute.property-not-found-strategy=throw-exception
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
@@ -3,9 +3,11 @@ package com.redhat.cloud.notifications;
 import com.redhat.cloud.notifications.openbridge.Bridge;
 import org.mockserver.model.ClearType;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.MockServerLifecycleManager.getClient;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.RegexBody.regex;
@@ -67,5 +69,18 @@ public class MockServerConfig {
         getClient().clear(request()
                         .withPath("/api/smartevents_mgmt/v1/bridges/" + bridge.getId() + "/processors"),
                 ClearType.EXPECTATIONS);
+    }
+
+    // TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
+    public static void mockBopOrgIdTranslation(String accountId) {
+        getClient()
+                .when(request()
+                        .withMethod("POST")
+                        .withPath("/v2/accountMapping/orgIds")
+                        .withBody(Json.encode(List.of(accountId)))
+                )
+                .respond(response()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(Json.encode(Map.of(accountId, DEFAULT_ORG_ID))));
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -85,5 +85,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
         props.put("quarkus.rest-client.it-s2s.url", getMockServerUrl());
         props.put("quarkus.rest-client.ob.url", getMockServerUrl());
         props.put("quarkus.rest-client.kc.url", getMockServerUrl());
+        // TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
+        props.put("quarkus.rest-client.bop.url", getMockServerUrl());
     }
 }


### PR DESCRIPTION
The translation is disabled by default and can be enabled with `notifications.translate-account-id-to-org-id=true`.

If the call to BOP fails for any reason, the Kafka message processing will continue (with a missing org ID) and a warn message will be logged and trigger a Sentry alert.

Org IDs are cached indefinitely because the translation result never changes for a given EAN.