### PR TITLE
[RHCLOUD-22065] fix: reference to the Sources endpoint in the properties

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -79,4 +79,4 @@ quarkus.scheduler.metrics.enabled=true
 
 # Sources integration URLs and details. It is used to store the secrets' data for the camel and webhook endpoints.
 quarkus.rest-client.sources.read-timeout=1000
-quarkus.rest-client.sources.url=${clowder.endpoints.sources-api:http://localhost:8000}
+quarkus.rest-client.sources.url=${clowder.endpoints.sources-api-svc:http://localhost:8000}


### PR DESCRIPTION
We need to reference the ClowdApp name plus the deployment name for it to work.

## Links

[RHCLOUD-22065](https://issues.redhat.com/browse/RHCLOUD-22065)