### PR TITLE
Reduce noise in engine log

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/openbridge/BridgeHelper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/openbridge/BridgeHelper.java
@@ -108,9 +108,7 @@ public class BridgeHelper {
             return new BridgeAuth("- OB not enabled token -");
         }
 
-        Log.debug("In getAuthToken()");
-
-        BridgeAuth ba = null;
+        BridgeAuth ba;
         try {
             ba = new BridgeAuth(getAuthTokenInternal());
         } catch (Exception e) {


### PR DESCRIPTION
This will remove the following entries from the engine log: (we currently have tons of them)
```
2022-10-04 15:06:42,000 DEBUG [com.red.clo.not.ope.BridgeHelper] (executor-thread-3) In getAuthToken()
2022-10-04 15:06:41,588 INFO  [com.red.clo.not.eve.EventConsumer] (executor-thread-3) NOID: Event with openshift/advisor/new-recommendation did not have an incoming id or messageId 
```
It also changes another log entry a bit:
```
2022-10-04 15:30:29,847 INFO  [com.red.clo.not.eve.EventConsumer] (executor-thread-0) Processing received action [id=null, rh-message-id=null, orgId=default-org-id, baet=my-bundle/policies-lifecycle-test/all]
2022-10-04 15:30:27,824 INFO  [com.red.clo.not.eve.EventConsumer] (executor-thread-0) Processing received action [id=null, rh-message-id=c7ca59a0-97c5-4657-bf09-3e8011f7c4e4, orgId=default-org-id, baet=my-bundle/Policies/Any]
```