### PR TITLE
NOTIF-603 Make Org ID mandatory and account optional in DB

### DIFF
--- a/aggregator/src/test/java/com/redhat/cloud/notifications/db/EmailAggregationResourcesTest.java
+++ b/aggregator/src/test/java/com/redhat/cloud/notifications/db/EmailAggregationResourcesTest.java
@@ -10,15 +10,12 @@ import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.transaction.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
@@ -38,27 +35,23 @@ public class EmailAggregationResourcesTest {
     @Inject
     ResourceHelpers resourceHelpers;
 
-    @Inject
-    EntityManager entityManager;
-
     @Test
     void testAllMethods() {
 
         LocalDateTime start = LocalDateTime.now(UTC).minusHours(1L);
         LocalDateTime end = LocalDateTime.now(UTC).plusHours(1L);
 
-        addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, APP_NAME, PAYLOAD1);
-        addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
-        addEmailAggregation("other-account", BUNDLE_NAME, APP_NAME, PAYLOAD2);
-        addEmailAggregation(ACCOUNT_ID, "other-bundle", APP_NAME, PAYLOAD2);
-        addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, "other-app", PAYLOAD2);
+        addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD1);
+        addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
+        addEmailAggregation("other-account", "other-org-id", BUNDLE_NAME, APP_NAME, PAYLOAD2);
+        addEmailAggregation(ACCOUNT_ID, ORG_ID, "other-bundle", APP_NAME, PAYLOAD2);
+        addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, "other-app", PAYLOAD2);
 
         EmailAggregationKey key = new EmailAggregationKey(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME);
 
         List<EmailAggregationKey> keys = emailAggregationResources.getApplicationsWithPendingAggregation(start, end);
         assertEquals(4, keys.size());
-        assertEquals(ACCOUNT_ID, keys.get(0).getAccountId());
-        assertNull(keys.get(0).getOrgId());
+        assertEquals(ORG_ID, keys.get(0).getOrgId());
         assertEquals(BUNDLE_NAME, keys.get(0).getBundle());
         assertEquals(APP_NAME, keys.get(0).getApplication());
 
@@ -67,42 +60,6 @@ public class EmailAggregationResourcesTest {
 
         keys = emailAggregationResources.getApplicationsWithPendingAggregation(start, end);
         assertEquals(3, keys.size());
-    }
-
-    @Test
-    void shouldNotMapOrgId() {
-        LocalDateTime start = LocalDateTime.now(UTC).minusHours(1L);
-        LocalDateTime end = LocalDateTime.now(UTC).plusHours(1L);
-
-        addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, APP_NAME, PAYLOAD1);
-        addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
-        addEmailAggregation("other-account", BUNDLE_NAME, APP_NAME, PAYLOAD2);
-        addEmailAggregation(ACCOUNT_ID, "other-bundle", APP_NAME, PAYLOAD2);
-        addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, "other-app", PAYLOAD2);
-
-        List<EmailAggregationKey> keys = emailAggregationResources.getApplicationsWithPendingAggregation(start, end);
-
-        assertNull(keys.get(0).getOrgId());
-
-        clearEmailAggregations();
-    }
-
-    @Test
-    void shouldMapOrgId() {
-        LocalDateTime start = LocalDateTime.now(UTC).minusHours(1L);
-        LocalDateTime end = LocalDateTime.now(UTC).plusHours(1L);
-
-        addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD1);
-        addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
-        addEmailAggregation("other-account", ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
-        addEmailAggregation(ACCOUNT_ID, ORG_ID, "other-bundle", APP_NAME, PAYLOAD2);
-        addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, "other-app", PAYLOAD2);
-
-        List<EmailAggregationKey> keys = emailAggregationResources.getApplicationsWithPendingAggregation(start, end);
-
-        assertEquals("987654321", keys.get(0).getOrgId());
-
-        clearEmailAggregations();
     }
 
     private void addEmailAggregation(String accountId, String orgId, String bundleName, String applicationName, JsonObject payload) {
@@ -114,21 +71,5 @@ public class EmailAggregationResourcesTest {
         aggregation.setPayload(payload);
 
         resourceHelpers.addEmailAggregation(aggregation);
-    }
-
-    private void addEmailAggregation(String accountId, String bundleName, String applicationName, JsonObject payload) {
-        EmailAggregation aggregation = new EmailAggregation();
-        aggregation.setAccountId(accountId);
-        aggregation.setBundleName(bundleName);
-        aggregation.setApplicationName(applicationName);
-        aggregation.setPayload(payload);
-
-        resourceHelpers.addEmailAggregation(aggregation);
-    }
-
-    @Transactional
-    void clearEmailAggregations() {
-        entityManager.createQuery("DELETE FROM EmailAggregation")
-                .executeUpdate();
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
@@ -27,7 +27,7 @@ public class EmailSubscriptionRepository {
         String query = "INSERT INTO endpoint_email_subscriptions(account_id, org_id, user_id, application_id, subscription_type) " +
                 "SELECT :accountId, :orgId, :userId, a.id, :subscriptionType " +
                 "FROM applications a, bundles b WHERE a.bundle_id = b.id AND a.name = :applicationName AND b.name = :bundleName " +
-                "ON CONFLICT (account_id, user_id, application_id, subscription_type) DO UPDATE SET org_id = :orgId";
+                "ON CONFLICT (org_id, user_id, application_id, subscription_type) DO NOTHING"; // The value is already on the database, this is OK
         // HQL does not support the ON CONFLICT clause so we need a native query here
         entityManager.createNativeQuery(query)
                 .setParameter("accountId", accountNumber)
@@ -43,7 +43,7 @@ public class EmailSubscriptionRepository {
     @Transactional
     public boolean unsubscribe(String accountNumber, String orgId, String username, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
         if (orgIdHelper.useOrgId(orgId)) {
-            String query = "DELETE FROM EmailSubscription WHERE orgId = :orgId AND id.userId = :userId " +
+            String query = "DELETE FROM EmailSubscription WHERE id.orgId = :orgId AND id.userId = :userId " +
                     "AND id.applicationId = (SELECT a.id FROM Application a, Bundle b WHERE a.bundle.id = b.id " +
                     "AND b.name = :bundleName AND a.name = :applicationName) AND id.subscriptionType = :subscriptionType";
             entityManager.createQuery(query)
@@ -54,7 +54,7 @@ public class EmailSubscriptionRepository {
                     .setParameter("subscriptionType", subscriptionType)
                     .executeUpdate();
         } else {
-            String query = "DELETE FROM EmailSubscription WHERE id.accountId = :accountId AND id.userId = :userId " +
+            String query = "DELETE FROM EmailSubscription WHERE accountId = :accountId AND id.userId = :userId " +
                     "AND id.applicationId = (SELECT a.id FROM Application a, Bundle b WHERE a.bundle.id = b.id " +
                     "AND b.name = :bundleName AND a.name = :applicationName) AND id.subscriptionType = :subscriptionType";
             entityManager.createQuery(query)
@@ -71,7 +71,7 @@ public class EmailSubscriptionRepository {
     public EmailSubscription getEmailSubscription(String accountNumber, String orgId, String username, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
         if (orgIdHelper.useOrgId(orgId)) {
             String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
-                    "WHERE es.orgId = :orgId AND es.id.userId = :userId " +
+                    "WHERE es.id.orgId = :orgId AND es.id.userId = :userId " +
                     "AND b.name = :bundleName AND a.name = :applicationName AND es.id.subscriptionType = :subscriptionType";
             try {
                 return entityManager.createQuery(query, EmailSubscription.class)
@@ -86,7 +86,7 @@ public class EmailSubscriptionRepository {
             }
         } else {
             String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
-                    "WHERE es.id.accountId = :accountId AND es.id.userId = :userId " +
+                    "WHERE es.accountId = :accountId AND es.id.userId = :userId " +
                     "AND b.name = :bundleName AND a.name = :applicationName AND es.id.subscriptionType = :subscriptionType";
             try {
                 return entityManager.createQuery(query, EmailSubscription.class)
@@ -105,14 +105,14 @@ public class EmailSubscriptionRepository {
     public List<EmailSubscription> getEmailSubscriptionsForUser(String accountNumber, String orgId, String username) {
         if (orgIdHelper.useOrgId(orgId)) {
             String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
-                    "WHERE es.orgId = :orgId AND es.id.userId = :userId";
+                    "WHERE es.id.orgId = :orgId AND es.id.userId = :userId";
             return entityManager.createQuery(query, EmailSubscription.class)
                     .setParameter("orgId", orgId)
                     .setParameter("userId", username)
                     .getResultList();
         } else {
             String query = "SELECT es FROM EmailSubscription es LEFT JOIN FETCH es.application a LEFT JOIN FETCH a.bundle b " +
-                    "WHERE es.id.accountId = :accountId AND es.id.userId = :userId";
+                    "WHERE es.accountId = :accountId AND es.id.userId = :userId";
             return entityManager.createQuery(query, EmailSubscription.class)
                     .setParameter("accountId", accountNumber)
                     .setParameter("userId", username)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/EventsMigrationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/EventsMigrationResourceTest.java
@@ -38,8 +38,8 @@ public class EventsMigrationResourceTest {
 
         EventType eventType = createEventType();
 
-        Event event1 = createEvent(eventType, "account-123", null);
-        Event event2 = createEvent(eventType, "account-456", null);
+        Event event1 = createEvent(eventType, "account-123", "org-id-123");
+        Event event2 = createEvent(eventType, "account-456", "org-id-456");
         Event event3 = createEvent(eventType, "account-789", "org-id-789");
 
         given()

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EmailSubscription.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EmailSubscription.java
@@ -17,7 +17,7 @@ public class EmailSubscription {
     private EmailSubscriptionId id;
 
     @Size(max = 50)
-    private String orgId;
+    private String accountId;
 
     @ManyToOne
     @MapsId("applicationId")
@@ -29,19 +29,19 @@ public class EmailSubscription {
     }
 
     public String getAccountId() {
-        return id.accountId;
+        return accountId;
     }
 
     public void setAccountId(String accountId) {
-        id.accountId = accountId;
+        this.accountId = accountId;
     }
 
     public String getOrgId() {
-        return orgId;
+        return id.orgId;
     }
 
     public void setOrgId(String orgId) {
-        this.orgId = orgId;
+        id.orgId = orgId;
     }
 
     public String getUserId() {

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionId.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EmailSubscriptionId.java
@@ -15,7 +15,7 @@ public class EmailSubscriptionId implements Serializable {
 
     @NotNull
     @Size(max = 50)
-    public String accountId;
+    public String orgId;
 
     @NotNull
     @Size(max = 50)
@@ -36,7 +36,7 @@ public class EmailSubscriptionId implements Serializable {
         }
         if (o instanceof EmailSubscriptionId) {
             EmailSubscriptionId other = (EmailSubscriptionId) o;
-            return Objects.equals(accountId, other.accountId) &&
+            return Objects.equals(orgId, other.orgId) &&
                     Objects.equals(userId, other.userId) &&
                     Objects.equals(subscriptionType, other.subscriptionType) &&
                     Objects.equals(applicationId, other.applicationId);
@@ -46,6 +46,6 @@ public class EmailSubscriptionId implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountId, userId, subscriptionType, applicationId);
+        return Objects.hash(orgId, userId, subscriptionType, applicationId);
     }
 }

--- a/database/src/main/resources/db/migration/V1.58.0__NOTIF-603_anemic_tenants.sql
+++ b/database/src/main/resources/db/migration/V1.58.0__NOTIF-603_anemic_tenants.sql
@@ -1,0 +1,26 @@
+-- Table: behavior_group
+DROP INDEX ix_behavior_group_account_id;
+
+-- Table: email_aggregation
+ALTER TABLE email_aggregation
+    ALTER COLUMN account_id DROP NOT NULL,
+    ALTER COLUMN org_id SET NOT NULL;
+
+-- Table: endpoint_email_subscriptions
+ALTER TABLE endpoint_email_subscriptions
+    DROP CONSTRAINT pk_endpoint_email_subscriptions,
+    DROP CONSTRAINT uq_endpoint_email_subscriptions,
+    ALTER COLUMN account_id DROP NOT NULL,
+    ALTER COLUMN org_id SET NOT NULL,
+    ADD CONSTRAINT pk_endpoint_email_subscriptions PRIMARY KEY (org_id, user_id, subscription_type, application_id);
+
+-- Table: endpoints
+DROP INDEX ix_endpoints_account_id;
+
+-- Table: event
+DROP INDEX ix_event_account_id;
+DROP INDEX ix_event_account_id_application_id;
+DROP INDEX ix_event_index_only_scan;
+ALTER TABLE event
+    ALTER COLUMN account_id DROP NOT NULL,
+    ALTER COLUMN org_id SET NOT NULL;

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EmailSubscriptionRepository.java
@@ -19,7 +19,7 @@ public class EmailSubscriptionRepository {
 
     public List<String> getEmailSubscribersUserId(String accountId, String orgId, String bundleName, String applicationName, EmailSubscriptionType subscriptionType) {
         if (orgIdHelper.useOrgId(orgId)) {
-            String query = "SELECT es.id.userId FROM EmailSubscription es WHERE orgId = :orgId AND application.bundle.name = :bundleName " +
+            String query = "SELECT es.id.userId FROM EmailSubscription es WHERE id.orgId = :orgId AND application.bundle.name = :bundleName " +
                     "AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
             return statelessSessionFactory.getCurrentSession().createQuery(query, String.class)
                     .setParameter("orgId", orgId)
@@ -28,7 +28,7 @@ public class EmailSubscriptionRepository {
                     .setParameter("subscriptionType", subscriptionType)
                     .getResultList();
         } else {
-            String query = "SELECT es.id.userId FROM EmailSubscription es WHERE id.accountId = :accountId AND application.bundle.name = :bundleName " +
+            String query = "SELECT es.id.userId FROM EmailSubscription es WHERE accountId = :accountId AND application.bundle.name = :bundleName " +
                     "AND application.name = :applicationName AND id.subscriptionType = :subscriptionType";
             return statelessSessionFactory.getCurrentSession().createQuery(query, String.class)
                     .setParameter("accountId", accountId)

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EmailAggregationRepositoryTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
@@ -71,17 +70,15 @@ public class EmailAggregationRepositoryTest {
 
         statelessSessionFactory.withSession(statelessSession -> {
             clearEmailAggregations();
-            resourceHelpers.addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, APP_NAME, PAYLOAD1);
-            resourceHelpers.addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
-            resourceHelpers.addEmailAggregation("other-account", ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
-            resourceHelpers.addEmailAggregation(ACCOUNT_ID, "other-bundle", APP_NAME, PAYLOAD2);
-            resourceHelpers.addEmailAggregation(ACCOUNT_ID, BUNDLE_NAME, "other-app", PAYLOAD2);
+            resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD1);
+            resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD2);
+            resourceHelpers.addEmailAggregation("other-account", "other-org-id", BUNDLE_NAME, APP_NAME, PAYLOAD2);
+            resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, "other-bundle", APP_NAME, PAYLOAD2);
+            resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, "other-app", PAYLOAD2);
 
             List<EmailAggregation> aggregations = emailAggregationRepository.getEmailAggregation(key, start, end);
             assertEquals(2, aggregations.size());
 
-            assertNull(aggregations.get(0).getOrgId());
-            assertNull(aggregations.get(1).getOrgId());
             assertTrue(aggregations.stream().map(EmailAggregation::getAccountId).allMatch(ACCOUNT_ID::equals));
             assertTrue(aggregations.stream().map(EmailAggregation::getBundleName).allMatch(BUNDLE_NAME::equals));
             assertTrue(aggregations.stream().map(EmailAggregation::getApplicationName).allMatch(APP_NAME::equals));
@@ -148,7 +145,7 @@ public class EmailAggregationRepositoryTest {
             assertFalse(resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, APP_NAME, null));
             assertFalse(resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, BUNDLE_NAME, null, PAYLOAD1));
             assertFalse(resourceHelpers.addEmailAggregation(ACCOUNT_ID, ORG_ID, null, APP_NAME, PAYLOAD1));
-            assertFalse(resourceHelpers.addEmailAggregation(null, ORG_ID, BUNDLE_NAME, APP_NAME, PAYLOAD1));
+            assertFalse(resourceHelpers.addEmailAggregation(ACCOUNT_ID, null, BUNDLE_NAME, APP_NAME, PAYLOAD1));
         });
     }
 


### PR DESCRIPTION
Depends on #1354.

:warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning:
This PR must be merged after #1354 and after the Event Log has been successfully tested with `NOTIFICATIONS_EVENTS_USE_ORG_ID=true` on prod.
:warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning:

This change is required to make the app compatible with anemic tenants.