### PR TITLE
[RHCLOUD-21830] feature: annotation to disallow internal hosts

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -97,4 +97,22 @@ public class TestHelpers {
         assertEquals(desc, testAdapter.apply(values));
     }
 
+    /**
+     * Extracts the constraint violation from the returned response.
+     * @param response the response to extract the constraint violation from.
+     * @return the extracted constraint violation message, or an invalid message instead, intended to make the
+     * assertions fail.
+     */
+    public static String extractConstraintViolationFromResponse(final String response) {
+        final var json = new JsonObject(response);
+
+        final JsonArray constraintViolations = json.getJsonArray("violations");
+        if (constraintViolations.size() != 1) {
+            return String.format("one constraint violation expected, more were returned in the payload: %s", response);
+        }
+
+        final JsonObject arrayElement = constraintViolations.getJsonObject(0);
+
+        return arrayElement.getString("message");
+    }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -1706,46 +1706,30 @@ public class EndpointResourceTest extends DbIsolatedTest {
     @Test
     void testEndpointInvalidUrls() {
         // Set up the RBAC access for the test.
-        final String orgId = "endpoint-invalid-urls";
-        final String userName = "user";
-
-        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(orgId, orgId, userName);
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("endpoint-invalid-urls", "endpoint-invalid-urls", "user");
         final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
 
         MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
 
-        // Set up the fixture data.
-        final var disableSslVerification = false;
-        final HttpType method = HttpType.POST;
-        final String password = "endpoint-invalid-urls-basic-authentication-password";
-        final String username = "endpoint-invalid-urls-basic-authentication-username";
-        final String secretToken = "endpoint-invalid-urls-secret-token";
-
         // Create the properties for the endpoint. Leave the URL so that we can set it afterwards.
         final var camelProperties = new CamelProperties();
-        camelProperties.setBasicAuthentication(new BasicAuthentication(username, password));
-        camelProperties.setDisableSslVerification(disableSslVerification);
-        camelProperties.setSecretToken(secretToken);
+        camelProperties.setBasicAuthentication(new BasicAuthentication("endpoint-invalid-urls-basic-authentication-username", "endpoint-invalid-urls-basic-authentication-password"));
+        camelProperties.setDisableSslVerification(false);
+        camelProperties.setSecretToken("endpoint-invalid-urls-secret-token");
 
         final var webhookProperties = new WebhookProperties();
-        webhookProperties.setBasicAuthentication(new BasicAuthentication(username, password));
-        webhookProperties.setDisableSslVerification(disableSslVerification);
-        webhookProperties.setMethod(method);
-        webhookProperties.setSecretToken(secretToken);
+        webhookProperties.setBasicAuthentication(new BasicAuthentication("endpoint-invalid-urls-basic-authentication-username", "endpoint-invalid-urls-basic-authentication-password"));
+        webhookProperties.setDisableSslVerification(false);
+        webhookProperties.setMethod(HttpType.POST);
+        webhookProperties.setSecretToken("endpoint-invalid-urls-secret-token");
 
         // Create an endpoint without the type and the properties set.
-        final var name = "endpoint-invalid-urls-name";
-        final var description = "endpoint-invalid-urls-description";
-        final var enabled = true;
-        final var serverErrors = 0;
-        final var subType = "slack";
-
         final var endpoint = new Endpoint();
-        endpoint.setDescription(description);
-        endpoint.setEnabled(enabled);
-        endpoint.setName(name);
-        endpoint.setServerErrors(serverErrors);
-        endpoint.setSubType(subType);
+        endpoint.setDescription("endpoint-invalid-urls-description");
+        endpoint.setEnabled(true);
+        endpoint.setName("endpoint-invalid-urls-name");
+        endpoint.setServerErrors(0);
+        endpoint.setSubType("slack");
 
         // Create a simple class to make testing easier.
         final class TestCase {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -19,6 +19,8 @@ import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.IntegrationTemplate;
 import com.redhat.cloud.notifications.models.Template;
 import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidator;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidatorTest;
 import com.redhat.cloud.notifications.openbridge.Bridge;
 import com.redhat.cloud.notifications.openbridge.BridgeHelper;
 import com.redhat.cloud.notifications.openbridge.BridgeItemList;
@@ -31,6 +33,7 @@ import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1695,6 +1698,218 @@ public class EndpointResourceTest extends DbIsolatedTest {
         assertEquals(0, endpointPage.getData().size());
     }
 
+    /**
+     * Tests that when an invalid URL is provided via the endpoint's properties, regardless if those properties are
+     * {@link CamelProperties} or {@link WebhookProperties}, the proper constraint violation message is returned from
+     * the handler.
+     */
+    @Test
+    void testEndpointInvalidUrls() {
+        // Set up the RBAC access for the test.
+        final String orgId = "endpoint-invalid-urls";
+        final String userName = "user";
+
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(orgId, orgId, userName);
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+
+        // Set up the fixture data.
+        final var disableSslVerification = false;
+        final HttpType method = HttpType.POST;
+        final String password = "endpoint-invalid-urls-basic-authentication-password";
+        final String username = "endpoint-invalid-urls-basic-authentication-username";
+        final String secretToken = "endpoint-invalid-urls-secret-token";
+
+        // Create the properties for the endpoint. Leave the URL so that we can set it afterwards.
+        final var camelProperties = new CamelProperties();
+        camelProperties.setBasicAuthentication(new BasicAuthentication(username, password));
+        camelProperties.setDisableSslVerification(disableSslVerification);
+        camelProperties.setSecretToken(secretToken);
+
+        final var webhookProperties = new WebhookProperties();
+        webhookProperties.setBasicAuthentication(new BasicAuthentication(username, password));
+        webhookProperties.setDisableSslVerification(disableSslVerification);
+        webhookProperties.setMethod(method);
+        webhookProperties.setSecretToken(secretToken);
+
+        // Create an endpoint without the type and the properties set.
+        final var name = "endpoint-invalid-urls-name";
+        final var description = "endpoint-invalid-urls-description";
+        final var enabled = true;
+        final var serverErrors = 0;
+        final var subType = "slack";
+
+        final var endpoint = new Endpoint();
+        endpoint.setDescription(description);
+        endpoint.setEnabled(enabled);
+        endpoint.setName(name);
+        endpoint.setServerErrors(serverErrors);
+        endpoint.setSubType(subType);
+
+        // Create a simple class to make testing easier.
+        final class TestCase {
+            public final String expectedErrorMessage;
+            public final String[] testUrls;
+
+            TestCase(final String expectedErrorMessage, final String[] testUrls) {
+                this.expectedErrorMessage = expectedErrorMessage;
+                this.testUrls = testUrls;
+            }
+        }
+
+        // Create all the test cases we will be testing in this test.
+        final List<TestCase> testCases = new ArrayList<>();
+        testCases.add(
+            new TestCase(ValidNonPrivateUrlValidator.INVALID_URL, ValidNonPrivateUrlValidatorTest.malformedUrls)
+        );
+
+        testCases.add(
+            new TestCase(ValidNonPrivateUrlValidator.INVALID_URL, ValidNonPrivateUrlValidatorTest.malformedUris)
+        );
+
+        testCases.add(
+            new TestCase(ValidNonPrivateUrlValidator.INVALID_SCHEME, ValidNonPrivateUrlValidatorTest.invalidSchemes)
+        );
+
+        testCases.add(
+            new TestCase(ValidNonPrivateUrlValidator.PRIVATE_IP, ValidNonPrivateUrlValidatorTest.internalHosts)
+        );
+
+        testCases.add(
+            new TestCase(
+                ValidNonPrivateUrlValidator.UNKNOWN_HOST,
+                ValidNonPrivateUrlValidatorTest.unknownHosts
+            )
+        );
+
+        // Test the URLs with both camel and webhook endpoints.
+        for (final var testCase : testCases) {
+            for (final var url : testCase.testUrls) {
+                // Test with a camel endpoint.
+                camelProperties.setUrl(url);
+                endpoint.setType(EndpointType.CAMEL);
+                endpoint.setProperties(camelProperties);
+
+                final String camelResponse =
+                    given()
+                        .header(identityHeader)
+                        .when()
+                        .contentType(JSON)
+                        .body(Json.encode(endpoint))
+                        .post("/endpoints")
+                        .then()
+                        .statusCode(400)
+                        .extract()
+                        .asString();
+
+                final String camelConstraintViolation = TestHelpers.extractConstraintViolationFromResponse(camelResponse);
+
+                Assertions.assertEquals(testCase.expectedErrorMessage, camelConstraintViolation, String.format("unexpected constraint violation for url \"%s\"", url));
+
+                // Test with a webhook endpoint.
+                webhookProperties.setUrl(url);
+                endpoint.setType(EndpointType.WEBHOOK);
+                endpoint.setProperties(webhookProperties);
+
+                final String webhookResponse =
+                    given()
+                        .header(identityHeader)
+                        .when()
+                        .contentType(JSON)
+                        .body(Json.encode(endpoint))
+                        .post("/endpoints")
+                        .then()
+                        .statusCode(400)
+                        .extract()
+                        .asString();
+
+                final String webhookConstraintViolation = TestHelpers.extractConstraintViolationFromResponse(webhookResponse);
+
+                Assertions.assertEquals(testCase.expectedErrorMessage, webhookConstraintViolation, String.format("unexpected constraint violation for url \"%s\"", url));
+            }
+        }
+    }
+
+    /**
+     * Tests that when a valid URL is provided via the endpoint's properties, regardless if those properties are
+     * {@link CamelProperties} or {@link WebhookProperties}, no constraint violations are raised.
+     */
+    @Test
+    void testEndpointValidUrls() {
+        // Set up the RBAC access for the test.
+        final String orgId = "endpoint-invalid-urls";
+        final String userName = "user";
+
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(orgId, orgId, userName);
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+
+        // Set up the fixture data.
+        final var disableSslVerification = false;
+        final HttpType method = HttpType.POST;
+        final String password = "endpoint-invalid-urls-basic-authentication-password";
+        final String username = "endpoint-invalid-urls-basic-authentication-username";
+        final String secretToken = "endpoint-invalid-urls-secret-token";
+
+        // Create the properties for the endpoint. Leave the URL so that we can set it afterwards.
+        final var camelProperties = new CamelProperties();
+        camelProperties.setBasicAuthentication(new BasicAuthentication(username, password));
+        camelProperties.setDisableSslVerification(disableSslVerification);
+        camelProperties.setSecretToken(secretToken);
+
+        final var webhookProperties = new WebhookProperties();
+        webhookProperties.setBasicAuthentication(new BasicAuthentication(username, password));
+        webhookProperties.setDisableSslVerification(disableSslVerification);
+        webhookProperties.setMethod(method);
+        webhookProperties.setSecretToken(secretToken);
+
+        // Create an endpoint without the type and the properties set.
+        final var name = "endpoint-invalid-urls-name";
+        final var description = "endpoint-invalid-urls-description";
+        final var enabled = true;
+        final var serverErrors = 0;
+        final var subType = "slack";
+
+        final var endpoint = new Endpoint();
+        endpoint.setDescription(description);
+        endpoint.setEnabled(enabled);
+        endpoint.setName(name);
+        endpoint.setServerErrors(serverErrors);
+        endpoint.setSubType(subType);
+
+        for (final var url : ValidNonPrivateUrlValidatorTest.validUrls) {
+            // Test with a camel endpoint.
+            camelProperties.setUrl(url);
+            endpoint.setType(EndpointType.CAMEL);
+            endpoint.setProperties(camelProperties);
+
+            given()
+                .header(identityHeader)
+                .when()
+                .contentType(JSON)
+                .body(Json.encode(endpoint))
+                .post("/endpoints")
+                .then()
+                .statusCode(200);
+
+            // Test with a webhook endpoint.
+            webhookProperties.setUrl(url);
+            endpoint.setType(EndpointType.WEBHOOK);
+            endpoint.setProperties(webhookProperties);
+
+            given()
+                .header(identityHeader)
+                .when()
+                .contentType(JSON)
+                .body(Json.encode(endpoint))
+                .post("/endpoints")
+                .then()
+                .statusCode(200);
+        }
+    }
+
     private void assertSystemEndpointTypeError(String message, EndpointType endpointType) {
         assertTrue(message.contains(String.format(
                 "Is not possible to create or alter endpoint with type %s, check API for alternatives",
@@ -1734,5 +1949,4 @@ public class EndpointResourceTest extends DbIsolatedTest {
             assertNotNull(responsePoint.getString("id"));
         }
     }
-
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -1729,7 +1729,6 @@ public class EndpointResourceTest extends DbIsolatedTest {
         endpoint.setEnabled(true);
         endpoint.setName("endpoint-invalid-urls-name");
         endpoint.setServerErrors(0);
-        endpoint.setSubType("slack");
 
         // Create a simple class to make testing easier.
         final class TestCase {
@@ -1772,6 +1771,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             for (final var url : testCase.testUrls) {
                 // Test with a camel endpoint.
                 camelProperties.setUrl(url);
+                endpoint.setSubType("slack");
                 endpoint.setType(EndpointType.CAMEL);
                 endpoint.setProperties(camelProperties);
 
@@ -1793,6 +1793,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
                 // Test with a webhook endpoint.
                 webhookProperties.setUrl(url);
+                // Reset the subtype since it doesn't make sense a "slack" subtype for webhook endpoints.
+                endpoint.setSubType(null);
                 endpoint.setType(EndpointType.WEBHOOK);
                 endpoint.setProperties(webhookProperties);
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.db.converters.BasicAuthenticationConverter;
 import com.redhat.cloud.notifications.db.converters.MapConverter;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 
 import javax.persistence.Column;
 import javax.persistence.Convert;
@@ -21,6 +22,7 @@ import java.util.Map;
 public class CamelProperties extends EndpointProperties implements SourcesSecretable {
 
     @NotNull
+    @ValidNonPrivateUrl
     private String url;
 
     @NotNull

--- a/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.db.converters.BasicAuthenticationConverter;
 import com.redhat.cloud.notifications.db.converters.HttpTypeConverter;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 
 import javax.persistence.Column;
 import javax.persistence.Convert;
@@ -20,7 +21,9 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 @Table(name = "endpoint_webhooks")
 @JsonNaming(SnakeCaseStrategy.class)
 public class WebhookProperties extends EndpointProperties implements SourcesSecretable {
+
     @NotNull
+    @ValidNonPrivateUrl
     private String url;
 
     @NotNull

--- a/common/src/main/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrl.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrl.java
@@ -1,0 +1,25 @@
+package com.redhat.cloud.notifications.models.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines the annotation to make sure that the provided {@link String} field is a valid {@link java.net.URL}, contains
+ * a proper {@link java.net.URI}, that it has a "http" or "https" scheme, and that the host doesn't point to a private
+ * IP. For the reasoning behind this last validation please check
+ * <a href="https://issues.redhat.com/browse/RHCLOUD-21830">RHCLOUD-21830</a> for more details.
+ */
+@Constraint(validatedBy = ValidNonPrivateUrlValidator.class)
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface ValidNonPrivateUrl {
+    Class<?>[] groups() default {};
+    String message() default ValidNonPrivateUrlValidator.INVALID_URL;
+    Class<? extends Payload>[] payload() default {};
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidator.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidator.java
@@ -1,0 +1,99 @@
+package com.redhat.cloud.notifications.models.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.UnknownHostException;
+
+public class ValidNonPrivateUrlValidator implements ConstraintValidator<ValidNonPrivateUrl, String> {
+
+    // Error messages.
+    public static final String INVALID_SCHEME = "The provided URL does not contain a valid scheme. It should be either \"http\" or \"https\"";
+    public static final String INVALID_URI = "The provided URL cannot be converted to a valid URI";
+    public static final String INVALID_URL = "The provided URL is invalid";
+    public static final String PRIVATE_IP = "The provided URL's hostname resolves to a private IP";
+    public static final String UNKNOWN_HOST = "The IP address of the provided host cannot be determined";
+
+    // Allowed protocol schemes.
+    private static final String SCHEME_HTTP = "http";
+    private static final String SCHEME_HTTPS = "https";
+
+    @Override
+    public void initialize(final ValidNonPrivateUrl constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    /**
+     * <p>Validates the following things on the provided raw URL:
+     * <ul>
+     *     <li>The raw URL is a well-formed {@link URL}.</li>
+     *     <li>The raw URL contains a well-formed {@link URI}.</li>
+     *     <li>The raw URL has a valid "http" or "https" scheme.</li>
+     *     <li>The raw URL has a hostname which doesn't point to an internal IP.</li>
+     * </ul>
+     * </p>
+     * @param rawUrl the {@link String} URL to validate.
+     * @param constraintValidatorContext the constraint validation context.
+     * @return true if the {@link String} contains a well-formed URL, a well-formed URI, a "http" or "https" scheme and
+     * a hostname which doesn't point to an internal IP.
+     */
+    @Override
+    public boolean isValid(final String rawUrl, ConstraintValidatorContext constraintValidatorContext) {
+        final URL url;
+        final URI uri;
+        try {
+            // May throw a MalformedURLException...
+            url = new URL(rawUrl);
+            // May throw a URISyntaxException...
+            uri = url.toURI();
+        } catch (final MalformedURLException e) {
+            this.replaceDefaultMessage(constraintValidatorContext, INVALID_URL);
+
+            return false;
+        } catch (final URISyntaxException e) {
+            this.replaceDefaultMessage(constraintValidatorContext, INVALID_URI);
+
+            return false;
+        }
+
+        final String scheme = uri.getScheme();
+        if (!SCHEME_HTTP.equals(scheme) && !SCHEME_HTTPS.equals(scheme)) {
+            this.replaceDefaultMessage(constraintValidatorContext, INVALID_SCHEME);
+
+            return false;
+        }
+
+        // Check that the URL doesn't point to an internal IP.
+        final InetAddress address;
+        try {
+            address = InetAddress.getByName(url.getHost());
+        } catch (UnknownHostException e) {
+            this.replaceDefaultMessage(constraintValidatorContext, UNKNOWN_HOST);
+
+            return false;
+        }
+
+        // If the given host's IP is in the private range, then it's invalid.
+        if (address.isSiteLocalAddress()) {
+            this.replaceDefaultMessage(constraintValidatorContext, PRIVATE_IP);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Replaces the default validator's message with the custom provided message.
+     * @param context the validation context to replace the default message from.
+     * @param message the validation message that wants to be returned instead.
+     */
+    private void replaceDefaultMessage(ConstraintValidatorContext context, final String message) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidator.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidator.java
@@ -12,11 +12,10 @@ import java.net.UnknownHostException;
 public class ValidNonPrivateUrlValidator implements ConstraintValidator<ValidNonPrivateUrl, String> {
 
     // Error messages.
-    public static final String INVALID_SCHEME = "The provided URL does not contain a valid scheme. It should be either \"http\" or \"https\"";
-    public static final String INVALID_URI = "The provided URL cannot be converted to a valid URI";
-    public static final String INVALID_URL = "The provided URL is invalid";
-    public static final String PRIVATE_IP = "The provided URL's hostname resolves to a private IP";
-    public static final String UNKNOWN_HOST = "The IP address of the provided host cannot be determined";
+    public static final String INVALID_SCHEME = "The endpoint URL must start with \"http\" or \"https\"";
+    public static final String INVALID_URL = "The endpoint's URL is invalid";
+    public static final String PRIVATE_IP = "The host of the endpoint's URL host resolves to a private IP";
+    public static final String UNKNOWN_HOST = "The IP address of the endpoint URL's host cannot be determined";
 
     // Allowed protocol schemes.
     private static final String SCHEME_HTTP = "http";
@@ -50,12 +49,8 @@ public class ValidNonPrivateUrlValidator implements ConstraintValidator<ValidNon
             url = new URL(rawUrl);
             // May throw a URISyntaxException...
             uri = url.toURI();
-        } catch (final MalformedURLException e) {
+        } catch (final MalformedURLException | URISyntaxException e) {
             this.replaceDefaultMessage(constraintValidatorContext, INVALID_URL);
-
-            return false;
-        } catch (final URISyntaxException e) {
-            this.replaceDefaultMessage(constraintValidatorContext, INVALID_URI);
 
             return false;
         }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidator.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidator.java
@@ -14,7 +14,7 @@ public class ValidNonPrivateUrlValidator implements ConstraintValidator<ValidNon
     // Error messages.
     public static final String INVALID_SCHEME = "The endpoint URL must start with \"http\" or \"https\"";
     public static final String INVALID_URL = "The endpoint's URL is invalid";
-    public static final String PRIVATE_IP = "The host of the endpoint's URL host resolves to a private IP";
+    public static final String PRIVATE_IP = "The host of the endpoint's URL resolves to a private IP";
     public static final String UNKNOWN_HOST = "The IP address of the endpoint URL's host cannot be determined";
 
     // Allowed protocol schemes.

--- a/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
@@ -10,6 +10,13 @@ import javax.validation.ValidatorFactory;
 
 public class ValidNonPrivateUrlValidatorTest {
 
+    public static final String[] internalHosts = {"https://192.168.0.1", "https://172.16.0.1", "https://10.0.0.1", "https://192.168.0.1", "https://172.16.0.1", "https://10.0.0.1"};
+    public static final String[] invalidSchemes = {"ftp://redhat.com"};
+    public static final String[] malformedUris = {"https://example.com /hello", "https:/\\/example.com"};
+    public static final String[] malformedUrls = {"htt:/example.com", "redhat.com", "redhat"};
+    public static final String[] validUrls = new String[]{"http://redhat.com", "https://redhat.com"};
+    public static final String[] unknownHosts = {"https://non-existing-webpage-test-one-two-three.com", "http://another-non-existing-webpage.com"};
+
     private static Validator validator;
 
     /**
@@ -41,8 +48,6 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void validUrlTest() {
-        final var validUrls = new String[]{"http://redhat.com", "https://redhat.com"};
-
         for (final var url : validUrls) {
             final var validUrl = new SimpleDto(url);
 
@@ -57,8 +62,6 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void malformedUrlsTest() {
-        final String[] malformedUrls = {"htt:/example.com", "redhat.com", "redhat"};
-
         final var expectedNumberConstraintViolations = 1;
         for (final var malformedUrl : malformedUrls) {
             final var invalid = new SimpleDto(malformedUrl);
@@ -77,8 +80,6 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void malformedUrisTest() {
-        final String[] malformedUris = {"https://example.com /hello", "https:/\\/example.com"};
-
         final var expectedNumberConstraintViolations = 1;
         for (final var malformedUri : malformedUris) {
             final var invalid = new SimpleDto(malformedUri);
@@ -97,8 +98,6 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void invalidSchemesTest() {
-        final String[] invalidSchemes = {"ftp://redhat.com"};
-
         for (final var scheme : invalidSchemes) {
             final var invalidScheme = new SimpleDto(scheme);
 
@@ -119,8 +118,6 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void internalHostsTest() {
-        final String[] internalHosts = {"https://192.168.0.1", "https://172.16.0.1", "https://10.0.0.1", "https://192.168.0.1", "https://172.16.0.1", "https://10.0.0.1"};
-
         for (final var internalHost : internalHosts) {
             final var internal = new SimpleDto(internalHost);
 
@@ -142,8 +139,6 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void unknownHostTest() {
-        final String[] unknownHosts = {"https://non-existing-webpage-test-one-two-three.com", "http://another-non-existing-webpage.com"};
-
         final var expectedNumberConstraintViolations = 1;
         for (final var unknownHost : unknownHosts) {
             final var invalid = new SimpleDto(unknownHost);

--- a/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
@@ -87,7 +87,7 @@ public class ValidNonPrivateUrlValidatorTest {
             Assertions.assertEquals(expectedNumberConstraintViolations, constraintViolations.size(), "unexpected number of constraint violations");
 
             for (final var cv : constraintViolations) {
-                Assertions.assertEquals(ValidNonPrivateUrlValidator.INVALID_URI, cv.getMessage(), "unexpected error message received");
+                Assertions.assertEquals(ValidNonPrivateUrlValidator.INVALID_URL, cv.getMessage(), "unexpected error message received");
             }
         }
     }

--- a/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
@@ -1,0 +1,159 @@
+package com.redhat.cloud.notifications.models.validation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+public class ValidNonPrivateUrlValidatorTest {
+
+    private static Validator validator;
+
+    /**
+     * Sets up the validator.
+     */
+    @BeforeAll
+    public static void setUp() {
+        final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+
+        validator = validatorFactory.getValidator();
+
+        validatorFactory.close();
+    }
+
+    /**
+     * A simple DTO class that will help with the annotation validations.
+     */
+    private static class SimpleDto {
+        SimpleDto(final String url) {
+            this.url = url;
+        }
+
+        @ValidNonPrivateUrl
+        private final String url;
+    }
+
+    /**
+     * Tests that a proper URL with an allowed scheme and an external IP doesn't generate any constraint violations.
+     */
+    @Test
+    public void validUrlTest() {
+        final var validUrls = new String[]{"http://redhat.com", "https://redhat.com"};
+
+        for (final var url : validUrls) {
+            final var validUrl = new SimpleDto(url);
+
+            final var constraintViolations = validator.validate(validUrl);
+
+            Assertions.assertEquals(0, constraintViolations.size(), "unexpected constraint violations:" + constraintViolations);
+        }
+    }
+
+    /**
+     * Tests that the malformed URLs generate constraint violations.
+     */
+    @Test
+    public void malformedUrlsTest() {
+        final String[] malformedUrls = {"htt:/example.com", "redhat.com", "redhat"};
+
+        final var expectedNumberConstraintViolations = 1;
+        for (final var malformedUrl : malformedUrls) {
+            final var invalid = new SimpleDto(malformedUrl);
+
+            final var constraintViolations = validator.validate(invalid);
+            Assertions.assertEquals(expectedNumberConstraintViolations, constraintViolations.size(), "unexpected number of constraint violations");
+
+            for (final var cv : constraintViolations) {
+                Assertions.assertEquals(ValidNonPrivateUrlValidator.INVALID_URL, cv.getMessage(), "unexpected error message received");
+            }
+        }
+    }
+
+    /**
+     * Tests that the malformed URIs generate constraint violations.
+     */
+    @Test
+    public void malformedUrisTest() {
+        final String[] malformedUris = {"https://example.com /hello", "https:/\\/example.com"};
+
+        final var expectedNumberConstraintViolations = 1;
+        for (final var malformedUri : malformedUris) {
+            final var invalid = new SimpleDto(malformedUri);
+
+            final var constraintViolations = validator.validate(invalid);
+            Assertions.assertEquals(expectedNumberConstraintViolations, constraintViolations.size(), "unexpected number of constraint violations");
+
+            for (final var cv : constraintViolations) {
+                Assertions.assertEquals(ValidNonPrivateUrlValidator.INVALID_URI, cv.getMessage(), "unexpected error message received");
+            }
+        }
+    }
+
+    /**
+     * Tests that URLs with disallowed schemes generate constraint violations.
+     */
+    @Test
+    public void invalidSchemesTest() {
+        final String[] invalidSchemes = {"ftp://redhat.com"};
+
+        for (final var scheme : invalidSchemes) {
+            final var invalidScheme = new SimpleDto(scheme);
+
+            final var constraintViolations = validator.validate(invalidScheme);
+            Assertions.assertEquals(1, constraintViolations.size(), "unexpected constraint violations:" + constraintViolations);
+
+            for (final var cv : constraintViolations) {
+                Assertions.assertEquals(ValidNonPrivateUrlValidator.INVALID_SCHEME, cv.getMessage(), "unexpected error message received");
+            }
+        }
+    }
+
+    /**
+     * Tests that private IP ranges generate constraint violations. This can also be tested by adding a
+     * <code>10.0.0.1 fake-local-host.com</code> line on the <code>/etc/hosts</code> file, which simulates a host in the
+     * private and internal network. However, since this is hard to do programmatically, because it requires tampering
+     * with {@link java.net.InetAddress} or creating a fake DNS server, it has not been done in the test.
+     */
+    @Test
+    public void internalHostsTest() {
+        final String[] internalHosts = {"https://192.168.0.1", "https://172.16.0.1", "https://10.0.0.1", "https://192.168.0.1", "https://172.16.0.1", "https://10.0.0.1"};
+
+        for (final var internalHost : internalHosts) {
+            final var internal = new SimpleDto(internalHost);
+
+            final var constraintViolations = validator.validate(internal);
+            Assertions.assertEquals(
+                    1,
+                    constraintViolations.size(),
+                    String.format("unexpected constraint violations for host \"%s\": %s", internalHost, constraintViolations)
+            );
+
+            for (final var cv : constraintViolations) {
+                Assertions.assertEquals(ValidNonPrivateUrlValidator.PRIVATE_IP, cv.getMessage(), "unexpected error message received");
+            }
+        }
+    }
+
+    /**
+     * Tests that unknown hosts generate constraint violations.
+     */
+    @Test
+    public void unknownHostTest() {
+        final String[] unknownHosts = {"https://non-existing-webpage-test-one-two-three.com", "http://another-non-existing-webpage.com"};
+
+        final var expectedNumberConstraintViolations = 1;
+        for (final var unknownHost : unknownHosts) {
+            final var invalid = new SimpleDto(unknownHost);
+
+            final var constraintViolations = validator.validate(invalid);
+            Assertions.assertEquals(expectedNumberConstraintViolations, constraintViolations.size(), "unexpected number of constraint violations");
+
+            for (final var cv : constraintViolations) {
+                Assertions.assertEquals(ValidNonPrivateUrlValidator.UNKNOWN_HOST, cv.getMessage(), "unexpected error message received");
+            }
+        }
+    }
+}

--- a/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
@@ -14,7 +14,7 @@ public class ValidNonPrivateUrlValidatorTest {
     public static final String[] invalidSchemes = {"ftp://redhat.com"};
     public static final String[] malformedUris = {"https://example.com /hello", "https:/\\/example.com"};
     public static final String[] malformedUrls = {"htt:/example.com", "redhat.com", "redhat"};
-    public static final String[] validUrls = new String[]{"http://redhat.com", "https://redhat.com"};
+    public static final String[] validUrls = {"http://redhat.com", "https://redhat.com"};
     public static final String[] unknownHosts = {"https://non-existing-webpage-test-one-two-three.com", "http://another-non-existing-webpage.com"};
 
     private static Validator validator;

--- a/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
@@ -24,11 +24,9 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @BeforeAll
     public static void setUp() {
-        final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
-
-        validator = validatorFactory.getValidator();
-
-        validatorFactory.close();
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            validator = validatorFactory.getValidator();
+        }
     }
 
     /**

--- a/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/models/validation/ValidNonPrivateUrlValidatorTest.java
@@ -60,17 +60,7 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void malformedUrlsTest() {
-        final var expectedNumberConstraintViolations = 1;
-        for (final var malformedUrl : malformedUrls) {
-            final var invalid = new SimpleDto(malformedUrl);
-
-            final var constraintViolations = validator.validate(invalid);
-            Assertions.assertEquals(expectedNumberConstraintViolations, constraintViolations.size(), "unexpected number of constraint violations");
-
-            for (final var cv : constraintViolations) {
-                Assertions.assertEquals(ValidNonPrivateUrlValidator.INVALID_URL, cv.getMessage(), "unexpected error message received");
-            }
-        }
+        this.testHosts(malformedUrls, ValidNonPrivateUrlValidator.INVALID_URL);
     }
 
     /**
@@ -78,17 +68,7 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void malformedUrisTest() {
-        final var expectedNumberConstraintViolations = 1;
-        for (final var malformedUri : malformedUris) {
-            final var invalid = new SimpleDto(malformedUri);
-
-            final var constraintViolations = validator.validate(invalid);
-            Assertions.assertEquals(expectedNumberConstraintViolations, constraintViolations.size(), "unexpected number of constraint violations");
-
-            for (final var cv : constraintViolations) {
-                Assertions.assertEquals(ValidNonPrivateUrlValidator.INVALID_URL, cv.getMessage(), "unexpected error message received");
-            }
-        }
+        this.testHosts(malformedUris, ValidNonPrivateUrlValidator.INVALID_URL);
     }
 
     /**
@@ -96,16 +76,7 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void invalidSchemesTest() {
-        for (final var scheme : invalidSchemes) {
-            final var invalidScheme = new SimpleDto(scheme);
-
-            final var constraintViolations = validator.validate(invalidScheme);
-            Assertions.assertEquals(1, constraintViolations.size(), "unexpected constraint violations:" + constraintViolations);
-
-            for (final var cv : constraintViolations) {
-                Assertions.assertEquals(ValidNonPrivateUrlValidator.INVALID_SCHEME, cv.getMessage(), "unexpected error message received");
-            }
-        }
+        this.testHosts(invalidSchemes, ValidNonPrivateUrlValidator.INVALID_SCHEME);
     }
 
     /**
@@ -116,20 +87,7 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void internalHostsTest() {
-        for (final var internalHost : internalHosts) {
-            final var internal = new SimpleDto(internalHost);
-
-            final var constraintViolations = validator.validate(internal);
-            Assertions.assertEquals(
-                    1,
-                    constraintViolations.size(),
-                    String.format("unexpected constraint violations for host \"%s\": %s", internalHost, constraintViolations)
-            );
-
-            for (final var cv : constraintViolations) {
-                Assertions.assertEquals(ValidNonPrivateUrlValidator.PRIVATE_IP, cv.getMessage(), "unexpected error message received");
-            }
-        }
+        this.testHosts(internalHosts, ValidNonPrivateUrlValidator.PRIVATE_IP);
     }
 
     /**
@@ -137,15 +95,25 @@ public class ValidNonPrivateUrlValidatorTest {
      */
     @Test
     public void unknownHostTest() {
+        this.testHosts(unknownHosts, ValidNonPrivateUrlValidator.UNKNOWN_HOST);
+    }
+
+    /**
+     * Tests the given host to only return one single constraint validation, and of the expected error message.
+     * @param urls the URLs to validate.
+     * @param expectedErrorMessage the expected error message it should be returned by the validator.
+     */
+    private void testHosts(final String[] urls, final String expectedErrorMessage) {
         final var expectedNumberConstraintViolations = 1;
-        for (final var unknownHost : unknownHosts) {
-            final var invalid = new SimpleDto(unknownHost);
+
+        for (final var url : urls) {
+            final var invalid = new SimpleDto(url);
 
             final var constraintViolations = validator.validate(invalid);
             Assertions.assertEquals(expectedNumberConstraintViolations, constraintViolations.size(), "unexpected number of constraint violations");
 
             for (final var cv : constraintViolations) {
-                Assertions.assertEquals(ValidNonPrivateUrlValidator.UNKNOWN_HOST, cv.getMessage(), "unexpected error message received");
+                Assertions.assertEquals(expectedErrorMessage, cv.getMessage(), "unexpected error message received");
             }
         }
     }


### PR DESCRIPTION
This annotation should help in filtering the URLs that we are given that have internal IPs or hostnames that point to internal IPs. That way we can mitigate part of the SSRF attacks.

## Links

[[RHCLOUD-21830]](https://issues.redhat.com/browse/RHCLOUD-21830)