### PR TITLE
RHCLOUD-22344 Fail requests with unknown sort configuration

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -15,8 +15,7 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public class Query {
 
-    // NOTIF-674 Change to "^[a-z0-9_-]+(:(asc|desc))?$" after the IQE test stops using the .
-    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9._-]+(:(asc|desc))?$", CASE_INSENSITIVE);
+    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9_-]+(:(asc|desc))?$", CASE_INSENSITIVE);
 
     private static final int DEFAULT_RESULTS_PER_PAGE  = 20;
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -17,7 +17,8 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public class Query {
 
-    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9_-]+(:(asc|desc))?$", CASE_INSENSITIVE);
+    // NOTIF-674 Change to "^[a-z0-9_-]+(:(asc|desc))?$" after the frontend has been updated
+    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9._-]+(:(asc|desc))?$", CASE_INSENSITIVE);
 
     private static final int DEFAULT_RESULTS_PER_PAGE = 20;
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -174,7 +174,7 @@ public class Query {
         }
 
         if (sortFields == null) {
-            Log.errorf("Sort fields are not set - this mean that an API is using sorting without specifying what sort values are allowed");
+            Log.error("Sort fields are not set - this means that an API is using sorting without specifying what sort values are allowed");
             throw new InternalServerErrorException("SortFields are not set");
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.db;
 
+import io.quarkus.logging.Log;
 import io.sentry.Sentry;
 
 import javax.ws.rs.BadRequestException;
@@ -8,6 +9,7 @@ import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.QueryParam;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -17,7 +19,7 @@ public class Query {
 
     private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9_-]+(:(asc|desc))?$", CASE_INSENSITIVE);
 
-    private static final int DEFAULT_RESULTS_PER_PAGE  = 20;
+    private static final int DEFAULT_RESULTS_PER_PAGE = 20;
 
     @QueryParam("limit")
     @DefaultValue(DEFAULT_RESULTS_PER_PAGE + "")
@@ -38,6 +40,7 @@ public class Query {
 
     private String defaultSortBy;
     private Map<String, String> sortFields;
+    private Set<String> deprecatedSortFields;
 
     // Used by test
     public static Query queryWithSortBy(String sortBy) {
@@ -47,12 +50,24 @@ public class Query {
     }
 
     public void setSortFields(Map<String, String> sortFields) {
+        setSortFields(sortFields, null);
+    }
+
+    public void setSortFields(Map<String, String> sortFields, Set<String> deprecatedSortFields) {
         sortFields.keySet().forEach(key -> {
             if (!key.toLowerCase().equals(key)) {
                 throw new IllegalArgumentException("All keys of sort fields must be specified in lower case");
             }
         });
         this.sortFields = Map.copyOf(sortFields);
+        if (deprecatedSortFields != null) {
+            deprecatedSortFields.forEach(key -> {
+                if (!sortFields.containsKey(key)) {
+                    throw new IllegalArgumentException("Deprecated field not found in sort fields: " + key);
+                }
+            });
+            this.deprecatedSortFields = Set.copyOf(deprecatedSortFields);
+        }
     }
 
     public void setDefaultSortBy(String defaultSortBy) {
@@ -169,10 +184,16 @@ public class Query {
 
         String[] sortSplit = sortBy.split(":");
         Sort sort = new Sort(sortSplit[0]);
-        if (!sortFields.containsKey(sort.sortColumn.toLowerCase())) {
+        final String lowerCaseSortColumn = sort.sortColumn.toLowerCase();
+        if (!sortFields.containsKey(lowerCaseSortColumn)) {
             throw new BadRequestException("Unknown sort field specified: " + sort.sortColumn);
         } else {
-            sort.sortColumn = sortFields.get(sort.sortColumn.toLowerCase());
+            // NOTIF-674 Delete after confirming all deprecated fields are no longer used
+            if (deprecatedSortFields != null && deprecatedSortFields.contains(lowerCaseSortColumn)) {
+                Log.warnf("NOTIF-674 Using deprecated sort field: %s", lowerCaseSortColumn);
+            }
+
+            sort.sortColumn = sortFields.get(lowerCaseSortColumn);
         }
 
         if (sortSplit.length > 1) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -1,7 +1,6 @@
 package com.redhat.cloud.notifications.db;
 
 import io.quarkus.logging.Log;
-import io.sentry.Sentry;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications.db;
 
-import io.quarkus.logging.Log;
 import io.sentry.Sentry;
 
 import javax.ws.rs.BadRequestException;
@@ -16,7 +15,7 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public class Query {
 
-    // NOTIF-674 Change to "^[a-z0-9_-]+(:(asc|desc))?$" after the frontend has been updated
+    // NOTIF-674 Change to "^[a-z0-9_-]+(:(asc|desc))?$" after the IQE test stops using the .
     private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9._-]+(:(asc|desc))?$", CASE_INSENSITIVE);
 
     private static final int DEFAULT_RESULTS_PER_PAGE  = 20;

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -174,9 +174,8 @@ public class Query {
         }
 
         if (sortFields == null) {
-            InternalServerErrorException isee = new InternalServerErrorException("SortFields are not set");
-            Sentry.captureException(isee);
-            throw isee;
+            Log.errorf("Sort fields are not set - this mean that an API is using sorting without specifying what sort values are allowed");
+            throw new InternalServerErrorException("SortFields are not set");
         }
 
         if (!SORT_BY_PATTERN.matcher(sortBy).matches()) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -186,7 +186,7 @@ public class ApplicationRepository {
 
     public List<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId, String eventTypeName) {
         if (limiter != null) {
-            limiter.setSortFields(EventType.SORT_FIELDS);
+            limiter.setSortFields(EventType.SORT_FIELDS, EventType.DEPRECATED_SORT_FIELDS);
         }
 
         return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -418,7 +418,7 @@ public class BehaviorGroupRepository {
         String query = "SELECT bg FROM BehaviorGroup bg JOIN bg.behaviors b WHERE (bg.orgId = :orgId OR bg.orgId IS NULL) AND b.eventType.id = :eventTypeId";
 
         if (limiter != null) {
-            limiter.setSortFields(BehaviorGroup.SORT_FIELDS);
+            limiter.setSortFields(BehaviorGroup.SORT_FIELDS, BehaviorGroup.DEPRECATED_SORT_FIELDS);
             query = limiter.getModifiedQuery(query);
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
@@ -30,7 +30,7 @@ public class NotificationRepository {
         query += ") FROM NotificationHistory nh WHERE nh.endpoint.id = :endpointId AND nh.event.orgId = :orgId";
 
         if (limiter != null) {
-            limiter.setSortFields(NotificationHistory.SORT_FIELDS);
+            limiter.setSortFields(NotificationHistory.SORT_FIELDS, NotificationHistory.DEPRECATED_SORT_FIELDS);
             query = limiter.getModifiedQuery(query);
         }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -416,15 +416,6 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
                 Query.Sort.Order.ASC,
                 IntStream.range(0, 10).boxed().map(Object::toString).collect(Collectors.toList())
         );
-
-        // NOTIF-674 Remove these entries after the frontend has been updated
-        TestHelpers.testSorting(
-                "displayname",
-                query -> behaviorGroupRepository.findBehaviorGroupsByEventTypeId(DEFAULT_ORG_ID, eventType.getId(), query),
-                behaviorGroups -> behaviorGroups.stream().map(BehaviorGroup::getDisplayName).collect(Collectors.toList()),
-                Query.Sort.Order.ASC,
-                IntStream.range(0, 10).boxed().map(Object::toString).collect(Collectors.toList())
-        );
     }
 
     @Transactional

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -416,6 +416,15 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
                 Query.Sort.Order.ASC,
                 IntStream.range(0, 10).boxed().map(Object::toString).collect(Collectors.toList())
         );
+
+        // NOTIF-674 Remove these entries after the frontend has been updated
+        TestHelpers.testSorting(
+                "displayname",
+                query -> behaviorGroupRepository.findBehaviorGroupsByEventTypeId(DEFAULT_ORG_ID, eventType.getId(), query),
+                behaviorGroups -> behaviorGroups.stream().map(BehaviorGroup::getDisplayName).collect(Collectors.toList()),
+                Query.Sort.Order.ASC,
+                IntStream.range(0, 10).boxed().map(Object::toString).collect(Collectors.toList())
+        );
     }
 
     @Transactional

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -1013,8 +1013,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .when()
                 .get("/endpoints?limit=100")
                 .then()
-                // NOTIF-674 Should have status code 400
-                .statusCode(500);
+                .statusCode(400);
 
     }
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -37,7 +37,15 @@ import static javax.persistence.FetchType.LAZY;
 public class BehaviorGroup extends CreationUpdateTimestamped {
 
     public static final Map<String, String> SORT_FIELDS = Map.of(
-            "display_name", "bg.displayName"
+            "display_name", "bg.displayName",
+
+            // NOTIF-674 Remove these entries after the frontend has been updated
+            "displayname", "bg.displayName"
+    );
+
+    // NOTIF-674 Delete after confirming all deprecated fields are no longer used
+    public static final Set<String> DEPRECATED_SORT_FIELDS = Set.of(
+            "displayname"
     );
 
     @Id

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BehaviorGroup.java
@@ -37,10 +37,7 @@ import static javax.persistence.FetchType.LAZY;
 public class BehaviorGroup extends CreationUpdateTimestamped {
 
     public static final Map<String, String> SORT_FIELDS = Map.of(
-            "display_name", "bg.displayName",
-
-            // NOTIF-674 Remove these entries after the frontend has been updated
-            "displayname", "bg.displayName"
+            "display_name", "bg.displayName"
     );
 
     @Id

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -38,9 +38,7 @@ public class EventType {
     public static final Map<String, String> SORT_FIELDS = Map.of(
             "name", "name",
             "display_name", "e.displayName",
-            "application", "e.application.displayName",
-            // NOTIF-674 Remove after IQE tests are updated
-            "e.name", "e.name"
+            "application", "e.application.displayName"
     );
 
     @Id

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -39,9 +39,6 @@ public class EventType {
             "name", "name",
             "display_name", "e.displayName",
             "application", "e.application.displayName",
-            // NOTIF-674 Remove these entries after the frontend has been updated
-            "e.application.displayname", "e.application.displayName",
-            "e.displayname", "e.displayName",
             // NOTIF-674 Remove after IQE tests are updated
             "e.name", "e.name"
     );

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -38,7 +38,17 @@ public class EventType {
     public static final Map<String, String> SORT_FIELDS = Map.of(
             "name", "name",
             "display_name", "e.displayName",
-            "application", "e.application.displayName"
+            "application", "e.application.displayName",
+            // NOTIF-674 Remove these entries after the frontend has been updated
+            "e.application.displayname", "e.application.displayName",
+            "e.displayname", "e.displayName",
+            // NOTIF-674 Remove after IQE tests are updated
+            "e.name", "e.name"
+    );
+
+    // NOTIF-674 Delete after confirming all deprecated fields are no longer used
+    public static final Set<String> DEPRECATED_SORT_FIELDS = Set.of(
+            "e.application.displayname", "e.displayname", "e.name"
     );
 
     @Id

--- a/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -18,6 +18,7 @@ import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
@@ -31,7 +32,16 @@ public class NotificationHistory extends CreationTimestamped {
             "created", "nh.created",
             "invocation_time", "nh.invocationTime",
             "invocation_result", "nh.invocationResult",
-            "status", "nh.status"
+            "status", "nh.status",
+            // NOTIF-674 Delete after the frontend has been updated
+            "nh.created", "nh.created",
+            "invocationtime", "nh.invocationTime",
+            "invocationresult", "nh.invocationResult"
+    );
+
+    // NOTIF-674 Delete after confirming all deprecated fields are no longer used
+    public static final Set<String> DEPRECATED_SORT_FIELDS = Set.of(
+            "nh.created", "invocationtime", "invocationresult"
     );
 
     @Id

--- a/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -36,12 +36,13 @@ public class NotificationHistory extends CreationTimestamped {
             // NOTIF-674 Delete after the frontend has been updated
             "nh.created", "nh.created",
             "invocationtime", "nh.invocationTime",
-            "invocationresult", "nh.invocationResult"
+            "invocationresult", "nh.invocationResult",
+            "endpoint_id", "endpoint_id"
     );
 
     // NOTIF-674 Delete after confirming all deprecated fields are no longer used
     public static final Set<String> DEPRECATED_SORT_FIELDS = Set.of(
-            "nh.created", "invocationtime", "invocationresult"
+            "nh.created", "invocationtime", "invocationresult", "endpoint_id"
     );
 
     @Id

--- a/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/NotificationHistory.java
@@ -31,11 +31,7 @@ public class NotificationHistory extends CreationTimestamped {
             "created", "nh.created",
             "invocation_time", "nh.invocationTime",
             "invocation_result", "nh.invocationResult",
-            "status", "nh.status",
-            // NOTIF-674 Delete after the frontend has been updated
-            "nh.created", "nh.created",
-            "invocationtime", "nh.invocationTime",
-            "invocationresult", "nh.invocationResult"
+            "status", "nh.status"
     );
 
     @Id


### PR DESCRIPTION
As confirmed by sentry - all the unknown columns used in the last 30 days come from the unknown sort tests (things like: `08EEXZP9vB`, `KSvIe2Qm5h`, etc).

There is however one using `endpoint_id` - which is used in  [EndpointResource.getEndpointHistory](https://github.com/RedHatInsights/notifications-backend/blob/f5ece5f791d33ebce78d5e59a4b12ef3399453a8/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java#L570-L575)

https://github.com/RedHatInsights/notifications-backend/blob/f5ece5f791d33ebce78d5e59a4b12ef3399453a8/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java#L570-L575

This is however useless, as all the contents belong to the same endpoint, so adding and marking as deprecated.