### PR TITLE
[RHCLOUD-21733]feature: remove default endpoints from the database

### DIFF
--- a/database/src/main/resources/db/migration/V1.67.0__RHCLOUD-21733_remove-default-endpoints.sql
+++ b/database/src/main/resources/db/migration/V1.67.0__RHCLOUD-21733_remove-default-endpoints.sql
@@ -1,0 +1,5 @@
+DELETE FROM
+    endpoints
+WHERE
+    endpoint_type = 2 -- stands for default endpoint types.
+;


### PR DESCRIPTION
After researching we have found out that it is safe to remove the endpoints from the database.


# Links
[[RHCLOUD-21733]](https://issues.redhat.com/browse/RHCLOUD-21733)