### PR TITLE
Log 4xx errors at warn level while calling BOP

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -187,7 +187,11 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
                     }
                 } else {
                     // Redirects etc should have been followed by the vertx (test this)
-                    Log.debugf("Webhook request to %s failed: %d %s %s", url, resp.statusCode(), resp.statusMessage(), payload);
+                    if (isEmailEndpoint) {
+                        Log.warnf("Webhook request to %s failed: %d %s %s", url, resp.statusCode(), resp.statusMessage(), payload);
+                    } else {
+                        Log.debugf("Webhook request to %s failed: %d %s %s", url, resp.statusCode(), resp.statusMessage(), payload);
+                    }
                     history.setInvocationResult(false);
                     // TODO NOTIF-512 Should we disable endpoints in case of 3xx status code?
                     if (featureFlipper.isDisableWebhookEndpointsOnFailure()) {


### PR DESCRIPTION
4xx errors shouldn't go unnoticed when we call BOP.

From now on, they will be logged at `warn` level (and generate a Sentry alert) instead of `debug`.