### PR TITLE
Dummy commit to trigger a fresh deployment on stage

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -31,7 +31,6 @@ quarkus.log.category."com.redhat.cloud.notifications".level=INFO
 
 rbac.enabled=true
 internal-rbac.enabled=false
-
 %test.internal-rbac.enabled=true
 
 # RBAC configuration used during user authentication. It is used when a public REST API is called.


### PR DESCRIPTION
I fixed several issues in `app-interface` and `do-nothing.yaml` files earlier today. The `notifications-stage-ref` pipeline run in Tekton is stuck with old notifications (backend/gw) commits for some reason so far. Let's see if a new commit will update the ref to the latest one.