### PR TITLE
Revert "Make do-nothing a job instead of a cronjob (#1474)"

### DIFF
--- a/.rhcicd/do-nothing.yaml
+++ b/.rhcicd/do-nothing.yaml
@@ -16,6 +16,7 @@ objects:
     jobs:
     - name: job
       restartPolicy: Never
+      schedule: "0 0 * * *"
       podSpec:
         image: registry.access.redhat.com/ubi8-minimal:8.6-902.1661794353
         command: 


### PR DESCRIPTION
Making it a `job` wasn't a good idea 😄 