### PR TITLE
NOTIF-764 Return 401 when org_id is missing in the x-rh-identity header

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/ConsolePrincipalFactory.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/ConsolePrincipalFactory.java
@@ -5,11 +5,19 @@ import com.redhat.cloud.notifications.auth.principal.rhid.RhIdentity;
 import com.redhat.cloud.notifications.auth.principal.turnpike.TurnpikeIdentity;
 import com.redhat.cloud.notifications.auth.principal.turnpike.TurnpikePrincipal;
 
+import static com.redhat.cloud.notifications.Constants.X_RH_IDENTITY_HEADER;
+
 public class ConsolePrincipalFactory {
 
-    public static ConsolePrincipal<?> fromIdentity(ConsoleIdentity identity) {
+    private static final String MISSING_ORG_ID_MSG = "The org_id field is missing or blank in the " + X_RH_IDENTITY_HEADER + " header";
+
+    public static ConsolePrincipal<?> fromIdentity(ConsoleIdentity identity) throws IllegalIdentityHeaderException {
         if (identity instanceof RhIdentity) {
-            return new RhIdPrincipal((RhIdentity) identity);
+            RhIdPrincipal principal = new RhIdPrincipal((RhIdentity) identity);
+            if (principal.getOrgId() == null || principal.getOrgId().isBlank()) {
+                throw new IllegalIdentityHeaderException(MISSING_ORG_ID_MSG);
+            }
+            return principal;
         } else if (identity instanceof TurnpikeIdentity) {
             return new TurnpikePrincipal((TurnpikeIdentity) identity);
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/IllegalIdentityHeaderException.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/IllegalIdentityHeaderException.java
@@ -1,0 +1,8 @@
+package com.redhat.cloud.notifications.auth.principal;
+
+public class IllegalIdentityHeaderException extends Exception {
+
+    public IllegalIdentityHeaderException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProviderTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProviderTest.java
@@ -1,0 +1,51 @@
+package com.redhat.cloud.notifications.auth;
+
+import com.redhat.cloud.notifications.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.Header;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyString;
+
+@QuarkusTest
+public class ConsoleIdentityProviderTest {
+
+    @Test
+    void testNullOrgId() {
+        Header identityHeader = buildIdentityHeader(null);
+        given()
+                .header(identityHeader)
+                .when().get("/notifications/eventTypes")
+                .then()
+                .statusCode(401)
+                .body(emptyString()); // We must NOT leak security impl details such as a missing field in the x-rh-identity header.
+    }
+
+    @Test
+    void testEmptyOrgId() {
+        Header identityHeader = buildIdentityHeader("");
+        given()
+                .header(identityHeader)
+                .when().get("/notifications/eventTypes")
+                .then()
+                .statusCode(401)
+                .body(emptyString()); // We must NOT leak security impl details such as a missing field in the x-rh-identity header.
+    }
+
+    @Test
+    void testBlankOrgId() {
+        Header identityHeader = buildIdentityHeader("   ");
+        given()
+                .header(identityHeader)
+                .when().get("/notifications/eventTypes")
+                .then()
+                .statusCode(401)
+                .body(emptyString()); // We must NOT leak security impl details such as a missing field in the x-rh-identity header.
+    }
+
+    private static Header buildIdentityHeader(String orgId) {
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("account-id", orgId, "johndoe");
+        return TestHelpers.createRHIdentityHeader(identityHeaderValue);
+    }
+}


### PR DESCRIPTION
If the `org_id` field is missing in the `x-rh-identity` header, the client will receive a 401 HTTP status in the response and an exception will be logged at `ERROR` level from this location:

https://github.com/RedHatInsights/notifications-backend/blob/5364662f96b485d735440c1373ddaa8b591196e5/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProvider.java#L160-L164

```
2022-09-05 10:37:42,201 ERROR [com.red.clo.not.aut.ConsoleIdentityProvider] (vert.x-eventloop-thread-0) Error while processing identity: io.quarkus.security.AuthenticationFailedException
	at com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.lambda$authenticate$3(ConsoleIdentityProvider.java:115)
	[...]
Caused by: com.redhat.cloud.notifications.auth.principal.IllegalIdentityHeaderException: The org_id field is missing or blank in the x-rh-identity header
	at com.redhat.cloud.notifications.auth.principal.ConsolePrincipalFactory.fromIdentity(ConsolePrincipalFactory.java:16)
	at com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.lambda$authenticate$7(ConsoleIdentityProvider.java:112)
	[...]
```
This is not supposed to happen while processing public HTTP requests because the upstream security layers should always include the `org_id` field in the header. It can happen though during an IQE test when the header is built by the test.