### PR TITLE
RHCLOUD-22541 Stop persisting notification history for aggregation email

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
@@ -77,7 +77,7 @@ public class EmailSender {
         bopApiToken = LineBreakCleaner.clean(bopApiToken);
     }
 
-    public void sendEmail(User user, Event event, TemplateInstance subject, TemplateInstance body) {
+    public void sendEmail(User user, Event event, TemplateInstance subject, TemplateInstance body, boolean persistHistory) {
         final HttpRequest<Buffer> bopRequest = this.buildBOPHttpRequest();
         LocalDateTime start = LocalDateTime.now(UTC);
 
@@ -98,7 +98,7 @@ public class EmailSender {
             webhookSender.doHttpRequest(
                     event, endpoint,
                     bopRequest,
-                    getPayload(user, action, subject, body), "POST", bopUrl);
+                    getPayload(user, action, subject, body), "POST", bopUrl, persistHistory);
 
             processedTimer.stop(registry.timer("processor.email.processed", "bundle", action.getBundle(), "application", action.getApplication()));
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -197,7 +197,7 @@ public class EmailSubscriptionTypeProcessor extends EndpointTypeProcessor {
                 .getEmailSubscribersUserId(action.getOrgId(), action.getBundle(), action.getApplication(), emailSubscriptionType));
 
         for (User user : recipientResolver.recipientUsers(action.getOrgId(), requests, subscribers)) {
-            emailSender.sendEmail(user, event, subject, body);
+            emailSender.sendEmail(user, event, subject, body, true);
         }
     }
 
@@ -276,7 +276,7 @@ public class EmailSubscriptionTypeProcessor extends EndpointTypeProcessor {
                 event.setId(UUID.randomUUID());
                 event.setAction(action);
 
-                emailSender.sendEmail(aggregation.getKey(), event, subject, body);
+                emailSender.sendEmail(aggregation.getKey(), event, subject, body, false);
             }
         }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -136,7 +136,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
 
         JsonObject payload = transformer.transform(event.getAction());
 
-        doHttpRequest(event, endpoint, req, payload, properties.getMethod().name(), properties.getUrl());
+        doHttpRequest(event, endpoint, req, payload, properties.getMethod().name(), properties.getUrl(), true);
     }
 
     private WebClient getWebClient(boolean disableSSLVerification) {
@@ -147,7 +147,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
         }
     }
 
-    public void doHttpRequest(Event event, Endpoint endpoint, HttpRequest<Buffer> req, JsonObject payload, String method, String url) {
+    public void doHttpRequest(Event event, Endpoint endpoint, HttpRequest<Buffer> req, JsonObject payload, String method, String url, boolean persistHistory) {
         final long startTime = System.currentTimeMillis();
 
         try {
@@ -240,7 +240,9 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
                 if (serverError) {
                     throw new ServerErrorException(history);
                 }
-                persistNotificationHistory(history);
+                if (persistHistory) {
+                    persistNotificationHistory(history);
+                }
             });
         } catch (Exception e) {
             NotificationHistory history;
@@ -257,7 +259,9 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
                 details.put("error_message", e.getMessage()); // TODO This message isn't always the most descriptive..
                 history.setDetails(details.getMap());
             }
-            persistNotificationHistory(history);
+            if (persistHistory) {
+                persistNotificationHistory(history);
+            }
         }
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -46,6 +46,7 @@ import static com.redhat.cloud.notifications.processors.email.EmailSubscriptionT
 import static com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.AGGREGATION_COMMAND_PROCESSED_COUNTER_NAME;
 import static com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.AGGREGATION_COMMAND_REJECTED_COUNTER_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -97,13 +98,13 @@ class EmailSubscriptionTypeProcessorTest {
     @Test
     void shouldNotProcessWhenEndpointsAreNull() {
         testee.process(new Event(), null);
-        verify(sender, never()).sendEmail(any(User.class), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class));
+        verify(sender, never()).sendEmail(any(User.class), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean());
     }
 
     @Test
     void shouldNotProcessWhenEndpointsAreEmpty() {
         testee.process(new Event(), List.of());
-        verify(sender, never()).sendEmail(any(User.class), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class));
+        verify(sender, never()).sendEmail(any(User.class), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean());
     }
 
     @Test
@@ -238,8 +239,8 @@ class EmailSubscriptionTypeProcessorTest {
         endpoint.setType(EndpointType.EMAIL_SUBSCRIPTION);
 
         testee.process(event, List.of(endpoint));
-        verify(sender, times(1)).sendEmail(eq(user1), eq(event), any(TemplateInstance.class), any(TemplateInstance.class));
-        verify(sender, times(1)).sendEmail(eq(user2), eq(event), any(TemplateInstance.class), any(TemplateInstance.class));
+        verify(sender, times(1)).sendEmail(eq(user1), eq(event), any(TemplateInstance.class), any(TemplateInstance.class), eq(true));
+        verify(sender, times(1)).sendEmail(eq(user2), eq(event), any(TemplateInstance.class), any(TemplateInstance.class), eq(true));
         featureFlipper.setUseDefaultTemplate(false);
     }
 


### PR DESCRIPTION
The following exception is thrown because when an aggregation email is sent, we're passing a fake Event object to WebhookTypeProcessor#doHttpRequest. That event does not exist in the DB (which is perfectly normal).
```
2022-10-19 20:00:20,910 ERROR [org.hib.eng.jdb.spi.SqlExceptionHelper] (executor-thread-249) ERROR: insert or update on table "notification_history" violates foreign key constraint "fk_notification_history_event_id"
  Detail: Key (event_id)=(d079d730-9557-4ad1-b17c-211538cdc281) is not present in table "event".
2022-10-19 20:00:20,911 ERROR [com.red.clo.not.pro.EndpointTypeProcessor] (executor-thread-249) Notification history creation failed for Endpoint{id=40ab7fad-b7fa-4c34-8a39-4075f8a8d86c, accountId='5685364', orgId='7931872', name='Email subscription', description='', enabled=true, type=EMAIL_SUBSCRIPTION, subType=null, status=READY', created=2021-04-22T19:21:14.523357, updated=null, properties=com.redhat.cloud.notifications.models.EmailSubscriptionProperties@85c0ab9f, serverErrors=0}: javax.persistence.PersistenceException: org.hibernate.exception.ConstraintViolationException: could not execute statement
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:154)
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:181)
	at org.hibernate.query.internal.AbstractProducedQuery.executeUpdate(AbstractProducedQuery.java:1705)
	at com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository.createNotificationHistory(NotificationHistoryRepository.java:43)
	at com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository_Subclass.createNotificationHistory$$superforward1(Unknown Source)
	at com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository_Subclass$$function$$2.apply(Unknown Source)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:53)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.invokeInOurTx(TransactionalInterceptorBase.java:133)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.invokeInOurTx(TransactionalInterceptorBase.java:104)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired.doIntercept(TransactionalInterceptorRequired.java:38)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.intercept(TransactionalInterceptorBase.java:58)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired.intercept(TransactionalInterceptorRequired.java:32)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired_Bean.intercept(Unknown Source)
	at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)
	at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:40)
	at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:32)
	at com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository_Subclass.createNotificationHistory(Unknown Source)
	at com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository_ClientProxy.createNotificationHistory(Unknown Source)
	at com.redhat.cloud.notifications.processors.EndpointTypeProcessor.persistNotificationHistory(EndpointTypeProcessor.java:21)
	at com.redhat.cloud.notifications.processors.webhooks.WebhookTypeProcessor.lambda$doHttpRequest$1(WebhookTypeProcessor.java:243)
	at dev.failsafe.Functions.lambda$toCtxSupplier$9(Functions.java:228)
	at dev.failsafe.Functions.lambda$get$0(Functions.java:46)
	at dev.failsafe.internal.RetryPolicyExecutor.lambda$apply$0(RetryPolicyExecutor.java:74)
	at dev.failsafe.SyncExecutionImpl.executeSync(SyncExecutionImpl.java:187)
	at dev.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:376)
	at dev.failsafe.FailsafeExecutor.run(FailsafeExecutor.java:220)
	at com.redhat.cloud.notifications.processors.webhooks.WebhookTypeProcessor.doHttpRequest(WebhookTypeProcessor.java:154)
	at com.redhat.cloud.notifications.processors.webhooks.WebhookTypeProcessor_ClientProxy.doHttpRequest(Unknown Source)
	at com.redhat.cloud.notifications.processors.email.EmailSender.sendEmail(EmailSender.java:98)
	at com.redhat.cloud.notifications.processors.email.EmailSender_ClientProxy.sendEmail(Unknown Source)
	at com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.processAggregateEmailsByAggregationKey(EmailSubscriptionTypeProcessor.java:279)
	at com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.lambda$consumeEmailAggregations$2(EmailSubscriptionTypeProcessor.java:222)
	at com.redhat.cloud.notifications.db.StatelessSessionFactory.withSession(StatelessSessionFactory.java:31)
	at com.redhat.cloud.notifications.db.StatelessSessionFactory_ClientProxy.withSession(Unknown Source)
	at com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor.consumeEmailAggregations(EmailSubscriptionTypeProcessor.java:221)
	at com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor_ClientProxy.consumeEmailAggregations(Unknown Source)
	at com.redhat.cloud.notifications.processors.email.EmailSubscriptionTypeProcessor_SmallRyeMessagingInvoker_consumeEmailAggregations_b33873551c9baeee48d50c300224d498c49ccd50.invoke(Unknown Source)
	at io.smallrye.reactive.messaging.providers.AbstractMediator.lambda$invokeBlocking$4(AbstractMediator.java:116)
	at io.smallrye.context.impl.wrappers.SlowContextualConsumer.accept(SlowContextualConsumer.java:21)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateWithEmitter.subscribe(UniCreateWithEmitter.java:22)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.operators.uni.builders.UniCreateFromDeferredSupplier.subscribe(UniCreateFromDeferredSupplier.java:36)
	at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:36)
	at io.smallrye.mutiny.groups.UniSubscribe.withSubscriber(UniSubscribe.java:52)
	at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:112)
	at io.smallrye.mutiny.groups.UniSubscribe.with(UniSubscribe.java:89)
	at io.vertx.mutiny.core.Context$1.handle(Context.java:170)
	at io.vertx.mutiny.core.Context$1.handle(Context.java:168)
	at io.vertx.core.impl.ContextBase.lambda$null$0(ContextBase.java:137)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:264)
	at io.vertx.core.impl.ContextBase.lambda$executeBlocking$1(ContextBase.java:135)
	at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:557)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.hibernate.exception.ConstraintViolationException: could not execute statement
	at org.hibernate.exception.internal.SQLStateConversionDelegate.convert(SQLStateConversionDelegate.java:109)
	at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:37)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:113)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:99)
	at org.hibernate.engine.jdbc.internal.ResultSetReturnImpl.executeUpdate(ResultSetReturnImpl.java:200)
	at org.hibernate.engine.query.spi.NativeSQLQueryPlan.performExecuteUpdate(NativeSQLQueryPlan.java:107)
	at org.hibernate.internal.StatelessSessionImpl.executeNativeUpdate(StatelessSessionImpl.java:736)
	at org.hibernate.query.internal.NativeQueryImpl.doExecuteUpdate(NativeQueryImpl.java:299)
	at org.hibernate.query.internal.AbstractProducedQuery.executeUpdate(AbstractProducedQuery.java:1696)
	... 56 more
Caused by: org.postgresql.util.PSQLException: ERROR: insert or update on table "notification_history" violates foreign key constraint "fk_notification_history_event_id"
  Detail: Key (event_id)=(d079d730-9557-4ad1-b17c-211538cdc281) is not present in table "event".
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2676)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2366)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:356)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:496)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:413)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:190)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:152)
	at io.agroal.pool.wrapper.PreparedStatementWrapper.executeUpdate(PreparedStatementWrapper.java:88)
	at org.hibernate.engine.jdbc.internal.ResultSetReturnImpl.executeUpdate(ResultSetReturnImpl.java:197)
	... 60 more
```