### PR TITLE
[RHCLOUD-22178] Include environment URLs when serializing Actions

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -272,7 +272,7 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
                 .build(BridgeEventService.class);
 
         // Include the environment's URL when sending the event.
-        ce.put("environment_url", this.environment.url());
+        body.put("environment_url", this.environment.url());
 
         JsonObject payload = JsonObject.mapFrom(ce);
         try {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -15,6 +15,7 @@ import com.redhat.cloud.notifications.openbridge.BridgeAuth;
 import com.redhat.cloud.notifications.openbridge.BridgeEventService;
 import com.redhat.cloud.notifications.openbridge.RhoseErrorMetricsRecorder;
 import com.redhat.cloud.notifications.processors.EndpointTypeProcessor;
+import com.redhat.cloud.notifications.templates.models.Environment;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -85,6 +86,12 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
 
     @Inject
     RhoseErrorMetricsRecorder rhoseErrorMetricsRecorder;
+
+    /**
+     * Used to send the environment's URL on OpenBridge events.
+     */
+    @Inject
+    Environment environment;
 
     private Bridge bridge;
 
@@ -256,6 +263,9 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
         BridgeEventService evtSvc = RestClientBuilder.newBuilder()
                 .baseUri(URI.create(bridge.getEndpoint()))
                 .build(BridgeEventService.class);
+
+        // Include the environment's URL when sending the event.
+        ce.put("environment_url", this.environment.url());
 
         JsonObject payload = JsonObject.mapFrom(ce);
         try {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -63,6 +63,13 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
     public static final String CLOUD_EVENT_TYPE_PREFIX = "com.redhat.console.notification.toCamel.";
     public static final String CAMEL_SUBTYPE_HEADER = "CAMEL_SUBTYPE";
     public static final String PROCESSORNAME = "processorname";
+    /**
+     * Constants for the {@link CamelTypeProcessor#callOpenBridge(JsonObject, UUID, String, CamelProperties, String, String)}.
+     * function.
+     */
+    public static final String SOURCE = "notifications";
+    public static final String SPEC_VERSION = "1.0";
+    public static final String TYPE = "myType";
 
     @Inject
     FeatureFlipper featureFlipper;
@@ -246,9 +253,9 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
         Map<String, Object> ce = new HashMap<>();
 
         ce.put("id", id);
-        ce.put("source", "notifications"); // Source of original event?
-        ce.put("specversion", "1.0");
-        ce.put("type", "myType"); // Type of original event?
+        ce.put("source", SOURCE); // Source of original event?
+        ce.put("specversion", SPEC_VERSION);
+        ce.put("type", TYPE); // Type of original event?
         ce.put(ORG_ID_FILTER_NAME, orgId);
         ce.put(PROCESSORNAME, extras.get(PROCESSORNAME));
         ce.put("originaleventid", originalEventId);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -155,7 +155,7 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
         }
         metaData.put("_originalId", originalEventId);
 
-        JsonObject payload = transformer.transform(event.getAction());
+        JsonObject payload = transformer.toJsonObject(event.getAction());
         UUID historyId = UUID.randomUUID();
 
         JsonObject metadataAsJson = new JsonObject();

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -88,7 +88,7 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
     RhoseErrorMetricsRecorder rhoseErrorMetricsRecorder;
 
     /**
-     * Used to send the environment's URL on OpenBridge events.
+     * Used to send the environment's URL on RHOSE events.
      */
     @Inject
     Environment environment;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -134,7 +134,7 @@ public class EmailSubscriptionTypeProcessor extends EndpointTypeProcessor {
                 aggregation.setApplicationName(action.getApplication());
                 aggregation.setBundleName(action.getBundle());
 
-                JsonObject transformedAction = baseTransformer.transform(action);
+                JsonObject transformedAction = baseTransformer.toJsonObject(action);
                 aggregation.setPayload(transformedAction);
                 emailAggregationRepository.addEmailAggregation(aggregation);
             }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -134,7 +134,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
             req.basicAuthentication(properties.getBasicAuthentication().getUsername(), properties.getBasicAuthentication().getPassword());
         }
 
-        JsonObject payload = transformer.transform(event.getAction());
+        JsonObject payload = transformer.toJsonObject(event.getAction());
 
         doHttpRequest(event, endpoint, req, payload, properties.getMethod().name(), properties.getUrl());
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
@@ -11,6 +11,18 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class BaseTransformer {
 
+    // JSON property names' definition.
+    public static final String ACCOUNT_ID = "account_id";
+    public static final String APPLICATION = "application";
+    public static final String BUNDLE = "bundle";
+    public static final String CONTEXT = "context";
+    public static final String EVENT_TYPE = "event_type";
+    public static final String EVENTS = "events";
+    public static final String METADATA = "metadata";
+    public static final String ORG_ID = "org_id";
+    public static final String PAYLOAD = "payload";
+    public static final String TIMESTAMP = "timestamp";
+
     /**
      * Transforms the given action into a {@link JsonObject}.
      * @param action the {@link Action} to transform.
@@ -19,24 +31,24 @@ public class BaseTransformer {
     public JsonObject toJsonObject(final Action action) {
         JsonObject message = new JsonObject();
 
-        message.put("account_id", action.getAccountId());
-        message.put("application", action.getApplication());
-        message.put("bundle", action.getBundle());
-        message.put("context", JsonObject.mapFrom(action.getContext()));
-        message.put("event_type", action.getEventType());
+        message.put(ACCOUNT_ID, action.getAccountId());
+        message.put(APPLICATION, action.getApplication());
+        message.put(BUNDLE, action.getBundle());
+        message.put(CONTEXT, JsonObject.mapFrom(action.getContext()));
+        message.put(EVENT_TYPE, action.getEventType());
         message.put(
-            "events",
+            EVENTS,
             new JsonArray(
                 action.getEvents().stream().map(
                     event -> Map.of(
-                        "metadata", JsonObject.mapFrom(event.getMetadata()),
-                        "payload", JsonObject.mapFrom(event.getPayload())
+                        METADATA, JsonObject.mapFrom(event.getMetadata()),
+                        PAYLOAD, JsonObject.mapFrom(event.getPayload())
                     )
                 ).collect(Collectors.toList())
             )
         );
-        message.put("org_id", action.getOrgId());
-        message.put("timestamp", action.getTimestamp().toString());
+        message.put(ORG_ID, action.getOrgId());
+        message.put(TIMESTAMP, action.getTimestamp().toString());
 
         return message;
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
@@ -11,23 +11,32 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class BaseTransformer {
 
-    public JsonObject transform(Action action) {
-        return toJsonObject(action);
-    }
-
-    protected JsonObject toJsonObject(Action action) {
+    /**
+     * Transforms the given action into a {@link JsonObject}.
+     * @param action the {@link Action} to transform.
+     * @return a {@link JsonObject} containing the given action.
+     */
+    public JsonObject toJsonObject(final Action action) {
         JsonObject message = new JsonObject();
-        message.put("bundle", action.getBundle());
-        message.put("application", action.getApplication());
-        message.put("event_type", action.getEventType());
+
         message.put("account_id", action.getAccountId());
+        message.put("application", action.getApplication());
+        message.put("bundle", action.getBundle());
+        message.put("context", JsonObject.mapFrom(action.getContext()));
+        message.put("event_type", action.getEventType());
+        message.put(
+            "events",
+            new JsonArray(
+                action.getEvents().stream().map(
+                    event -> Map.of(
+                        "metadata", JsonObject.mapFrom(event.getMetadata()),
+                        "payload", JsonObject.mapFrom(event.getPayload())
+                    )
+                ).collect(Collectors.toList())
+            )
+        );
         message.put("org_id", action.getOrgId());
         message.put("timestamp", action.getTimestamp().toString());
-        message.put("events", new JsonArray(action.getEvents().stream().map(event -> Map.of(
-                "metadata", JsonObject.mapFrom(event.getMetadata()),
-                "payload", JsonObject.mapFrom(event.getPayload())
-        )).collect(Collectors.toList())));
-        message.put("context", JsonObject.mapFrom(action.getContext()));
 
         return message;
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/ComplianceTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ComplianceTestHelpers.java
@@ -56,7 +56,7 @@ public class ComplianceTestHelpers {
 
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
         aggregation.setPayload(payload);
 
         return aggregation;

--- a/engine/src/test/java/com/redhat/cloud/notifications/DriftTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/DriftTestHelpers.java
@@ -52,7 +52,7 @@ public class DriftTestHelpers {
 
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
         aggregation.setPayload(payload);
 
         return aggregation;

--- a/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
@@ -80,7 +80,7 @@ public class InventoryTestHelpers {
 
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
         aggregation.setPayload(payload);
 
         return aggregation;

--- a/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
@@ -55,7 +55,7 @@ public class PatchTestHelpers {
         ));
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
         aggregation.setPayload(payload);
 
         return aggregation;
@@ -108,7 +108,7 @@ public class PatchTestHelpers {
         ));
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
         aggregation.setPayload(payload);
 
         return aggregation;

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -60,7 +60,7 @@ public class TestHelpers {
 
         emailActionMessage.setOrgId(orgId);
 
-        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
         aggregation.setPayload(payload);
 
         return aggregation;

--- a/engine/src/test/java/com/redhat/cloud/notifications/VulnerabilityTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/VulnerabilityTestHelpers.java
@@ -39,7 +39,7 @@ public class VulnerabilityTestHelpers {
                                                             .build())
                                     .build()
         ));
-        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
         aggregation.setPayload(payload);
 
         return aggregation;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -430,7 +430,6 @@ class CamelTypeProcessorTest {
         Assertions.assertEquals(CamelTypeProcessor.SOURCE, json.getString("source"), "the \"source\" values don't match");
         Assertions.assertEquals(FIXTURE_CAMEL_EXTRAS_PROCESSOR_NAME, json.getString("processorname"), "the \"processorname\" values don't match");
         Assertions.assertEquals(CamelTypeProcessor.TYPE, json.getString("type"), "the \"type\" values don't match");
-        Assertions.assertEquals(this.environment.url(), json.getString("environment_url"), "the \"environment_url\" values don't match");
         Assertions.assertEquals(FIXTURE_EVENT_ORIGINAL_UUID.toString(), json.getString("originaleventid"), "the \"originaleventid\" values don't match");
 
         // Assert that the "data" object is present.
@@ -438,8 +437,6 @@ class CamelTypeProcessorTest {
 
         // Assert the results for the fields in the "data" object.
         final JsonObject data = json.getJsonObject("data");
-        Assertions.assertTrue(data.containsKey("context"), "the \"context\" field is not present");
-        Assertions.assertTrue(data.containsKey("events"), "the \"events\" field is not present");
 
         // Assert the values for the fields in the "data" object.
         Assertions.assertEquals(FIXTURE_ACTION_ACCOUNT_ID, data.getString("account_id"), "the \"account_id\" values don't match");
@@ -450,11 +447,12 @@ class CamelTypeProcessorTest {
         Assertions.assertEquals(FIXTURE_ACTION_TIMESTAMP.toString(), data.getString("timestamp"), "the \"timestamp\" values don't match");
 
         // Assert the fields and the values in the "context" object.
+        Assertions.assertTrue(data.containsKey("context"), "the \"context\" field is not present");
         final JsonObject context = data.getJsonObject("context");
-        Assertions.assertTrue(context.containsKey(FIXTURE_ACTION_CONTEXT), String.format("the expected \"%s\" context field is not present", FIXTURE_ACTION_CONTEXT));
         Assertions.assertEquals(FIXTURE_ACTION_CONTEXT_VALUE, context.getString(FIXTURE_ACTION_CONTEXT), String.format("the \"%s\" context values don't match", FIXTURE_ACTION_CONTEXT_VALUE));
 
         // Assert the "events" array.
+        Assertions.assertTrue(data.containsKey("events"), "the \"events\" field is not present");
         final JsonArray events = data.getJsonArray("events");
         if (events.size() != 1) {
             Assertions.fail(String.format("the events array has an unexpected number of elements. Want %s, got %s", 1, events.size()));
@@ -467,10 +465,6 @@ class CamelTypeProcessorTest {
 
         // Assert the "payload" object in the event.
         final JsonObject payload = eventResult.getJsonObject("payload");
-        Assertions.assertTrue(payload.containsKey(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY), String.format("the \"%s\" payload field is not present", FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY));
-        Assertions.assertTrue(payload.containsKey(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_2), String.format("the \"%s\" payload field is not present", FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_2));
-        Assertions.assertTrue(payload.containsKey(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_3), String.format("the \"%s\" payload field is not present", FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_3));
-
         Assertions.assertEquals(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_VALUE, payload.getString(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY), "the payload's additional property value doesn't match");
         Assertions.assertEquals(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_2_VALUE, payload.getString(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_2), "the payload's additional property value doesn't match");
         Assertions.assertEquals(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_3_VALUE, payload.getString(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_3), "the payload's additional property value doesn't match");

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -152,7 +152,7 @@ class CamelTypeProcessorTest {
     NotificationHistoryRepository notificationHistoryRepository;
 
     /**
-     * Used to test that the environment's URL is properly set when sending events to Open Bridge.
+     * Used to test that the environment's URL is properly set when sending events to RHOSE.
      */
     @Inject
     Environment environment;
@@ -359,17 +359,17 @@ class CamelTypeProcessorTest {
     }
 
     /**
-     * Tests that the payload sent to Open Bridge is the one that is expected.
+     * Tests that the payload sent to RHOSE is the one that is expected.
      */
     @Test
     void callOpenBridgeExpectedJson() {
-        // Set "Open Bridge" feature enabled to be able to test this.
+        // Set "RHOSE" feature enabled to be able to test this.
         this.featureFlipper.setObEnabled(true);
 
         // The path that will be set up in the Mock Server, and that will be used as the Bridge's endpoint.
         final String testMockServerPath = "/events/slack/json-output-check";
 
-        // Create a request expectation for when the Open Bridge sends the request. It is created separately because
+        // Create a request expectation for when the RHOSE sends the request. It is created separately because
         // it is needed later to retrieve the requests that match with this expectation.
         final HttpRequest expectedRequest = HttpRequest.request().withPath(testMockServerPath).withMethod(HttpMethod.POST);
         MockServerLifecycleManager.getClient().when(expectedRequest).respond(
@@ -384,7 +384,7 @@ class CamelTypeProcessorTest {
         Endpoint endpoint = buildCamelEndpoint(event.getAction().getAccountId());
         endpoint.setSubType("slack");
 
-        // Set up some mock Open Bridge endpoints (simulate a valid bridge)
+        // Set up some mock RHOSE endpoints (simulate a valid bridge)
         final String eventsEndpoint = MockServerLifecycleManager.getMockServerUrl() + testMockServerPath;
         Log.infof("The event's endpoint is set to %s", eventsEndpoint);
 
@@ -499,7 +499,7 @@ class CamelTypeProcessorTest {
         // Clear the path from the Mock Server since this won't be used by any other test.
         MockServerLifecycleManager.getClient().clear(request().withPath(testMockServerPath), ClearType.ALL);
 
-        // Clear also the Open Bridge endpoints for this test.
+        // Clear also the RHOSE endpoints for this test.
         MockServerConfig.clearOpenBridgeEndpoints(bridge);
 
         // Reset the feature flag to false in order to avoid affecting any other tests.

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -88,13 +88,6 @@ class CamelTypeProcessorTest {
     public static final String SUB_TYPE = "sub-type";
 
     /**
-     * The following constants are hard coded in {@link CamelTypeProcessor#callOpenBridge(JsonObject, UUID, String, CamelProperties, String, String)}.
-     */
-    private static final String FIXTURE_TYPE = "myType";
-    private static final String FIXTURE_SOURCE = "notifications";
-    private static final String FIXTURE_SPEC_VERSION = "1.0";
-
-    /**
      * Endpoint fixtures for the {@link #buildEvent()} function.
      */
     private static final UUID FIXTURE_EVENT_ORIGINAL_UUID = UUID.randomUUID();
@@ -441,13 +434,13 @@ class CamelTypeProcessorTest {
 
         // Assert the values for the top level fields.
         Assertions.assertEquals(DEFAULT_ORG_ID, json.getString("rhorgid"), "the \"rhorgid\" values don't match");
-        Assertions.assertEquals(FIXTURE_SPEC_VERSION, json.getString("specversion"), "the \"specversion\" values don't match");
+        Assertions.assertEquals(CamelTypeProcessor.SPEC_VERSION, json.getString("specversion"), "the \"specversion\" values don't match");
         // The UUID is randomly generated, so the only way to test that the ID is valid is to check if it is a valid
         // UUID.
         UUID.fromString(json.getString("id"));
-        Assertions.assertEquals(FIXTURE_SOURCE, json.getString("source"), "the \"source\" values don't match");
+        Assertions.assertEquals(CamelTypeProcessor.SOURCE, json.getString("source"), "the \"source\" values don't match");
         Assertions.assertEquals(FIXTURE_CAMEL_EXTRAS_PROCESSOR_NAME, json.getString("processorname"), "the \"processorname\" values don't match");
-        Assertions.assertEquals(FIXTURE_TYPE, json.getString("type"), "the \"type\" values don't match");
+        Assertions.assertEquals(CamelTypeProcessor.TYPE, json.getString("type"), "the \"type\" values don't match");
         Assertions.assertEquals(this.environment.url(), json.getString("environment_url"), "the \"environment_url\" values don't match");
         Assertions.assertEquals(FIXTURE_EVENT_ORIGINAL_UUID.toString(), json.getString("originaleventid"), "the \"originaleventid\" values don't match");
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -420,19 +420,8 @@ class CamelTypeProcessorTest {
         final HttpRequest req = recordedRequests[0];
         final JsonObject json = new JsonObject(req.getBodyAsString());
 
-        // Assert the results for the top level fields.
-        Assertions.assertTrue(json.containsKey("rhorgid"), "the expected \"rhorgid\" field is not present");
-        Assertions.assertTrue(json.containsKey("specversion"), "the expected \"specversion\" field is not present");
-        Assertions.assertTrue(json.containsKey("id"), "the expected \"id\" field is not present");
-        Assertions.assertTrue(json.containsKey("source"), "the expected \"source|\" field is not present");
-        Assertions.assertTrue(json.containsKey("processorname"), "the expected \"processorname\" field is not present");
-        Assertions.assertTrue(json.containsKey("type"), "the expected \"type\" field is not present");
-        Assertions.assertTrue(json.containsKey("originaleventid"), "the expected \"originaleventid\" field is not present");
-        Assertions.assertTrue(json.containsKey("environment_url"), "the expected \"environment_url\" key is not present");
-        Assertions.assertTrue(json.containsKey("data"), "the expected \"data\" field is not present");
-        Assertions.assertEquals(this.environment.url(), json.getString("environment_url"), "the environment URL isn't the same");
-
         // Assert the values for the top level fields.
+        Assertions.assertEquals(this.environment.url(), json.getString("environment_url"), "the environment URL isn't the same");
         Assertions.assertEquals(DEFAULT_ORG_ID, json.getString("rhorgid"), "the \"rhorgid\" values don't match");
         Assertions.assertEquals(CamelTypeProcessor.SPEC_VERSION, json.getString("specversion"), "the \"specversion\" values don't match");
         // The UUID is randomly generated, so the only way to test that the ID is valid is to check if it is a valid
@@ -444,16 +433,13 @@ class CamelTypeProcessorTest {
         Assertions.assertEquals(this.environment.url(), json.getString("environment_url"), "the \"environment_url\" values don't match");
         Assertions.assertEquals(FIXTURE_EVENT_ORIGINAL_UUID.toString(), json.getString("originaleventid"), "the \"originaleventid\" values don't match");
 
+        // Assert that the "data" object is present.
+        Assertions.assertTrue(json.containsKey("data"), "the expected \"data\" field is not present");
+
         // Assert the results for the fields in the "data" object.
         final JsonObject data = json.getJsonObject("data");
-        Assertions.assertTrue(data.containsKey("account_id"), "the \"account_id\" field is not present");
-        Assertions.assertTrue(data.containsKey("application"), "the \"application\" field is not present");
-        Assertions.assertTrue(data.containsKey("bundle"), "the \"bundle\" field is not present");
         Assertions.assertTrue(data.containsKey("context"), "the \"context\" field is not present");
-        Assertions.assertTrue(data.containsKey("event_type"), "the \"event_type\" field is not present");
         Assertions.assertTrue(data.containsKey("events"), "the \"events\" field is not present");
-        Assertions.assertTrue(data.containsKey("org_id"), "the \"org_id\" field is not present");
-        Assertions.assertTrue(data.containsKey("timestamp"), "the \"timestamp\" field is not present");
 
         // Assert the values for the fields in the "data" object.
         Assertions.assertEquals(FIXTURE_ACTION_ACCOUNT_ID, data.getString("account_id"), "the \"account_id\" values don't match");

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -421,7 +421,6 @@ class CamelTypeProcessorTest {
         final JsonObject json = new JsonObject(req.getBodyAsString());
 
         // Assert the values for the top level fields.
-        Assertions.assertEquals(this.environment.url(), json.getString("environment_url"), "the environment URL isn't the same");
         Assertions.assertEquals(DEFAULT_ORG_ID, json.getString("rhorgid"), "the \"rhorgid\" values don't match");
         Assertions.assertEquals(CamelTypeProcessor.SPEC_VERSION, json.getString("specversion"), "the \"specversion\" values don't match");
         // The UUID is randomly generated, so the only way to test that the ID is valid is to check if it is a valid
@@ -439,6 +438,7 @@ class CamelTypeProcessorTest {
         final JsonObject data = json.getJsonObject("data");
 
         // Assert the values for the fields in the "data" object.
+        Assertions.assertEquals(this.environment.url(), data.getString("environment_url"), "the environment URL isn't the same");
         Assertions.assertEquals(FIXTURE_ACTION_ACCOUNT_ID, data.getString("account_id"), "the \"account_id\" values don't match");
         Assertions.assertEquals(FIXTURE_ACTION_APP, data.getString("application"), "the \"application\" values don't match");
         Assertions.assertEquals(FIXTURE_ACTION_BUNDLE, data.getString("bundle"), "the \"bundle\" values don't match");

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessorTest.java
@@ -88,7 +88,7 @@ class CamelTypeProcessorTest {
     public static final String SUB_TYPE = "sub-type";
 
     /**
-     * Endpoint fixtures for the {@link #buildEvent()} function.
+     * Event fixtures for the {@link #buildEvent()} function.
      */
     private static final UUID FIXTURE_EVENT_ORIGINAL_UUID = UUID.randomUUID();
     private static final String FIXTURE_ACTION_ORG_ID = "test-event-org-id";

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregatorTest.java
@@ -84,7 +84,7 @@ public class ResourceOptimizationPayloadAggregatorTest {
         aggregation.setBundleName("rhel");
         aggregation.setApplicationName("resource-optimization");
         aggregation.setOrgId(DEFAULT_ORG_ID);
-        aggregation.setPayload(new BaseTransformer().transform(action));
+        aggregation.setPayload(new BaseTransformer().toJsonObject(action));
         return aggregation;
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/RhosakEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/RhosakEmailAggregatorTest.java
@@ -242,7 +242,7 @@ class RhosakEmailAggregatorTest {
         emailActionMessage.setAccountId(ACCOUNT_ID);
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
         aggregation.setPayload(payload);
 
         return aggregation;
@@ -281,7 +281,7 @@ class RhosakEmailAggregatorTest {
         emailActionMessage.setAccountId(ACCOUNT_ID);
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.transform(emailActionMessage);
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
         aggregation.setPayload(payload);
 
         return aggregation;

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
@@ -1,17 +1,81 @@
 package com.redhat.cloud.notifications.transformers;
 
 import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class BaseTransformerTest {
 
     private final BaseTransformer baseTransformer = new BaseTransformer();
+
+    // Below are the fixtures defined for the tests.
+    private static final String FIXTURE_ACCOUNT_ID = "account-id-test";
+    private static final String FIXTURE_APPLICATION = "application-test";
+    private static final String FIXTURE_BUNDLE = "bundle-test";
+    private static Context FIXTURE_CONTEXT;
+    private static final String FIXTURE_CONTEXT_ADDITIONAL_PROPERTY = "context-additional-property";
+    private static final String FIXTURE_CONTEXT_ADDITIONAL_PROPERTY_VALUE = "context-additional-property-value";
+    private static final String FIXTURE_EVENT_TYPE = "event-type-test";
+    private static List<Event> FIXTURE_EVENTS;
+    private static final String FIXTURE_METADATA_ADDITIONAL_PROPERTY = "event-metadata-additional-property";
+    private static final String FIXTURE_METADATA_ADDITIONAL_PROPERTY_VALUE = "event-metadata-additional-property-value";
+    private static final String FIXTURE_ORG_ID = "org-id-test";
+    private static final String FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY = "event-payload-additional-property";
+    private static final String FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_VALUE = "event-payload-additional-property-value";
+    private static final LocalDateTime FIXTURE_TIMESTAMP = LocalDateTime.of(2022, 1, 1, 0, 0, 0);
+
+    // JSON property names' definition.
+    private static final String ACCOUNT_ID = "account_id";
+    private static final String APPLICATION = "application";
+    private static final String BUNDLE = "bundle";
+    private static final String CONTEXT = "context";
+    private static final String EVENT_TYPE = "event_type";
+    private static final String EVENTS = "events";
+    private static final String METADATA = "metadata";
+    private static final String ORG_ID = "org_id";
+    private static final String PAYLOAD = "payload";
+    private static final String TIMESTAMP = "timestamp";
+
+    /**
+     * Sets up the context and a list with one event for the tests.
+     */
+    @BeforeAll
+    static void setUp() {
+        final Context context = new Context();
+
+        context.setAdditionalProperty(FIXTURE_CONTEXT_ADDITIONAL_PROPERTY, FIXTURE_CONTEXT_ADDITIONAL_PROPERTY_VALUE);
+
+        FIXTURE_CONTEXT = context;
+
+        final List<Event> events = new ArrayList<>();
+        final Event event = new Event();
+
+        final Metadata metadata = new Metadata();
+        metadata.setAdditionalProperty(FIXTURE_METADATA_ADDITIONAL_PROPERTY, FIXTURE_METADATA_ADDITIONAL_PROPERTY_VALUE);
+        event.setMetadata(metadata);
+
+        final Payload payload = new Payload();
+        payload.setAdditionalProperty(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY, FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_VALUE);
+        event.setPayload(payload);
+
+        events.add(event);
+        FIXTURE_EVENTS = events;
+    }
 
     @Test
     void shouldContainOrgId() {
@@ -21,7 +85,7 @@ class BaseTransformerTest {
 
         final JsonObject jsonObject = baseTransformer.toJsonObject(action);
 
-        assertEquals("someOrgId", jsonObject.getString("org_id"));
+        assertEquals("someOrgId", jsonObject.getString(ORG_ID));
     }
 
     @Test
@@ -29,8 +93,61 @@ class BaseTransformerTest {
         Action action = new Action();
         action.setTimestamp(LocalDateTime.of(2022, 12, 24, 12, 0));
 
-        final JsonObject jsonObject = testee.toJsonObject(action);
+        final JsonObject jsonObject = baseTransformer.toJsonObject(action);
 
-        assertNull(jsonObject.getString("org_id"));
+        assertNull(jsonObject.getString(ORG_ID));
+    }
+
+    /**
+     * Tests that a proper JSON payload is generated from a fully populated {@link Action}.
+     */
+    @Test
+    void toJsonObjectTest() {
+        Action action = new Action();
+
+        action.setAccountId(FIXTURE_ACCOUNT_ID);
+        action.setApplication(FIXTURE_APPLICATION);
+        action.setBundle(FIXTURE_BUNDLE);
+        action.setContext(FIXTURE_CONTEXT);
+        action.setEventType(FIXTURE_EVENT_TYPE);
+        action.setEvents(FIXTURE_EVENTS);
+        action.setOrgId(FIXTURE_ORG_ID);
+        action.setTimestamp(FIXTURE_TIMESTAMP);
+
+        // Call the function under test.
+        JsonObject result = this.baseTransformer.toJsonObject(action);
+
+        // Assert that all the properties from the Action are present in the JSON object.
+        assertTrue(result.containsKey(ACCOUNT_ID), "the account id is missing from the resulting JSON object");
+        assertTrue(result.containsKey(APPLICATION), "the application is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BUNDLE), "the bundle is missing from the resulting JSON object");
+        assertTrue(result.containsKey(CONTEXT), "the context is missing from the resulting JSON object");
+        assertTrue(result.containsKey(EVENT_TYPE), "the event type is missing from the resulting JSON object");
+        assertTrue(result.containsKey(EVENTS), "the events is missing from the resulting JSON object");
+        assertTrue(result.containsKey(ORG_ID), "the org id is missing from the resulting JSON object");
+        assertTrue(result.containsKey(TIMESTAMP), "the timestamp is missing from the resulting JSON object");
+
+        // Assert the values.
+        assertEquals(FIXTURE_ACCOUNT_ID, result.getString(ACCOUNT_ID), "the account id isn't the same");
+        assertEquals(FIXTURE_APPLICATION, result.getString(APPLICATION), "the application isn't the same");
+        assertEquals(FIXTURE_BUNDLE, result.getString(BUNDLE), "the bundle isn't the same");
+        assertEquals(FIXTURE_EVENT_TYPE, result.getString(EVENT_TYPE), "the event type isn't the same");
+
+        final JsonArray events = result.getJsonArray(EVENTS);
+        if (events.size() != FIXTURE_EVENTS.size()) {
+            fail("the number of events in the JSON file is different from the test data");
+        }
+
+        final JsonObject event = events.getJsonObject(0);
+        final JsonObject metadata = event.getJsonObject(METADATA);
+        assertTrue(metadata.containsKey(FIXTURE_METADATA_ADDITIONAL_PROPERTY), "the metadata object doesn't contain the additional property's key");
+        assertEquals(FIXTURE_METADATA_ADDITIONAL_PROPERTY_VALUE, metadata.getString(FIXTURE_METADATA_ADDITIONAL_PROPERTY), "the metadata's additional property's value isn't the same");
+
+        final JsonObject payload = event.getJsonObject(PAYLOAD);
+        assertTrue(payload.containsKey(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY));
+        assertEquals(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_VALUE, payload.getString(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY), "the payload's additional property's value isn't the same");
+
+        assertEquals(FIXTURE_ORG_ID, result.getString(ORG_ID), "the org id isn't the same");
+        assertEquals(FIXTURE_TIMESTAMP, LocalDateTime.parse(result.getString(TIMESTAMP)), "the timestamp isn't the same");
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -75,27 +74,6 @@ class BaseTransformerTest {
 
         events.add(event);
         FIXTURE_EVENTS = events;
-    }
-
-    @Test
-    void shouldContainOrgId() {
-        Action action = new Action();
-        action.setOrgId("someOrgId");
-        action.setTimestamp(LocalDateTime.of(2022, 12, 24, 12, 0));
-
-        final JsonObject jsonObject = baseTransformer.toJsonObject(action);
-
-        assertEquals("someOrgId", jsonObject.getString(ORG_ID));
-    }
-
-    @Test
-    void shouldNotRaiseAnExceptionWhenOrgIdIsMissing() {
-        Action action = new Action();
-        action.setTimestamp(LocalDateTime.of(2022, 12, 24, 12, 0));
-
-        final JsonObject jsonObject = baseTransformer.toJsonObject(action);
-
-        assertNull(jsonObject.getString(ORG_ID));
     }
 
     /**

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class BaseTransformerTest {
 
-    private final BaseTransformer testee = new BaseTransformer();
+    private final BaseTransformer baseTransformer = new BaseTransformer();
 
     @Test
     void shouldContainOrgId() {
@@ -19,7 +19,7 @@ class BaseTransformerTest {
         action.setOrgId("someOrgId");
         action.setTimestamp(LocalDateTime.of(2022, 12, 24, 12, 0));
 
-        final JsonObject jsonObject = testee.toJsonObject(action);
+        final JsonObject jsonObject = baseTransformer.toJsonObject(action);
 
         assertEquals("someOrgId", jsonObject.getString("org_id"));
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
@@ -38,18 +38,6 @@ class BaseTransformerTest {
     private static final String FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_VALUE = "event-payload-additional-property-value";
     private static final LocalDateTime FIXTURE_TIMESTAMP = LocalDateTime.of(2022, 1, 1, 0, 0, 0);
 
-    // JSON property names' definition.
-    private static final String ACCOUNT_ID = "account_id";
-    private static final String APPLICATION = "application";
-    private static final String BUNDLE = "bundle";
-    private static final String CONTEXT = "context";
-    private static final String EVENT_TYPE = "event_type";
-    private static final String EVENTS = "events";
-    private static final String METADATA = "metadata";
-    private static final String ORG_ID = "org_id";
-    private static final String PAYLOAD = "payload";
-    private static final String TIMESTAMP = "timestamp";
-
     /**
      * Sets up the context and a list with one event for the tests.
      */
@@ -96,36 +84,36 @@ class BaseTransformerTest {
         JsonObject result = this.baseTransformer.toJsonObject(action);
 
         // Assert that all the properties from the Action are present in the JSON object.
-        assertTrue(result.containsKey(ACCOUNT_ID), "the account id is missing from the resulting JSON object");
-        assertTrue(result.containsKey(APPLICATION), "the application is missing from the resulting JSON object");
-        assertTrue(result.containsKey(BUNDLE), "the bundle is missing from the resulting JSON object");
-        assertTrue(result.containsKey(CONTEXT), "the context is missing from the resulting JSON object");
-        assertTrue(result.containsKey(EVENT_TYPE), "the event type is missing from the resulting JSON object");
-        assertTrue(result.containsKey(EVENTS), "the events is missing from the resulting JSON object");
-        assertTrue(result.containsKey(ORG_ID), "the org id is missing from the resulting JSON object");
-        assertTrue(result.containsKey(TIMESTAMP), "the timestamp is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.ACCOUNT_ID), "the account id is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.APPLICATION), "the application is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.BUNDLE), "the bundle is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.CONTEXT), "the context is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.EVENT_TYPE), "the event type is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.EVENTS), "the events is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.ORG_ID), "the org id is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.TIMESTAMP), "the timestamp is missing from the resulting JSON object");
 
         // Assert the values.
-        assertEquals(FIXTURE_ACCOUNT_ID, result.getString(ACCOUNT_ID), "the account id isn't the same");
-        assertEquals(FIXTURE_APPLICATION, result.getString(APPLICATION), "the application isn't the same");
-        assertEquals(FIXTURE_BUNDLE, result.getString(BUNDLE), "the bundle isn't the same");
-        assertEquals(FIXTURE_EVENT_TYPE, result.getString(EVENT_TYPE), "the event type isn't the same");
+        assertEquals(FIXTURE_ACCOUNT_ID, result.getString(BaseTransformer.ACCOUNT_ID), "the account id isn't the same");
+        assertEquals(FIXTURE_APPLICATION, result.getString(BaseTransformer.APPLICATION), "the application isn't the same");
+        assertEquals(FIXTURE_BUNDLE, result.getString(BaseTransformer.BUNDLE), "the bundle isn't the same");
+        assertEquals(FIXTURE_EVENT_TYPE, result.getString(BaseTransformer.EVENT_TYPE), "the event type isn't the same");
 
-        final JsonArray events = result.getJsonArray(EVENTS);
+        final JsonArray events = result.getJsonArray(BaseTransformer.EVENTS);
         if (events.size() != FIXTURE_EVENTS.size()) {
             fail("the number of events in the JSON file is different from the test data");
         }
 
         final JsonObject event = events.getJsonObject(0);
-        final JsonObject metadata = event.getJsonObject(METADATA);
+        final JsonObject metadata = event.getJsonObject(BaseTransformer.METADATA);
         assertTrue(metadata.containsKey(FIXTURE_METADATA_ADDITIONAL_PROPERTY), "the metadata object doesn't contain the additional property's key");
         assertEquals(FIXTURE_METADATA_ADDITIONAL_PROPERTY_VALUE, metadata.getString(FIXTURE_METADATA_ADDITIONAL_PROPERTY), "the metadata's additional property's value isn't the same");
 
-        final JsonObject payload = event.getJsonObject(PAYLOAD);
+        final JsonObject payload = event.getJsonObject(BaseTransformer.PAYLOAD);
         assertTrue(payload.containsKey(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY));
         assertEquals(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_VALUE, payload.getString(FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY), "the payload's additional property's value isn't the same");
 
-        assertEquals(FIXTURE_ORG_ID, result.getString(ORG_ID), "the org id isn't the same");
-        assertEquals(FIXTURE_TIMESTAMP, LocalDateTime.parse(result.getString(TIMESTAMP)), "the timestamp isn't the same");
+        assertEquals(FIXTURE_ORG_ID, result.getString(BaseTransformer.ORG_ID), "the org id isn't the same");
+        assertEquals(FIXTURE_TIMESTAMP, LocalDateTime.parse(result.getString(BaseTransformer.TIMESTAMP)), "the timestamp isn't the same");
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
@@ -83,21 +83,16 @@ class BaseTransformerTest {
         // Call the function under test.
         JsonObject result = this.baseTransformer.toJsonObject(action);
 
-        // Assert that all the properties from the Action are present in the JSON object.
-        assertTrue(result.containsKey(BaseTransformer.ACCOUNT_ID), "the account id is missing from the resulting JSON object");
-        assertTrue(result.containsKey(BaseTransformer.APPLICATION), "the application is missing from the resulting JSON object");
-        assertTrue(result.containsKey(BaseTransformer.BUNDLE), "the bundle is missing from the resulting JSON object");
-        assertTrue(result.containsKey(BaseTransformer.CONTEXT), "the context is missing from the resulting JSON object");
-        assertTrue(result.containsKey(BaseTransformer.EVENT_TYPE), "the event type is missing from the resulting JSON object");
-        assertTrue(result.containsKey(BaseTransformer.EVENTS), "the events is missing from the resulting JSON object");
-        assertTrue(result.containsKey(BaseTransformer.ORG_ID), "the org id is missing from the resulting JSON object");
-        assertTrue(result.containsKey(BaseTransformer.TIMESTAMP), "the timestamp is missing from the resulting JSON object");
-
         // Assert the values.
         assertEquals(FIXTURE_ACCOUNT_ID, result.getString(BaseTransformer.ACCOUNT_ID), "the account id isn't the same");
         assertEquals(FIXTURE_APPLICATION, result.getString(BaseTransformer.APPLICATION), "the application isn't the same");
         assertEquals(FIXTURE_BUNDLE, result.getString(BaseTransformer.BUNDLE), "the bundle isn't the same");
         assertEquals(FIXTURE_EVENT_TYPE, result.getString(BaseTransformer.EVENT_TYPE), "the event type isn't the same");
+
+        // Assert that the keys that contain inner JSON arrays or objects are present.
+        assertTrue(result.containsKey(BaseTransformer.CONTEXT), "the context is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.EVENTS), "the events is missing from the resulting JSON object");
+        assertTrue(result.containsKey(BaseTransformer.ORG_ID), "the org id is missing from the resulting JSON object");
 
         final JsonArray events = result.getJsonArray(BaseTransformer.EVENTS);
         if (events.size() != FIXTURE_EVENTS.size()) {


### PR DESCRIPTION
The PR:

- Removes the `transform` function in favor of `toJsonObject`, since we could use just a single function instead of having scattered calls to the two functions.
- Adds a test to make sure that, at least, the structure we've defined will remain consistent in the future.
- Adds the environment URL every time the action gets serialized, so that it can be associated with the environment it must be checked on.