### PR TITLE
NOTIF-181 Remove references to context in default templates

### DIFF
--- a/engine/src/main/resources/templates/Default/instantEmailBody.html
+++ b/engine/src/main/resources/templates/Default/instantEmailBody.html
@@ -461,7 +461,7 @@
                                 <tr>
                                     <td class="rh-masthead__subhead">
                                         <h1>
-                                            {action.eventType} triggered - {action.context.system_check_in.toUtcFormat()}
+                                            {action.eventType} triggered
                                         </h1>
                                     </td>
                                 </tr>

--- a/engine/src/main/resources/templates/Default/instantEmailTitle.txt
+++ b/engine/src/main/resources/templates/Default/instantEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.context.system_check_in.toUtcFormat()} - {action.bundle}/{action.application}/{action.eventType} triggered
+{action.bundle}/{action.application}/{action.eventType} triggered


### PR DESCRIPTION
Content in context is free-form and depending the application - we cannot assume anything there.