### PR TITLE
Purge old data in email_aggregation

### DIFF
--- a/database/src/main/resources/db/migration/V1.56.0__purge_email_aggregation.sql
+++ b/database/src/main/resources/db/migration/V1.56.0__purge_email_aggregation.sql
@@ -1,0 +1,1 @@
+DELETE FROM email_aggregation WHERE created < '2022-08-01';


### PR DESCRIPTION
Because of the EAN to OrgID migration, I took a look using `gabi` at the `email_aggregation` table on prod and noticed that we have a lot of records that have been stuck for almost two months there:
```
Query: select count(*) from email_aggregation where created < '2022-08-01'
Result: 262363
```
The aggregated data got stuck between June 23rd and July 21st:
```
Query: select min(created) from email_aggregation where created < '2022-08-01'
Result: 2022-06-23T00:01:11.21142Z
Query: select max(created) from email_aggregation where created < '2022-08-01'
Result: 2022-07-21T23:28:07.344388Z
```
That data came almost exclusively from the QA account: (:warning: Sensitive data hidden on purpose :warning:)
```
Query: select account_id, count(*) from email_aggregation where created < '2022-08-01' group by account_id
Result: ["QA account","262358"],["Other public account 1","4"],["Other public account 2","1"]
```
During that period, we received a lot of Sentry alerts because of an error during the aggregation process of the QA account data. That error was most likely caused by the unusually huge volume of data to process. The QA account got cleaned after that and everything went back to normal.

I think it's safe to run the SQL script in this PR to remove the data that is stuck on prod.