### PR TITLE
NOTIF-181 Check if the wrapped template supports the type

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/Default.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/Default.java
@@ -44,11 +44,19 @@ public class Default implements EmailTemplate {
     }
 
     public TemplateInstance getTitle(String eventType, EmailSubscriptionType type) {
-        return this.wrappedEmailTemplate.getTitle(eventType, type);
+        if (wrappedEmailTemplate.isSupported(eventType, type)) {
+            return this.wrappedEmailTemplate.getTitle(eventType, type);
+        }
+
+        return null;
     }
 
     public TemplateInstance getBody(String eventType, EmailSubscriptionType type) {
-        return this.wrappedEmailTemplate.getBody(eventType, type);
+        if (wrappedEmailTemplate.isSupported(eventType, type)) {
+            return this.wrappedEmailTemplate.getBody(eventType, type);
+        }
+
+        return null;
     }
 
     @CheckedTemplate(requireTypeSafeExpressions = false)

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -164,12 +164,12 @@ class EmailSubscriptionTypeProcessorTest {
                 .thenReturn(new Default(new EmailTemplate() {
                     @Override
                     public TemplateInstance getTitle(String eventType, EmailSubscriptionType type) {
-                        return null;
+                        throw new UnsupportedOperationException("Not supported");
                     }
 
                     @Override
                     public TemplateInstance getBody(String eventType, EmailSubscriptionType type) {
-                        return null;
+                        throw new UnsupportedOperationException("Not supported");
                     }
 
                     @Override


### PR DESCRIPTION
Checks if the wrapped email template is supported - if not, returns null.
Updated tests to reflect the actual use case (throws exceptions instead of returning null)