### PR TITLE
NOTIF-370 Ensure the behavior group name is per bundle

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -69,7 +69,7 @@ public class BehaviorGroupRepository {
                     .setParameter("id", behaviorGroupId)
                     .getSingleResult();
         } catch (NoResultException nre) {
-            throw new NotFoundException("Behavior group not found", nre);
+            throw new NotFoundException("Behavior group not found");
         }
     }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -63,8 +63,14 @@ public class BehaviorGroupRepository {
         return this.create(null, null, behaviorGroup, true);
     }
 
-    public BehaviorGroup get(UUID behaviorGroupId) {
-        return entityManager.find(BehaviorGroup.class, behaviorGroupId);
+    public UUID getBundleId(UUID behaviorGroupId) {
+        try {
+            return entityManager.createQuery("SELECT bundle.id FROM BehaviorGroup WHERE id = :id", UUID.class)
+                    .setParameter("id", behaviorGroupId)
+                    .getSingleResult();
+        } catch (NoResultException nre) {
+            throw new NotFoundException("Behavior group not found", nre);
+        }
     }
 
     @Transactional

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -168,9 +168,7 @@ public class BehaviorGroupRepository {
             q = q.setParameter("orgId", orgId);
         }
 
-        if (q.executeUpdate() == 0) {
-            throw new BadRequestException("Behavior group not updated - probably the behavior group was not part of the orgId");
-        }
+        q.executeUpdate();
     }
 
     private void checkBehaviorGroupDisplayNameDuplicate(String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -15,7 +15,6 @@ import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
 import javax.validation.Valid;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -63,6 +63,10 @@ public class BehaviorGroupRepository {
         return this.create(null, null, behaviorGroup, true);
     }
 
+    public BehaviorGroup get(UUID behaviorGroupId) {
+        return entityManager.find(BehaviorGroup.class, behaviorGroupId);
+    }
+
     @Transactional
     BehaviorGroup create(String accountId, String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {
         checkBehaviorGroupDisplayNameDuplicate(orgId, behaviorGroup, isDefaultBehaviorGroup);
@@ -165,7 +169,7 @@ public class BehaviorGroupRepository {
             return;
         }
 
-        String hql = "SELECT COUNT(*) FROM BehaviorGroup WHERE displayName = :displayName";
+        String hql = "SELECT COUNT(*) FROM BehaviorGroup WHERE displayName = :displayName AND bundle.id = :bundleId";
         if (behaviorGroup.getId() != null) { // The behavior group already exists in the DB, it's being updated.
             hql += " AND id != :behaviorGroupId";
         }
@@ -176,7 +180,9 @@ public class BehaviorGroupRepository {
         }
 
         TypedQuery<Long> query = entityManager.createQuery(hql, Long.class)
-                .setParameter("displayName", behaviorGroup.getDisplayName());
+                .setParameter("displayName", behaviorGroup.getDisplayName())
+                .setParameter("bundleId", behaviorGroup.getBundleId());
+
         if (behaviorGroup.getId() != null) {
             query.setParameter("behaviorGroupId", behaviorGroup.getId());
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -15,6 +15,7 @@ import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
 import javax.validation.Valid;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -63,10 +64,11 @@ public class BehaviorGroupRepository {
         return this.create(null, null, behaviorGroup, true);
     }
 
-    public UUID getBundleId(UUID behaviorGroupId) {
+    public UUID getBundleId(String orgId, UUID behaviorGroupId) {
         try {
-            return entityManager.createQuery("SELECT bundle.id FROM BehaviorGroup WHERE id = :id", UUID.class)
+            return entityManager.createQuery("SELECT bundle.id FROM BehaviorGroup WHERE id = :id and orgId = :orgId", UUID.class)
                     .setParameter("id", behaviorGroupId)
+                    .setParameter("orgId", orgId)
                     .getSingleResult();
         } catch (NoResultException nre) {
             throw new NotFoundException("Behavior group not found");

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -137,16 +137,16 @@ public class BehaviorGroupRepository {
         return behaviorGroups;
     }
 
-    public boolean update(String orgId, BehaviorGroup behaviorGroup) {
-        return this.update(orgId, behaviorGroup, false);
+    public void update(String orgId, BehaviorGroup behaviorGroup) {
+        this.update(orgId, behaviorGroup, false);
     }
 
-    public boolean updateDefault(BehaviorGroup behaviorGroup) {
-        return this.update(null, behaviorGroup, true);
+    public void updateDefault(BehaviorGroup behaviorGroup) {
+        this.update(null, behaviorGroup, true);
     }
 
     @Transactional
-    boolean update(String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehavior) {
+    void update(String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehavior) {
         checkBehaviorGroupDisplayNameDuplicate(orgId, behaviorGroup, isDefaultBehavior);
 
         checkBehaviorGroup(behaviorGroup.getId(), isDefaultBehavior);
@@ -166,7 +166,9 @@ public class BehaviorGroupRepository {
             q = q.setParameter("orgId", orgId);
         }
 
-        return q.executeUpdate() > 0;
+        if (q.executeUpdate() == 0) {
+            throw new BadRequestException("Behavior group not updated - probably the behavior group was not part of the orgId");
+        }
     }
 
     private void checkBehaviorGroupDisplayNameDuplicate(String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -275,14 +275,21 @@ public class NotificationResource {
         String orgId = getOrgId(sec);
 
         if (request.displayName != null) {
-            BehaviorGroup behaviorGroup = behaviorGroupRepository.get(id);
-            if (behaviorGroup == null || !Objects.equals(behaviorGroup.getOrgId(), orgId)) {
-                throw new NotFoundException("Behavior group not found");
+            UUID bundleId = behaviorGroupRepository.getBundleId(id);
+            BehaviorGroup behaviorGroup = new BehaviorGroup();
+            behaviorGroup.setId(id);
+            behaviorGroup.setDisplayName(request.displayName);
+            behaviorGroup.setBundleId(bundleId);
+
+            boolean didUpdate;
+            try {
+                didUpdate = behaviorGroupRepository.update(orgId, behaviorGroup);
+            } catch (BadRequestException badRequestException) {
+                // The duplicate name in bundle id validation failed - keep the responses consistent by returning false.
+                didUpdate = false;
             }
 
-            behaviorGroup.setDisplayName(request.displayName);
-
-            if (!behaviorGroupRepository.update(orgId, behaviorGroup)) {
+            if (!didUpdate) {
                 return Response.status(200).type(APPLICATION_JSON).entity(false).build();
             }
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -275,15 +275,12 @@ public class NotificationResource {
         String orgId = getOrgId(sec);
 
         if (request.displayName != null) {
-            BehaviorGroup databaseBehaviorGroup = behaviorGroupRepository.get(id);
-            if (databaseBehaviorGroup == null) {
+            BehaviorGroup behaviorGroup = behaviorGroupRepository.get(id);
+            if (behaviorGroup == null || !Objects.equals(behaviorGroup.getOrgId(), orgId)) {
                 throw new NotFoundException("Behavior group not found");
             }
 
-            BehaviorGroup behaviorGroup = new BehaviorGroup();
-            behaviorGroup.setId(id);
             behaviorGroup.setDisplayName(request.displayName);
-            behaviorGroup.setBundleId(databaseBehaviorGroup.getBundleId());
 
             if (!behaviorGroupRepository.update(orgId, behaviorGroup)) {
                 return Response.status(200).type(APPLICATION_JSON).entity(false).build();

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -275,9 +275,15 @@ public class NotificationResource {
         String orgId = getOrgId(sec);
 
         if (request.displayName != null) {
+            BehaviorGroup databaseBehaviorGroup = behaviorGroupRepository.get(id);
+            if (databaseBehaviorGroup == null) {
+                throw new NotFoundException("Behavior group not found");
+            }
+
             BehaviorGroup behaviorGroup = new BehaviorGroup();
             behaviorGroup.setId(id);
             behaviorGroup.setDisplayName(request.displayName);
+            behaviorGroup.setBundleId(databaseBehaviorGroup.getBundleId());
 
             if (!behaviorGroupRepository.update(orgId, behaviorGroup)) {
                 return Response.status(200).type(APPLICATION_JSON).entity(false).build();

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -275,7 +275,7 @@ public class NotificationResource {
         String orgId = getOrgId(sec);
 
         if (request.displayName != null) {
-            UUID bundleId = behaviorGroupRepository.getBundleId(id);
+            UUID bundleId = behaviorGroupRepository.getBundleId(orgId, id);
             BehaviorGroup behaviorGroup = new BehaviorGroup();
             behaviorGroup.setId(id);
             behaviorGroup.setDisplayName(request.displayName);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -281,17 +281,7 @@ public class NotificationResource {
             behaviorGroup.setDisplayName(request.displayName);
             behaviorGroup.setBundleId(bundleId);
 
-            boolean didUpdate;
-            try {
-                didUpdate = behaviorGroupRepository.update(orgId, behaviorGroup);
-            } catch (BadRequestException badRequestException) {
-                // The duplicate name in bundle id validation failed - keep the responses consistent by returning false.
-                didUpdate = false;
-            }
-
-            if (!didUpdate) {
-                return Response.status(200).type(APPLICATION_JSON).entity(false).build();
-            }
+            behaviorGroupRepository.update(orgId, behaviorGroup);
         }
 
         if (request.endpointIds != null) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -359,7 +359,8 @@ public class InternalResource {
     @RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)
     public boolean updateDefaultBehaviorGroup(@PathParam("id") UUID id, @NotNull @Valid BehaviorGroup behaviorGroup) {
         behaviorGroup.setId(id);
-        return behaviorGroupRepository.updateDefault(behaviorGroup);
+        behaviorGroupRepository.updateDefault(behaviorGroup);
+        return true;
     }
 
     @DELETE

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -229,16 +229,16 @@ public class ResourceHelpers {
         return behaviorGroupRepository.findBehaviorGroupsByEndpointId(DEFAULT_ORG_ID, endpointId);
     }
 
-    public Boolean updateBehaviorGroup(BehaviorGroup behaviorGroup) {
-        return behaviorGroupRepository.update(DEFAULT_ORG_ID, behaviorGroup);
+    public void updateBehaviorGroup(BehaviorGroup behaviorGroup) {
+        behaviorGroupRepository.update(DEFAULT_ORG_ID, behaviorGroup);
     }
 
     public Boolean deleteBehaviorGroup(UUID behaviorGroupId) {
         return behaviorGroupRepository.delete(DEFAULT_ORG_ID, behaviorGroupId);
     }
 
-    public Boolean updateDefaultBehaviorGroup(BehaviorGroup behaviorGroup) {
-        return behaviorGroupRepository.updateDefault(behaviorGroup);
+    public void updateDefaultBehaviorGroup(BehaviorGroup behaviorGroup) {
+        behaviorGroupRepository.updateDefault(behaviorGroup);
     }
 
     public Boolean deleteDefaultBehaviorGroup(UUID behaviorGroupId) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -37,6 +37,7 @@ public class ResourceHelpers {
     public static final String TEST_APP_NAME_2 = "myothertester";
     public static final String TEST_EVENT_TYPE_FORMAT = "eventtype%d";
     public static final String TEST_BUNDLE_NAME = "testbundle";
+    public static final String TEST_BUNDLE_2_NAME = "testbundle2";
 
     @Inject
     EndpointRepository endpointRepository;

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -35,6 +35,7 @@ import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPTION;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -189,7 +190,7 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
         assertNotNull(bundle.getCreated());
 
         // Update behavior group.
-        assertTrue(updateBehaviorGroup(behaviorGroup.getId(), newDisplayName));
+        assertDoesNotThrow(() -> updateBehaviorGroup(behaviorGroup.getId(), newDisplayName));
         entityManager.clear(); // We need to clear the session L1 cache before checking the update result.
 
         behaviorGroups = behaviorGroupRepository.findByBundleId(DEFAULT_ORG_ID, bundle.getId());
@@ -222,7 +223,7 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
         assertNotNull(bundle.getCreated());
 
         // Update behavior group.
-        assertTrue(updateDefaultBehaviorGroup(behaviorGroup.getId(), newDisplayName));
+        assertDoesNotThrow(() -> updateDefaultBehaviorGroup(behaviorGroup.getId(), newDisplayName));
         entityManager.clear(); // We need to clear the session L1 cache before checking the update result.
 
         behaviorGroups = behaviorGroupRepository.findByBundleId(DEFAULT_ORG_ID, bundle.getId());
@@ -445,20 +446,20 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
         assertTrue(Pattern.compile("property path: [a-zA-Z0-9.]+displayName").matcher(e.getMessage()).find());
     }
 
-    private Boolean updateBehaviorGroup(UUID behaviorGroupId, String displayName) {
+    private void updateBehaviorGroup(UUID behaviorGroupId, String displayName) {
         BehaviorGroup behaviorGroup = new BehaviorGroup();
         behaviorGroup.setId(behaviorGroupId);
         behaviorGroup.setDisplayName(displayName);
         behaviorGroup.setBundleId(UUID.randomUUID()); // This should not have any effect, the bundle is not updatable.
-        return resourceHelpers.updateBehaviorGroup(behaviorGroup);
+        resourceHelpers.updateBehaviorGroup(behaviorGroup);
     }
 
-    private Boolean updateDefaultBehaviorGroup(UUID behaviorGroupId, String displayName) {
+    private void updateDefaultBehaviorGroup(UUID behaviorGroupId, String displayName) {
         BehaviorGroup behaviorGroup = new BehaviorGroup();
         behaviorGroup.setId(behaviorGroupId);
         behaviorGroup.setDisplayName(displayName);
         behaviorGroup.setBundleId(UUID.randomUUID()); // This should not have any effect, the bundle is not updatable.
-        return resourceHelpers.updateDefaultBehaviorGroup(behaviorGroup);
+        resourceHelpers.updateDefaultBehaviorGroup(behaviorGroup);
     }
 
     @Transactional

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -60,44 +60,44 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
 
     @Test
     void shouldThrowExceptionWhenCreatingWithExistingDisplayNameAndSameOrgId() {
-        if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
-            // The check is disabled from configuration.
-            return;
+        try {
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(true);
+            Bundle bundle = resourceHelpers.createBundle();
+            BehaviorGroup behaviorGroup1 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName", bundle.getId());
+
+            BehaviorGroup behaviorGroup2 = new BehaviorGroup();
+            behaviorGroup2.setAccountId(behaviorGroup1.getAccountId());
+            behaviorGroup2.setOrgId(behaviorGroup1.getOrgId());
+            behaviorGroup2.setDisplayName(behaviorGroup1.getDisplayName());
+            behaviorGroup2.setBundleId(bundle.getId());
+
+            BadRequestException e = assertThrows(BadRequestException.class, () -> {
+                behaviorGroupRepository.create(behaviorGroup2.getAccountId(), behaviorGroup2.getOrgId(), behaviorGroup2);
+            });
+            assertEquals("A behavior group with display name [" + behaviorGroup1.getDisplayName() + "] already exists", e.getMessage());
+        }  finally {
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(false);
         }
-
-        Bundle bundle = resourceHelpers.createBundle();
-        BehaviorGroup behaviorGroup1 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName", bundle.getId());
-
-        BehaviorGroup behaviorGroup2 = new BehaviorGroup();
-        behaviorGroup2.setAccountId(behaviorGroup1.getAccountId());
-        behaviorGroup2.setOrgId(behaviorGroup1.getOrgId());
-        behaviorGroup2.setDisplayName(behaviorGroup1.getDisplayName());
-        behaviorGroup2.setBundleId(bundle.getId());
-
-        BadRequestException e = assertThrows(BadRequestException.class, () -> {
-            behaviorGroupRepository.create(behaviorGroup2.getAccountId(), behaviorGroup2.getOrgId(), behaviorGroup2);
-        });
-        assertEquals("A behavior group with display name [" + behaviorGroup1.getDisplayName() + "] already exists", e.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenCreatingDefaultWithExistingDisplayName() {
-        if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
-            // The check is disabled from configuration.
-            return;
+        try {
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(true);
+            Bundle bundle = resourceHelpers.createBundle();
+            BehaviorGroup behaviorGroup1 = resourceHelpers.createDefaultBehaviorGroup("displayName", bundle.getId());
+
+            BehaviorGroup behaviorGroup2 = new BehaviorGroup();
+            behaviorGroup2.setDisplayName(behaviorGroup1.getDisplayName());
+            behaviorGroup2.setBundleId(bundle.getId());
+
+            BadRequestException e = assertThrows(BadRequestException.class, () -> {
+                behaviorGroupRepository.createDefault(behaviorGroup2);
+            });
+            assertEquals("A behavior group with display name [" + behaviorGroup1.getDisplayName() + "] already exists", e.getMessage());
+        }  finally {
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(false);
         }
-
-        Bundle bundle = resourceHelpers.createBundle();
-        BehaviorGroup behaviorGroup1 = resourceHelpers.createDefaultBehaviorGroup("displayName", bundle.getId());
-
-        BehaviorGroup behaviorGroup2 = new BehaviorGroup();
-        behaviorGroup2.setDisplayName(behaviorGroup1.getDisplayName());
-        behaviorGroup2.setBundleId(bundle.getId());
-
-        BadRequestException e = assertThrows(BadRequestException.class, () -> {
-            behaviorGroupRepository.createDefault(behaviorGroup2);
-        });
-        assertEquals("A behavior group with display name [" + behaviorGroup1.getDisplayName() + "] already exists", e.getMessage());
     }
 
     @Test
@@ -116,38 +116,38 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
 
     @Test
     void shouldThrowExceptionWhenUpdatingToExistingDisplayNameAndSameOrgId() {
-        if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
-            // The check is disabled from configuration.
-            return;
+        try {
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(true);
+            Bundle bundle = resourceHelpers.createBundle("name", "displayName");
+            BehaviorGroup behaviorGroup1 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName1", bundle.getId());
+            BehaviorGroup behaviorGroup2 = resourceHelpers.createBehaviorGroup(behaviorGroup1.getAccountId(), behaviorGroup1.getOrgId(), "displayName2", bundle.getId());
+            behaviorGroup2.setDisplayName(behaviorGroup1.getDisplayName());
+
+            BadRequestException e = assertThrows(BadRequestException.class, () -> {
+                behaviorGroupRepository.update(behaviorGroup2.getOrgId(), behaviorGroup2);
+            });
+            assertEquals("A behavior group with display name [" + behaviorGroup1.getDisplayName() + "] already exists", e.getMessage());
+        } finally {
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(false);
         }
-
-        Bundle bundle = resourceHelpers.createBundle("name", "displayName");
-        BehaviorGroup behaviorGroup1 = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName1", bundle.getId());
-        BehaviorGroup behaviorGroup2 = resourceHelpers.createBehaviorGroup(behaviorGroup1.getAccountId(), behaviorGroup1.getOrgId(), "displayName2", bundle.getId());
-        behaviorGroup2.setDisplayName(behaviorGroup1.getDisplayName());
-
-        BadRequestException e = assertThrows(BadRequestException.class, () -> {
-            behaviorGroupRepository.update(behaviorGroup2.getOrgId(), behaviorGroup2);
-        });
-        assertEquals("A behavior group with display name [" + behaviorGroup1.getDisplayName() + "] already exists", e.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenUpdatingDefaultToExistingDisplayName() {
-        if (!featureFlipper.isEnforceBehaviorGroupNameUnicity()) {
-            // The check is disabled from configuration.
-            return;
+        try {
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(true);
+            Bundle bundle = resourceHelpers.createBundle("name", "displayName");
+            BehaviorGroup behaviorGroup1 = resourceHelpers.createDefaultBehaviorGroup("displayName1", bundle.getId());
+            BehaviorGroup behaviorGroup2 = resourceHelpers.createDefaultBehaviorGroup("displayName2", bundle.getId());
+            behaviorGroup2.setDisplayName(behaviorGroup1.getDisplayName());
+
+            BadRequestException e = assertThrows(BadRequestException.class, () -> {
+                behaviorGroupRepository.updateDefault(behaviorGroup2);
+            });
+            assertEquals("A behavior group with display name [" + behaviorGroup1.getDisplayName() + "] already exists", e.getMessage());
+        } finally {
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(false);
         }
-
-        Bundle bundle = resourceHelpers.createBundle("name", "displayName");
-        BehaviorGroup behaviorGroup1 = resourceHelpers.createDefaultBehaviorGroup("displayName1", bundle.getId());
-        BehaviorGroup behaviorGroup2 = resourceHelpers.createDefaultBehaviorGroup("displayName2", bundle.getId());
-        behaviorGroup2.setDisplayName(behaviorGroup1.getDisplayName());
-
-        BadRequestException e = assertThrows(BadRequestException.class, () -> {
-            behaviorGroupRepository.updateDefault(behaviorGroup2);
-        });
-        assertEquals("A behavior group with display name [" + behaviorGroup1.getDisplayName() + "] already exists", e.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -559,10 +559,10 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         Set<UUID> eventTypes = apps.stream().findFirst().get().getEventTypes().stream().map(EventType::getId).collect(Collectors.toSet());
 
-        // Updating a behavior of other tenant yields 400
+        // Updating a behavior of other tenant yields 404 - i.e. can't find the behavior group
         UpdateBehaviorGroupRequest behaviorGroupRequest = new UpdateBehaviorGroupRequest();
         behaviorGroupRequest.displayName = "My behavior group 1.0";
-        updateBehaviorGroup(identityHeader, behaviorGroupIdOtherTenant, behaviorGroupRequest, 400);
+        updateBehaviorGroup(identityHeader, behaviorGroupIdOtherTenant, behaviorGroupRequest, 404);
         BehaviorGroup behaviorGroup = helpers.getBehaviorGroup(behaviorGroupIdOtherTenant);
         assertEquals("My behavior", behaviorGroup.getDisplayName()); // No change
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -51,7 +51,6 @@ import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_EVENT_TYPE_
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -563,13 +562,12 @@ public class NotificationResourceTest extends DbIsolatedTest {
         // Updating a behavior of other tenant yields false
         UpdateBehaviorGroupRequest behaviorGroupRequest = new UpdateBehaviorGroupRequest();
         behaviorGroupRequest.displayName = "My behavior group 1.0";
-        boolean response = updateBehaviorGroup(identityHeader, behaviorGroupIdOtherTenant, behaviorGroupRequest);
-        assertFalse(response);
+        updateBehaviorGroup(identityHeader, behaviorGroupIdOtherTenant, behaviorGroupRequest, 404);
         BehaviorGroup behaviorGroup = helpers.getBehaviorGroup(behaviorGroupIdOtherTenant);
         assertEquals("My behavior", behaviorGroup.getDisplayName()); // No change
 
         // Updating the behavior group displayName only
-        response = updateBehaviorGroup(identityHeader, behaviorGroupId, behaviorGroupRequest);
+        boolean response = updateBehaviorGroup(identityHeader, behaviorGroupId, behaviorGroupRequest);
         assertTrue(response);
         behaviorGroup = helpers.getBehaviorGroup(behaviorGroupId);
         assertEquals("My behavior group 1.0", behaviorGroup.getDisplayName());

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -6,6 +6,7 @@ import com.redhat.cloud.notifications.MockServerConfig.RbacAccess;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
@@ -25,6 +26,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +45,7 @@ import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.NO_ACCE
 import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.READ_ACCESS;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_APP_NAME;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_APP_NAME_2;
+import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_BUNDLE_2_NAME;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_BUNDLE_NAME;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_EVENT_TYPE_FORMAT;
 import static io.restassured.RestAssured.given;
@@ -77,10 +80,14 @@ public class NotificationResourceTest extends DbIsolatedTest {
     @Inject
     BehaviorGroupRepository behaviorGroupRepository;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @BeforeEach
     void beforeEach() {
         RestAssured.basePath = TestConstants.API_NOTIFICATIONS_V_1_0;
         MockServerConfig.clearRbac();
+        featureFlipper.setEnforceBehaviorGroupNameUnicity(true);
     }
 
     private Header initRbacMock(String accountId, String orgId, String username, RbacAccess access) {
@@ -556,7 +563,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
         // Updating a behavior of other tenant yields false
         UpdateBehaviorGroupRequest behaviorGroupRequest = new UpdateBehaviorGroupRequest();
         behaviorGroupRequest.displayName = "My behavior group 1.0";
-        Boolean response = updateBehaviorGroup(identityHeader, behaviorGroupIdOtherTenant, behaviorGroupRequest);
+        boolean response = updateBehaviorGroup(identityHeader, behaviorGroupIdOtherTenant, behaviorGroupRequest);
         assertFalse(response);
         BehaviorGroup behaviorGroup = helpers.getBehaviorGroup(behaviorGroupIdOtherTenant);
         assertEquals("My behavior", behaviorGroup.getDisplayName()); // No change
@@ -916,20 +923,79 @@ public class NotificationResourceTest extends DbIsolatedTest {
                 .statusCode(404);
     }
 
-    private CreateBehaviorGroupResponse createBehaviorGroup(Header identityHeader, CreateBehaviorGroupRequest request) {
-        return given()
+    @Test
+    void testBehaviorGroupSameName() {
+        try {
+            final String BEHAVIOR_GROUP_1_NAME = "BehaviorGroup1";
+            final String BEHAVIOR_GROUP_2_NAME = "BehaviorGroup2";
+
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(true);
+            Header identityHeader = initRbacMock("tenant", "sameBehaviorGroupName", "user", FULL_ACCESS);
+
+            Bundle bundle1 = helpers.createBundle(TEST_BUNDLE_NAME, "Bundle1");
+            Bundle bundle2 = helpers.createBundle(TEST_BUNDLE_2_NAME, "Bundle2");
+
+            CreateBehaviorGroupRequest createBehaviorGroupRequest = new CreateBehaviorGroupRequest();
+            createBehaviorGroupRequest.displayName = BEHAVIOR_GROUP_1_NAME;
+            createBehaviorGroupRequest.bundleId = bundle1.getId();
+
+            UUID behaviorGroup1Id = createBehaviorGroup(identityHeader, createBehaviorGroupRequest, 200).get().id;
+            assertNotNull(behaviorGroup1Id);
+
+            // same display name in same bundle is not possible
+            createBehaviorGroup(identityHeader, createBehaviorGroupRequest, 400);
+
+            // same display name in a different bundle is OK
+            createBehaviorGroupRequest.bundleId = bundle2.getId();
+            createBehaviorGroup(identityHeader, createBehaviorGroupRequest, 200);
+
+            // Different display name in bundle1
+            createBehaviorGroupRequest.bundleId = bundle1.getId();
+            createBehaviorGroupRequest.displayName = BEHAVIOR_GROUP_2_NAME;
+            createBehaviorGroup(identityHeader, createBehaviorGroupRequest, 200);
+
+            // Cannot update Behavior Group 1 name to "BehaviorGroup2"  as it already exists
+            UpdateBehaviorGroupRequest updateBehaviorGroupRequest = new UpdateBehaviorGroupRequest();
+            updateBehaviorGroupRequest.displayName = BEHAVIOR_GROUP_2_NAME;
+            updateBehaviorGroup(identityHeader, behaviorGroup1Id, updateBehaviorGroupRequest, 400);
+
+            // Can update other properties without changing the name
+            updateBehaviorGroupRequest.displayName = BEHAVIOR_GROUP_1_NAME;
+            updateBehaviorGroupRequest.eventTypeIds = Set.of();
+            updateBehaviorGroup(identityHeader, behaviorGroup1Id, updateBehaviorGroupRequest, 200);
+
+            // Can use other name
+            updateBehaviorGroupRequest.displayName = "OtherName";
+            updateBehaviorGroup(identityHeader, behaviorGroup1Id, updateBehaviorGroupRequest, 200);
+
+        } finally {
+            featureFlipper.setEnforceBehaviorGroupNameUnicity(false);
+        }
+    }
+
+    private Optional<CreateBehaviorGroupResponse> createBehaviorGroup(Header identityHeader, CreateBehaviorGroupRequest request, int expectedStatusCode) {
+        ValidatableResponse response = given()
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
                 .body(Json.encode(request))
                 .post("/notifications/behaviorGroups")
                 .then()
-                .statusCode(200).extract()
-                .as(CreateBehaviorGroupResponse.class);
+                .statusCode(expectedStatusCode);
+
+        if (expectedStatusCode == 200) {
+            return Optional.of(response.extract().as(CreateBehaviorGroupResponse.class));
+        }
+
+        return Optional.empty();
     }
 
-    private Boolean updateBehaviorGroup(Header identityHeader, UUID behaviorGroupId, UpdateBehaviorGroupRequest request) {
-        return given()
+    private CreateBehaviorGroupResponse createBehaviorGroup(Header identityHeader, CreateBehaviorGroupRequest request) {
+        return createBehaviorGroup(identityHeader, request, 200).get();
+    }
+
+    private Optional<Boolean> updateBehaviorGroup(Header identityHeader, UUID behaviorGroupId, UpdateBehaviorGroupRequest request, int expectedStatusCode) {
+        ValidatableResponse validatableResponse = given()
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
@@ -937,8 +1003,17 @@ public class NotificationResourceTest extends DbIsolatedTest {
                 .pathParam("behaviorGroupId", behaviorGroupId)
                 .put("/notifications/behaviorGroups/{behaviorGroupId}")
                 .then()
-                .statusCode(200).extract()
-                .as(Boolean.class);
+                .statusCode(expectedStatusCode);
+
+        if (expectedStatusCode == 200) {
+            return Optional.of(validatableResponse.extract().as(Boolean.class));
+        }
+
+        return Optional.empty();
+    }
+
+    private Boolean updateBehaviorGroup(Header identityHeader, UUID behaviorGroupId, UpdateBehaviorGroupRequest request) {
+        return updateBehaviorGroup(identityHeader, behaviorGroupId, request, 200).get();
     }
 
     private List<UUID> getEndpointsIds(String orgId, UUID behaviorGroupId) {

--- a/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
@@ -83,6 +83,11 @@ public class FeatureFlipper {
         return enforceBehaviorGroupNameUnicity;
     }
 
+    public void setEnforceBehaviorGroupNameUnicity(boolean enforceBehaviorGroupNameUnicity) {
+        checkTestLaunchMode();
+        this.enforceBehaviorGroupNameUnicity = enforceBehaviorGroupNameUnicity;
+    }
+
     public boolean isEnforceIntegrationNameUnicity() {
         return enforceIntegrationNameUnicity;
     }


### PR DESCRIPTION
This is what we were talking earlier - updated so it does the check per bundle

Will follow up with a migration PR to move rename all the repeated behavior groups and integrations