### PR TITLE
Support for account_id being null in the json string

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
@@ -69,7 +69,7 @@ public class Event {
     public Event() { }
 
     public Event(EventType eventType, String payload, Action action) {
-        this(action.getAccountId(), action.getOrgId(), eventType, action.getId());
+        this((String) action.getAccountId(), action.getOrgId(), eventType, action.getId());
         this.payload = payload;
         this.action = action;
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -123,9 +123,9 @@ public class EventConsumer {
                 if (featureFlipper.isUseOrgId()) {
                     Log.info("The org ID migration is enabled but the orgId field is missing or blank in the action");
                 }
-                if (featureFlipper.isTranslateAccountIdToOrgId() && action.getAccountId() != null && !action.getAccountId().isBlank()) {
+                if (featureFlipper.isTranslateAccountIdToOrgId() && action.getAccountId() != null && !action.getAccountId().toString().isBlank()) {
                     try {
-                        String orgId = orgIdTranslator.translate(action.getAccountId());
+                        String orgId = orgIdTranslator.translate((String) action.getAccountId());
                         action.setOrgId(orgId);
                     } catch (Exception e) {
                         Log.warn("Org ID translation failed", e);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
@@ -90,7 +90,7 @@ public class EmailSender {
 
         // uses canonical EmailSubscription
         try {
-            Endpoint endpoint = endpointRepository.getOrCreateDefaultEmailSubscription(action.getAccountId(), action.getOrgId());
+            Endpoint endpoint = endpointRepository.getOrCreateDefaultEmailSubscription((String) action.getAccountId(), action.getOrgId());
             Notification notification = new Notification(event, endpoint);
 
             // TODO Add recipients processing from policies-notifications processing (failed recipients)

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -135,7 +135,7 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
 
             if (shouldSaveAggregation) {
                 EmailAggregation aggregation = new EmailAggregation();
-                aggregation.setAccountId(action.getAccountId());
+                aggregation.setAccountId((String) action.getAccountId());
                 aggregation.setOrgId(action.getOrgId());
                 aggregation.setApplicationName(action.getApplication());
                 aggregation.setBundleName(action.getBundle());
@@ -190,9 +190,9 @@ public class EmailSubscriptionTypeProcessor implements EndpointTypeProcessor {
         ).collect(Collectors.toSet());
 
         Set<String> subscribers = Set.copyOf(emailSubscriptionRepository
-                .getEmailSubscribersUserId(action.getAccountId(), action.getOrgId(), action.getBundle(), action.getApplication(), emailSubscriptionType));
+                .getEmailSubscribersUserId((String) action.getAccountId(), action.getOrgId(), action.getBundle(), action.getApplication(), emailSubscriptionType));
 
-        return recipientResolver.recipientUsers(action.getAccountId(), action.getOrgId(), requests, subscribers)
+        return recipientResolver.recipientUsers((String) action.getAccountId(), action.getOrgId(), requests, subscribers)
                 .stream()
                 .map(user -> emailSender.sendEmail(user, event, subject, body))
                 // The value may be an empty Optional in case of Qute template exception.

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -118,9 +118,9 @@ public class CamelTypeProcessorTest {
 
         // We need input data for the test.
         Event event = buildEvent();
-        Endpoint endpoint1 = buildCamelEndpoint(event.getAction().getAccountId());
+        Endpoint endpoint1 = buildCamelEndpoint((String) event.getAction().getAccountId());
         CamelProperties properties1 = endpoint1.getProperties(CamelProperties.class);
-        Endpoint endpoint2 = buildCamelEndpoint(event.getAction().getAccountId());
+        Endpoint endpoint2 = buildCamelEndpoint((String) event.getAction().getAccountId());
 
         // Let's trigger the processing.
         List<NotificationHistory> result = processor.process(event, List.of(endpoint1, endpoint2));
@@ -183,7 +183,7 @@ public class CamelTypeProcessorTest {
         Event event = buildEvent();
         event.setAccountId("rhid123");
         event.setOrgId(DEFAULT_ORG_ID);
-        Endpoint endpoint = buildCamelEndpoint(event.getAction().getAccountId());
+        Endpoint endpoint = buildCamelEndpoint((String) event.getAction().getAccountId());
         endpoint.setSubType("slack");
 
         featureFlipper.setObEnabled(true);

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
         <mockserver-netty-no-dependencies.version>5.14.0</mockserver-netty-no-dependencies.version>
 
-        <insights-notification-schemas-java.version>0.15</insights-notification-schemas-java.version>
+        <insights-notification-schemas-java.version>0.16</insights-notification-schemas-java.version>
         <clowder-quarkus-config-source.version>1.2.0</clowder-quarkus-config-source.version>
 
         <quarkus-logging-cloudwatch.version>4.6.4</quarkus-logging-cloudwatch.version>


### PR DESCRIPTION
Uses the version 0.16 of the schema, where the `account_id` can be the null value in the json string 
In a JSON a property can be `null`, `undefined` (explicitely or by not being present) or have other value. The java implementation considers a null java values for both the received `undefined` and `null` json values.

The only limitation is that `account_id` now is a java `Object` (by the way the json schema was made and maybe my poor knowledge of it, see [here](https://github.com/RedHatInsights/insights-schemas-java/pull/59))
