### PR TITLE
[RHCLOUD-22065] feature: include "sources-api" as a dependency on the engine

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -16,6 +16,7 @@ objects:
     - ingress
     - notifications-backend
     - rbac
+    - sources-api
     database:
       sharedDbAppName: notifications-backend
     kafkaTopics:


### PR DESCRIPTION
I forgot to include "sources-api" as a dependency for the engine, and that is making it complain that it doesn't find the Sources endpoint in the configuration file.

## Links

[[RHCLOUD-22065]](https://issues.redhat.com/browse/RHCLOUD-22065)