### PR TITLE
Log processor status_message in EndpointReadyChecker

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointReadyChecker.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointReadyChecker.java
@@ -80,7 +80,8 @@ public class EndpointReadyChecker {
             try {
                 Processor processor = bridgeApiService.getProcessorById(bridge.getId(), processorId, bridgeAuth.getToken());
                 String status = processor.getStatus();
-                Log.debugf("  Status reported by OB for processor %s : %s", processorId, status);
+                String statusMessage = processor.getStatus_message();
+                Log.debugf("Processor[id=%s, status=%s, status_message=%s]", processorId, status, statusMessage);
                 if ("ready".equals(status)) {
                     ep.setStatus(EndpointStatus.READY);
                 }

--- a/common/src/main/java/com/redhat/cloud/notifications/openbridge/Processor.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/openbridge/Processor.java
@@ -45,6 +45,8 @@ public class Processor {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String status;
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    public String status_message;
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String href;
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public String submitted_at;
@@ -92,6 +94,14 @@ public class Processor {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public String getStatus_message() {
+        return status_message;
+    }
+
+    public void setStatus_message(String status_message) {
+        this.status_message = status_message;
     }
 
     public String getHref() {


### PR DESCRIPTION
This will help us understand why a processor creation failed in RHOSE.