### PR TITLE
NOTIF-674 Limit fields of sort expressions

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -16,7 +16,7 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 public class Query {
 
     // NOTIF-674 Change to "^([a-z0-9_-]+)(:(asc|desc))?$" after the frontend has been updated
-    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^([a-z0-9._-]+)(:(asc|desc))?$", CASE_INSENSITIVE);
+    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9._-]+(:(asc|desc))?$", CASE_INSENSITIVE);
 
     private static final int DEFAULT_RESULTS_PER_PAGE  = 20;
 
@@ -165,14 +165,14 @@ public class Query {
         }
 
         if (!SORT_BY_PATTERN.matcher(sortBy).matches()) {
-            throw new BadRequestException("Invalid 'sortBy' query parameter");
+            throw new BadRequestException("Invalid 'sort_by' query parameter");
         }
 
         String[] sortSplit = sortBy.split(":");
         Sort sort = new Sort(sortSplit[0]);
         if (!sortFields.containsKey(sort.sortColumn.toLowerCase())) {
             Log.warnf("NOTIF-674 Unknown sort field passed: ", sort.sortColumn);
-            throw new BadRequestException("Invalid sort by field: " + sort.sortColumn);
+            throw new BadRequestException("Invalid sort_by field: " + sort.sortColumn);
         } else {
             sort.sortColumn = sortFields.get(sort.sortColumn.toLowerCase());
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -153,7 +153,6 @@ public class Query {
         }
 
         if (sortFields == null) {
-            // Throw an exception after migrating all the usages.
             Log.warnf("NOTIF-674 SortFields not set.");
             sortFields = Map.of();
             throw new BadRequestException("Allowed sort fields not set for this query");

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -15,7 +15,8 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public class Query {
 
-    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^([a-z0-9_-]+)(:(asc|desc))?$", CASE_INSENSITIVE);
+    // NOTIF-674 Change to "^([a-z0-9_-]+)(:(asc|desc))?$" after the frontend has been updated
+    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^([a-z0-9._-]+)(:(asc|desc))?$", CASE_INSENSITIVE);
 
     private static final int DEFAULT_RESULTS_PER_PAGE  = 20;
 
@@ -42,11 +43,16 @@ public class Query {
     public void setSortFields(String[] sortFields) {
         this.sortFields = new HashMap<>();
         for (String sortField : sortFields) {
-            this.sortFields.put(sortField, sortField);
+            this.sortFields.put(sortField.toLowerCase(), sortField);
         }
     }
 
     public void setSortFields(Map<String, String> sortFields) {
+        sortFields.keySet().forEach(key -> {
+            if (!key.toLowerCase().equals(key)) {
+                throw new IllegalArgumentException("All keys of sort fields must be specified in lower case");
+            }
+        });
         this.sortFields = Map.copyOf(sortFields);
     }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -15,7 +15,7 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public class Query {
 
-    // NOTIF-674 Change to "^([a-z0-9_-]+)(:(asc|desc))?$" after the frontend has been updated
+    // NOTIF-674 Change to "^[a-z0-9_-]+(:(asc|desc))?$" after the frontend has been updated
     private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9._-]+(:(asc|desc))?$", CASE_INSENSITIVE);
 
     private static final int DEFAULT_RESULTS_PER_PAGE  = 20;
@@ -161,7 +161,6 @@ public class Query {
         if (sortFields == null) {
             Log.warnf("NOTIF-674 SortFields not set.");
             sortFields = Map.of();
-            throw new BadRequestException("Allowed sort fields not set for this query");
         }
 
         if (!SORT_BY_PATTERN.matcher(sortBy).matches()) {
@@ -172,7 +171,6 @@ public class Query {
         Sort sort = new Sort(sortSplit[0]);
         if (!sortFields.containsKey(sort.sortColumn.toLowerCase())) {
             Log.warnf("NOTIF-674 Unknown sort field passed: ", sort.sortColumn);
-            throw new BadRequestException("Invalid sort_by field: " + sort.sortColumn);
         } else {
             sort.sortColumn = sortFields.get(sort.sortColumn.toLowerCase());
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -5,7 +5,6 @@ import io.quarkus.logging.Log;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -40,11 +39,11 @@ public class Query {
     private String defaultSortBy;
     private Map<String, String> sortFields;
 
-    public void setSortFields(String[] sortFields) {
-        this.sortFields = new HashMap<>();
-        for (String sortField : sortFields) {
-            this.sortFields.put(sortField.toLowerCase(), sortField);
-        }
+    // Used by test
+    public static Query queryWithSortBy(String sortBy) {
+        Query query = new Query();
+        query.sortBy = sortBy;
+        return query;
     }
 
     public void setSortFields(Map<String, String> sortFields) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -5,11 +5,9 @@ import io.quarkus.logging.Log;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -121,14 +119,14 @@ public class Query {
         }
     }
 
-    public Sort getSort() {
+    public Optional<Sort> getSort() {
         // Endpoints: sort by: name, type, "last connection status" (?), enabled
         //      -> endpoint_id, name, endpoint_type, enabled are the accepted parameter names
         // TODO Should they be id, name, type, enabled for consistency and then modified in the actual query to Postgres?
         // And if it's not an accepted value? Throw exception?
 
         if (sortBy == null || sortBy.length() < 1) {
-            return null;
+            return Optional.empty();
         }
 
         if (sortFields == null) {
@@ -156,7 +154,8 @@ public class Query {
                 } catch (IllegalArgumentException | NullPointerException iae) {
                 }
             }
-            return sort;
+
+            return Optional.of(sort);
         }
     }
 
@@ -164,9 +163,9 @@ public class Query {
         // Use the internal Query
         // What's the proper order? SORT first, then LIMIT? COUNT as last one?
         String query = basicQuery;
-        Sort sort = getSort();
-        if (sort != null) {
-            query = modifyWithSort(query, sort);
+        Optional<Sort> sort = getSort();
+        if (sort.isPresent()) {
+            query = modifyWithSort(query, sort.get());
         }
         return query;
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.db;
 
+import io.quarkus.logging.Log;
+
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
@@ -132,7 +134,8 @@ public class Query {
             throw new BadRequestException("Invalid 'sort_by' query parameter");
         } else {
             Sort sort = new Sort(sortSplit[0]);
-            if (!sortFields.contains(sort.sortColumn)) {
+            if (!sortFields.contains(sort.sortColumn.toLowerCase())) {
+                Log.warnf("Unknown sort field passed: ", sort.sortColumn);
                 throw new BadRequestException("Unknown sort field " + sort.sortColumn);
             }
             if (sortSplit.length > 1) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/builder/QueryBuilder.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/builder/QueryBuilder.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.db.Query;
 
 import javax.persistence.TypedQuery;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 public class QueryBuilder<T> {
@@ -52,9 +53,9 @@ public class QueryBuilder<T> {
         return this;
     }
 
-    public QueryBuilder<T> sort(Query.Sort sort) {
-        if (sort != null) {
-            rawSort = " " + sort.getSortQuery();
+    public QueryBuilder<T> sort(Optional<Query.Sort> sort) {
+        if (sort.isPresent()) {
+            rawSort = " " + sort.get().getSortQuery();
         }
 
         return this;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -25,7 +25,6 @@ import java.util.function.Supplier;
 @ApplicationScoped
 public class ApplicationRepository {
 
-
     @Inject
     EntityManager entityManager;
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 @ApplicationScoped
 public class ApplicationRepository {
 
+    private static final String[] EVENT_TYPE_SORT_FIELDS = {"name", "displayName"};
     @Inject
     EntityManager entityManager;
 
@@ -185,6 +186,7 @@ public class ApplicationRepository {
     }
 
     public List<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId, String eventTypeName) {
+        limiter.setSortFields(EVENT_TYPE_SORT_FIELDS);
         return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName)
                 .join(JoinBuilder.builder().leftJoinFetch("e.application"))
                 .limit(limiter != null ? limiter.getLimit() : null)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 @ApplicationScoped
 public class ApplicationRepository {
 
-    private static final String[] EVENT_TYPE_SORT_FIELDS = {"name", "displayName"};
+
     @Inject
     EntityManager entityManager;
 
@@ -186,7 +186,7 @@ public class ApplicationRepository {
     }
 
     public List<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId, String eventTypeName) {
-        limiter.setSortFields(EVENT_TYPE_SORT_FIELDS);
+        limiter.setSortFields(EventType.SORT_FIELDS);
         return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName)
                 .join(JoinBuilder.builder().leftJoinFetch("e.application"))
                 .limit(limiter != null ? limiter.getLimit() : null)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -186,7 +186,10 @@ public class ApplicationRepository {
     }
 
     public List<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId, String eventTypeName) {
-        limiter.setSortFields(EventType.SORT_FIELDS);
+        if (limiter != null) {
+            limiter.setSortFields(EventType.SORT_FIELDS);
+        }
+
         return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName)
                 .join(JoinBuilder.builder().leftJoinFetch("e.application"))
                 .limit(limiter != null ? limiter.getLimit() : null)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -405,6 +405,7 @@ public class BehaviorGroupRepository {
         String query = "SELECT bg FROM BehaviorGroup bg JOIN bg.behaviors b WHERE (bg.orgId = :orgId OR bg.orgId IS NULL) AND b.eventType.id = :eventTypeId";
 
         if (limiter != null) {
+            limiter.setSortFields(BehaviorGroup.SORT_FIELDS);
             query = limiter.getModifiedQuery(query);
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -34,7 +34,8 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class EndpointRepository {
     private static final String[] ENDPOINT_SORT_FIELDS = {"name", "enabled", "endpoint_type"};
- @Inject
+
+    @Inject
     EntityManager entityManager;
 
     @Transactional

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -149,8 +149,9 @@ public class EndpointRepository {
     }
 
     public List<Endpoint> getEndpoints(String orgId, @Nullable String name, Query limiter) {
-        limiter.setSortFields(ENDPOINT_SORT_FIELDS);
-
+        if (limiter != null) {
+            limiter.setSortFields(ENDPOINT_SORT_FIELDS);
+        }
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Query.Sort sort = limiter == null ? null : limiter.getSort();
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -79,6 +79,9 @@ public class EndpointRepository {
     }
 
     public List<Endpoint> getEndpointsPerCompositeType(String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly, Query limiter) {
+        if (limiter != null) {
+            limiter.setSortFields(Endpoint.SORT_FIELDS);
+        }
 
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Optional<Query.Sort> sort = limiter == null ? Optional.empty() : limiter.getSort();

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -83,7 +83,7 @@ public class EndpointRepository {
     public List<Endpoint> getEndpointsPerCompositeType(String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly, Query limiter) {
 
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
-        Query.Sort sort = limiter == null ? null : limiter.getSort();
+        Optional<Query.Sort> sort = limiter == null ? Optional.empty() : limiter.getSort();
         List<Endpoint> endpoints = EndpointRepository.queryBuilderEndpointsPerType(orgId, name, type, activeOnly)
                 .limit(limit)
                 .sort(sort)
@@ -153,7 +153,7 @@ public class EndpointRepository {
             limiter.setSortFields(ENDPOINT_SORT_FIELDS);
         }
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
-        Query.Sort sort = limiter == null ? null : limiter.getSort();
+        Optional<Query.Sort> sort = limiter == null ? Optional.empty() : limiter.getSort();
 
         // TODO Add the ability to modify the getEndpoints to return also with JOIN to application_eventtypes_endpoints link table
         //      or should I just create a new method for it?

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -33,8 +33,6 @@ import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class EndpointRepository {
-    private static final String[] ENDPOINT_SORT_FIELDS = {"name", "enabled", "endpoint_type"};
-
     @Inject
     EntityManager entityManager;
 
@@ -150,7 +148,7 @@ public class EndpointRepository {
 
     public List<Endpoint> getEndpoints(String orgId, @Nullable String name, Query limiter) {
         if (limiter != null) {
-            limiter.setSortFields(ENDPOINT_SORT_FIELDS);
+            limiter.setSortFields(Endpoint.SORT_FIELDS);
         }
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Optional<Query.Sort> sort = limiter == null ? Optional.empty() : limiter.getSort();

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -33,8 +33,8 @@ import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class EndpointRepository {
-
-    @Inject
+    private static final String[] ENDPOINT_SORT_FIELDS = {"name", "enabled", "endpoint_type"};
+ @Inject
     EntityManager entityManager;
 
     @Transactional
@@ -148,6 +148,8 @@ public class EndpointRepository {
     }
 
     public List<Endpoint> getEndpoints(String orgId, @Nullable String name, Query limiter) {
+        limiter.setSortFields(ENDPOINT_SORT_FIELDS);
+
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Query.Sort sort = limiter == null ? null : limiter.getSort();
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -40,6 +40,7 @@ public class EventRepository {
                                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                       Set<Boolean> invocationResults, boolean fetchNotificationHistory, Query query) {
         query.setSortFields(sortFields);
+        query.setDefaultSortBy("created:DESC");
         Optional<Query.Sort> sort = query.getSort();
         List<UUID> eventIds = getEventIds(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, query);
         String hql;
@@ -50,7 +51,7 @@ public class EventRepository {
         }
 
         if (sort.isPresent()) {
-            hql += sort.get().getSortQuery();
+            hql += getOrderBy(sort.get());
         }
 
         return entityManager.createQuery(hql, Event.class)
@@ -71,6 +72,14 @@ public class EventRepository {
         return query.getSingleResult();
     }
 
+    private String getOrderBy(Query.Sort sort) {
+        if (!sort.getSortColumn().equals("e.created")) {
+            return " " + sort.getSortQuery() + ", e.created DESC";
+        } else {
+            return " " + sort.getSortQuery();
+        }
+    }
+
     private List<UUID> getEventIds(String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                         LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                         Set<Boolean> invocationResults, Query query) {
@@ -85,7 +94,7 @@ public class EventRepository {
         Optional<Query.Sort> sort = query.getSort();
 
         if (sort.isPresent()) {
-            hql += sort.get().getSortQuery();
+            hql += getOrderBy(sort.get());
         }
 
         TypedQuery<UUID> typedQuery = entityManager.createQuery(hql, UUID.class);

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications.db.repositories;
 
-import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.EndpointType;
@@ -15,7 +14,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -26,20 +24,10 @@ public class EventRepository {
     @Inject
     EntityManager entityManager;
 
-    @Inject
-    FeatureFlipper featureFlipper;
-
-    private final Map<String, String> sortFields = Map.of(
-            "bundle", "e.bundleDisplayName",
-            "application", "e.applicationDisplayName",
-            "event", "e.eventTypeDisplayName",
-            "created", "e.created"
-    );
-
     public List<Event> getEvents(String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                       Set<Boolean> invocationResults, boolean fetchNotificationHistory, Query query) {
-        query.setSortFields(sortFields);
+        query.setSortFields(Event.SORT_FIELDS);
         query.setDefaultSortBy("created:DESC");
         Optional<Query.Sort> sort = query.getSort();
         List<UUID> eventIds = getEventIds(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, query);

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -83,12 +83,7 @@ public class EventRepository {
     private List<UUID> getEventIds(String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                         LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                         Set<Boolean> invocationResults, Query query) {
-        String hql = "SELECT e.id FROM Event e WHERE ";
-        if (featureFlipper.isUseOrgIdInEvents()) {
-            hql += "e.orgId = :orgId";
-        } else {
-            hql += "e.accountId = :accountId";
-        }
+        String hql = "SELECT e.id FROM Event e WHERE e.orgId = :orgId";
 
         hql = addHqlConditions(hql, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults);
         Optional<Query.Sort> sort = query.getSort();

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
@@ -31,6 +31,7 @@ public class NotificationRepository {
         query += ") FROM NotificationHistory nh WHERE nh.endpoint.id = :endpointId AND nh.event.orgId = :orgId";
 
         if (limiter != null) {
+            limiter.setSortFields(NotificationHistory.SORT_FIELDS);
             query = limiter.getModifiedQuery(query);
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -150,7 +150,6 @@ public class EndpointResource {
             @QueryParam("active") Boolean activeOnly,
             @QueryParam("name") String name) {
         String orgId = getOrgId(sec);
-        query.setSortFields(Endpoint.SORT_FIELDS);
 
         List<Endpoint> endpoints;
         Long count;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -150,6 +150,7 @@ public class EndpointResource {
             @QueryParam("active") Boolean activeOnly,
             @QueryParam("name") String name) {
         String orgId = getOrgId(sec);
+        query.setSortFields(Endpoint.SORT_FIELDS);
 
         List<Endpoint> endpoints;
         Long count;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
@@ -49,8 +49,7 @@ public class EventResource {
     @Produces(APPLICATION_JSON)
     @RolesAllowed(RBAC_READ_NOTIFICATIONS_EVENTS)
     @Operation(summary = "Retrieve the event log entries.", description =
-            "Allowed sort_by values are bundle, application, event and created. Optionally the ordering can be specified by appending a colon followed by "
-            + " asc (ascending) or desc (descending). e.g. bundle:desc. Default to asc if no order is specified and created:desc if nothing is specified."
+            "Allowed `sort_by` fields are `bundle`, `application`, `event` and `created`. The ordering can be optionally specified by appending `:asc` or `:desc` to the field, e.g. `bundle:desc`. Defaults to `desc` for the `created` field and to `asc` for all other fields."
     )
     public Page<EventLogEntry> getEvents(@Context SecurityContext securityContext, @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
                                          @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
@@ -16,6 +16,7 @@ import org.jboss.resteasy.reactive.RestQuery;
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -51,7 +52,7 @@ public class EventResource {
     public Page<EventLogEntry> getEvents(@Context SecurityContext securityContext, @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
                                          @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
                                          @RestQuery Set<String> endpointTypes, @RestQuery Set<Boolean> invocationResults,
-                                         @RestQuery Query query,
+                                         @BeanParam Query query,
                                          @RestQuery boolean includeDetails, @RestQuery boolean includePayload, @RestQuery boolean includeActions) {
         if (query.getLimit().getLimit() < 1 || query.getLimit().getLimit() > 200) {
             throw new BadRequestException("Invalid 'limit' query parameter, its value must be between 1 and 200");

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
@@ -48,7 +48,10 @@ public class EventResource {
     @GET
     @Produces(APPLICATION_JSON)
     @RolesAllowed(RBAC_READ_NOTIFICATIONS_EVENTS)
-    @Operation(summary = "Retrieve the event log entries.")
+    @Operation(summary = "Retrieve the event log entries.", description =
+            "Allowed sort_by values are bundle, application, event and created. Optionally the ordering can be specified by appending a colon followed by "
+            + " asc (ascending) or desc (descending). e.g. bundle:desc. Default to asc if no order is specified and created:desc if nothing is specified."
+    )
     public Page<EventLogEntry> getEvents(@Context SecurityContext securityContext, @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
                                          @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
                                          @RestQuery Set<String> endpointTypes, @RestQuery Set<Boolean> invocationResults,

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.routers;
 
+import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.repositories.EventRepository;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.EndpointType;
@@ -15,7 +16,6 @@ import org.jboss.resteasy.reactive.RestQuery;
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -28,21 +28,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
 import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS;
 import static com.redhat.cloud.notifications.routers.EventResource.PATH;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
-import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path(PATH)
 public class EventResource {
 
     public static final String PATH = API_NOTIFICATIONS_V_1_0 + "/notifications/events";
-    public static final Pattern SORT_BY_PATTERN = Pattern.compile("^([a-z0-9_-]+):(asc|desc)$", CASE_INSENSITIVE);
 
     @Inject
     EventRepository eventRepository;
@@ -52,15 +49,12 @@ public class EventResource {
     @RolesAllowed(RBAC_READ_NOTIFICATIONS_EVENTS)
     @Operation(summary = "Retrieve the event log entries.")
     public Page<EventLogEntry> getEvents(@Context SecurityContext securityContext, @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
-                                              @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
-                                              @RestQuery Set<String> endpointTypes, @RestQuery Set<Boolean> invocationResults,
-                                              @RestQuery @DefaultValue("10") int limit, @RestQuery @DefaultValue("0") int offset, @RestQuery String sortBy,
-                                              @RestQuery boolean includeDetails, @RestQuery boolean includePayload, @RestQuery boolean includeActions) {
-        if (limit < 1 || limit > 200) {
+                                         @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
+                                         @RestQuery Set<String> endpointTypes, @RestQuery Set<Boolean> invocationResults,
+                                         @RestQuery Query query,
+                                         @RestQuery boolean includeDetails, @RestQuery boolean includePayload, @RestQuery boolean includeActions) {
+        if (query.getLimit().getLimit() < 1 || query.getLimit().getLimit() > 200) {
             throw new BadRequestException("Invalid 'limit' query parameter, its value must be between 1 and 200");
-        }
-        if (sortBy != null && !SORT_BY_PATTERN.matcher(sortBy).matches()) {
-            throw new BadRequestException("Invalid 'sortBy' query parameter");
         }
 
         Set<EndpointType> basicTypes = Collections.emptySet();
@@ -85,7 +79,7 @@ public class EventResource {
         }
 
         String orgId = getOrgId(securityContext);
-        List<Event> events = eventRepository.getEvents(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, limit, offset, sortBy);
+        List<Event> events = eventRepository.getEvents(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, query);
         List<EventLogEntry> eventLogEntries = events.stream().map(event -> {
             List<EventLogEntryAction> actions;
             if (!includeActions) {
@@ -122,7 +116,7 @@ public class EventResource {
         Meta meta = new Meta();
         meta.setCount(count);
 
-        Map<String, String> links = PageLinksBuilder.build(PATH, count, limit, offset);
+        Map<String, String> links = PageLinksBuilder.build(PATH, count, query);
 
         Page<EventLogEntry> page = new Page<>();
         page.setData(eventLogEntries);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/PageLinksBuilder.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/PageLinksBuilder.java
@@ -1,9 +1,15 @@
 package com.redhat.cloud.notifications.routers.models;
 
+import com.redhat.cloud.notifications.db.Query;
+
 import java.util.HashMap;
 import java.util.Map;
 
 public class PageLinksBuilder {
+
+    public static Map<String, String> build(String apiPath, long count, Query query) {
+        return build(apiPath, count, query.getLimit().getLimit(), query.getLimit().getOffset());
+    }
 
     public static Map<String, String> build(String apiPath, long count, long limit, long currentOffset) {
         Map<String, String> links = new HashMap<>();

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/QueryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/QueryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import javax.ws.rs.BadRequestException;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -21,16 +22,20 @@ public class QueryTest {
         Query query = new Query();
         assertTrue(query.getSort().isEmpty());
 
+        // NOTIF-674 Enable it back once we start throwing the exceptions
         // Throws BadRequest if sortBy* is provided without sort fields
         query = new Query();
         query.sortBy = "foo:desc";
-        assertThrows(BadRequestException.class, query::getSort);
+        // assertThrows(BadRequestException.class, query::getSort);
+        assertDoesNotThrow(query::getSort);
 
+        // NOTIF-674 Enable it back once we start throwing the exceptions
         // Throws BadRequest if sortBy* is not found in the sort fields
         query = new Query();
         query.sortBy = "foo:desc";
         query.setSortFields(Map.of("bar", "e.bar"));
-        assertThrows(BadRequestException.class, query::getSort);
+        // assertThrows(BadRequestException.class, query::getSort);
+        assertDoesNotThrow(query::getSort);
 
         // Throws BadRequest if sortBy* has a wrong syntax
         query = new Query();

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/QueryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/QueryTest.java
@@ -1,0 +1,76 @@
+package com.redhat.cloud.notifications.db;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.BadRequestException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class QueryTest {
+
+    @Test
+    public void testSort() {
+
+        // Sort is empty if nothing is provided
+        Query query = new Query();
+        assertTrue(query.getSort().isEmpty());
+
+        // Throws BadRequest if sortBy* is provided without sort fields
+        query = new Query();
+        query.sortBy = "foo:desc";
+        assertThrows(BadRequestException.class, query::getSort);
+
+        // Throws BadRequest if sortBy* is not found in the sort fields
+        query = new Query();
+        query.sortBy = "foo:desc";
+        query.setSortFields(Map.of("bar", "e.bar"));
+        assertThrows(BadRequestException.class, query::getSort);
+
+        // Throws BadRequest if sortBy* has a wrong syntax
+        query = new Query();
+        query.sortBy = "i am not a valid sortby::";
+        query.setSortFields(Map.of("bar", "e.bar"));
+        assertThrows(BadRequestException.class, query::getSort);
+
+        // sortBy defaults to order asc if not specified
+        query = new Query();
+        query.sortBy = "bar";
+        query.setSortFields(Map.of("bar", "e.bar"));
+        Query.Sort sort = query.getSort().get();
+        assertEquals("e.bar", sort.getSortColumn());
+        assertEquals(Query.Sort.Order.ASC, sort.getSortOrder());
+
+        // throws BadRequest if the order is not valid
+        query = new Query();
+        query.sortBy = "bar:foo";
+        query.setSortFields(Map.of("bar", "e.bar"));
+        assertThrows(BadRequestException.class, query::getSort);
+
+        // sortBy (sortByDeprecated) is used if sort_by is not specified
+        query = new Query();
+        query.sortByDeprecated = "foo";
+        assertEquals("foo", query.getSortBy());
+
+        // sort_by has higher preference that sortBy query param
+        query = new Query();
+        query.sortBy = "foo";
+        query.sortByDeprecated = "bar";
+        assertEquals("foo", query.getSortBy());
+
+        // default sortBy is used if none of the sortBy* were specified
+        query = new Query();
+        query.setDefaultSortBy("foo");
+        assertEquals("foo", query.getSortBy());
+
+        // null if provided if no default or any sortBy* is used
+        query = new Query();
+        assertNull(query.getSortBy());
+    }
+
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/builder/QueryBuilderTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/builder/QueryBuilderTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.persistence.TypedQuery;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
@@ -193,7 +194,7 @@ public class QueryBuilderTest {
         assertEquals(
                 "SELECT o FROM Object o ORDER BY o.col ASC",
                 QueryBuilder.builder(Object.class).alias("o")
-                        .sort(new Query.Sort("o.col", Query.Sort.Order.ASC))
+                        .sort(Optional.of(new Query.Sort("o.col", Query.Sort.Order.ASC)))
                         .buildRawQuery()
         );
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -1,14 +1,23 @@
 package com.redhat.cloud.notifications.db.repositories;
 
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import javax.persistence.TypedQuery;
+import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
@@ -19,6 +28,81 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @QuarkusTest
 public class EndpointRepositoryTest {
+
+    private static final String NOT_USED = "not-used";
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @Inject
+    EndpointRepository endpointRepository;
+
+    @Test
+    void shouldSortCorrectly() {
+        String orgId = "endpoint-repository-test-sort";
+
+        List<Endpoint> createdEndpointList = List.of(
+            resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, orgId, EndpointType.CAMEL, NOT_USED, "1", NOT_USED, null, true),
+            resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, orgId, EndpointType.WEBHOOK, NOT_USED, "2", NOT_USED, null, true),
+            resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, orgId, EndpointType.EMAIL_SUBSCRIPTION, NOT_USED, "3", NOT_USED, null, true),
+            resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, orgId, EndpointType.CAMEL, NOT_USED, "4", NOT_USED, null, false),
+            resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, orgId, EndpointType.CAMEL, NOT_USED, "5", NOT_USED, null, false),
+            resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, orgId, EndpointType.CAMEL, NOT_USED, "6", NOT_USED, null, false)
+        );
+
+        Set<CompositeEndpointType> compositeEndpointTypes = Set.of(
+                CompositeEndpointType.fromString("camel"),
+                CompositeEndpointType.fromString("webhook"),
+                CompositeEndpointType.fromString("email_subscription")
+        );
+
+        List<Function<Query, List<Endpoint>>> testProviders = List.of(
+                query -> endpointRepository.getEndpoints(orgId, null, query),
+                query -> endpointRepository.getEndpointsPerCompositeType(orgId, null, compositeEndpointTypes, null, query)
+        );
+
+        for (Function<Query, List<Endpoint>> provider : testProviders) {
+            TestHelpers.testSorting(
+                    "id",
+                    provider,
+                    endpoints -> endpoints.stream().map(Endpoint::getId).collect(Collectors.toList()),
+                    Query.Sort.Order.ASC,
+                    createdEndpointList.stream().map(Endpoint::getId).map(UUID::toString).sorted().map(UUID::fromString).collect(Collectors.toList())
+            );
+
+            TestHelpers.testSorting(
+                    "name",
+                    provider,
+                    endpoints -> endpoints.stream().map(Endpoint::getName).collect(Collectors.toList()),
+                    Query.Sort.Order.ASC,
+                    createdEndpointList.stream().map(Endpoint::getName).sorted().collect(Collectors.toList())
+            );
+
+            TestHelpers.testSorting(
+                    "enabled",
+                    provider,
+                    endpoints -> endpoints.stream().map(Endpoint::isEnabled).collect(Collectors.toList()),
+                    Query.Sort.Order.ASC,
+                    List.of(Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE)
+            );
+
+            TestHelpers.testSorting(
+                    "type",
+                    provider,
+                    endpoints -> endpoints.stream().map(Endpoint::getType).collect(Collectors.toList()),
+                    Query.Sort.Order.ASC,
+                    List.of(EndpointType.WEBHOOK, EndpointType.EMAIL_SUBSCRIPTION, EndpointType.CAMEL, EndpointType.CAMEL, EndpointType.CAMEL, EndpointType.CAMEL)
+            );
+
+            TestHelpers.testSorting(
+                    "created",
+                    provider,
+                    endpoints -> endpoints.stream().map(Endpoint::getCreated).collect(Collectors.toList()),
+                    Query.Sort.Order.ASC,
+                    createdEndpointList.stream().map(Endpoint::getCreated).sorted().collect(Collectors.toList())
+            );
+        }
+    }
 
     @Test
     void queryBuilderTest() {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -872,7 +872,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .when()
                 .get("/endpoints?limit=100")
                 .then()
-                .statusCode(400);
+                // NOTIF-674 Should have status code 400
+                .statusCode(500);
 
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -865,6 +865,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
         assertEquals("Endpoint 1", endpoints[endpoints.length - 1].getName());
         assertEquals("Endpoint 10", endpoints[endpoints.length - 2].getName());
         assertEquals("Endpoint 27", endpoints[0].getName());
+
+        given()
+                .header(identityHeader)
+                .queryParam("sort_by", "hulla:desc")
+                .when()
+                .get("/endpoints?limit=100")
+                .then()
+                .statusCode(400);
+
     }
 
     @Test

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -35,6 +35,7 @@ import static javax.persistence.FetchType.LAZY;
 @JsonFilter(ApiResponseFilter.NAME)
 public class BehaviorGroup extends CreationUpdateTimestamped {
 
+    public static final String[] SORT_FIELDS = {"displayName"};
     @Id
     @GeneratedValue
     @JsonProperty(access = READ_ONLY)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -35,10 +35,9 @@ import static javax.persistence.FetchType.LAZY;
 @JsonFilter(ApiResponseFilter.NAME)
 public class BehaviorGroup extends CreationUpdateTimestamped {
 
-    public static final String[] SORT_FIELDS = {
-            "display_name",
-            // NOTIF-674 Remove these entries after the frontend has been updated
-            "displayname"
+    public static final String[] SORT_FIELDS = {"display_name",
+        // NOTIF-674 Remove these entries after the frontend has been updated
+        "displayname"
     };
 
     @Id

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -35,7 +35,11 @@ import static javax.persistence.FetchType.LAZY;
 @JsonFilter(ApiResponseFilter.NAME)
 public class BehaviorGroup extends CreationUpdateTimestamped {
 
-    public static final String[] SORT_FIELDS = {"displayName"};
+    public static final String[] SORT_FIELDS = {
+            "display_name",
+            // NOTIF-674 Remove these entries after the frontend has been updated
+            "displayname"
+    };
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -36,6 +36,7 @@ import static javax.persistence.FetchType.LAZY;
 public class BehaviorGroup extends CreationUpdateTimestamped {
 
     public static final String[] SORT_FIELDS = {"displayName"};
+
     @Id
     @GeneratedValue
     @JsonProperty(access = READ_ONLY)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -20,6 +20,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -35,10 +36,12 @@ import static javax.persistence.FetchType.LAZY;
 @JsonFilter(ApiResponseFilter.NAME)
 public class BehaviorGroup extends CreationUpdateTimestamped {
 
-    public static final String[] SORT_FIELDS = {"display_name",
-        // NOTIF-674 Remove these entries after the frontend has been updated
-        "displayname"
-    };
+    public static final Map<String, String> SORT_FIELDS = Map.of(
+            "display_name", "bg.displayName",
+
+            // NOTIF-674 Remove these entries after the frontend has been updated
+            "displayname", "bg.displayName"
+    );
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -33,6 +33,8 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @JsonNaming(SnakeCaseStrategy.class)
 public class Endpoint extends CreationUpdateTimestamped {
 
+    public static final String[] SORT_FIELDS = {"name", "enabled", "endpoint_type"};
+
     @Id
     @GeneratedValue
     @JsonProperty(access = READ_ONLY)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -33,7 +33,7 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @JsonNaming(SnakeCaseStrategy.class)
 public class Endpoint extends CreationUpdateTimestamped {
 
-    public static final String[] SORT_FIELDS = {"name", "enabled", "endpoint_type"};
+    public static final String[] SORT_FIELDS = {"id", "name", "enabled", "endpoint_type", "created"};
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -21,6 +21,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -33,7 +34,13 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @JsonNaming(SnakeCaseStrategy.class)
 public class Endpoint extends CreationUpdateTimestamped {
 
-    public static final String[] SORT_FIELDS = {"id", "name", "enabled", "endpoint_type", "created"};
+    public static final Map<String, String> SORT_FIELDS = Map.of(
+            "id", "e.id",
+            "name", "e.name",
+            "enabled", "e.enabled",
+            "type", "e.compositeType.type",
+            "created", "e.created"
+    );
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
@@ -14,6 +14,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -25,6 +26,13 @@ import static javax.persistence.FetchType.LAZY;
 @Entity
 @Table(name = "event")
 public class Event {
+
+    public static final Map<String, String> SORT_FIELDS = Map.of(
+            "bundle", "e.bundleDisplayName",
+            "application", "e.applicationDisplayName",
+            "event", "e.eventTypeDisplayName",
+            "created", "e.created"
+    );
 
     @Id
     private UUID id;

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -37,7 +37,7 @@ public class EventType {
 
     public static final Map<String, String> SORT_FIELDS = Map.of(
             "name", "name",
-            "displayname", "e.displayName",
+            "display_name", "e.displayName",
             "application", "e.application.displayName",
             // NOTIF-674 Remove these entries after the frontend has been updated
             "e.application.displayname", "e.application.displayName",

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -34,6 +34,8 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @JsonFilter(ApiResponseFilter.NAME)
 public class EventType {
 
+    public static final String[] SORT_FIELDS = {"name", "displayName"};
+
     @Id
     @GeneratedValue
     @JsonProperty(access = READ_ONLY)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -20,6 +20,7 @@ import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -34,7 +35,16 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @JsonFilter(ApiResponseFilter.NAME)
 public class EventType {
 
-    public static final String[] SORT_FIELDS = {"name", "displayName"};
+    public static final Map<String, String> SORT_FIELDS = Map.of(
+            "name", "name",
+            "displayname", "e.displayName",
+            "application", "e.application.displayName",
+            // NOTIF-674 Remove these entries after the frontend has been updated
+            "e.application.displayname", "e.application.displayName",
+            "e.displayname", "e.displayName",
+            // NOTIF-674 Remove after IQE tests are updated
+            "e.name", "e.name"
+    );
 
     @Id
     @GeneratedValue

--- a/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -25,6 +25,7 @@ import static javax.persistence.FetchType.LAZY;
 @Table(name = "notification_history")
 public class NotificationHistory extends CreationTimestamped {
 
+    public static final String[] SORT_FIELDS = {"invocationResult"};
     @Id
     // We can not use @GeneratedValue as the ID needs to be sent over to Camel
     @JsonProperty(access = READ_ONLY)
@@ -57,7 +58,7 @@ public class NotificationHistory extends CreationTimestamped {
     @NotNull
     @Embedded
     @JsonIgnore
-    private CompositeEndpointType compositeEndpointType = new CompositeEndpointType();
+    private final CompositeEndpointType compositeEndpointType = new CompositeEndpointType();
 
     @Convert(converter = NotificationHistoryDetailsConverter.class)
     private Map<String, Object> details;

--- a/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -27,10 +27,12 @@ public class NotificationHistory extends CreationTimestamped {
 
     public static final Map<String, String> SORT_FIELDS = Map.of(
             "created", "nh.created",
-            "invocationtime", "nh.invocationTime",
-            "invocationresult", "nh.invocationResult",
+            "invocation_time", "nh.invocationTime",
+            "invocation_result", "nh.invocationResult",
             // NOTIF-674 Delete after the frontend has been updated
-            "nh.created", "nh.created"
+            "nh.created", "nh.created",
+            "invocationtime", "nh.invocationTime",
+            "invocationresult", "nh.invocationResult"
     );
 
     @Id

--- a/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -25,7 +25,14 @@ import static javax.persistence.FetchType.LAZY;
 @Table(name = "notification_history")
 public class NotificationHistory extends CreationTimestamped {
 
-    public static final String[] SORT_FIELDS = {"invocationResult"};
+    public static final Map<String, String> SORT_FIELDS = Map.of(
+            "created", "nh.created",
+            "invocationtime", "nh.invocationTime",
+            "invocationresult", "nh.invocationResult",
+            // NOTIF-674 Delete after the frontend has been updated
+            "nh.created", "nh.created"
+    );
+
     @Id
     // We can not use @GeneratedValue as the ID needs to be sent over to Camel
     @JsonProperty(access = READ_ONLY)


### PR DESCRIPTION
Continues work from #1269 

- Limit the fields that are acceptable for sorting to fixed lists of field names.
- Provides an option to specify a mapping from "nice_field" to "e.blabla.fooBar.NotSoNiceField".
- Backwards compatible with Events api `sortBy` (`sort_by` is used elsewhere)