### PR TITLE
Run PR check with the latest engine image

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -3,7 +3,7 @@
 set -exv
 
 source ./.rhcicd/pr_check_backend.sh
-docker build . -f docker/Dockerfile.notifications-engine.jvm
+source ./.rhcicd/pr_check_engine.sh
 docker build . -f docker/Dockerfile.notifications-aggregator.jvm
 docker build . -f docker/Dockerfile.notifications-camel-demo-log.jvm
 

--- a/.rhcicd/pr_check_engine.sh
+++ b/.rhcicd/pr_check_engine.sh
@@ -2,8 +2,8 @@
 
 # Clowder config
 export APP_NAME="notifications"
-export COMPONENT_NAME="notifications-backend"
-export IMAGE="quay.io/cloudservices/notifications-backend"
+export COMPONENT_NAME="notifications-engine"
+export IMAGE="quay.io/cloudservices/notifications-engine"
 export DEPLOY_TIMEOUT="900"
 
 # IQE plugin config
@@ -17,17 +17,18 @@ CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
 curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 # Build the image and push to Quay
-export DOCKERFILE=docker/Dockerfile.notifications-backend.jvm
+export DOCKERFILE=docker/Dockerfile.notifications-engine.jvm
 source $CICD_ROOT/build.sh
 
 # Deploy on ephemeral
-export COMPONENTS="notifications-backend"
+export COMPONENTS="notifications-engine"
 # Chaining the notifications-backend PR check with the notifications-engine PR check is
 # not possible by default because the same ephemeral namespace is reserved and released
 # during the former and is no longer available during the latter. The following line
 # works around that limitation and triggers a new namespace reservation for each PR check.
-export JOB_NAME="notifications-backend"
+export JOB_NAME="notifications-engine"
 source $CICD_ROOT/deploy_ephemeral_env.sh
 
 # Run smoke tests with ClowdJobInvocation
+export COMPONENT_NAME="notifications-backend" # IQE tests won't run without this "hack".
 source $CICD_ROOT/cji_smoke_test.sh


### PR DESCRIPTION
Until now, the `notifications-engine` version that was tested by the IQE plugin on ephemeral was not the latest one.

Things would be simpler if `backend` and `engine` were hosted in separate repos.