### PR TITLE
NOTIF-820 Make email endpoints READY when created

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -33,6 +33,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static com.redhat.cloud.notifications.models.EndpointStatus.READY;
+
 @ApplicationScoped
 public class EndpointRepository {
     @Inject
@@ -142,6 +144,7 @@ public class EndpointRepository {
         endpoint.setDescription("System email endpoint");
         endpoint.setName("Email endpoint");
         endpoint.setType(EndpointType.EMAIL_SUBSCRIPTION);
+        endpoint.setStatus(READY);
 
         return createEndpoint(endpoint);
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.redhat.cloud.notifications.models.EndpointStatus.READY;
 import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPTION;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
@@ -66,6 +67,7 @@ public class EndpointRepository {
         endpoint.setDescription("System email endpoint");
         endpoint.setName("Email endpoint");
         endpoint.setType(EMAIL_SUBSCRIPTION);
+        endpoint.setStatus(READY);
         endpoint.prePersist();
         properties.setEndpoint(endpoint);
 


### PR DESCRIPTION
The prod DB contains a few email endpoints with `status = UNKNOWN`. Emails endpoints should always be `READY`.

This PR must be deployed on prod before #1546 is merged.