### PR TITLE
Run ANALYZE after daily VACUUM

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -400,10 +400,10 @@ objects:
     clean.sql: |
       \timing
       CALL cleanEventLog();
-      VACUUM event;
-      VACUUM notification_history;
+      VACUUM ANALYZE event;
+      VACUUM ANALYZE notification_history;
       CALL cleanKafkaMessagesIds();
-      VACUUM kafka_message;
+      VACUUM ANALYZE kafka_message;
 - apiVersion: v1
   kind: ConfigMap
   metadata:


### PR DESCRIPTION
`ANALYZE` updates Postgres' optimizer statistics. The query planner can only work better after that.

I don't know why I didn't add it to the cronjob initially. We already used `VACUUM ANALYZE` from Flyway scripts in the past.