### PR TITLE
Fix email templates preview in admin UI

### DIFF
--- a/admin-console/src/main/webapp/src/pages/EmailTemplatePage.tsx
+++ b/admin-console/src/main/webapp/src/pages/EmailTemplatePage.tsx
@@ -44,7 +44,7 @@ const defaultPayload = JSON.stringify({
     application: 'policies',
     event_type: 'policy-triggered',
     timestamp: '2021-08-05T16:21:14.243',
-    account_id: '5758117',
+    org_id: '5758117',
     // eslint-disable-next-line max-len
     context: '{"inventory_id":"80f7e57d-a16a-4189-82af-1d68a747c8b3","system_check_in":"2021-08-05T16:21:12.953036","display_name":"cool display name"}',
     events: [

--- a/admin-console/src/main/webapp/src/pages/RenderEmailPage.tsx
+++ b/admin-console/src/main/webapp/src/pages/RenderEmailPage.tsx
@@ -46,7 +46,7 @@ const defaultPayload = JSON.stringify({
     application: 'policies',
     event_type: 'policy-triggered',
     timestamp: '2021-08-05T16:21:14.243',
-    account_id: '5758117',
+    org_id: '5758117',
     // eslint-disable-next-line max-len
     context: '{"inventory_id":"80f7e57d-a16a-4189-82af-1d68a747c8b3","system_check_in":"2021-08-05T16:21:12.953036","display_name":"cool display name"}',
     events: [


### PR DESCRIPTION
The email templates preview currently shows an error message when the page is first loaded on stage because we made the `org_id` field mandatory and the default payload from that page doesn't have that field.