### PR TITLE
[RHCLOUD-22065] Sources logs tweaks

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
@@ -106,7 +106,7 @@ public class SecretUtils {
             if (basicAuthId != null) {
                 if (this.isBasicAuthNullOrBlank(basicAuth)) {
                     this.sourcesService.delete(basicAuthId);
-                    Log.infof("[endpoint_id: %s] Basic authentication secret deleted in Sources during an endpoint update operation", endpoint.getId());
+                    Log.infof("[endpoint_id: %s][secret_id: %s] Basic authentication secret deleted in Sources during an endpoint update operation", endpoint.getId(), basicAuthId);
 
                     props.setBasicAuthenticationSourcesId(null);
                 } else {

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
@@ -65,7 +65,7 @@ public class SecretUtils {
             if (!this.isBasicAuthNullOrBlank(basicAuth)) {
                 final long id = this.createBasicAuthentication(basicAuth);
 
-                Log.infof("[endpoint_id: %s][secret_id: %s] Basic authentication secret created in Sources", endpoint.getId(), id);
+                Log.infof("[secret_id: %s] Basic authentication secret created in Sources", id);
 
                 props.setBasicAuthenticationSourcesId(id);
             }
@@ -74,7 +74,7 @@ public class SecretUtils {
             if (secretToken != null && !secretToken.isBlank()) {
                 final long id = this.createSecretTokenSecret(secretToken);
 
-                Log.infof("[endpoint_id: %s][secret_id: %s] Secret token secret created in Sources", endpoint.getId(), id);
+                Log.infof("[secret_id: %s] Secret token secret created in Sources", id);
 
                 props.setSecretTokenSourcesId(id);
             }

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
@@ -120,7 +120,7 @@ public class SecretUtils {
                 }
             } else {
                 if (this.isBasicAuthNullOrBlank(basicAuth)) {
-                    Log.infof("[endpoint_id: %s] Basic authentication secret not created in Sources: the basic authentication object is null", endpoint.getId());
+                    Log.debugf("[endpoint_id: %s] Basic authentication secret not created in Sources: the basic authentication object is null", endpoint.getId());
                 } else {
                     final long id = this.createBasicAuthentication(basicAuth);
                     Log.infof("[endpoint_id: %s][secret_id: %s] Basic authentication secret created in Sources during an endpoint update operation", endpoint.getId(), id);
@@ -148,7 +148,7 @@ public class SecretUtils {
                 }
             } else {
                 if (secretToken == null || secretToken.isBlank()) {
-                    Log.infof("[endpoint_id: %s] Secret token secret not created in Sources: the secret token object is null or blank", endpoint.getId());
+                    Log.debugf("[endpoint_id: %s] Secret token secret not created in Sources: the secret token object is null or blank", endpoint.getId());
                 } else {
                     final long id = this.createSecretTokenSecret(secretToken);
 


### PR DESCRIPTION
Basically:

* Includes the created secret ID for all the log statements that make sense to have it.
* Puts the "the secret was not created due to null/blank objects" log statement in the "debug" level.
* Removes the endpoint's IDs when creating the secrets, because at that point the endpoints are not yet persisted, and their IDs are null.


## Links

[[RHCLOUD-22065]](https://issues.redhat.com/browse/RHCLOUD-22065)