### PR TITLE
RHCLOUD-22573 Fix NPE when saving a notificationHistory

### DIFF
--- a/database/src/main/resources/db/migration/V1.66.0__notification_history_status.sql
+++ b/database/src/main/resources/db/migration/V1.66.0__notification_history_status.sql
@@ -1,0 +1,4 @@
+UPDATE notification_history SET status = CASE
+    WHEN invocation_result IS true THEN 'SUCCESS'
+    ELSE 'FAILED_INTERNAL'
+    END WHERE status is NULL;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -250,6 +250,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
                 history = ((ServerErrorException) e).getNotificationHistory();
             } else {
                 history = buildNotificationHistory(event, endpoint, startTime);
+                history.setStatus(NotificationStatus.FAILED_INTERNAL);
 
                 Log.debugf("Failed: %s", e.getMessage());
 


### PR DESCRIPTION
 - If there was an exception in the sending mechanism, the history was created without status, causing the NPE