### PR TITLE
NOTIF-744 Replace BOP with IT users service

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -123,7 +123,7 @@ public class EventConsumer {
                 if (featureFlipper.isUseOrgId()) {
                     Log.info("The org ID migration is enabled but the orgId field is missing or blank in the action");
                 }
-                if (featureFlipper.isTranslateAccountIdToOrgId()) {
+                if (featureFlipper.isTranslateAccountIdToOrgId() && action.getAccountId() != null && !action.getAccountId().isBlank()) {
                     try {
                         String orgId = orgIdTranslator.translate(action.getAccountId());
                         action.setOrgId(orgId);

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/ITUserServiceV2.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/ITUserServiceV2.java
@@ -3,27 +3,19 @@ package com.redhat.cloud.notifications.events.orgid;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import java.util.List;
-import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 // TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
-@RegisterRestClient(configKey = "bop")
-public interface Bop {
+@RegisterRestClient(configKey = "it-s2s")
+public interface ITUserServiceV2 {
 
     @POST
-    @Path("/v2/accountMapping/orgIds")
+    @Path("/v2/findAccount")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    Map<String, String> translateAccountIdsToOrgIds(
-            @HeaderParam("x-rh-apitoken") String apiToken,
-            @HeaderParam("x-rh-clientid") String clientId,
-            @HeaderParam("x-rh-insights-env") String insightsEnv,
-            List<String> accountIds
-    );
+    OrgIdResponse getOrgId(OrgIdRequest request);
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdRequest.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdRequest.java
@@ -1,0 +1,5 @@
+package com.redhat.cloud.notifications.events.orgid;
+
+public class OrgIdRequest {
+    public OrgIdRequestBy by;
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdRequestBy.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdRequestBy.java
@@ -1,0 +1,5 @@
+package com.redhat.cloud.notifications.events.orgid;
+
+public class OrgIdRequestBy {
+    public String ebsAccountNumber;
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdResponse.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdResponse.java
@@ -1,0 +1,8 @@
+package com.redhat.cloud.notifications.events.orgid;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OrgIdResponse {
+    public String id;
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdTranslator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdTranslator.java
@@ -2,39 +2,30 @@ package com.redhat.cloud.notifications.events.orgid;
 
 import io.quarkus.cache.CacheResult;
 import io.quarkus.logging.Log;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.List;
-import java.util.Map;
 
 // TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
 @ApplicationScoped
 public class OrgIdTranslator {
 
-    @ConfigProperty(name = "processor.email.bop_apitoken")
-    String bopApiToken;
-
-    @ConfigProperty(name = "processor.email.bop_client_id")
-    String bopClientId;
-
-    @ConfigProperty(name = "processor.email.bop_env")
-    String bopEnv;
-
     @Inject
     @RestClient
-    Bop bop;
+    ITUserServiceV2 itUserServiceV2;
 
     @CacheResult(cacheName = "account-id-to-org-id")
     public String translate(String accountId) {
         Log.debugf("Calling BOP to translate EAN %s to an org ID", accountId);
-        Map<String, String> result = bop.translateAccountIdsToOrgIds(bopApiToken, bopClientId, bopEnv, List.of(accountId));
-        if (result != null && !result.isEmpty()) {
-            String orgId = result.get(accountId);
-            Log.debugf("EAN %s translated to org ID %s", accountId, orgId);
-            return orgId;
+        OrgIdRequestBy by = new OrgIdRequestBy();
+        by.ebsAccountNumber = accountId;
+        OrgIdRequest request = new OrgIdRequest();
+        request.by = by;
+        OrgIdResponse response = itUserServiceV2.getOrgId(request);
+        if (response != null && response.id != null) {
+            Log.debugf("EAN %s translated to org ID %s", accountId, response.id);
+            return response.id;
         } else {
             Log.debugf("BOP did not know EAN %s", accountId);
             return null;

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdTranslator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/orgid/OrgIdTranslator.java
@@ -17,7 +17,7 @@ public class OrgIdTranslator {
 
     @CacheResult(cacheName = "account-id-to-org-id")
     public String translate(String accountId) {
-        Log.debugf("Calling BOP to translate EAN %s to an org ID", accountId);
+        Log.debugf("Calling IT users service to translate EAN %s to an org ID", accountId);
         OrgIdRequestBy by = new OrgIdRequestBy();
         by.ebsAccountNumber = accountId;
         OrgIdRequest request = new OrgIdRequest();
@@ -27,7 +27,7 @@ public class OrgIdTranslator {
             Log.debugf("EAN %s translated to org ID %s", accountId, response.id);
             return response.id;
         } else {
-            Log.debugf("BOP did not know EAN %s", accountId);
+            Log.debugf("IT users service did not know EAN %s", accountId);
             return null;
         }
     }

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -97,9 +97,6 @@ processor.email.bop_client_id=policies
 processor.email.bop_env=qa
 processor.email.no_reply=no-reply@redhat.com
 
-# TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
-quarkus.rest-client.bop.url=${processor.email.bop_url}
-
 # qute
 quarkus.qute.property-not-found-strategy=throw-exception
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
@@ -1,9 +1,9 @@
 package com.redhat.cloud.notifications;
 
 import com.redhat.cloud.notifications.openbridge.Bridge;
+import io.vertx.core.json.JsonObject;
 import org.mockserver.model.ClearType;
 
-import java.util.List;
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.MockServerLifecycleManager.getClient;
@@ -72,15 +72,17 @@ public class MockServerConfig {
     }
 
     // TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
-    public static void mockBopOrgIdTranslation(String accountId) {
+    public static void mockBopOrgIdTranslation() {
+        JsonObject response = new JsonObject();
+        response.put("id", DEFAULT_ORG_ID);
+
         getClient()
                 .when(request()
                         .withMethod("POST")
-                        .withPath("/v2/accountMapping/orgIds")
-                        .withBody(Json.encode(List.of(accountId)))
+                        .withPath("/v2/findAccount")
                 )
                 .respond(response()
                         .withHeader("Content-Type", "application/json")
-                        .withBody(Json.encode(Map.of(accountId, DEFAULT_ORG_ID))));
+                        .withBody(response.toString()));
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -85,7 +85,5 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
         props.put("quarkus.rest-client.it-s2s.url", getMockServerUrl());
         props.put("quarkus.rest-client.ob.url", getMockServerUrl());
         props.put("quarkus.rest-client.kc.url", getMockServerUrl());
-        // TODO NOTIF-744 Remove this as soon as all onboarded apps include the org_id field in their Kafka messages.
-        props.put("quarkus.rest-client.bop.url", getMockServerUrl());
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -171,7 +171,7 @@ public class EventConsumerTest {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction();
         action.setOrgId(null);
-        MockServerConfig.mockBopOrgIdTranslation(action.getAccountId());
+        MockServerConfig.mockBopOrgIdTranslation();
         String payload = serializeAction(action);
         UUID messageId = UUID.randomUUID();
         Message<String> message = buildMessageWithId(messageId.toString().getBytes(UTF_8), payload);


### PR DESCRIPTION
Calling BOP to translate an `account_id` to an `org_id` didn't work on stage because of certificate issues.

This PR replaces the BOP call with an IT users service call, which should work because we already configured the certificate for that service. I reverse engineered BOP to determine how to call the IT users service and translate the `account_id`. It may not work on first try but it's still disabled by default with the feature flag so it won't do any harm.