### PR TITLE
Remove unavailable settings from user preferences call

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
@@ -169,13 +169,16 @@ public class UserConfigResource {
             for (Application application : applicationRepository.getApplications(bundle.getName())) {
                 ApplicationSettingsValue applicationSettingsValue = new ApplicationSettingsValue();
                 applicationSettingsValue.displayName = application.getDisplayName();
-                settingsValues.bundles.get(bundle.getName()).applications.put(application.getName(), applicationSettingsValue);
                 for (EmailSubscriptionType emailSubscriptionType : EmailSubscriptionType.values()) {
                     // TODO NOTIF-450 How do we deal with a failure here? What kind of response should be sent to the UI when the engine is down?
                     boolean supported = templateEngineClient.isSubscriptionTypeSupported(bundle.getName(), application.getName(), emailSubscriptionType);
                     if (supported) {
-                        settingsValues.bundles.get(bundle.getName()).applications.get(application.getName()).notifications.put(emailSubscriptionType, false);
+                        applicationSettingsValue.notifications.put(emailSubscriptionType, false);
                     }
+                }
+
+                if (applicationSettingsValue.notifications.size() > 0) {
+                    settingsValues.bundles.get(bundle.getName()).applications.put(application.getName(), applicationSettingsValue);
                 }
             }
             List<EmailSubscription> emailSubscriptions = emailSubscriptionRepository.getEmailSubscriptionsForUser(account, orgId, username);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
@@ -319,6 +319,19 @@ public class UserConfigResourceTest extends DbIsolatedTest {
         assertNotNull(rhelPolicy2, "RHEL policies not found");
         assertEquals(1, rhelPolicy2.fields.get(0).fields.size());
         assertEquals("bundles[rhel].applications[policies].notifications[INSTANT]", rhelPolicy2.fields.get(0).fields.get(0).name);
+
+        // Skip the application if there are no supported types
+        when(templateEngineClient.isSubscriptionTypeSupported(bundle, application, INSTANT)).thenReturn(FALSE);
+        when(templateEngineClient.isSubscriptionTypeSupported(bundle, application, DAILY)).thenReturn(FALSE);
+        settingsValueJsonForm = given()
+                .header(identityHeader)
+                .when().get("/user-config/notification-preference?bundleName=rhel")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().body().as(SettingsValueJsonForm.class);
+        rhelPolicy = rhelPolicyForm(settingsValueJsonForm);
+        assertNull(rhelPolicy, "RHEL policies was not supposed to be here");
     }
 
 }


### PR DESCRIPTION
Remove (from user preferences) applications  that don't have any valid option.

e.g. We want to stop showing empty applications here such as `Storage broker` or `Internal`:

![Screenshot_2022-08-22_10-36-24](https://user-images.githubusercontent.com/3845764/185973305-caac3024-77f5-4f04-8ae4-e64c48cff7de.png)
