### PR TITLE
[RHCLOUD-22065] fix: NullPointerException when sending blank basic authentications

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SecretUtilsTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SecretUtilsTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
 
 @QuarkusTest
 public class SecretUtilsTest {
@@ -542,5 +543,37 @@ public class SecretUtilsTest {
         // Assert that the underlying "delete" function wasn't called at all, since neither the "basic authentication"
         // nor the "secret token" have valid IDs set.
         Mockito.verifyNoInteractions(this.sourcesServiceMock);
+    }
+
+    /**
+     * Tests that when a valid "basic authentication" object is passed, the function returns that it isn't blank.
+     */
+    @Test
+    void isBasicAuthNullOrBlankTest() {
+        final var basicAuth = new BasicAuthentication("username", "password");
+
+        Assertions.assertFalse(this.secretUtils.isBasicAuthNullOrBlank(basicAuth), "the basic authentication should have not been considered as blank");
+    }
+
+    /**
+     * Tests that when a blank "password" and "username" combination is given, the "basic authentication" object is
+     * considered blank.
+     */
+    @Test
+    void itIsBasicAuthNullOrBlankTest() {
+        final var blankBasicAuths = new ArrayList<BasicAuthentication>();
+
+        blankBasicAuths.add(new BasicAuthentication());
+        blankBasicAuths.add(new BasicAuthentication(null, null));
+        blankBasicAuths.add(new BasicAuthentication(null, ""));
+        blankBasicAuths.add(new BasicAuthentication("", null));
+        blankBasicAuths.add(new BasicAuthentication("", ""));
+        blankBasicAuths.add(new BasicAuthentication(null, "     "));
+        blankBasicAuths.add(new BasicAuthentication("     ", null));
+        blankBasicAuths.add(new BasicAuthentication("     ", "     "));
+
+        for (final var basicAuth : blankBasicAuths) {
+            Assertions.assertTrue(this.secretUtils.isBasicAuthNullOrBlank(basicAuth), "the basic authentication should have been considered as blank");
+        }
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.SourcesSecretable;
 import io.quarkus.logging.Log;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -225,11 +226,12 @@ public class SecretUtils {
      * @param basicAuthentication the object to check.
      * @return {@code true} if the object is null, or if the password and the username are blank.
      */
-    private boolean isBasicAuthNullOrBlank(final BasicAuthentication basicAuthentication) {
+    protected boolean isBasicAuthNullOrBlank(final BasicAuthentication basicAuthentication) {
         if (basicAuthentication == null) {
             return true;
         }
 
-        return basicAuthentication.getUsername().isBlank() && basicAuthentication.getPassword().isBlank();
+        // We use StringUtils instead of calling directly "isBlank" on the fields to avoid null pointer exceptions.
+        return StringUtils.isBlank(basicAuthentication.getPassword()) && StringUtils.isBlank(basicAuthentication.getUsername());
     }
 }


### PR DESCRIPTION
When sending blank passwords or usernames inside the basic authentication objects, the "isBlank" calls triggered a NullPointerException.

## Links

[[RHCLOUD-22065]](https://issues.redhat.com/browse/RHCLOUD-22065)