### PR TITLE
Shorten RHOSE log entry to fix Kibana dashboard

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelTypeProcessor.java
@@ -194,7 +194,7 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
             long endTime;
             NotificationHistory history = getHistoryStub(endpoint, event, 0L, historyId);
             try {
-                callOpenBridge(payload, historyId, orgId, camelProperties, integrationName, originalEventId);
+                callOpenBridge(payload, historyId, orgId, camelProperties, endpoint.getSubType(), originalEventId);
                 history.setStatus(NotificationStatus.SENT);
             } catch (Exception e) {
                 history.setStatus(NotificationStatus.FAILED_INTERNAL);
@@ -241,7 +241,7 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
 
     }
 
-    private void callOpenBridge(JsonObject body, UUID id, String orgId, CamelProperties camelProperties, String integrationName, String originalEventId) {
+    private void callOpenBridge(JsonObject body, UUID id, String orgId, CamelProperties camelProperties, String endpointSubType, String originalEventId) {
 
         if (!featureFlipper.isObEnabled()) {
             Log.debug("Ob not enabled, doing nothing");
@@ -261,8 +261,8 @@ public class CamelTypeProcessor extends EndpointTypeProcessor {
         ce.put("originaleventid", originalEventId);
         // TODO add dataschema
 
-        Log.infof("SE: Sending Event with historyId=%s, orgId=%s, processorName=%s, processorId=%s, integration=%s, origId=%s",
-                id.toString(), orgId, extras.get(PROCESSORNAME), extras.get("processorId"), integrationName, originalEventId);
+        Log.infof("SE: Sending Event with historyId=%s, orgId=%s, processorName=%s, processorId=%s, action=%s, origId=%s",
+                id.toString(), orgId, extras.get(PROCESSORNAME), extras.get("processorId"), endpointSubType, originalEventId);
 
         body.remove(NOTIF_METADATA_KEY); // Not needed on OB
         ce.put("data", body);


### PR DESCRIPTION
Kibana has a [256 chars limit](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html) for log entry messages that are indexed. If that limit is exceeded, the messages are still displayed in the Kibana UI but they can't be queried to build Kibana dashboards.

This PR removes the integration name from our log entry which guarantees that the log entry will never exceed 256 characters. We didn't really need that name in the first place. The `processorName` field of the log entry already contains the endpoint ID from the Notifications DB.