### PR TITLE
NOTIF-603 Restore initial probes failure thresholds

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -322,7 +322,7 @@ objects:
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 116
+          failureThreshold: 3
         livenessProbe:
           httpGet:
             path: /health/live
@@ -332,7 +332,7 @@ objects:
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 116
+          failureThreshold: 3
         env:
         - name: ENV_NAME
           value: ${ENV_NAME}


### PR DESCRIPTION
The [big DB migration](https://github.com/RedHatInsights/notifications-backend/pull/1354) is done, we don't need huge failure thresholds anymore.