### PR TITLE
RHCLOUD-22519 Use RHOSE delete lifecycle

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointReadyChecker.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointReadyChecker.java
@@ -88,6 +88,9 @@ public class EndpointReadyChecker {
                 if ("failed".equals(status)) {
                     ep.setStatus(EndpointStatus.FAILED);
                 }
+                if ("deleted".equals(status)) {
+                    em.remove(ep);
+                }
             } catch (WebApplicationException wae) {
                 String path = "GET " + BASE_PATH + "/{bridgeId}/processors/{processorId}";
                 rhoseErrorMetricsRecorder.record(path, wae);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -365,8 +365,9 @@ public class EndpointResource {
             } catch (Exception ex) {
                 Log.warn("Deletion of processor failed: ", ex);
             }
+        } else {
+            endpointRepository.deleteEndpoint(orgId, id);
         }
-        endpointRepository.deleteEndpoint(orgId, id);
 
         // Clean up the secrets in Sources.
         if (this.featureFlipper.isSourcesUsedAsSecretsBackend()) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -659,6 +659,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
                     .when().delete("/endpoints/" + id)
                     .then()
                     .statusCode(204);
+
+            Endpoint endpoint = given()
+                    .header(identityHeader)
+                    .contentType(JSON)
+                    .body(Json.encode(ep))
+                    .when()
+                    .get("/endpoints/" + id)
+                    .then()
+                    .statusCode(200)
+                    .extract().as(Endpoint.class);
+
+            assertEquals(EndpointStatus.DELETING, endpoint.getStatus());
         }
 
         MockServerConfig.clearOpenBridgeEndpoints(bridge);


### PR DESCRIPTION
 Instead of immediatly delete the endpoints, if they are managed by RHOSE  mark them for deletion and start the deletion process in the processor