### PR TITLE
NOTIF-744 Clean up IT users service configuration

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/itservice/ITUserService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/itservice/ITUserService.java
@@ -15,7 +15,7 @@ import java.util.List;
 public interface ITUserService {
 
     @POST
-    @Path("/findUsers")
+    @Path("/v2/findUsers")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     List<ITUserResponse> getUsers(ITUserRequest itUserRequest);

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -73,9 +73,9 @@ quarkus.rest-client.rbac-s2s.read-timeout=120000
 
 # IT User service
 # these entries are needed because of a bug in quarkus: https://github.com/quarkusio/quarkus/issues/8384
-%prod.quarkus.rest-client."com.redhat.cloud.notifications.recipients.itservice.ITUserService".url=${QUARKUS_REST_CLIENT_IT_S2S_URL:FILL_ME}/v2
-%prod.quarkus.rest-client."com.redhat.cloud.notifications.recipients.itservice.ITUserService".key-store=file:${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE:FILL_ME}
-%prod.quarkus.rest-client."com.redhat.cloud.notifications.recipients.itservice.ITUserService".key-store-password=${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_PASSWORD:FILL_ME}
+%prod.quarkus.rest-client.it-s2s.url=FILL_ME
+%prod.quarkus.rest-client.it-s2s.key-store=file:${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE:FILL_ME}
+%prod.quarkus.rest-client.it-s2s.key-store-password=${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_PASSWORD:FILL_ME}
 
 # Used for service to service communication
 rbac.service-to-service.application=notifications


### PR DESCRIPTION
I just noticed that the IT users service configuration was a bit "unusual" and because of that the new service that translates `account_id` to `org_id` didn't work. Things should work better after this PR.