### PR TITLE
Fix integration disabled template title

### DIFF
--- a/engine/src/main/resources/templates/ConsoleNotifications/integrationDisabledTitle.txt
+++ b/engine/src/main/resources/templates/ConsoleNotifications/integrationDisabledTitle.txt
@@ -1,1 +1,1 @@
-{action.context.system_check_in.toUtcFormat()} - Integration '{action.payload.endpoint_name}' was disabled
+{action.timestamp.toUtcFormat()} - Integration '{action.payload.endpoint_name}' was disabled


### PR DESCRIPTION
Fixes
```
io.quarkus.qute.TemplateException: Rendering error in template [ConsoleNotifications/integrationDisabledTitle.txt] line 1: Property "toUtcFormat" not found on the base object "null" in expression {action.context.system_check_in.toUtcFormat()}
```