### PR TITLE
NOTIF-181 Adding default template for preprod environments

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -182,6 +182,8 @@ objects:
           value: ${QUARKUS_REST_CLIENT_OB_URL}
         - name: QUARKUS_REST_CLIENT_KC_URL
           value: ${QUARKUS_REST_CLIENT_KC_URL}
+        - name: NOTIFICATIONS_USE_DEFAULT_TEMPLATE
+          value: ${NOTIFICATIONS_USE_DEFAULT_TEMPLATE}
 parameters:
 - name: BACKOFFICE_CLIENT_ENV
   description: Back-office client environment
@@ -293,4 +295,6 @@ parameters:
   value: "false"
 - name: SENTRY_ENABLED
   description: Enable Sentry (or not)
+  value: "false"
+- name: NOTIFICATIONS_USE_DEFAULT_TEMPLATE
   value: "false"

--- a/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
@@ -51,12 +51,20 @@ public class FeatureFlipper {
     @ConfigProperty(name = "notifications.kafka-consumed-total-checker.enabled", defaultValue = "false")
     boolean kafkaConsumedTotalCheckerEnabled;
 
+    @ConfigProperty(name = "notifications.use-default-template", defaultValue = "false")
+    boolean useDefaultTemplate;
+
+    @ConfigProperty(name = "notifications.use-templates-from-db", defaultValue = "false")
+    boolean useTemplatesFromDb;
+
     void logFeaturesStatusAtStartup(@Observes StartupEvent event) {
         Log.infof("=== %s startup status ===", FeatureFlipper.class.getSimpleName());
         Log.infof("The behavior groups unique name constraint is %s", enforceBehaviorGroupNameUnicity ? "enabled" : "disabled");
         Log.infof("The RHOSE (OpenBridge) integration is %s", obEnabled ? "enabled" : "disabled");
         Log.infof("The actions reinjection in case of Camel integration error is %s", enableReInject ? "enabled" : "disabled");
         Log.infof("The Kafka outage detector is %s", kafkaConsumedTotalCheckerEnabled ? "enabled" : "disabled");
+        Log.infof("The use of default templates is %s", useDefaultTemplate ? "enabled" : "disabled");
+        Log.infof("The use of templates from database is %s", useTemplatesFromDb ? "enabled" : "disabled");
     }
 
     public boolean isEnforceBehaviorGroupNameUnicity() {
@@ -83,6 +91,24 @@ public class FeatureFlipper {
     public void setKafkaConsumedTotalCheckerEnabled(boolean kafkaConsumedTotalCheckerEnabled) {
         // It's ok to override this config value at runtime.
         this.kafkaConsumedTotalCheckerEnabled = kafkaConsumedTotalCheckerEnabled;
+    }
+
+    public boolean isUseDefaultTemplate() {
+        return useDefaultTemplate;
+    }
+
+    public void setUseDefaultTemplate(boolean useDefaultTemplate) {
+        checkTestLaunchMode();
+        this.useDefaultTemplate = useDefaultTemplate;
+    }
+
+    public boolean isUseTemplatesFromDb() {
+        return useTemplatesFromDb;
+    }
+
+    public void setUseTemplatesFromDb(boolean useTemplatesFromDb) {
+        checkTestLaunchMode();
+        this.useTemplatesFromDb = useTemplatesFromDb;
     }
 
     /**

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
@@ -97,7 +97,7 @@ public class TemplateRepository {
         }
 
         try {
-            defaultEmailTemplate = Optional.of(getInternalDefaultInstantTemplate());
+            defaultEmailTemplate = Optional.of(loadDefaultEmailTemplate());
         } catch (Exception exception) {
             defaultEmailTemplate = Optional.empty();
             Log.warn("Could not load the instant default email template", exception);

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
@@ -106,7 +106,7 @@ public class TemplateRepository {
         return defaultEmailTemplate;
     }
 
-    private InstantEmailTemplate getInternalDefaultInstantTemplate() throws Exception {
+    private InstantEmailTemplate loadDefaultEmailTemplate() throws Exception {
         final String instantEmailSubjectPath = "templates/Default/instantEmailTitle.txt";
         final String instantEmailBodyPath = "templates/Default/instantEmailBody.html";
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
@@ -1,13 +1,19 @@
 package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import com.redhat.cloud.notifications.models.InstantEmailTemplate;
+import com.redhat.cloud.notifications.models.Template;
+import io.quarkus.logging.Log;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.persistence.NoResultException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -20,8 +26,17 @@ public class TemplateRepository {
     @Inject
     StatelessSessionFactory statelessSessionFactory;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
+    private Optional<InstantEmailTemplate> defaultEmailTemplate = null;
+
     public boolean isEmailSubscriptionSupported(String bundleName, String appName, EmailSubscriptionType subscriptionType) {
         if (subscriptionType == INSTANT) {
+            if (featureFlipper.isUseDefaultTemplate()) {
+                return true;
+            }
+
             String hql = "SELECT COUNT(*) FROM InstantEmailTemplate " +
                     "WHERE eventType.application.bundle.name = :bundleName AND eventType.application.name = :appName";
             return statelessSessionFactory.getCurrentSession().createQuery(hql, Long.class)
@@ -52,6 +67,10 @@ public class TemplateRepository {
                     .getSingleResult();
             return Optional.of(emailTemplate);
         } catch (NoResultException e) {
+            if (featureFlipper.isUseDefaultTemplate()) {
+                return getDefaultEmailTemplate();
+            }
+
             return Optional.empty();
         }
     }
@@ -70,5 +89,49 @@ public class TemplateRepository {
         } catch (NoResultException e) {
             return Optional.empty();
         }
+    }
+
+    private Optional<InstantEmailTemplate> getDefaultEmailTemplate() {
+        if (defaultEmailTemplate != null) {
+            return defaultEmailTemplate;
+        }
+
+        try {
+            defaultEmailTemplate = Optional.of(getInternalDefaultInstantTemplate());
+        } catch (Exception exception) {
+            defaultEmailTemplate = Optional.empty();
+            Log.warn("Could not load the instant default email template", exception);
+        }
+
+        return defaultEmailTemplate;
+    }
+
+    private InstantEmailTemplate getInternalDefaultInstantTemplate() throws Exception {
+        final String instantEmailSubjectPath = "templates/Default/instantEmailTitle.txt";
+        final String instantEmailBodyPath = "templates/Default/instantEmailBody.html";
+
+        String templateSubjectData = Files.readString(
+                Paths.get(this.getClass().getClassLoader().getResource(instantEmailSubjectPath).toURI()),
+                StandardCharsets.UTF_8
+        );
+
+        String templateBodyData = Files.readString(
+                Paths.get(this.getClass().getClassLoader().getResource(instantEmailBodyPath).toURI()),
+                StandardCharsets.UTF_8
+        );
+
+        Template templateSubject = new Template();
+        templateSubject.setData(templateSubjectData);
+        templateSubject.setName("default-title-instant-template");
+
+        Template templateBody = new Template();
+        templateBody.setData(templateBodyData);
+        templateBody.setName("default-body-instant-template");
+
+        InstantEmailTemplate instantEmailTemplate = new InstantEmailTemplate();
+        instantEmailTemplate.setSubjectTemplate(templateSubject);
+        instantEmailTemplate.setBodyTemplate(templateBody);
+
+        return instantEmailTemplate;
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -162,14 +162,13 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
         if (featureFlipper.isUseTemplatesFromDb()) {
             Optional<InstantEmailTemplate> instantEmailTemplate = templateRepository
                     .findInstantEmailTemplate(event.getEventType().getId());
-            if (instantEmailTemplate.isPresent()) {
+            if (instantEmailTemplate.isEmpty()) {
+                return Collections.emptyList();
+            } else {
                 String subjectData = instantEmailTemplate.get().getSubjectTemplate().getData();
                 subject = templateService.compileTemplate(subjectData, "subject");
                 String bodyData = instantEmailTemplate.get().getBodyTemplate().getData();
                 body = templateService.compileTemplate(bodyData, "body");
-            } else {
-                subject = null;
-                body = null;
             }
         } else {
             if (!emailTemplate.isSupported(action.getEventType(), emailSubscriptionType)) {
@@ -187,7 +186,6 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
                 if (featureFlipper.isUseDefaultTemplate()) {
                     fileTemplateBody = Default.getBody(fileTemplateSubject != null, fileTemplateBody != null);
                     fileTemplateSubject = Default.getTitle();
-
                 } else {
                     return Collections.emptyList();
                 }
@@ -195,10 +193,6 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
 
             subject = fileTemplateSubject;
             body = fileTemplateBody;
-        }
-
-        if (subject == null || body == null) {
-            return Collections.emptyList();
         }
 
         Set<RecipientSettings> requests = Stream.concat(

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.processors.email;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
 import com.redhat.cloud.notifications.db.repositories.EmailSubscriptionRepository;
@@ -23,6 +24,7 @@ import com.redhat.cloud.notifications.recipients.RecipientSettings;
 import com.redhat.cloud.notifications.recipients.User;
 import com.redhat.cloud.notifications.recipients.request.ActionRecipientSettings;
 import com.redhat.cloud.notifications.recipients.request.EndpointRecipientSettings;
+import com.redhat.cloud.notifications.templates.Default;
 import com.redhat.cloud.notifications.templates.EmailTemplate;
 import com.redhat.cloud.notifications.templates.EmailTemplateFactory;
 import com.redhat.cloud.notifications.templates.TemplateService;
@@ -33,7 +35,6 @@ import io.quarkus.logging.Log;
 import io.quarkus.qute.TemplateInstance;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.vertx.core.json.JsonObject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 
@@ -52,8 +53,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.redhat.cloud.notifications.templates.TemplateService.USE_TEMPLATES_FROM_DB_KEY;
-
 @ApplicationScoped
 public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
 
@@ -65,9 +64,6 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
     private static final List<EmailSubscriptionType> NON_INSTANT_SUBSCRIPTION_TYPES = Arrays.stream(EmailSubscriptionType.values())
             .filter(emailSubscriptionType -> emailSubscriptionType != EmailSubscriptionType.INSTANT)
             .collect(Collectors.toList());
-
-    @ConfigProperty(name = USE_TEMPLATES_FROM_DB_KEY)
-    boolean useTemplatesFromDb;
 
     @Inject
     EmailSubscriptionRepository emailSubscriptionRepository;
@@ -105,6 +101,9 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
     @Inject
     TemplateService templateService;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     private Counter processedEmailCount;
     private Counter rejectedAggregationCommandCount;
     private Counter processedAggregationCommandCount;
@@ -126,7 +125,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
             Action action = event.getAction();
             final EmailTemplate template = emailTemplateFactory.get(action.getBundle(), action.getApplication());
             boolean shouldSaveAggregation;
-            if (useTemplatesFromDb) {
+            if (featureFlipper.isUseTemplatesFromDb()) {
                 shouldSaveAggregation = templateRepository.isEmailAggregationSupported(action.getBundle(), action.getApplication(), NON_INSTANT_SUBSCRIPTION_TYPES);
             } else {
                 shouldSaveAggregation = NON_INSTANT_SUBSCRIPTION_TYPES.stream()
@@ -157,26 +156,45 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
         processedEmailCount.increment();
         Action action = event.getAction();
 
-        TemplateInstance subject;
-        TemplateInstance body;
+        final TemplateInstance subject;
+        final TemplateInstance body;
 
-        if (useTemplatesFromDb) {
+        if (featureFlipper.isUseTemplatesFromDb()) {
             Optional<InstantEmailTemplate> instantEmailTemplate = templateRepository
                     .findInstantEmailTemplate(event.getEventType().getId());
-            if (instantEmailTemplate.isEmpty()) {
-                return Collections.emptyList();
-            } else {
+            if (instantEmailTemplate.isPresent()) {
                 String subjectData = instantEmailTemplate.get().getSubjectTemplate().getData();
                 subject = templateService.compileTemplate(subjectData, "subject");
                 String bodyData = instantEmailTemplate.get().getBodyTemplate().getData();
                 body = templateService.compileTemplate(bodyData, "body");
+            } else {
+                subject = null;
+                body = null;
             }
         } else {
             if (!emailTemplate.isSupported(action.getEventType(), emailSubscriptionType)) {
                 return Collections.emptyList();
             }
-            subject = emailTemplate.getTitle(action.getEventType(), emailSubscriptionType);
-            body = emailTemplate.getBody(action.getEventType(), emailSubscriptionType);
+
+            TemplateInstance fileTemplateSubject = emailTemplate.getTitle(action.getEventType(), emailSubscriptionType);
+            TemplateInstance fileTemplateBody = emailTemplate.getBody(action.getEventType(), emailSubscriptionType);
+
+            if (fileTemplateSubject == null || fileTemplateBody == null) {
+                if (fileTemplateSubject != null || fileTemplateBody != null) {
+                    Log.warnf("Only one of the subject and body was found for event: %s/%s/%s", event.getBundleDisplayName(), event.getApplicationDisplayName(), event.getEventTypeDisplayName());
+                }
+
+                if (featureFlipper.isUseDefaultTemplate()) {
+                    fileTemplateBody = Default.getBody(fileTemplateSubject != null, fileTemplateBody != null);
+                    fileTemplateSubject = Default.getTitle();
+
+                } else {
+                    return Collections.emptyList();
+                }
+            }
+
+            subject = fileTemplateSubject;
+            body = fileTemplateBody;
         }
 
         if (subject == null || body == null) {
@@ -238,7 +256,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
         TemplateInstance subject = null;
         TemplateInstance body = null;
 
-        if (useTemplatesFromDb) {
+        if (featureFlipper.isUseTemplatesFromDb()) {
             Optional<AggregationEmailTemplate> aggregationEmailTemplate = templateRepository
                     .findAggregationEmailTemplate(aggregationKey.getBundle(), aggregationKey.getApplication(), emailSubscriptionType);
             if (aggregationEmailTemplate.isPresent()) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/Default.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/Default.java
@@ -1,0 +1,71 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.models.EmailSubscriptionType;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+
+/**
+ * Name needs to be "Default" to read templates from resources/templates/Default
+ *
+ * This class handles the default emails by wrapping the original EmailTemplate.
+ * If the title or body is already supported, it will pass trough.
+ * If the title or body is not supported in the wrapped class AND the type is instant, it will return the default one.
+ * Else it will throw an exception (or reuse the one provided by the call to the wrapped class)
+ * This is only useful for the templates as files flow.
+ *
+ * For templates in database, it provides static methods for getting the TemplateInstance for the title and body.
+ */
+public class Default implements EmailTemplate {
+    // After migration, we can remove this file
+
+    final EmailTemplate wrappedEmailTemplate;
+
+    public Default(EmailTemplate wrappedEmailTemplate) {
+        this.wrappedEmailTemplate = wrappedEmailTemplate;
+    }
+
+    public static TemplateInstance getTitle() {
+        return Templates.instantEmailTitle();
+    }
+
+    public static TemplateInstance getBody(boolean hasTitle, boolean hasBody) {
+        String missingTemplateWarning = null;
+
+        if (hasTitle != hasBody) {
+            missingTemplateWarning = String.format(
+                    "The %s template was found but not the %s template.",
+                    hasTitle ? "title" : "body",
+                    hasTitle ? "body" : "title"
+            );
+        }
+
+        return Templates.instantEmailBody()
+                        .data("mixed_usage_missing_warning", missingTemplateWarning);
+    }
+
+    public TemplateInstance getTitle(String eventType, EmailSubscriptionType type) {
+        return this.wrappedEmailTemplate.getTitle(eventType, type);
+    }
+
+    public TemplateInstance getBody(String eventType, EmailSubscriptionType type) {
+        return this.wrappedEmailTemplate.getBody(eventType, type);
+    }
+
+    @CheckedTemplate(requireTypeSafeExpressions = false)
+    private static class Templates {
+
+        public static native TemplateInstance instantEmailTitle();
+
+        public static native TemplateInstance instantEmailBody();
+    }
+
+    @Override
+    public boolean isSupported(String eventType, EmailSubscriptionType type) {
+        return type == EmailSubscriptionType.INSTANT || wrappedEmailTemplate.isSupported(eventType, type);
+    }
+
+    @Override
+    public boolean isEmailSubscriptionSupported(EmailSubscriptionType type) {
+        return type == EmailSubscriptionType.INSTANT || wrappedEmailTemplate.isEmailSubscriptionSupported(type);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateFactory.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateFactory.java
@@ -1,9 +1,11 @@
 package com.redhat.cloud.notifications.templates;
 
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import io.quarkus.qute.TemplateInstance;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 @ApplicationScoped
 public class EmailTemplateFactory {
@@ -30,7 +32,18 @@ public class EmailTemplateFactory {
     private static final String BUNDLE_ANSIBLE = "ansible";
     private static final String APP_ANSIBLE_REPORTS = "reports";
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     public EmailTemplate get(String bundle, String application) {
+        if (featureFlipper.isUseDefaultTemplate()) {
+            return new Default(this.getInternal(bundle, application));
+        }
+
+        return this.getInternal(bundle, application);
+    }
+
+    private EmailTemplate getInternal(String bundle, String application) {
         if (bundle.equalsIgnoreCase(RHEL)) {
             switch (application.toLowerCase()) {
                 case POLICIES:
@@ -78,6 +91,7 @@ public class EmailTemplateFactory {
                 return new Rbac();
             }
         }
+
         return new EmailTemplateNotSupported();
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineResource.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineResource.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.templates;
 
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
@@ -8,7 +9,6 @@ import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateRequest;
 import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateResponse;
 import com.redhat.cloud.notifications.utils.ActionParser;
 import io.quarkus.qute.TemplateInstance;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.resteasy.reactive.RestQuery;
 
 import javax.inject.Inject;
@@ -22,14 +22,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
-import static com.redhat.cloud.notifications.templates.TemplateService.USE_TEMPLATES_FROM_DB_KEY;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path(API_INTERNAL + "/template-engine")
 public class TemplateEngineResource {
-
-    @ConfigProperty(name = USE_TEMPLATES_FROM_DB_KEY)
-    boolean useTemplatesFromDb;
 
     @Inject
     ActionParser actionParser;
@@ -43,11 +39,14 @@ public class TemplateEngineResource {
     @Inject
     TemplateRepository templateRepository;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @GET
     @Path("/subscription_type_supported")
     @Produces(APPLICATION_JSON)
     public Boolean isSubscriptionTypeSupported(@NotNull @RestQuery String bundleName, @NotNull @RestQuery String applicationName, @NotNull @RestQuery EmailSubscriptionType subscriptionType) {
-        if (useTemplatesFromDb) {
+        if (featureFlipper.isUseTemplatesFromDb()) {
             return templateRepository.isEmailSubscriptionSupported(bundleName, applicationName, subscriptionType);
         } else {
             return emailTemplateFactory.get(bundleName, applicationName).isEmailSubscriptionSupported(subscriptionType);

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/extensions/ActionExtension.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/extensions/ActionExtension.java
@@ -1,19 +1,38 @@
 package com.redhat.cloud.notifications.templates.extensions;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Parser;
 import com.redhat.cloud.notifications.ingress.Payload;
 import io.quarkus.qute.TemplateExtension;
 
-// TODO NOTIF-484 Remove this annotation, it has no effect while using a standalone Qute engine.
-@TemplateExtension(matchName = TemplateExtension.ANY)
 public class ActionExtension {
 
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // TODO NOTIF-484 Remove this annotation, it has no effect while using a standalone Qute engine.
+    @TemplateExtension(matchName = TemplateExtension.ANY)
     public static Object getFromContext(Context context, String key) {
         return context.getAdditionalProperties().get(key);
     }
 
+    // TODO NOTIF-484 Remove this annotation, it has no effect while using a standalone Qute engine.
+    @TemplateExtension(matchName = TemplateExtension.ANY)
     public static Object getFromPayload(Payload payload, String key) {
         return payload.getAdditionalProperties().get(key);
     }
 
+    // TODO NOTIF-484 Remove this annotation, it has no effect while using a standalone Qute engine.
+    @TemplateExtension
+    public static String toPrettyJson(Action action) {
+        try {
+            // Ensures we are encoding the action as per our configured encoder
+            String encodedAction = Parser.encode(action);
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(encodedAction));
+        } catch (JsonProcessingException jpe) {
+            throw new RuntimeException("Error while transforming action to json", jpe);
+        }
+    }
 }

--- a/engine/src/main/resources/templates/Default/instantEmailBody.html
+++ b/engine/src/main/resources/templates/Default/instantEmailBody.html
@@ -1,0 +1,541 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Red Hat Insights</title>
+    {|
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Text&display=swap');
+
+        .rh-masthead__content-title,
+        .rh-masthead__metric-block-count,
+        .rh-masthead__metric-block-text,
+        .rh-masthead__subhead {
+            font-family: 'Red Hat Display', Helvetica, sans-serif;
+        }
+
+        body,
+        .rh-content__block,
+        .rh-data-table,
+        .rh-masthead__subhead {
+            font-family: 'Red Hat Text', Helvetica, sans-serif;
+        }
+
+        #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" message */
+        body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:100%; -ms-text-size-adjust:100%;} /* Prevent WebKit and Windows mobile changing default text sizes */
+        table, td{mso-table-lspace:0pt; mso-table-rspace:0pt;} /* Remove spacing between tables in Outlook 2007 and up */
+        img{-ms-interpolation-mode:bicubic;} /* Allow smoother rendering of resized image in Internet Explorer */
+
+        /* reset styles */
+        img{border:0; height:auto; line-height:100%; outline:none; text-decoration:none;}
+        table{border-collapse:collapse !important;}
+        a{text-decoration: none !important;}
+
+        /* Remove space around email design */
+        html,
+        body {
+            margin: 0 auto !important;
+            padding: 0 !important;
+            height: 100% !important;
+            width: 100% !important;
+            background-color: #fff;
+        }
+
+        /* Stop Outlook resizing small text */
+        * {
+            -ms-text-size-adjust: 100%;
+        }
+        /* Stop Outlook from adding extra spacing to tables */
+        table, td {
+            mso-table-lspace: 0pt !important;
+            mso-table-rspace: 0pt !important;
+        }
+        /* Better rendering method when resizing impages in Outlook IE */
+        img {
+            -ms-interpolation-mode:bicubic;
+        }
+
+        a {
+            text-decoration: none;
+            color: #fff;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            font-family: 'Red Hat Display', sans-serif;
+            font-size: 16px;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        p {
+            margin-top: 0;
+        }
+
+        h1:last-child,
+        h2:last-child,
+        h3:last-child,
+        h4:last-child,
+        h5:last-child,
+        h6:last-child,
+        p:last-child {
+            margin-bottom: 0;
+        }
+
+
+        .rh-masthead__content-title h1,
+        .rh-masthead__content-title h2,
+        .rh-masthead__content-title h3,
+        .rh-masthead__content-title h4,
+        .rh-masthead__subhead h1,
+        .rh-masthead__subhead h2,
+        .rh-masthead__subhead h3,
+        .rh-masthead__subhead h4 {
+            font-weight: 400;
+            line-height: 1;
+        }
+
+        .rh-body-table,
+        .rh-body-cell {
+            height:100% !important;
+            margin:0;
+            padding:0;
+            width:100% !important;
+        }
+
+        .rh-body-table {
+            background-color: #f5f5f5;
+            background-color: #fff;
+        }
+
+        .rh-page {
+            padding: 0 0 30px 0;
+            background: #efefef;
+        }
+
+        .rh-template-container {
+            padding: 0 0 30px 0;
+            width: 600px;
+        }
+
+        .rh-template-container,
+        .rh-template-container > tbody {
+            background: #ededed;
+        }
+
+        .rh-head,
+        .rh-body,
+        .rh-footer {
+            margin: 0;
+            mso-line-height-rule: exactly;
+            font-family: arial;
+            font-size: 16px;
+            box-sizing: border-box;
+        }
+
+        .rh-body {
+            padding: 0 20px 20px 20px;
+        }
+
+        .rh-body,
+        .rh-masthead,
+        .rh-content,
+        .rh-data-table,
+        .rh-head {
+            width: 100% !important;
+        }
+
+        .rh-head {
+            padding: 0 0 20px 0;
+        }
+
+        .rh-footer {
+            padding: 10px 20px 30px 20px;
+        }
+
+        .rh-masthead__content {
+            background-color: #090a0a !important;
+            background-color: #030303 !important;
+            background-image: url(https://console.redhat.com/apps/frontend-assets/email-assets/bg_masthead-hat.png);
+            background-size: cover;
+        }
+
+        .rh-masthead__subhead {
+            background-color: #282828 !important;
+            padding: 20px;
+            color: #ffffff !important;
+            font-size: 18px;
+            text-align: center;
+        }
+
+        .rh-masthead__block {
+            width: 200px;
+        }
+
+        .rh-masthead__brand {
+            padding: 5px 20px 5px 20px;
+            background-color: #151515 !important;
+            background-repeat: repeat;
+            background-image: url(https://console.redhat.com/apps/frontend-assets/email-assets/bg_151515.jpg);
+            text-align: center;
+        }
+
+        .rh-masthead__brand-link {
+            display: block;
+            text-align: center;
+        }
+
+        .rh-masthead__content {
+            background-color: #151515;
+            background-size: cover;
+            background-repeat: no-repeat;
+        }
+
+        .rh-masthead__content-title {
+            padding: 20px 20px 20px 20px;
+            margin: 0 0 10px 0;
+            color: #ffffff;
+            font-size: 18px;
+            position: relative;
+            font-weight: 400;
+        }
+
+        .rh-masthead__metric-block-count {
+            display: block;
+            padding-bottom: 10px;
+            text-align: center;
+            font-size: 28px;
+            word-break:break-all;
+            color: #ffffff !important;
+            line-height: 1;
+        }
+
+        .rh-masthead__metric-block-text {
+            display: block;
+            padding: 0 20px 40px 20px;
+            word-break: break-all;
+            color: #ffffff !important;
+            line-height: 1;
+            font-size: 14px;
+        }
+
+        .rh-masthead__metric-block-icon {
+            padding: 0 0 20px;
+            display: block;
+        }
+
+        .rh-content + .rh-content {
+            padding: 0 0 20px 0;
+        }
+
+        .rh-content a {
+            color: #0066cc;
+        }
+
+        .rh-content {
+            background: #efefef;
+        }
+
+        .rh-content table {
+            background: #fff;
+        }
+
+        /* Content block */
+        .rh-content__block {
+            max-width: 100%;
+            padding: 20px 20px 20px 20px;
+            overflow: hidden;
+        }
+
+        .rh-content tr + tr .rh-content__block {
+            padding-top: 0;
+        }
+
+        .rh-content .rh-content__block {
+            background-color: #fff;
+        }
+
+        .rh-content__block-title {
+            font-weight: bold;
+        }
+
+        .rh-footer__text {
+            font-size: 14px;
+        }
+
+        .rh-footer__text a {
+            color: #0066cc;
+        }
+
+        .rh-content__spacer {
+            font-size: 0;
+            line-height: 0;
+            height: 20px;
+            background-color: #ffffff;
+        }
+
+        .rh-cta-link {
+            display:block;
+            padding: 10px 20px;
+            background-color: #0066cc;
+            border-radius: 3px;
+            text-decoration:none;
+            font-weight:bold;
+        }
+
+        .rh-cta-link a {
+            color:#ffffff;
+            text-decoration: none;
+        }
+
+        .rh-data-table thead th {
+            font-weight: 700;
+            text-align: left;
+        }
+
+        .rh-data-table tbody th {
+            font-weight: 500;
+            text-align: left;
+            width: 200px;
+        }
+
+        .rh-data-table.rh-m-bordered th {
+            padding: 10px;
+            text-align: left;
+            font-size: 14px;
+            font-weight: 500;
+            text-transform: uppercase;
+            background-color: #ededed;
+        }
+
+        .rh-data-table.rh-m-bordered td {
+            padding: 10px;
+            text-align: left;
+        }
+
+        .rh-data-table.rh-m-bordered {
+            border-collapse: collapse;
+        }
+
+        .rh-table-header {
+            text-align: left;
+            padding-bottom: 0;
+        }
+
+        .rh-m-bordered th,
+        .rh-m-bordered td {
+            border-width: 1px;
+            border-color: #b8bbbe;
+            border-style: solid;
+        }
+
+        .rh-m-bordered tr:nth-child(even) {
+            background-color: #fafafa;
+        }
+
+        .rh-color__red {
+            color: #a30000;
+        }
+
+        .rh-color__orange {
+            color: #ec7a08;
+        }
+
+        .rh-color__green {
+            color: #486b00;
+        }
+
+        .rh-m-block {
+            display: block;
+        }
+
+        .rh-url {
+            word-break: break-word;
+        }
+
+        .rh-stack > * + * {
+            margin-top: 10px;
+        }
+
+        .rh-inline {
+            display: flex;
+            align-items: center;
+        }
+
+        .rh-icon {
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            line-height: 1;
+        }
+
+        .rh-inline > * + * {
+            display: inline-block;
+            margin-left: 5px;
+        }
+
+        /* dark mode hacks */
+        [data-ogsc] .rh-masthead__brand,
+        [data-ogsb] .rh-masthead__brand {
+            background-color: #151515 !important;
+        }
+
+        @media only screen and (max-width: 320px) {
+            .rh-masthead__block {
+                width: 100% !important;
+                display: block !important;
+            }
+        }
+
+        @media only screen and (max-width: 480px) {
+            .rh-template-container {
+                max-width: 480px !important;
+                /*@editable*/ width:100% !important;
+            }
+
+            .rh-data-table tbody th {
+                width: auto !important;
+            }
+
+            .rh-data-table th,
+            .rh-data-table td {
+                font-size: 14px;
+            }
+
+            .rh-data-table.rh-m-bordered th,
+            .rh-data-table.rh-m-bordered td {
+                padding: 5px;
+                text-align: left;
+            }
+        }
+
+        @media only screen and (max-width: 600px) {
+            body{
+                width: 100% !important;
+                min-width: 100% !important;
+            }
+
+            .rh-template-container {
+                max-width: 600px !important;
+                /*@editable*/ width:100% !important;
+            }
+
+            .rh-masthead__block {
+                width: 33%;
+                max-width: 200px;
+            }
+        }
+    </style>
+|}
+</head>
+
+<body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" class="rh-body">
+<center>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" class="rh-body-table">
+        <tr>
+            <td align="center" valign="top" class="rh-body-cell">
+                <table border="0" cellpadding="0" cellspacing="0" class="rh-template-container">
+
+                    <!-- Head -->
+                    <tr>
+                        <td class="rh-head">
+                            <table class="rh-masthead" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <!--Red Hat logo-->
+                                    <td align="center" class="rh-masthead__brand" bgcolor="#151515">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
+                                            <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
+                                        </a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="rh-masthead__subhead">
+                                        <h1>
+                                            {action.eventType} triggered - {action.context.system_check_in.toUtcFormat()}
+                                        </h1>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <!-- end head -->
+
+                    <!-- Body section -->
+                    <tr>
+                        <td class="rh-body">
+                            <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td class="rh-content__block">
+                                        <p>{action.bundle}/{action.application}/{action.eventType} notification was triggered.</p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="rh-content__block">
+                                        <p>You are receiving this email because the email template associated with this event type is not configured properly.</p>
+                                        {#if mixed_usage_missing_warning != null}<p>{mixed_usage_missing_warning}</p>{/if}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="rh-content__block">
+                                        <p>Please see the <a class="rh-url" href="https://core-platform-apps.pages.redhat.com/notifications-docs/dev/user-guide/email-templates.html">documentation</a> for information about setting up email templates.</p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="rh-content__block">
+                                        <table class="rh-data-table rh-m-bordered">
+                                            <thead>
+                                            <tr>
+                                                <th>RAW ACTION CONTENT</th>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr style="font-size: 14px;">
+                                                <td><pre>{action.toPrettyJson()}</pre></td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <!-- end body section -->
+
+                    <!-- Footer -->
+                    <tr>
+                        <td class="rh-footer">
+                            <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td class="rh-footer__text">
+                                        This email was sent by Red Hat Insights |<a href="{environment.url}/user-preferences/notifications/{action.bundle}" target="_blank">&nbsp;Manage notification preferences</a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <!-- end footer -->
+
+                    <!-- Ensure padding bottom - don't remove empty row -->
+                    <tr>
+                        <td>
+                        </td>
+                    </tr>
+                    <!-- leave - empty row -->
+
+                </table>
+            </td>
+        </tr>
+    </table>
+</center>
+</body>
+</html>

--- a/engine/src/main/resources/templates/Default/instantEmailTitle.txt
+++ b/engine/src/main/resources/templates/Default/instantEmailTitle.txt
@@ -1,0 +1,1 @@
+{action.context.system_check_in.toUtcFormat()} - {action.bundle}/{action.application}/{action.eventType} triggered

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -94,7 +94,7 @@ class EmailSubscriptionTypeProcessorTest {
     @BeforeEach
     void beforeEach() {
         featureFlipper.setUseTemplatesFromDb(false);
-        featureFlipper.setUseTemplatesFromDb(false);
+        featureFlipper.setUseDefaultTemplate(false);
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -202,9 +202,9 @@ class EmailSubscriptionTypeProcessorTest {
         User user2 = new User();
         user2.setUsername("bar");
 
-        when(emailSubscriptionRepository.getEmailSubscribersUserId(any(), any(), any(), any(), any()))
+        when(emailSubscriptionRepository.getEmailSubscribersUserId(any(), any(), any(), any()))
             .thenReturn(List.of(user1.getUsername(), user2.getUsername()));
-        when(recipientResolver.recipientUsers(any(), any(),  any(), any()))
+        when(recipientResolver.recipientUsers(any(),  any(), any()))
             .thenReturn(Set.of(user1, user2));
         when(sender.sendEmail(any(), any(), any(), any())).thenReturn(Optional.of(new NotificationHistory()));
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -2,15 +2,34 @@ package com.redhat.cloud.notifications.processors.email;
 
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
+import com.redhat.cloud.notifications.db.repositories.EmailSubscriptionRepository;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.AggregationCommand;
 import com.redhat.cloud.notifications.models.EmailAggregationKey;
+import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
+import com.redhat.cloud.notifications.models.EmailSubscriptionType;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.NotificationHistory;
+import com.redhat.cloud.notifications.recipients.RecipientResolver;
+import com.redhat.cloud.notifications.recipients.User;
 import com.redhat.cloud.notifications.templates.Blank;
+import com.redhat.cloud.notifications.templates.Default;
+import com.redhat.cloud.notifications.templates.EmailTemplate;
 import com.redhat.cloud.notifications.templates.EmailTemplateFactory;
+import io.quarkus.qute.TemplateInstance;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.enterprise.inject.Any;
@@ -18,13 +37,19 @@ import javax.inject.Inject;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
 import static com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.AGGREGATION_CHANNEL;
 import static com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.AGGREGATION_COMMAND_ERROR_COUNTER_NAME;
 import static com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.AGGREGATION_COMMAND_PROCESSED_COUNTER_NAME;
 import static com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.AGGREGATION_COMMAND_REJECTED_COUNTER_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -48,8 +73,29 @@ class EmailSubscriptionTypeProcessorTest {
     @InjectMock
     EmailAggregationRepository emailAggregationRepository;
 
+    @InjectMock
+    EmailSubscriptionRepository emailSubscriptionRepository;
+
+    @InjectMock
+    RecipientResolver recipientResolver;
+
+    @InjectMock
+    EmailSender sender;
+
+    @Inject
+    StatelessSessionFactory statelessSessionFactory;
+
     @Inject
     MicrometerAssertionHelper micrometerAssertionHelper;
+
+    @Inject
+    FeatureFlipper featureFlipper;
+
+    @BeforeEach
+    void beforeEach() {
+        featureFlipper.setUseTemplatesFromDb(false);
+        featureFlipper.setUseTemplatesFromDb(false);
+    }
 
     @Test
     void shouldNotProcessWhenEndpointsAreNull() {
@@ -110,6 +156,94 @@ class EmailSubscriptionTypeProcessorTest {
         verifyNoMoreInteractions(emailAggregationRepository);
 
         micrometerAssertionHelper.clearSavedValues();
+    }
+
+    @Test
+    void shouldSendDefaultEmailTemplatesAsFiles() {
+        when(emailTemplateFactory.get(anyString(), anyString()))
+                .thenReturn(new Default(new EmailTemplate() {
+                    @Override
+                    public TemplateInstance getTitle(String eventType, EmailSubscriptionType type) {
+                        return null;
+                    }
+
+                    @Override
+                    public TemplateInstance getBody(String eventType, EmailSubscriptionType type) {
+                        return null;
+                    }
+
+                    @Override
+                    public boolean isSupported(String eventType, EmailSubscriptionType type) {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isEmailSubscriptionSupported(EmailSubscriptionType type) {
+                        return false;
+                    }
+                }));
+        shouldSendDefaultEmail();
+    }
+
+    @Test
+    void shouldSendDefaultEmailTemplatesFromDatabase() {
+        featureFlipper.setUseTemplatesFromDb(true);
+        statelessSessionFactory.withSession(statelessSession -> {
+            shouldSendDefaultEmail();
+        });
+        featureFlipper.setUseTemplatesFromDb(false);
+    }
+
+    void shouldSendDefaultEmail() {
+        featureFlipper.setUseDefaultTemplate(true);
+
+        User user1 = new User();
+        user1.setUsername("foo");
+        User user2 = new User();
+        user2.setUsername("bar");
+
+        when(emailSubscriptionRepository.getEmailSubscribersUserId(any(), any(), any(), any(), any()))
+            .thenReturn(List.of(user1.getUsername(), user2.getUsername()));
+        when(recipientResolver.recipientUsers(any(), any(),  any(), any()))
+            .thenReturn(Set.of(user1, user2));
+        when(sender.sendEmail(any(), any(), any(), any())).thenReturn(Optional.of(new NotificationHistory()));
+
+        Event event = new Event();
+        EventType eventType = new EventType();
+        eventType.setId(UUID.randomUUID());
+        event.setEventType(eventType);
+        event.setId(UUID.randomUUID());
+        event.setAction(
+                new Action.ActionBuilder()
+                        .withOrgId("123456")
+                        .withEventType("triggered")
+                        .withApplication("policies")
+                        .withBundle("rhel")
+                        .withTimestamp(LocalDateTime.of(2022, 8, 24, 13, 30, 0, 0))
+                        .withContext(
+                                new Context.ContextBuilder()
+                                        .withAdditionalProperty("foo", "im foo")
+                                        .withAdditionalProperty("bar", Map.of("baz", "im baz"))
+                                        .build()
+                        )
+                        .withEvents(List.of(
+                                new com.redhat.cloud.notifications.ingress.Event.EventBuilder()
+                                        .withMetadata(new Metadata())
+                                        .withPayload(new Payload())
+                                        .build()
+                        ))
+                        .build()
+        );
+
+        Endpoint endpoint = new Endpoint();
+        endpoint.setProperties(new EmailSubscriptionProperties());
+        endpoint.setType(EndpointType.EMAIL_SUBSCRIPTION);
+
+        List<NotificationHistory> notifications = testee.process(event, List.of(
+                endpoint
+        ));
+        assertEquals(2, notifications.size());
+        featureFlipper.setUseDefaultTemplate(false);
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.templates;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.StatelessSessionFactory;
 import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
@@ -24,7 +25,6 @@ import java.util.UUID;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
-import static com.redhat.cloud.notifications.templates.TemplateService.USE_TEMPLATES_FROM_DB_KEY;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,14 +49,17 @@ public class EmailTemplateMigrationServiceTest {
     @Inject
     StatelessSessionFactory statelessSessionFactory;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @BeforeEach
     void beforeEach() {
-        System.setProperty(USE_TEMPLATES_FROM_DB_KEY, "true");
+        featureFlipper.setUseTemplatesFromDb(true);
     }
 
     @AfterEach
     void afterEach() {
-        System.clearProperty(USE_TEMPLATES_FROM_DB_KEY);
+        featureFlipper.setUseTemplatesFromDb(false);
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestDefaultTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestDefaultTemplate.java
@@ -1,0 +1,85 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.templates.models.Environment;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestDefaultTemplate {
+
+    @Inject
+    Environment environment;
+
+    @Test
+    public void testInstantEmailTitle() {
+        Action action = TestHelpers.createPoliciesAction("", "my-bundle", "my-app", "FooMachine");
+        String result = Default.getTitle()
+                .data("action", action)
+                .render();
+
+        assertTrue(result.contains("my-bundle/my-app/test-email-subscription-instant triggered"), "Title contains the bundle/app/event-type");
+    }
+
+    @Test
+    public void testInstantEmailBody() {
+        Action action = TestHelpers.createPoliciesAction("", "my-bundle", "my-app", "FooMachine");
+        String result = Default.getBody(false, false)
+                .data("action", action)
+                .data("environment", environment)
+                .render();
+
+        assertTrue(result.contains("my-bundle/my-app/test-email-subscription-instant notification was triggered"), "Body should contain bundle/app/event-type");
+        assertTrue(result.contains("You are receiving this email because the email template associated with this event type is not configured properly"));
+    }
+
+    @Test
+    public void testWithTemplateCombinations() {
+        final String titleFoundButNotBody = "The title template was found but not the body template.";
+        final String bodyFoundButNotTitle = "The body template was found but not the title template.";
+
+        Action action = TestHelpers.createPoliciesAction("", "my-bundle", "my-app", "FooMachine");
+
+        // None
+        String result = Default.getBody(false, false)
+                .data("action", action)
+                .data("environment", environment)
+                .render();
+
+        assertFalse(result.contains(titleFoundButNotBody));
+        assertFalse(result.contains(bodyFoundButNotTitle));
+
+        // Only title
+        result = Default.getBody(true, false)
+                .data("action", action)
+                .data("environment", environment)
+                .render();
+
+        assertTrue(result.contains(titleFoundButNotBody));
+        assertFalse(result.contains(bodyFoundButNotTitle));
+
+        // Only body
+        result = Default.getBody(false, true)
+                .data("action", action)
+                .data("environment", environment)
+                .render();
+
+        assertFalse(result.contains(titleFoundButNotBody));
+        assertTrue(result.contains(bodyFoundButNotTitle));
+
+        // both - but should never use this case
+        result = Default.getBody(true, true)
+                .data("action", action)
+                .data("environment", environment)
+                .render();
+
+        assertFalse(result.contains(titleFoundButNotBody));
+        assertFalse(result.contains(bodyFoundButNotTitle));
+    }
+}

--- a/engine/src/test/resources/qute/expected-pretty-json-action.json
+++ b/engine/src/test/resources/qute/expected-pretty-json-action.json
@@ -1,0 +1,19 @@
+{
+  "version" : "2.0.0",
+  "bundle" : "rhel",
+  "application" : "policies",
+  "event_type" : "triggered",
+  "timestamp" : "2022-08-24T13:30:00",
+  "org_id" : "123456",
+  "context" : {
+    "foo" : "im foo",
+    "bar" : {
+      "baz" : "im baz"
+    }
+  },
+  "events" : [ {
+    "payload" : { },
+    "metadata" : { }
+  } ],
+  "recipients" : [ ]
+}


### PR DESCRIPTION
Adds a new flag to decide if we use a default email template. This is meant for pre-production as it will include the json content of the notification.

The default email template is only going to be used if the application didn't provide (already) a template themselves.

Todo:
 - [x] Use the flag to allow to subscribe to user preferences 
 - [x] Add tests

For a fake notification with bundle: `my-bundle`, application: `my-app` and event type: `test-email-subscription-instant`

The title is: `03 Aug 2020 15:22 UTC - my-bundle/my-app/test-email-subscription-instant triggered`

And the content of the email is:

![Screenshot_2022-08-19_07-22-55](https://user-images.githubusercontent.com/3845764/185628455-c6214c1a-ae51-40aa-821f-ce8aa619a808.png)
