### PR TITLE
[RHCLOUD-22065] feature: Clowder environment variables for the Sources integration

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -203,6 +203,8 @@ objects:
           value: ${QUARKUS_REST_CLIENT_OB_URL}
         - name: QUARKUS_REST_CLIENT_KC_URL
           value: ${QUARKUS_REST_CLIENT_KC_URL}
+        - name: NOTIFICATIONS_USE_SOURCES_SECRETS_BACKEND
+          value: ${SOURCES_ENABLED}
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -337,3 +339,6 @@ parameters:
 - name: FLOORIST_LOGLEVEL
   description: Floorist loglevel config
   value: 'INFO'
+- name: SOURCES_ENABLED
+  description: Is the Sources integration enabled? This makes the backend store the endpoint properties' secrets there.
+  value: "false"


### PR DESCRIPTION
I forgot to include the required environment variables to be able to enable the Sources integration in Clowder.

## Links

[RHCLOUD-22065](https://issues.redhat.com/browse/RHCLOUD-22065)