### PR TITLE
Fix the JsonProperty of isAdmin and isOrgAdmin

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/routers/models/Meta.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/models/Meta.java
@@ -1,10 +1,12 @@
 package com.redhat.cloud.notifications.routers.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import javax.validation.constraints.NotNull;
 
 @JsonSerialize
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Meta {
     @NotNull
     private Long count;

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacUser.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacUser.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.recipients.rbac;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -10,7 +11,9 @@ public class RbacUser {
     private String email;
     private String firstName;
     private String lastName;
+    @JsonProperty(value = "is_active")
     private Boolean isActive;
+    @JsonProperty(value = "is_org_admin")
     private Boolean isOrgAdmin;
 
     public String getUsername() {

--- a/engine/src/test/java/com/redhat/cloud/notifications/recipients/rbac/RbacUserTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/recipients/rbac/RbacUserTest.java
@@ -1,0 +1,39 @@
+package com.redhat.cloud.notifications.recipients.rbac;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.notifications.routers.models.Page;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RbacUserTest {
+
+    static class RbacUserPage extends Page<RbacUser> {
+
+    }
+
+    @Test
+    public void shouldDeserializeAPage() throws Exception {
+        String json = "{\"meta\":{\"count\":5,\"limit\":10,\"offset\":0},\"links\":{\"first\":\"/api/rbac/v1/groups/some-id/principals/?limit=10&offset=0\",\"next\":null,\"previous\":null,\"last\":\"/api/rbac/v1/groups/some-id/principals/?limit=10&offset=0\"},\"data\":[{\"username\":\"user1\",\"email\":\"user1@somewhere\",\"first_name\":\"user1-name\",\"last_name\":null,\"is_active\":true,\"is_org_admin\":false},{\"username\":\"user2\",\"email\":\"user2@somewhere\",\"first_name\":\"user2-name\",\"last_name\":\"user2-lastname\",\"is_active\":true,\"is_org_admin\":true},{\"username\":\"user3\",\"email\":\"user3@somewhere\",\"first_name\":\"user3-name\",\"last_name\":null,\"is_active\":true,\"is_org_admin\":true},{\"username\":\"user4\",\"email\":\"user4@somewhere\",\"first_name\": null,\"last_name\":null,\"is_active\":true,\"is_org_admin\":true},{\"username\":\"user5\",\"email\":\"user5@somewhere\",\"first_name\":\"user5-name\",\"last_name\":null,\"is_active\":false,\"is_org_admin\":true}]}";
+        ObjectMapper mapper = new ObjectMapper();
+
+        RbacUserPage page = mapper.readValue(json, RbacUserPage.class);
+        assertEquals(Long.valueOf(5), page.getMeta().getCount());
+
+        testRbacUser(page.getData().get(0), "user1", "user1@somewhere", "user1-name", null, true, false);
+        testRbacUser(page.getData().get(1), "user2", "user2@somewhere", "user2-name", "user2-lastname", true, true);
+        testRbacUser(page.getData().get(2), "user3", "user3@somewhere", "user3-name", null, true, true);
+        testRbacUser(page.getData().get(3), "user4", "user4@somewhere", null, null, true, true);
+        testRbacUser(page.getData().get(4), "user5", "user5@somewhere", "user5-name", null, false, true);
+    }
+
+    private void testRbacUser(RbacUser user, String username, String email, String firstName, String lastName, boolean isActive, boolean isOrgadmin) {
+        assertEquals(username, user.getUsername());
+        assertEquals(email, user.getEmail());
+        assertEquals(firstName, user.getFirstName());
+        assertEquals(lastName, user.getLastName());
+        assertEquals(isActive, user.getActive());
+        assertEquals(isOrgadmin, user.getOrgAdmin());
+    }
+
+}


### PR DESCRIPTION
 - SnakeCaseStrategy turns `isActive` to `active` - we are receiving `is_active` - adding the explicit property instead
 - The same applies for `isOrgAdmin`