### PR TITLE
NOTIF-781 Use dynamic ConsoleDot host in all email templates

### DIFF
--- a/engine/src/main/resources/templates/Advisor/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Advisor/insightsEmailBody.html
@@ -553,7 +553,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" border="0">
                                         </a>
                                     </td>
@@ -580,7 +580,7 @@
                                 <tbody>
                                 <tr>
                                     <td class="rh-footer__text">
-                                        This email was sent by Red Hat Insights |<a href="https://console.redhat.com/user-preferences/notifications/rhel" target="_blank">&nbsp;Manage notification preferences</a>
+                                        This email was sent by Red Hat Insights |<a href="{environment.url}/user-preferences/notifications/rhel" target="_blank">&nbsp;Manage notification preferences</a>
                                     </td>
                                 </tr>
                                 </tbody>

--- a/engine/src/main/resources/templates/Advisor/newRecommendationInstantEmailBody.html
+++ b/engine/src/main/resources/templates/Advisor/newRecommendationInstantEmailBody.html
@@ -78,7 +78,7 @@
                         <!-- Hi {{user.first_name}},
                         <br>
                         <br> -->
-                        Your system <a href="https://console.redhat.com/insights/advisor/systems/{action.context.inventory_id}" target="_blank">{action.context.display_name}</a> has {action.events.size()} new recommendations.
+                        Your system <a href="{environment.url}/insights/advisor/systems/{action.context.inventory_id}" target="_blank">{action.context.display_name}</a> has {action.events.size()} new recommendations.
                     </p>
                 </td>
             </tr>
@@ -90,7 +90,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" class="rh-button-table">
                         <tr>
                             <td class="rh-cta-link" align="center">
-                                <a target="_blank" href="https://console.redhat.com/insights/advisor/systems/{action.context.inventory_id}">
+                                <a target="_blank" href="{environment.url}/insights/advisor/systems/{action.context.inventory_id}">
                                         <span>
                                           Go to system page
                                         </span>

--- a/engine/src/main/resources/templates/Advisor/resolvedRecommendationInstantEmailBody.html
+++ b/engine/src/main/resources/templates/Advisor/resolvedRecommendationInstantEmailBody.html
@@ -78,7 +78,7 @@
                         <!-- Hi {{user.first_name}},
                         <br>
                         <br> -->
-                        Your system <a href="https://console.redhat.com/insights/advisor/systems/{action.context.inventory_id}" target="_blank">{action.context.display_name}</a> has {action.events.size()} resolved recommendations.
+                        Your system <a href="{environment.url}/insights/advisor/systems/{action.context.inventory_id}" target="_blank">{action.context.display_name}</a> has {action.events.size()} resolved recommendations.
                     </p>
                 </td>
             </tr>
@@ -90,7 +90,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" class="rh-button-table">
                         <tr>
                             <td class="rh-cta-link" align="center">
-                                <a target="_blank" href="https://console.redhat.com/insights/advisor/systems/{action.context.inventory_id}">
+                                <a target="_blank" href="{environment.url}/insights/advisor/systems/{action.context.inventory_id}">
                                         <span>
                                           Go to system page
                                         </span>

--- a/engine/src/main/resources/templates/AdvisorOpenshift/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/AdvisorOpenshift/insightsEmailBody.html
@@ -553,7 +553,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" border="0">
                                         </a>
                                     </td>
@@ -580,7 +580,7 @@
                                 <tbody>
                                 <tr>
                                     <td class="rh-footer__text">
-                                        This email was sent by Red Hat Insights |<a href="https://console.redhat.com/user-preferences/notifications/openshift" target="_blank">&nbsp;Manage email preferences</a>
+                                        This email was sent by Red Hat Insights |<a href="{environment.url}/user-preferences/notifications/openshift" target="_blank">&nbsp;Manage email preferences</a>
                                     </td>
                                 </tr>
                                 </tbody>

--- a/engine/src/main/resources/templates/Ansible/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Ansible/insightsEmailBody.html
@@ -552,7 +552,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" border="0">
                                         </a>
                                     </td>
@@ -579,7 +579,7 @@
                                 <tbody>
                                 <tr>
                                     <td class="rh-footer__text">
-                                        This email was sent by Red Hat Insights |<a href="https://console.redhat.com/user-preferences/notifications/ansible" target="_blank">&nbsp;Manage notification preferences</a>
+                                        This email was sent by Red Hat Insights |<a href="{environment.url}/user-preferences/notifications/ansible" target="_blank">&nbsp;Manage notification preferences</a>
                                     </td>
                                 </tr>
                                 </tbody>

--- a/engine/src/main/resources/templates/Ansible/instantEmailBody.html
+++ b/engine/src/main/resources/templates/Ansible/instantEmailBody.html
@@ -9,7 +9,7 @@
 <tr>
     <td class="rh-content__block">
         <div class="rh-stack">
-            <a class="rh-url" href="https://console.redhat.com/ansible/insights/reports/{action.context.slug}"><b>Download now</b></a>
+            <a class="rh-url" href="{environment.url}/ansible/insights/reports/{action.context.slug}"><b>Download now</b></a>
         </div>
     </td>
 </tr>

--- a/engine/src/main/resources/templates/Compliance/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Compliance/insightsEmailBody.html
@@ -561,7 +561,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>
@@ -592,7 +592,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        You received this notification because of selections you made in your <a href="https://console.redhat.com/user-preferences/notifications/rhel" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
+                                        You received this notification because of selections you made in your <a href="{environment.url}/user-preferences/notifications/rhel" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/CostManagement/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/CostManagement/insightsEmailBody.html
@@ -561,7 +561,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>
@@ -592,7 +592,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        You received this notification because of selections you made in your <a href="https://console.redhat.com/user-preferences/notifications/openshift" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
+                                        You received this notification because of selections you made in your <a href="{environment.url}/user-preferences/notifications/openshift" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/Drift/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Drift/dailyEmailBody.html
@@ -78,7 +78,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" class="rh-button-table">
                         <tr>
                             <td class="rh-cta-link" align="center">
-                                <a target="_blank" href="https://console.redhat.com/insights/drift/baselines">
+                                <a target="_blank" href="{environment.url}/insights/drift/baselines">
                                         <span>
                                           Go to Baselines
                                         </span>
@@ -114,7 +114,7 @@
                             {#for key in action.context.drift.keySet()}
                             <tr>
                                 <td>
-                                    <a href="https://console.redhat.com/insights/drift/baselines/{action.context.drift.get(key).baseline_id}">{action.context.drift.get(key).baseline_name}</a>
+                                    <a href="{environment.url}/insights/drift/baselines/{action.context.drift.get(key).baseline_id}">{action.context.drift.get(key).baseline_name}</a>
                                 </td>
                                 <td class="rh-severity">
                                     {action.context.drift.get(key).unique_system_count}

--- a/engine/src/main/resources/templates/Drift/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Drift/insightsEmailBody.html
@@ -561,7 +561,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>
@@ -592,7 +592,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        This email was sent by Red Hat Insights |<a href="https://console.redhat.com/user-preferences/notifications/rhel" target="_blank">&nbsp;Manage notification preferences</a>
+                                        This email was sent by Red Hat Insights |<a href="{environment.url}/user-preferences/notifications/rhel" target="_blank">&nbsp;Manage notification preferences</a>
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/Drift/newBaselineDriftInstantEmailBody.html
+++ b/engine/src/main/resources/templates/Drift/newBaselineDriftInstantEmailBody.html
@@ -38,7 +38,7 @@
                         Hi,
                         <br>
                         <br>
-                        Your system <a class="rh-url" href="https://console.redhat.com/insights/inventory/{action.context.inventory_id}"><b>{action.context.display_name}</b></a> has drifted from {action.events.size()} baseline{#if action.events.size() > 1}s{/if}
+                        Your system <a class="rh-url" href="{environment.url}/insights/inventory/{action.context.inventory_id}"><b>{action.context.display_name}</b></a> has drifted from {action.events.size()} baseline{#if action.events.size() > 1}s{/if}
                     </p>
                 </td>
             </tr>
@@ -50,7 +50,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" class="rh-button-table">
                         <tr>
                             <td class="rh-cta-link" align="center">
-                                <a target="_blank" href="https://console.redhat.com/insights/drift/baselines">
+                                <a target="_blank" href="{environment.url}/insights/drift/baselines">
                                         <span>
                                           Go to Baselines
                                         </span>
@@ -77,7 +77,7 @@
                 <td class="rh-content__block">
                   <div class="rh-card__header">
                     <h2>
-                      Baselines <a class="rh-url" href="https://console.redhat.com/insights/inventory/{action.context.inventory_id}"><b>{action.context.display_name}</b></a> has drifted from
+                      Baselines <a class="rh-url" href="{environment.url}/insights/inventory/{action.context.inventory_id}"><b>{action.context.display_name}</b></a> has drifted from
                     </h2>
                     <p></p>
                   </div>
@@ -92,7 +92,7 @@
                           {#each action.events}
                             <tr style="font-size: 14px;">
                               <td>
-                                <a href="https://console.redhat.com/insights/drift/baselines/{it.payload.baseline_id}" target="_blank">{it.payload.baseline_name}</a>
+                                <a href="{environment.url}/insights/drift/baselines/{it.payload.baseline_id}" target="_blank">{it.payload.baseline_name}</a>
                               </td>
                             </tr>
                                 {/each}

--- a/engine/src/main/resources/templates/Inventory/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Inventory/insightsEmailBody.html
@@ -453,7 +453,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>

--- a/engine/src/main/resources/templates/Patch/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Patch/insightsEmailBody.html
@@ -561,7 +561,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>
@@ -592,7 +592,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        You received this notification because of selections you made in your <a href="https://console.redhat.com/user-preferences/notifications/rhel" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
+                                        You received this notification because of selections you made in your <a href="{environment.url}/user-preferences/notifications/rhel" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/Policies/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Policies/dailyEmailBody.html
@@ -18,7 +18,7 @@
             <tbody>
             {#for key in action.context.policies.keySet()}
             <tr>
-                <td><a href="https://console.redhat.com/insights/policies/policy/{action.context.policies.get(key).policy_id}" target="_blank">{action.context.policies.get(key).policy_name}</a></td>
+                <td><a href="{environment.url}/insights/policies/policy/{action.context.policies.get(key).policy_id}" target="_blank">{action.context.policies.get(key).policy_name}</a></td>
                 <td>{action.context.policies.get(key).unique_system_count}</td>
             </tr>
             {/for}
@@ -31,7 +31,7 @@
         <table align="center">
             <tr>
                 <td class="rh-cta-link" align="center">
-                    <a target="_blank" href="https://console.redhat.com/insights/policies">
+                    <a target="_blank" href="{environment.url}/insights/policies">
                                 <span>
                                   Open Policies in Insights
                                 </span>

--- a/engine/src/main/resources/templates/Policies/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Policies/insightsEmailBody.html
@@ -453,7 +453,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>
@@ -484,7 +484,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        This email was sent by Red Hat Insights |<a href="https://console.redhat.com/user-preferences/notifications/rhel" target="_blank">&nbsp;Manage notification preferences</a>
+                                        This email was sent by Red Hat Insights |<a href="{environment.url}/user-preferences/notifications/rhel" target="_blank">&nbsp;Manage notification preferences</a>
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/Policies/instantEmailBody.html
+++ b/engine/src/main/resources/templates/Policies/instantEmailBody.html
@@ -9,7 +9,7 @@
 <tr>
     <td class="rh-content__block">
         <div class="rh-stack">
-            <a class="rh-url" href="https://console.redhat.com/insights/inventory/{action.context.inventory_id}"><b>{action.context.display_name}</b></a>
+            <a class="rh-url" href="{environment.url}/insights/inventory/{action.context.inventory_id}"><b>{action.context.display_name}</b></a>
         </div>
     </td>
 </tr>
@@ -25,7 +25,7 @@
                 {#if action.events.size() > 0}
                     {#each action.events}
                 <tr style="font-size: 14px;">
-                    <a href="https://console.redhat.com/insights/policies/policy/{it.payload.policy_id}" target="_blank">{it.payload.policy_name}</a>
+                    <a href="{environment.url}/insights/policies/policy/{it.payload.policy_id}" target="_blank">{it.payload.policy_name}</a>
                 </tr>
                     {/each}
                 {/if}
@@ -38,7 +38,7 @@
         <table align="center">
             <tr>
                 <td class="rh-cta-link" align="center">
-                    <a target="_blank" href="https://console.redhat.com/insights/policies">
+                    <a target="_blank" href="{environment.url}/insights/policies">
                                 <span>
                                   Open Policies in Insights
                                 </span>

--- a/engine/src/main/resources/templates/Rhosak/actionRequiredBody.html
+++ b/engine/src/main/resources/templates/Rhosak/actionRequiredBody.html
@@ -57,7 +57,7 @@
                         <tr>
                             <td class="rh-cta-link" align="center">
                                 <a target="_blank"
-                                   href="https://console.redhat.com/beta/application-services/streams/kafkas">
+                                   href="{environment.url}/beta/application-services/streams/kafkas">
                                     <span>Go to Kafka Instances page</span>
                                 </a>
                             </td>

--- a/engine/src/main/resources/templates/Rhosak/dailyRhosakEmailsBody.html
+++ b/engine/src/main/resources/templates/Rhosak/dailyRhosakEmailsBody.html
@@ -100,7 +100,7 @@
                 <td class="rh-cta-link" align="center">
                     <a
                             target="_blank"
-                            href="https://console.redhat.com/beta/application-services/streams/kafkas"
+                            href="{environment.url}/beta/application-services/streams/kafkas"
                     >
                                 <span>
                                   Go to Kafka Instances page

--- a/engine/src/main/resources/templates/Rhosak/instanceCreatedBody.html
+++ b/engine/src/main/resources/templates/Rhosak/instanceCreatedBody.html
@@ -29,7 +29,7 @@
                         The bootstrap server host and port of your OpenShift Streams instance are: <i>{action.context.bootstrap_server_host}</i>
                         <br/>
                         <br/>
-                        To get started with your instance, follow our <a href="https://console.redhat.com/beta/application-services/streams/resources?quickstart=getting-started" target="_blank">quick start</a> in the OpenShift Streams web console, or read our <a href="https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/1/guide/f351c4bd-9840-42ef-bcf2-b0c9be4ee30a" target="_blank">guide</a>.
+                        To get started with your instance, follow our <a href="{environment.url}/beta/application-services/streams/resources?quickstart=getting-started" target="_blank">quick start</a> in the OpenShift Streams web console, or read our <a href="https://access.redhat.com/documentation/en-us/red_hat_openshift_streams_for_apache_kafka/1/guide/f351c4bd-9840-42ef-bcf2-b0c9be4ee30a" target="_blank">guide</a>.
                         <br/>
                         <br/>
                         If you have any questions, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank">contact us</a>.
@@ -54,7 +54,7 @@
                     >
                         <tr>
                             <td class="rh-cta-link" align="center">
-                                <a target="_blank" href="https://console.redhat.com/beta/application-services/streams/kafkas">
+                                <a target="_blank" href="{environment.url}/beta/application-services/streams/kafkas">
                                     <span>Go to Kafka Instances page</span>
                                 </a>
                             </td>

--- a/engine/src/main/resources/templates/Rhosak/instanceDeletedBody.html
+++ b/engine/src/main/resources/templates/Rhosak/instanceDeletedBody.html
@@ -41,7 +41,7 @@
                     >
                         <tr>
                             <td class="rh-cta-link" align="center">
-                                <a target="_blank" href="https://console.redhat.com/beta/application-services/streams/kafkas">
+                                <a target="_blank" href="{environment.url}/beta/application-services/streams/kafkas">
                                     <span>Go to Kafka Instances page</span>
                                 </a>
                             </td>

--- a/engine/src/main/resources/templates/Rhosak/rhosakEmailBody.html
+++ b/engine/src/main/resources/templates/Rhosak/rhosakEmailBody.html
@@ -619,12 +619,12 @@
                                             bgcolor="#151515"
                                     >
                                         <a
-                                                href="https://console.redhat.com/"
+                                                href="{environment.url}"
                                                 target="_blank"
                                                 class="rh-masthead__brand-link"
                                         >
                                             <img
-                                                    src="https://console.redhat.com/apps/application-services/Logo-Red_Hat-OpenShift_Streams_for_Apache_Kafka-A-Reverse-RGB-310x117.png"
+                                                    src="{environment.url}/apps/application-services/Logo-Red_Hat-OpenShift_Streams_for_Apache_Kafka-A-Reverse-RGB-310x117.png"
                                                     alt="Red Hat OpenShift Streams for Apache Kafka logo"
                                                     width="310"
                                                     height="117"
@@ -676,7 +676,7 @@
                                     <td class="rh-footer__text">
                                         This email was sent by Red Hat OpenShift Streams for
                                         Apache Kafka |<a
-                                            href="https://console.redhat.com/user-preferences/notifications/application-services"
+                                            href="{environment.url}/user-preferences/notifications/application-services"
                                             target="_blank"
                                     >&nbsp;Manage notification preferences</a>
                                     </td>

--- a/engine/src/main/resources/templates/Rhosak/scheduledUpgradeBody.html
+++ b/engine/src/main/resources/templates/Rhosak/scheduledUpgradeBody.html
@@ -69,7 +69,7 @@
                         <tr>
                             <td class="rh-cta-link" align="center">
                                 <a target="_blank"
-                                   href="https://console.redhat.com/beta/application-services/streams/kafkas">
+                                   href="{environment.url}/beta/application-services/streams/kafkas">
                                     <span>
                                       Go to Kafka Instances page
                                     </span>

--- a/engine/src/main/resources/templates/Rhosak/serviceDisruptionBody.html
+++ b/engine/src/main/resources/templates/Rhosak/serviceDisruptionBody.html
@@ -55,7 +55,7 @@
                         <tr>
                             <td class="rh-cta-link" align="center">
                                 <a target="_blank"
-                                   href="https://console.redhat.com/beta/application-services/streams/kafkas">
+                                   href="{environment.url}/beta/application-services/streams/kafkas">
                                     <span>
                                       Go to Kafka Instances page
                                     </span>

--- a/engine/src/main/resources/templates/Sources/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Sources/insightsEmailBody.html
@@ -561,7 +561,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>
@@ -592,7 +592,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        You received this notification because of selections you made in your <a href="https://console.redhat.com/user-preferences/notifications/console" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
+                                        You received this notification because of selections you made in your <a href="{environment.url}/user-preferences/notifications/console" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/Vulnerability/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Vulnerability/insightsEmailBody.html
@@ -561,7 +561,7 @@
                                 <tr>
                                     <!--Red Hat logo-->
                                     <td align="center" class="rh-masthead__brand" bgcolor="#151515">
-                                        <a href="https://console.redhat.com/" target="_blank" class="rh-masthead__brand-link">
+                                        <a href="{environment.url}" target="_blank" class="rh-masthead__brand-link">
                                             <img src="https://console.redhat.com/apps/frontend-assets/email-assets/logo_insights.jpg" alt="Red Hat logo" width="182" height="90" class="rh-masthead__brand-img" />
                                         </a>
                                     </td>
@@ -592,7 +592,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        You received this notification because of selections you made in your <a href="https://console.redhat.com/user-preferences/notifications/rhel" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
+                                        You received this notification because of selections you made in your <a href="{environment.url}/user-preferences/notifications/rhel" target="_blank">Hybrid Cloud Console User Preferences</a>. You can opt in or out of receiving notifications by changing your User Preferences.
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/RhosakEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/RhosakEmailAggregatorTest.java
@@ -7,12 +7,14 @@ import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.templates.Rhosak.Templates;
+import com.redhat.cloud.notifications.templates.models.Environment;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -39,6 +41,9 @@ class RhosakEmailAggregatorTest {
     JsonObject context;
     JsonObject upgrades;
     JsonObject disruptions;
+
+    @Inject
+    Environment environment;
 
     @BeforeEach
     public void setup() {
@@ -189,9 +194,16 @@ class RhosakEmailAggregatorTest {
         aggregator.getContext().forEach(contextBuilder::withAdditionalProperty);
 
         emailActionMessage.setContext(contextBuilder.build());
-        String title = dailyTittleTemplateInstance.data("action", emailActionMessage).render();
+        String title = dailyTittleTemplateInstance
+                .data("action", emailActionMessage)
+                .data("environment", environment)
+                .render();
         assertTrue(title.contains("Red Hat OpenShift Streams for Apache Kafka Daily Report"), "Title must contain RHOSAK related digest info");
-        String body = dailyBodyTemplateInstance.data("action", emailActionMessage).data("user", Map.of("firstName", "machi1990", "lastName", "Last Name")).render();
+        String body = dailyBodyTemplateInstance
+                .data("action", emailActionMessage)
+                .data("user", Map.of("firstName", "machi1990", "lastName", "Last Name"))
+                .data("environment", environment)
+                .render();
         assertTrue(body.contains("The following table summarizes the OpenShift Streams instances affected by unexpected disruptions of the OpenShift Streams service."), "Body must contain service disruption summary");
         assertTrue(body.contains("The following table summarizes Kafka upgrade activity for your OpenShift Streams instances."), "Body must contain upgrades summary");
         assertTrue(body.contains("Hello machi1990."), "Body must contain greeting message");

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
@@ -57,6 +57,7 @@ public class TestAdvisorTemplate {
         Action action = TestHelpers.createAdvisorAction("123456", "resolved-recommendation");
         String result = Advisor.Templates.resolvedRecommendationInstantEmailTitle()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 4 resolved recommendations\n", result, "Title contains the number of reports created");
@@ -65,6 +66,7 @@ public class TestAdvisorTemplate {
         action.setEvents(List.of(action.getEvents().get(0)));
         result = Advisor.Templates.resolvedRecommendationInstantEmailTitle()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
         assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 1 resolved recommendation\n", result, "Title contains the number of reports created");
     }
@@ -84,6 +86,7 @@ public class TestAdvisorTemplate {
         Action action = TestHelpers.createAdvisorAction("123456", "new-recommendation");
         String result = Advisor.Templates.newRecommendationInstantEmailTitle()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 4 new recommendations\n", result, "Title contains the number of reports created");
@@ -92,6 +95,7 @@ public class TestAdvisorTemplate {
         action.setEvents(List.of(action.getEvents().get(0)));
         result = Advisor.Templates.newRecommendationInstantEmailTitle()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
         assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 1 new recommendation\n", result, "Title contains the number of reports created");
     }
@@ -101,6 +105,7 @@ public class TestAdvisorTemplate {
         Action action = TestHelpers.createAdvisorAction("123456", "new-recommendation");
         final String result = Advisor.Templates.newRecommendationInstantEmailBody()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         action.getEvents().forEach(event -> {
@@ -125,6 +130,7 @@ public class TestAdvisorTemplate {
         action.setEvents(action.getEvents().stream().filter(event -> event.getPayload().getAdditionalProperties().get("total_risk").equals("1")).collect(Collectors.toList()));
         String result2 = Advisor.Templates.newRecommendationInstantEmailBody()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         assertTrue(result2.contains("alt=\"Low severity\""), "Body 2 should contain low severity rule image");
@@ -138,6 +144,7 @@ public class TestAdvisorTemplate {
         Action action = TestHelpers.createAdvisorAction("123456", "deactivated-recommendation");
         String result = Advisor.Templates.deactivatedRecommendationInstantEmailTitle()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 2 deactivated recommendations\n", result, "Title contains the number of reports created");
@@ -146,6 +153,7 @@ public class TestAdvisorTemplate {
         action.setEvents(List.of(action.getEvents().get(0)));
         result = Advisor.Templates.deactivatedRecommendationInstantEmailTitle()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
         assertEquals("Red Hat Enterprise Linux - Advisor Instant Notification - 03 Oct 2020 15:22 UTC - 1 deactivated recommendation\n", result, "Title contains the number of reports created");
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestDriftTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestDriftTemplate.java
@@ -3,10 +3,12 @@ package com.redhat.cloud.notifications.templates;
 import com.redhat.cloud.notifications.DriftTestHelpers;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.processors.email.aggregators.DriftEmailPayloadAggregator;
+import com.redhat.cloud.notifications.templates.models.Environment;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -16,6 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 public class TestDriftTemplate {
+
+    @Inject
+    Environment environment;
+
     private DriftEmailPayloadAggregator aggregator;
 
     @BeforeEach
@@ -27,6 +33,7 @@ public class TestDriftTemplate {
         Action action = DriftTestHelpers.createDriftAction("rhel", "drift", "host-01", "Machine 1");
         String result = Drift.Templates.newBaselineDriftInstantEmailTitle()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
         assertTrue(result.contains("2 drifts from baseline detected on Machine 1"));
     }
@@ -36,6 +43,7 @@ public class TestDriftTemplate {
         Action action = DriftTestHelpers.createDriftAction("rhel", "drift", "host-01", "Machine 1");
         String result = Drift.Templates.newBaselineDriftInstantEmailBody()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
         assertTrue(result.contains("baseline_01"));
         assertTrue(result.contains("Machine 1"));
@@ -57,6 +65,7 @@ public class TestDriftTemplate {
         drift.put("end_time", endTime.toString());
         String result = Drift.Templates.dailyEmailTitle()
                 .data("action", Map.of("context", drift))
+                .data("environment", environment)
                 .render();
         //writeEmailTemplate(result, "driftEmailMultMult.html");
         assertTrue(result.contains("3 drifts from baseline detected on 2 unique system"));
@@ -74,6 +83,7 @@ public class TestDriftTemplate {
         drift.put("end_time", endTime.toString());
         String result = Drift.Templates.dailyEmailBody()
                 .data("action", Map.of("context", drift))
+                .data("environment", environment)
                 .render();
         //writeEmailTemplate(result, "driftEmailOneOne.html");
         assertTrue(result.contains("baseline_01"));
@@ -94,6 +104,7 @@ public class TestDriftTemplate {
         drift.put("end_time", endTime.toString());
         String result = Drift.Templates.dailyEmailBody()
                 .data("action", Map.of("context", drift))
+                .data("environment", environment)
                 .render();
         //writeEmailTemplate(result, "drfitEmailMultOne.html");
         assertTrue(result.contains("baseline_01"));
@@ -116,6 +127,7 @@ public class TestDriftTemplate {
         drift.put("end_time", endTime.toString());
         String result = Drift.Templates.dailyEmailBody()
                 .data("action", Map.of("context", drift))
+                .data("environment", environment)
                 .render();
         //writeEmailTemplate(result, "driftEmailOneMult.html");
         assertTrue(result.contains("baseline_01"));
@@ -138,6 +150,7 @@ public class TestDriftTemplate {
         drift.put("end_time", endTime.toString());
         String result = Drift.Templates.dailyEmailBody()
                 .data("action", Map.of("context", drift))
+                .data("environment", environment)
                 .render();
         //writeEmailTemplate(result, "driftEmailMultMult.html");
         assertTrue(result.contains("baseline_01"));

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOpenshiftAdvisorTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOpenshiftAdvisorTemplate.java
@@ -2,9 +2,11 @@ package com.redhat.cloud.notifications.templates;
 
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.templates.models.Environment;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -13,11 +15,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 public class TestOpenshiftAdvisorTemplate {
 
+    @Inject
+    Environment environment;
+
     @Test
     public void testInstantEmailTitle() {
         Action action = TestHelpers.createAdvisorOpenshiftAction("123456", "new-recommendation");
         String result = AdvisorOpenshift.Templates.newRecommendationInstantEmailTitle()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         assertTrue(result.contains("OpenShift - Advisor Instant Notification - "));
@@ -29,6 +35,7 @@ public class TestOpenshiftAdvisorTemplate {
         Action action = TestHelpers.createAdvisorOpenshiftAction("123456", "new-recommendation");
         final String result = AdvisorOpenshift.Templates.newRecommendationInstantEmailBody()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         action.getEvents().forEach(event -> {
@@ -57,6 +64,7 @@ public class TestOpenshiftAdvisorTemplate {
         action.setEvents(action.getEvents().stream().filter(event -> event.getPayload().getAdditionalProperties().get("total_risk").equals("1")).collect(Collectors.toList()));
         String result2 = AdvisorOpenshift.Templates.newRecommendationInstantEmailBody()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         assertTrue(result2.contains("alt=\"Low severity\""), "Body 2 should contain low severity rule image");

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestPoliciesTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestPoliciesTemplate.java
@@ -2,9 +2,11 @@ package com.redhat.cloud.notifications.templates;
 
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.templates.models.Environment;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -15,11 +17,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 public class TestPoliciesTemplate {
 
+    @Inject
+    Environment environment;
+
     @Test
     public void testInstantEmailTitle() {
         Action action = TestHelpers.createPoliciesAction("", "", "", "FooMachine");
         String result = Policies.Templates.instantEmailTitle()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         assertTrue(result.contains("2"), "Title contains the number of policies triggered");
@@ -31,6 +37,7 @@ public class TestPoliciesTemplate {
         Action action = TestHelpers.createPoliciesAction("", "", "", "FooMachine");
         String result = Policies.Templates.instantEmailBody()
                 .data("action", action)
+                .data("environment", environment)
                 .render();
 
         assertTrue(result.contains(TestHelpers.policyId1), "Body should contain policy id" + TestHelpers.policyId1);
@@ -74,6 +81,7 @@ public class TestPoliciesTemplate {
 
         String result = Policies.Templates.dailyEmailTitle()
                 .data("action", Map.of("context", payload))
+                .data("environment", environment)
                 .render();
 
         assertEquals("22 Apr 2021 - 3 policies triggered on 3 unique systems", result);
@@ -101,6 +109,7 @@ public class TestPoliciesTemplate {
 
         String result = Policies.Templates.dailyEmailTitle()
                 .data("action", Map.of("context", payload))
+                .data("environment", environment)
                 .render();
 
         assertEquals("22 Apr 2021 - 1 policy triggered on 1 system", result);
@@ -140,6 +149,7 @@ public class TestPoliciesTemplate {
 
         String result = Policies.Templates.dailyEmailBody()
                 .data("action", Map.of("context", payload))
+                .data("environment", environment)
                 .render();
 
         assertTrue(result.contains("<b>3 policies</b> triggered on <b>3 unique systems</b>"));
@@ -167,6 +177,7 @@ public class TestPoliciesTemplate {
 
         String result = Policies.Templates.dailyEmailBody()
                 .data("action", Map.of("context", payload))
+                .data("environment", environment)
                 .render();
 
         assertTrue(result.contains("<b>1 policy</b> triggered on <b>1 system</b>"));


### PR DESCRIPTION
This will fix a lot of links from email notifications sent on stage.