### PR TITLE
NOTIF-512 Notify org admins when a webhook is disabled

### DIFF
--- a/database/src/main/resources/db/migration/v1.60.0__NOTIF-512_webhook_disabled_event_type.sql
+++ b/database/src/main/resources/db/migration/v1.60.0__NOTIF-512_webhook_disabled_event_type.sql
@@ -1,0 +1,5 @@
+INSERT INTO event_type (id, application_id, name, display_name)
+SELECT gen_random_uuid(), a.id , 'integration-disabled', 'Integration disabled'
+FROM applications a, bundles b
+WHERE a.bundle_id = b.id AND a.name = 'notifications' AND b.name = 'console'
+ON CONFLICT DO NOTHING;

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifier.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifier.java
@@ -1,0 +1,81 @@
+package com.redhat.cloud.notifications.events;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Parser;
+import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.ingress.Recipient;
+import com.redhat.cloud.notifications.models.Endpoint;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.events.FromCamelHistoryFiller.EGRESS_CHANNEL;
+import static java.time.ZoneOffset.UTC;
+
+@ApplicationScoped
+public class IntegrationDisabledNotifier {
+
+    public static final String CLIENT_ERROR_TYPE = "client";
+    public static final String SERVER_ERROR_TYPE = "server";
+    public static final String CONSOLE_BUNDLE = "console";
+    public static final String NOTIFICATIONS_APP = "notifications";
+    public static final String INTEGRATION_DISABLED_EVENT_TYPE = "integration-disabled";
+    public static final String ERROR_TYPE_PROPERTY = "error_type";
+    public static final String ENDPOINT_ID_PROPERTY = "endpoint_id";
+    public static final String ENDPOINT_NAME_PROPERTY = "endpoint_name";
+    public static final String STATUS_CODE_PROPERTY = "status_code";
+    public static final String ERRORS_COUNT_PROPERTY = "errors_count";
+
+    @Channel(EGRESS_CHANNEL)
+    Emitter<String> emitter;
+
+    public void clientError(Endpoint endpoint, int statusCode) {
+        notify(endpoint, CLIENT_ERROR_TYPE, statusCode, 1);
+    }
+
+    public void tooManyServerErrors(Endpoint endpoint, int errorsCount) {
+        notify(endpoint, SERVER_ERROR_TYPE, -1, errorsCount);
+    }
+
+    private void notify(Endpoint endpoint, String errorType, int statusCode, int errorsCount) {
+        Payload.PayloadBuilderBase payloadBuilder = new Payload.PayloadBuilder()
+                .withAdditionalProperty(ERROR_TYPE_PROPERTY, errorType)
+                .withAdditionalProperty(ENDPOINT_ID_PROPERTY, endpoint.getId())
+                .withAdditionalProperty(ENDPOINT_NAME_PROPERTY, endpoint.getName())
+                .withAdditionalProperty(ERRORS_COUNT_PROPERTY, errorsCount);
+
+        if (statusCode > 0) {
+            payloadBuilder.withAdditionalProperty(STATUS_CODE_PROPERTY, statusCode);
+        }
+
+        Event event = new Event.EventBuilder()
+                .withPayload(payloadBuilder.build())
+                .build();
+
+        Recipient recipients = new Recipient.RecipientBuilder()
+                .withOnlyAdmins(true)
+                .withIgnoreUserPreferences(true)
+                .build();
+
+        Action action = new Action.ActionBuilder()
+                .withId(UUID.randomUUID())
+                .withBundle(CONSOLE_BUNDLE)
+                .withApplication(NOTIFICATIONS_APP)
+                .withEventType(INTEGRATION_DISABLED_EVENT_TYPE)
+                .withOrgId(endpoint.getOrgId())
+                .withTimestamp(LocalDateTime.now(UTC))
+                .withEvents(List.of(event))
+                .withRecipients(List.of(recipients))
+                .build();
+        String encodedAction = Parser.encode(action);
+
+        Message<String> message = KafkaMessageWithIdBuilder.build(encodedAction);
+        emitter.send(message);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/KafkaMessageWithIdBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/KafkaMessageWithIdBuilder.java
@@ -1,0 +1,21 @@
+package com.redhat.cloud.notifications.events;
+
+import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.events.KafkaMessageDeduplicator.MESSAGE_ID_HEADER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class KafkaMessageWithIdBuilder {
+
+    public static Message build(String payload) {
+        byte[] messageId = UUID.randomUUID().toString().getBytes(UTF_8);
+        OutgoingKafkaRecordMetadata metadata = OutgoingKafkaRecordMetadata.builder()
+                .withHeaders(new RecordHeaders().add(MESSAGE_ID_HEADER, messageId))
+                .build();
+        return Message.of(payload).addMetadata(metadata);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/ConsoleNotifications.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/ConsoleNotifications.java
@@ -4,21 +4,51 @@ import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 
+import static com.redhat.cloud.notifications.events.FromCamelHistoryFiller.INTEGRATION_FAILED_EVENT_TYPE;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.INTEGRATION_DISABLED_EVENT_TYPE;
+import static com.redhat.cloud.notifications.models.EmailSubscriptionType.INSTANT;
+
 // Name needs to be "ConsoleNotifications" to read templates from resources/templates/ConsoleNotifications
 public class ConsoleNotifications implements EmailTemplate {
+
+    private static final String NO_TITLE_FOUND_MSG = "No email title template found for ConsoleNotifications event_type: %s";
+    private static final String NO_BODY_FOUND_MSG = "No email body template found for ConsoleNotifications event_type: %s";
+
     @Override
     public TemplateInstance getTitle(String eventType, EmailSubscriptionType type) {
-        return Templates.failedIntegrationTitle();
+        if (type == INSTANT) {
+            switch (eventType) {
+                case INTEGRATION_FAILED_EVENT_TYPE:
+                    return Templates.failedIntegrationTitle();
+                case INTEGRATION_DISABLED_EVENT_TYPE:
+                    return Templates.integrationDisabledTitle();
+                default:
+                    // Do nothing.
+                    break;
+            }
+        }
+        throw new UnsupportedOperationException(String.format(NO_TITLE_FOUND_MSG, eventType));
     }
 
     @Override
     public TemplateInstance getBody(String eventType, EmailSubscriptionType type) {
-        return Templates.failedIntegrationBody();
+        if (type == INSTANT) {
+            switch (eventType) {
+                case INTEGRATION_FAILED_EVENT_TYPE:
+                    return Templates.failedIntegrationBody();
+                case INTEGRATION_DISABLED_EVENT_TYPE:
+                    return Templates.integrationDisabledBody();
+                default:
+                    // Do nothing.
+                    break;
+            }
+        }
+        throw new UnsupportedOperationException(String.format(NO_BODY_FOUND_MSG, eventType));
     }
 
     @Override
     public boolean isSupported(String eventType, EmailSubscriptionType type) {
-        return type.equals(EmailSubscriptionType.INSTANT);
+        return type.equals(INSTANT);
     }
 
     @Override
@@ -33,5 +63,8 @@ public class ConsoleNotifications implements EmailTemplate {
 
         public static native TemplateInstance failedIntegrationBody();
 
+        public static native TemplateInstance integrationDisabledTitle();
+
+        public static native TemplateInstance integrationDisabledBody();
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+import static com.redhat.cloud.notifications.events.FromCamelHistoryFiller.INTEGRATION_FAILED_EVENT_TYPE;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.INTEGRATION_DISABLED_EVENT_TYPE;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -119,10 +121,16 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/ConsoleNotifications folder.
          */
+        getOrCreateTemplate(warnings, "ConsoleNotifications/insightsEmailBody", "html", "Notifications Insights email body");
         createInstantEmailTemplate(
-                warnings, "console", "notifications", List.of("failed-integration"),
+                warnings, "console", "notifications", List.of(INTEGRATION_FAILED_EVENT_TYPE),
                 "ConsoleNotifications/failedIntegrationTitle", "txt", "Notifications failed integration email title",
                 "ConsoleNotifications/failedIntegrationBody", "txt", "Notifications failed integration email body"
+        );
+        createInstantEmailTemplate(
+                warnings, "console", "notifications", List.of(INTEGRATION_DISABLED_EVENT_TYPE),
+                "ConsoleNotifications/integrationDisabledTitle", "txt", "Notifications disabled integration email title",
+                "ConsoleNotifications/integrationDisabledBody", "html", "Notifications disabled integration email body"
         );
 
         /*

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -26,6 +26,8 @@ mp.messaging.outgoing.egress.topic=platform.notifications.ingress
 mp.messaging.outgoing.egress.group.id=integrations
 mp.messaging.outgoing.egress.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.egress.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+# Messages can be emitted on this topic from multiple emitters in our app
+mp.messaging.outgoing.egress.merge=true
 
 # Output queue to Camel (notifications-sender)
 mp.messaging.outgoing.toCamel.connector=smallrye-kafka

--- a/engine/src/main/resources/templates/ConsoleNotifications/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/ConsoleNotifications/insightsEmailBody.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Red Hat Insights</title>
+{|
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Text&display=swap');
+
+        .rh-masthead__content-title,
+        .rh-masthead__metric-block-count,
+        .rh-masthead__metric-block-text,
+        .rh-masthead__subhead {
+            font-family: 'Red Hat Display', Helvetica, sans-serif;
+        }
+
+        body,
+        .rh-content__block,
+        .rh-data-table,
+        .rh-masthead__subhead {
+            font-family: 'Red Hat Text', Helvetica, sans-serif;
+        }
+
+        #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" message */
+        body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:100%; -ms-text-size-adjust:100%;} /* Prevent WebKit and Windows mobile changing default text sizes */
+        table, td{mso-table-lspace:0pt; mso-table-rspace:0pt;} /* Remove spacing between tables in Outlook 2007 and up */
+        img{-ms-interpolation-mode:bicubic;} /* Allow smoother rendering of resized image in Internet Explorer */
+
+        /* reset styles */
+        img{border:0; height:auto; line-height:100%; outline:none; text-decoration:none;}
+        table{border-collapse:collapse !important;}
+        a{text-decoration: none !important;}
+
+        /* Remove space around email design */
+        html,
+        body {
+            margin: 0 auto !important;
+            padding: 0 !important;
+            height: 100% !important;
+            width: 100% !important;
+            background-color: #fff;
+        }
+
+        /* Stop Outlook resizing small text */
+        * {
+            -ms-text-size-adjust: 100%;
+        }
+        /* Stop Outlook from adding extra spacing to tables */
+        table, td {
+            mso-table-lspace: 0pt !important;
+            mso-table-rspace: 0pt !important;
+        }
+        /* Better rendering method when resizing impages in Outlook IE */
+        img {
+            -ms-interpolation-mode:bicubic;
+        }
+
+        a {
+            text-decoration: none;
+            color: #fff;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            font-family: 'Red Hat Display', sans-serif;
+            font-size: 16px;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        p {
+            margin-top: 0;
+        }
+
+        h1:last-child,
+        h2:last-child,
+        h3:last-child,
+        h4:last-child,
+        h5:last-child,
+        h6:last-child,
+        p:last-child {
+            margin-bottom: 0;
+        }
+
+
+        .rh-masthead__content-title h1,
+        .rh-masthead__content-title h2,
+        .rh-masthead__content-title h3,
+        .rh-masthead__content-title h4,
+        .rh-masthead__subhead h1,
+        .rh-masthead__subhead h2,
+        .rh-masthead__subhead h3,
+        .rh-masthead__subhead h4 {
+            font-weight: 400;
+            line-height: 1;
+        }
+
+        .rh-body-table,
+        .rh-body-cell {
+            height:100% !important;
+            margin:0;
+            padding:0;
+            width:100% !important;
+        }
+
+        .rh-body-table {
+            background-color: #f5f5f5;
+            background-color: #fff;
+        }
+
+        .rh-page {
+            padding: 0 0 30px 0;
+            background: #efefef;
+        }
+
+        .rh-template-container {
+            padding: 0 0 30px 0;
+            width: 600px;
+        }
+
+        .rh-template-container,
+        .rh-template-container > tbody {
+            background: #ededed;
+        }
+
+        .rh-head,
+        .rh-body,
+        .rh-footer {
+            margin: 0;
+            mso-line-height-rule: exactly;
+            font-family: arial;
+            font-size: 16px;
+            box-sizing: border-box;
+        }
+
+        .rh-body {
+            padding: 0 20px 20px 20px;
+        }
+
+        .rh-body,
+        .rh-masthead,
+        .rh-content,
+        .rh-data-table,
+        .rh-head {
+            width: 100% !important;
+        }
+
+        .rh-head {
+            padding: 0 0 20px 0;
+        }
+
+        .rh-footer {
+            padding: 10px 20px 30px 20px;
+        }
+
+        .rh-masthead__content {
+            background-color: #090a0a !important;
+            background-color: #030303 !important;
+            background-image: url(https://console.redhat.com/apps/frontend-assets/email-assets/bg_masthead-hat.png);
+            background-size: cover;
+        }
+
+        .rh-masthead__subhead {
+            background-color: #282828 !important;
+            padding: 20px;
+            color: #ffffff !important;
+            font-size: 18px;
+            text-align: center;
+        }
+
+        .rh-masthead__block {
+            width: 200px;
+        }
+
+        .rh-masthead__brand {
+            padding: 5px 20px 5px 20px;
+            background-color: #151515 !important;
+            background-repeat: repeat;
+            background-image: url(https://console.redhat.com/apps/frontend-assets/email-assets/bg_151515.jpg);
+            text-align: center;
+        }
+
+        .rh-masthead__brand-link {
+            display: block;
+            text-align: center;
+        }
+
+        .rh-masthead__content {
+            background-color: #151515;
+            background-size: cover;
+            background-repeat: no-repeat;
+        }
+
+        .rh-masthead__content-title {
+            padding: 20px 20px 20px 20px;
+            margin: 0 0 10px 0;
+            color: #ffffff;
+            font-size: 18px;
+            position: relative;
+            font-weight: 400;
+        }
+
+        .rh-masthead__metric-block-count {
+            display: block;
+            padding-bottom: 10px;
+            text-align: center;
+            font-size: 28px;
+            word-break:break-all;
+            color: #ffffff !important;
+            line-height: 1;
+        }
+
+        .rh-masthead__metric-block-text {
+            display: block;
+            padding: 0 20px 40px 20px;
+            word-break: break-all;
+            color: #ffffff !important;
+            line-height: 1;
+            font-size: 14px;
+        }
+
+        .rh-masthead__metric-block-icon {
+            padding: 0 0 20px;
+            display: block;
+        }
+
+        .rh-content + .rh-content {
+            padding: 0 0 20px 0;
+        }
+
+        .rh-content a {
+            color: #0066cc;
+        }
+
+        .rh-content {
+            background: #efefef;
+        }
+
+        .rh-content table {
+            background: #fff;
+        }
+
+        /* Content block */
+        .rh-content__block {
+            max-width: 100%;
+            padding: 20px 20px 20px 20px;
+            overflow: hidden;
+        }
+
+        .rh-content tr + tr .rh-content__block {
+            padding-top: 0;
+        }
+
+        .rh-content .rh-content__block {
+            background-color: #fff;
+        }
+
+        .rh-content__block-title {
+            font-weight: bold;
+        }
+
+        .rh-footer__text {
+            font-size: 14px;
+        }
+
+        .rh-footer__text a {
+            color: #0066cc;
+        }
+
+        .rh-content__spacer {
+            font-size: 0;
+            line-height: 0;
+            height: 20px;
+            background-color: #ffffff;
+        }
+
+        .rh-cta-link {
+            display:block;
+            padding: 10px 20px;
+            background-color: #0066cc;
+            border-radius: 3px;
+            text-decoration:none;
+            font-weight:bold;
+        }
+
+        .rh-cta-link a {
+            color:#ffffff;
+            text-decoration: none;
+        }
+
+        .rh-data-table thead th {
+            font-weight: 700;
+            text-align: left;
+        }
+
+        .rh-data-table tbody th {
+            font-weight: 500;
+            text-align: left;
+            width: 200px;
+        }
+
+        .rh-data-table.rh-m-bordered th {
+            padding: 10px;
+            text-align: left;
+            font-size: 14px;
+            font-weight: 500;
+            text-transform: uppercase;
+            background-color: #ededed;
+        }
+
+        .rh-data-table.rh-m-bordered td {
+            padding: 10px;
+            text-align: left;
+        }
+
+        .rh-data-table.rh-m-bordered {
+            border-collapse: collapse;
+        }
+
+        .rh-table-header {
+            text-align: left;
+            padding-bottom: 0;
+        }
+
+        .rh-m-bordered th,
+        .rh-m-bordered td {
+            border-width: 1px;
+            border-color: #b8bbbe;
+            border-style: solid;
+        }
+
+        .rh-m-bordered tr:nth-child(even) {
+            background-color: #fafafa;
+        }
+
+        .rh-color__red {
+            color: #a30000;
+        }
+
+        .rh-color__orange {
+            color: #ec7a08;
+        }
+
+        .rh-color__green {
+            color: #486b00;
+        }
+
+        .rh-m-block {
+            display: block;
+        }
+
+        .rh-url {
+            word-break: break-word;
+        }
+
+        .rh-stack > * + * {
+            margin-top: 10px;
+        }
+
+        .rh-inline {
+            display: flex;
+            align-items: center;
+        }
+
+        .rh-icon {
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            line-height: 1;
+        }
+
+        .rh-inline > * + * {
+            display: inline-block;
+            margin-left: 5px;
+        }
+
+        /* dark mode hacks */
+        [data-ogsc] .rh-masthead__brand,
+        [data-ogsb] .rh-masthead__brand {
+            background-color: #151515 !important;
+        }
+
+        @media only screen and (max-width: 320px) {
+            .rh-masthead__block {
+                width: 100% !important;
+                display: block !important;
+            }
+        }
+
+        @media only screen and (max-width: 480px) {
+            .rh-template-container {
+                max-width: 480px !important;
+                /*@editable*/ width:100% !important;
+            }
+
+            .rh-data-table tbody th {
+                width: auto !important;
+            }
+
+            .rh-data-table th,
+            .rh-data-table td {
+                font-size: 14px;
+            }
+
+            .rh-data-table.rh-m-bordered th,
+            .rh-data-table.rh-m-bordered td {
+                padding: 5px;
+                text-align: left;
+            }
+        }
+
+        @media only screen and (max-width: 600px) {
+            body{
+                width: 100% !important;
+                min-width: 100% !important;
+            }
+
+            .rh-template-container {
+                max-width: 600px !important;
+                /*@editable*/ width:100% !important;
+            }
+
+            .rh-masthead__block {
+                width: 33%;
+                max-width: 200px;
+            }
+        }
+    </style>
+|}
+</head>
+
+<body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" class="rh-body">
+<center>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" class="rh-body-table">
+        <tr>
+            <td align="center" valign="top" class="rh-body-cell">
+                <table border="0" cellpadding="0" cellspacing="0" class="rh-template-container">
+
+                    <!-- Head -->
+                    <tr>
+                        <td class="rh-head">
+                            <table class="rh-masthead" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <!--Red Hat logo-->
+                                    <td align="center" class="rh-masthead__brand" bgcolor="#151515">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
+                                            <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
+                                        </a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td class="rh-masthead__subhead">
+                                        <h1>{#insert content-title}{/}</h1>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <!-- end head -->
+
+                    <!-- Body section -->
+                    <tr>
+                        <td class="rh-body">
+                            <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                {#insert content-body}{/}
+                            </table>
+                        </td>
+                    </tr>
+                    <!-- end body section -->
+
+                    <!-- Footer -->
+                    <tr>
+                        <td class="rh-footer">
+                            <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td class="rh-footer__text">
+                                        This email was sent by Red Hat Insights | <a href="{environment.url}/user-preferences/notifications/console" target="_blank">Manage notification preferences</a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <!-- end footer -->
+
+                    <!-- Ensure padding bottom - don't remove empty row -->
+                    <tr>
+                        <td>
+                        </td>
+                    </tr>
+                    <!-- leave - empty row -->
+
+                </table>
+            </td>
+        </tr>
+    </table>
+</center>
+</body>
+</html>

--- a/engine/src/main/resources/templates/ConsoleNotifications/integrationDisabledBody.html
+++ b/engine/src/main/resources/templates/ConsoleNotifications/integrationDisabledBody.html
@@ -1,0 +1,41 @@
+{#include ConsoleNotifications/insightsEmailBody}
+{#content-title}Integration '{action.payload.endpoint_name}' was disabled{/content-title}
+{#content-body}
+<tr>
+    <td class="rh-content__block">
+        {#if action.payload.error_type == "client"}
+            <p>
+                Integration <a href="{environment.url}/settings/integrations?name={action.payload.endpoint_name}" target="_blank">{action.payload.endpoint_name}</a>
+                was disabled because the remote endpoint responded with an HTTP status code {action.payload.status_code}.
+            </p>
+            <p>
+                Please review the integration configuration from <a href="{environment.url}/settings/integrations?name={action.payload.endpoint_name}" target="_blank">Settings > Integrations</a>
+                to troubleshoot and re-enable the integration.
+            </p>
+        {#else}
+            <p>
+                Integration <a href="{environment.url}/settings/integrations?name={action.payload.endpoint_name}" target="_blank">{action.payload.endpoint_name}</a>
+                was disabled because the remote endpoint responded {action.payload.errors_count} times with a server error (HTTP status code 5xx).
+            </p>
+            <p>
+                Please re-enable the integration from <a href="{environment.url}/settings/integrations?name={action.payload.endpoint_name}" target="_blank">Settings > Integrations</a>
+                if the remote endpoint is ready to receive webhook calls.
+            </p>
+        {/if}
+    </td>
+</tr>
+<tr>
+    <td class="rh-content__block">
+        <table align="center">
+            <tr>
+                <td class="rh-cta-link" align="center">
+                    <a href="{environment.url}/settings/integrations?name={action.payload.endpoint_name}" target="_blank">
+                        <span>Open Integrations</span>
+                    </a>
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+{/content-body}
+{/include}

--- a/engine/src/main/resources/templates/ConsoleNotifications/integrationDisabledTitle.txt
+++ b/engine/src/main/resources/templates/ConsoleNotifications/integrationDisabledTitle.txt
@@ -1,0 +1,1 @@
+{action.context.system_check_in.toUtcFormat()} - Integration '{action.payload.endpoint_name}' was disabled

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -72,6 +72,14 @@ public class ResourceHelpers {
         return eventType;
     }
 
+    public EventType findEventType(UUID appId, String eventTypeName) {
+        String hql = "FROM EventType WHERE application.id = :applicationId AND name = :name";
+        return entityManager.createQuery(hql, EventType.class)
+                .setParameter("applicationId", appId)
+                .setParameter("name", eventTypeName)
+                .getSingleResult();
+    }
+
     @Transactional
     public Event createEvent(EventType eventType) {
         Event event = new Event();

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifierTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifierTest.java
@@ -1,0 +1,107 @@
+package com.redhat.cloud.notifications.events;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Parser;
+import com.redhat.cloud.notifications.models.Endpoint;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
+import io.smallrye.reactive.messaging.providers.connectors.InMemorySink;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.events.FromCamelHistoryFiller.EGRESS_CHANNEL;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.CLIENT_ERROR_TYPE;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.CONSOLE_BUNDLE;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.ENDPOINT_ID_PROPERTY;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.ENDPOINT_NAME_PROPERTY;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.ERRORS_COUNT_PROPERTY;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.ERROR_TYPE_PROPERTY;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.INTEGRATION_DISABLED_EVENT_TYPE;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.NOTIFICATIONS_APP;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.SERVER_ERROR_TYPE;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.STATUS_CODE_PROPERTY;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class IntegrationDisabledNotifierTest {
+
+    @Inject
+    IntegrationDisabledNotifier integrationDisabledNotifier;
+
+    @Inject
+    @Any
+    InMemoryConnector inMemoryConnector;
+
+    InMemorySink<String> egressChannel;
+
+    @PostConstruct
+    void postConstruct() {
+        egressChannel = inMemoryConnector.sink(EGRESS_CHANNEL);
+    }
+
+    @BeforeEach
+    @AfterEach
+    void clearEgressChannel() {
+        egressChannel.clear();
+    }
+
+    @Test
+    void testClientError() {
+        Endpoint endpoint = buildEndpoint();
+        int errorStatusCode = 401;
+        integrationDisabledNotifier.clientError(endpoint, errorStatusCode);
+        checkReceivedAction(endpoint, CLIENT_ERROR_TYPE, errorStatusCode, 1);
+    }
+
+    @Test
+    void testTooManyServerErrors() {
+        Endpoint endpoint = buildEndpoint();
+        integrationDisabledNotifier.tooManyServerErrors(endpoint, 10);
+        checkReceivedAction(endpoint, SERVER_ERROR_TYPE, -1, 10);
+    }
+
+    private void checkReceivedAction(Endpoint endpoint, String expectedErrorType, int expectedStatusCode, int expectedErrorsCount) {
+        await().until(() -> egressChannel.received().size() == 1);
+        String payload = egressChannel.received().get(0).getPayload();
+        Action action = Parser.decode(payload);
+
+        assertNotNull(action.getId());
+        assertEquals(CONSOLE_BUNDLE, action.getBundle());
+        assertEquals(NOTIFICATIONS_APP, action.getApplication());
+        assertEquals(INTEGRATION_DISABLED_EVENT_TYPE, action.getEventType());
+        assertEquals(endpoint.getOrgId(), action.getOrgId());
+        assertEquals(1, action.getEvents().size());
+        assertTrue(action.getRecipients().get(0).getOnlyAdmins());
+        assertTrue(action.getRecipients().get(0).getIgnoreUserPreferences());
+
+        Map<String, Object> additionalProperties = action.getEvents().get(0).getPayload().getAdditionalProperties();
+        assertEquals(expectedErrorType, additionalProperties.get(ERROR_TYPE_PROPERTY));
+        assertEquals(endpoint.getId().toString(), additionalProperties.get(ENDPOINT_ID_PROPERTY));
+        assertEquals(endpoint.getName(), additionalProperties.get(ENDPOINT_NAME_PROPERTY));
+        assertEquals(expectedErrorsCount, additionalProperties.get(ERRORS_COUNT_PROPERTY));
+        if (expectedStatusCode > 0) {
+            assertEquals(expectedStatusCode, additionalProperties.get(STATUS_CODE_PROPERTY));
+        }
+    }
+
+    private static Endpoint buildEndpoint() {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setId(UUID.randomUUID());
+        endpoint.setOrgId("org-id");
+        endpoint.setName("My webhook");
+        return endpoint;
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
@@ -24,6 +24,8 @@ import javax.persistence.EntityManager;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+import static com.redhat.cloud.notifications.events.FromCamelHistoryFiller.INTEGRATION_FAILED_EVENT_TYPE;
+import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.INTEGRATION_DISABLED_EVENT_TYPE;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -143,7 +145,8 @@ public class EmailTemplateMigrationServiceTest {
         Bundle console = findBundle("console");
         // App: notifications
         Application notifications = findApp("console", "notifications");
-        EventType failedIntegration = resourceHelpers.createEventType(notifications.getId(), "failed-integration");
+        EventType integrationFailed = resourceHelpers.findEventType(notifications.getId(), INTEGRATION_FAILED_EVENT_TYPE);
+        EventType integrationDisabled = resourceHelpers.createEventType(notifications.getId(), INTEGRATION_DISABLED_EVENT_TYPE);
         // App: sources
         Application sources = resourceHelpers.createApp(console.getId(), "sources");
         EventType availabilityStatus = resourceHelpers.createEventType(sources.getId(), "availability-status");
@@ -247,7 +250,8 @@ public class EmailTemplateMigrationServiceTest {
              * Bundle: console
              */
             // App: notifications
-            findAndCompileInstantEmailTemplate(failedIntegration.getId());
+            findAndCompileInstantEmailTemplate(integrationFailed.getId());
+            findAndCompileInstantEmailTemplate(integrationDisabled.getId());
             assertTrue(templateRepository.findAggregationEmailTemplate(console.getName(), notifications.getName(), DAILY).isEmpty());
             // App: sources
             findAndCompileInstantEmailTemplate(availabilityStatus.getId());


### PR DESCRIPTION
▶️ **Part 2 of NOTIF-512**

When a webhook is automatically disabled because of 4xx or 5xx failures, an action is emitted on the `platform.notifications.ingress` topic with the following information:
- bundle: `console`
- application: `notifications`
- event type: `integration-disabled`

The action also contains additional information about the issue:
- the endpoint ID and name
- the type of the error (client or server)
- the HTTP status in case of client error
- the number of errors in case of server errors

Using a default behavior group, the event type described above will be used to send an email notification to the org admins of the account that owns the disabled integration. The email body will vary depending on the type of the error.