### PR TITLE
Make do-nothing a job instead of a cronjob

### DIFF
--- a/.rhcicd/do-nothing.yaml
+++ b/.rhcicd/do-nothing.yaml
@@ -16,7 +16,6 @@ objects:
     jobs:
     - name: job
       restartPolicy: Never
-      schedule: "0 0 * * *"
       podSpec:
         image: quay.io/app-sre/ubi8-ubi-minimal:8.6-902
         command: 


### PR DESCRIPTION
`do-nothing` currently does even less than before (which was already nothing): the commits refs are not updated anymore in `stage-ref.yml`. Let's see if a job will work better than a cronjob.