### PR TITLE
[RHCLOUD-22667] feature: return bundle's display names on Slack notifications

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -138,7 +138,7 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
         getSecretToken(properties).ifPresent(secretToken -> metaData.put(TOKEN_HEADER, secretToken));
         getBasicAuth(properties).ifPresent(basicAuth -> metaData.put("basicAuth", basicAuth));
 
-        JsonObject payload = baseTransformer.toJsonObject(event.getAction());
+        final JsonObject payload = baseTransformer.toJsonObject(event);
         payload.put(NOTIF_METADATA_KEY, metaData);
 
         return payload;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -135,8 +135,8 @@ public class EmailSubscriptionTypeProcessor extends EndpointTypeProcessor {
                 aggregation.setApplicationName(action.getApplication());
                 aggregation.setBundleName(action.getBundle());
 
-                JsonObject transformedAction = baseTransformer.toJsonObject(action);
-                aggregation.setPayload(transformedAction);
+                final JsonObject transformedEvent = this.baseTransformer.toJsonObject(event);
+                aggregation.setPayload(transformedEvent);
                 emailAggregationRepository.addEmailAggregation(aggregation);
             }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/slack/SlackProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/slack/SlackProcessor.java
@@ -107,7 +107,7 @@ public class SlackProcessor extends EndpointTypeProcessor {
     private SlackNotification buildNotification(Event event, Endpoint endpoint, UUID historyId) {
         CamelProperties properties = endpoint.getProperties(CamelProperties.class);
 
-        JsonObject data = baseTransformer.toJsonObject(event.getAction());
+        JsonObject data = baseTransformer.toJsonObject(event);
         data.put("environment_url", environment.url());
 
         Map<Object, Object> dataAsMap;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/teams/TeamsProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/teams/TeamsProcessor.java
@@ -107,7 +107,7 @@ public class TeamsProcessor extends EndpointTypeProcessor {
     private TeamsNotification buildNotification(Event event, Endpoint endpoint, UUID historyId) {
         CamelProperties properties = endpoint.getProperties(CamelProperties.class);
 
-        JsonObject data = baseTransformer.toJsonObject(event.getAction());
+        JsonObject data = baseTransformer.toJsonObject(event);
         data.put("environment_url", environment.url());
 
         Map<Object, Object> dataAsMap;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -150,7 +150,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
             req.basicAuthentication(properties.getBasicAuthentication().getUsername(), properties.getBasicAuthentication().getPassword());
         }
 
-        JsonObject payload = transformer.toJsonObject(event.getAction());
+        final JsonObject payload = transformer.toJsonObject(event);
 
         doHttpRequest(event, endpoint, req, payload, properties.getMethod().name(), properties.getUrl(), true);
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.transformers;
 
 import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.models.Event;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -16,20 +17,24 @@ public class BaseTransformer {
     public static final String APPLICATION = "application";
     public static final String BUNDLE = "bundle";
     public static final String CONTEXT = "context";
+    public static final String DISPLAY_NAME = "display_name";
     public static final String EVENT_TYPE = "event_type";
     public static final String EVENTS = "events";
     public static final String METADATA = "metadata";
     public static final String ORG_ID = "org_id";
     public static final String PAYLOAD = "payload";
+    public static final String SOURCE = "source";
     public static final String TIMESTAMP = "timestamp";
 
     /**
-     * Transforms the given action into a {@link JsonObject}.
-     * @param action the {@link Action} to transform.
-     * @return a {@link JsonObject} containing the given action.
+     * Transforms the given event into a {@link JsonObject}.
+     * @param event the {@link Event} to transform.
+     * @return a {@link JsonObject} containing the given event.
      */
-    public JsonObject toJsonObject(final Action action) {
-        JsonObject message = new JsonObject();
+    public JsonObject toJsonObject(final Event event) {
+        final JsonObject message = new JsonObject();
+
+        final Action action = event.getAction();
 
         message.put(ACCOUNT_ID, action.getAccountId());
         message.put(APPLICATION, action.getApplication());
@@ -40,9 +45,9 @@ public class BaseTransformer {
             EVENTS,
             new JsonArray(
                 action.getEvents().stream().map(
-                    event -> Map.of(
-                        METADATA, JsonObject.mapFrom(event.getMetadata()),
-                        PAYLOAD, JsonObject.mapFrom(event.getPayload())
+                    ev -> Map.of(
+                        METADATA, JsonObject.mapFrom(ev.getMetadata()),
+                        PAYLOAD, JsonObject.mapFrom(ev.getPayload())
                     )
                 ).collect(Collectors.toList())
             )
@@ -50,7 +55,24 @@ public class BaseTransformer {
         message.put(ORG_ID, action.getOrgId());
         message.put(TIMESTAMP, action.getTimestamp().toString());
 
+        // Include the display names of the different objects.
+        // Since "insights-notifications-schemas-java:0.20".
+        final JsonObject source = new JsonObject();
+
+        final JsonObject sourceAppDisplayName = new JsonObject();
+        sourceAppDisplayName.put(DISPLAY_NAME, event.getApplicationDisplayName());
+        source.put(APPLICATION, sourceAppDisplayName);
+
+        final JsonObject sourceBundleDisplayName = new JsonObject();
+        sourceBundleDisplayName.put(DISPLAY_NAME, event.getBundleDisplayName());
+        source.put(BUNDLE, sourceBundleDisplayName);
+
+        final JsonObject sourceEventTypeDisplayName = new JsonObject();
+        sourceEventTypeDisplayName.put(DISPLAY_NAME, event.getEventTypeDisplayName());
+        source.put(EVENT_TYPE, sourceEventTypeDisplayName);
+
+        message.put(SOURCE, source);
+
         return message;
     }
-
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
@@ -6,7 +6,6 @@ import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
-import com.redhat.cloud.notifications.transformers.BaseTransformer;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -70,7 +69,7 @@ public class AdvisorTestHelpers {
         aggregation.setBundleName(action.getBundle());
         aggregation.setApplicationName(action.getApplication());
         aggregation.setOrgId(DEFAULT_ORG_ID);
-        aggregation.setPayload(new BaseTransformer().toJsonObject(action));
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(action));
 
         return aggregation;
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/ComplianceTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ComplianceTestHelpers.java
@@ -6,8 +6,6 @@ import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
-import com.redhat.cloud.notifications.transformers.BaseTransformer;
-import io.vertx.core.json.JsonObject;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,8 +14,6 @@ import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static java.time.ZoneOffset.UTC;
 
 public class ComplianceTestHelpers {
-
-    public static BaseTransformer baseTransformer = new BaseTransformer();
 
     public static EmailAggregation createEmailAggregation(String bundle, String application, String eventType, String policyId, String inventoryId) {
         EmailAggregation aggregation = new EmailAggregation();
@@ -56,8 +52,7 @@ public class ComplianceTestHelpers {
 
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
-        aggregation.setPayload(payload);
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
 
         return aggregation;
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/DriftTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/DriftTestHelpers.java
@@ -6,8 +6,6 @@ import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
-import com.redhat.cloud.notifications.transformers.BaseTransformer;
-import io.vertx.core.json.JsonObject;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,8 +13,6 @@ import java.util.List;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
 public class DriftTestHelpers {
-
-    public static BaseTransformer baseTransformer = new BaseTransformer();
 
     public static EmailAggregation createEmailAggregation(String bundle, String application, String baselineId, String baselineName, String inventory_id, String inventory_name) {
         EmailAggregation aggregation = new EmailAggregation();
@@ -52,8 +48,7 @@ public class DriftTestHelpers {
 
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
-        aggregation.setPayload(payload);
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
 
         return aggregation;
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
@@ -6,8 +6,6 @@ import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
-import com.redhat.cloud.notifications.transformers.BaseTransformer;
-import io.vertx.core.json.JsonObject;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,8 +14,6 @@ import java.util.Map;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
 public class InventoryTestHelpers {
-
-    public static BaseTransformer baseTransformer = new BaseTransformer();
 
     public static final String displayName1 = "random_name";
     public static final String errorMessage1 = "error 1";
@@ -80,8 +76,7 @@ public class InventoryTestHelpers {
 
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
-        aggregation.setPayload(payload);
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
 
         return aggregation;
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
@@ -7,8 +7,6 @@ import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.processors.email.aggregators.PatchEmailPayloadAggregator;
-import com.redhat.cloud.notifications.transformers.BaseTransformer;
-import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 
 import java.time.LocalDateTime;
@@ -19,8 +17,6 @@ import java.util.Map;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
 public class PatchTestHelpers {
-
-    public static BaseTransformer baseTransformer = new BaseTransformer();
 
     private static final String ADVISORY_NAME = "advisory_name";
     private static final String ADVISORY_TYPE = "advisory_type";
@@ -56,8 +52,7 @@ public class PatchTestHelpers {
         ));
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
-        aggregation.setPayload(payload);
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
 
         return aggregation;
     }
@@ -109,8 +104,7 @@ public class PatchTestHelpers {
         ));
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
-        aggregation.setPayload(payload);
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
 
         return aggregation;
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -11,6 +11,7 @@ import com.redhat.cloud.notifications.processors.email.aggregators.ResourceOptim
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -29,7 +30,6 @@ public class TestHelpers {
 
     public static final String HCC_LOGO_TARGET = "Logo-Red_Hat-Hybrid_Cloud_Console-A-Reverse-RGB.png";
 
-    public static BaseTransformer baseTransformer = new BaseTransformer();
     public static final String policyId1 = "abcd-efghi-jkl-lmn";
     public static final String policyName1 = "Foobar";
     public static final String policyId2 = "0123-456-789-5721f";
@@ -72,8 +72,7 @@ public class TestHelpers {
 
         emailActionMessage.setOrgId(orgId);
 
-        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
-        aggregation.setPayload(payload);
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
 
         return aggregation;
     }
@@ -650,5 +649,22 @@ public class TestHelpers {
             System.out.println("An error occurred");
             e.printStackTrace();
         }
+    }
+
+    /**
+     * Helper that wraps the given action in a
+     * {@link com.redhat.cloud.notifications.models.Event} type of event and
+     * returns the {@link JsonObject} representation of it. This wrapper is
+     * helpful to make certain tests compliant with the signature of the
+     * {@link BaseTransformer#toJsonObject(com.redhat.cloud.notifications.models.Event)}
+     * function.
+     * @param action the action to be wrapped and transformed.
+     * @return the {@link JsonObject} representation of the wrapped action.
+     */
+    public static JsonObject wrapActionToJsonObject(final Action action) {
+        com.redhat.cloud.notifications.models.Event event = new com.redhat.cloud.notifications.models.Event();
+        event.setAction(action);
+
+        return new BaseTransformer().toJsonObject(event);
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/VulnerabilityTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/VulnerabilityTestHelpers.java
@@ -6,8 +6,6 @@ import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 import com.redhat.cloud.notifications.processors.email.aggregators.VulnerabilityEmailPayloadAggregator;
-import com.redhat.cloud.notifications.transformers.BaseTransformer;
-import io.vertx.core.json.JsonObject;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,8 +14,6 @@ import java.util.Map;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
 public class VulnerabilityTestHelpers {
-
-    public static BaseTransformer baseTransformer = new BaseTransformer();
 
     public static EmailAggregation createEmailAggregation(String bundle, String application, String eventType, String cve) {
         EmailAggregation aggregation = new EmailAggregation();
@@ -39,8 +35,8 @@ public class VulnerabilityTestHelpers {
                                                             .build())
                                     .build()
         ));
-        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
-        aggregation.setPayload(payload);
+
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
 
         return aggregation;
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregatorTest.java
@@ -1,12 +1,12 @@
 package com.redhat.cloud.notifications.processors.email.aggregators;
 
+import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
-import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Test;
@@ -84,7 +84,8 @@ public class ResourceOptimizationPayloadAggregatorTest {
         aggregation.setBundleName("rhel");
         aggregation.setApplicationName("resource-optimization");
         aggregation.setOrgId(DEFAULT_ORG_ID);
-        aggregation.setPayload(new BaseTransformer().toJsonObject(action));
+
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(action));
         return aggregation;
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/RhosakEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/RhosakEmailAggregatorTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.processors.email.aggregators;
 
+import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Event;
@@ -21,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
-import static com.redhat.cloud.notifications.TestHelpers.baseTransformer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -242,8 +242,7 @@ class RhosakEmailAggregatorTest {
         emailActionMessage.setAccountId(ACCOUNT_ID);
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
-        aggregation.setPayload(payload);
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
 
         return aggregation;
     }
@@ -281,8 +280,7 @@ class RhosakEmailAggregatorTest {
         emailActionMessage.setAccountId(ACCOUNT_ID);
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
-        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
-        aggregation.setPayload(payload);
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
 
         return aggregation;
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class BaseTransformerTest {
@@ -24,11 +26,14 @@ class BaseTransformerTest {
     // Below are the fixtures defined for the tests.
     private static final String FIXTURE_ACCOUNT_ID = "account-id-test";
     private static final String FIXTURE_APPLICATION = "application-test";
+    private static final String FIXTURE_APPLICATION_DISPLAY_NAME = "application-display-name-test";
     private static final String FIXTURE_BUNDLE = "bundle-test";
+    private static final String FIXTURE_BUNDLE_DISPLAY_NAME = "bundle-test-display-name";
     private static Context FIXTURE_CONTEXT;
     private static final String FIXTURE_CONTEXT_ADDITIONAL_PROPERTY = "context-additional-property";
     private static final String FIXTURE_CONTEXT_ADDITIONAL_PROPERTY_VALUE = "context-additional-property-value";
     private static final String FIXTURE_EVENT_TYPE = "event-type-test";
+    private static final String FIXTURE_EVENT_TYPE_DISPLAY_NAME = "event-type-display-name-test";
     private static List<Event> FIXTURE_EVENTS;
     private static final String FIXTURE_METADATA_ADDITIONAL_PROPERTY = "event-metadata-additional-property";
     private static final String FIXTURE_METADATA_ADDITIONAL_PROPERTY_VALUE = "event-metadata-additional-property-value";
@@ -64,11 +69,11 @@ class BaseTransformerTest {
     }
 
     /**
-     * Tests that a proper JSON payload is generated from a fully populated {@link Action}.
+     * Tests that a proper JSON payload is generated from a fully populated {@link Event}.
      */
     @Test
     void toJsonObjectTest() {
-        Action action = new Action();
+        final Action action = new Action();
 
         action.setAccountId(FIXTURE_ACCOUNT_ID);
         action.setApplication(FIXTURE_APPLICATION);
@@ -79,8 +84,16 @@ class BaseTransformerTest {
         action.setOrgId(FIXTURE_ORG_ID);
         action.setTimestamp(FIXTURE_TIMESTAMP);
 
+        // Create an event for the "toJsonObject" function.
+        com.redhat.cloud.notifications.models.Event event = new com.redhat.cloud.notifications.models.Event();
+        event.setApplicationDisplayName(FIXTURE_APPLICATION_DISPLAY_NAME);
+        event.setBundleDisplayName(FIXTURE_BUNDLE_DISPLAY_NAME);
+        event.setEventTypeDisplayName(FIXTURE_EVENT_TYPE_DISPLAY_NAME);
+
+        event.setAction(action);
+
         // Call the function under test.
-        JsonObject result = this.baseTransformer.toJsonObject(action);
+        final JsonObject result = this.baseTransformer.toJsonObject(event);
 
         // Assert the values.
         assertEquals(action.getAccountId(), result.getString(BaseTransformer.ACCOUNT_ID), "the account id isn't the same");
@@ -89,6 +102,17 @@ class BaseTransformerTest {
         assertEquals(action.getEventType(), result.getString(BaseTransformer.EVENT_TYPE), "the event type isn't the same");
         assertEquals(action.getOrgId(), result.getString(BaseTransformer.ORG_ID), "the org id isn't the same");
         assertEquals(action.getTimestamp(), LocalDateTime.parse(result.getString(BaseTransformer.TIMESTAMP)), "the timestamp isn't the same");
+
+        // Assert the display names in the "source" key.
+        final JsonObject source = result.getJsonObject("source");
+        assertNotNull(source, String.format("the \"source\" object is missing from the resulting JSON: %s", result));
+
+        final JsonObject application = source.getJsonObject(BaseTransformer.APPLICATION);
+        Assertions.assertEquals(FIXTURE_APPLICATION_DISPLAY_NAME, application.getString(BaseTransformer.DISPLAY_NAME), "the display name of the application is incorrect");
+        final JsonObject bundle = source.getJsonObject(BaseTransformer.BUNDLE);
+        Assertions.assertEquals(FIXTURE_BUNDLE_DISPLAY_NAME, bundle.getString(BaseTransformer.DISPLAY_NAME), "the display name of the bundle is incorrect");
+        final JsonObject eventType = source.getJsonObject(BaseTransformer.EVENT_TYPE);
+        Assertions.assertEquals(FIXTURE_EVENT_TYPE_DISPLAY_NAME, eventType.getString(BaseTransformer.DISPLAY_NAME), "the display name of the event type is incorrect");
 
         // Assert that the expected context is present in the JSON output.
         if (!result.containsKey(BaseTransformer.CONTEXT)) {


### PR DESCRIPTION
The idea is to make the messages more user friendly, by allowing them to chose the more friendlier bundle display name, instead of it's schematic name.

I was initially going to have just one single `toJsonObject` which took an `Event`, but I was unsure about which approach was better. So I decided to have two instead, but I'm open to discussing this :eyes:

## Links

[[RHCLOUD-22667]](https://issues.redhat.com/browse/RHCLOUD-22667)