### PR TITLE
RHCLOUD-22573 Add a test to verify NotificationHistory status

### DIFF
--- a/engine/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/engine/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This adds a test to verify the status after an exception has been throw at any part of the processing.

It does so by mocking the `Failsafe.with` method to throw an exception.