### PR TITLE
RHCLOUD-23167 Adding tests for EndpointReadyChecker

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -13,13 +13,16 @@ import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.HttpType;
+import com.redhat.cloud.notifications.models.IntegrationTemplate;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.NotificationStatus;
+import com.redhat.cloud.notifications.models.Template;
 import com.redhat.cloud.notifications.models.WebhookProperties;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -258,5 +261,28 @@ public class ResourceHelpers {
 
     public Boolean deleteDefaultBehaviorGroup(UUID behaviorGroupId) {
         return behaviorGroupRepository.deleteDefault(behaviorGroupId);
+    }
+
+    @Transactional
+    public void setupTransformationTemplate() {
+        // Set up the transformationTemplate in the DB if needed
+        try {
+            entityManager.createQuery("FROM IntegrationTemplate WHERE templateKind = :templateKind", IntegrationTemplate.class)
+                    .setParameter("templateKind", IntegrationTemplate.TemplateKind.DEFAULT)
+                    .getSingleResult();
+        } catch (NoResultException nre) {
+            // Not found, creating one
+            Template template = new Template();
+            template.setName("aTemplate");
+            template.setDescription("what's this?");
+            template.setData("Li la lu");
+            entityManager.persist(template);
+
+            IntegrationTemplate gt = new IntegrationTemplate();
+            gt.setTemplateKind(IntegrationTemplate.TemplateKind.DEFAULT);
+            gt.setIntegrationType("slack");
+            gt.setTheTemplate(template);
+            entityManager.persist(gt);
+        }
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointReadyCheckerTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointReadyCheckerTest.java
@@ -1,0 +1,318 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.Json;
+import com.redhat.cloud.notifications.MockServerConfig;
+import com.redhat.cloud.notifications.TestConstants;
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.models.CamelProperties;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointStatus;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.openbridge.Bridge;
+import com.redhat.cloud.notifications.openbridge.BridgeApiService;
+import com.redhat.cloud.notifications.openbridge.BridgeItemList;
+import com.redhat.cloud.notifications.openbridge.Processor;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class EndpointReadyCheckerTest {
+
+    @Inject
+    EndpointReadyChecker endpointReadyChecker;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @Inject
+    FeatureFlipper featureFlipper;
+
+    @InjectMock
+    @RestClient
+    BridgeApiService bridgeApiService;
+
+    @BeforeEach
+    void beforeEach() {
+        RestAssured.basePath = TestConstants.API_INTEGRATIONS_V_1_0;
+        featureFlipper.setObEnabled(true);
+    }
+
+    @AfterEach
+    void afterEach() {
+        featureFlipper.setObEnabled(false);
+    }
+
+    private final String UNUSED = "UNUSED";
+
+    @Test
+    public void testAddingReady() {
+        final String PROCESSOR_ID = "processor-add-ready";
+
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(UNUSED, UNUSED, UNUSED);
+        Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+
+        mockBridge();
+        mockAddProcessor(PROCESSOR_ID);
+
+        Map<String, Object> jsonEndpoint = createEndpoint(identityHeader);
+
+        assertEquals("PROVISIONING", jsonEndpoint.get("status"));
+
+        Processor processor = new Processor(UNUSED);
+        processor.setStatus("ready");
+        processor.setStatus_message("Its ready!");
+        mockProcessor(PROCESSOR_ID, processor);
+
+        endpointReadyChecker.execute();
+        Endpoint endpoint = resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint.get("id").toString()));
+
+        assertEquals(EndpointStatus.READY, endpoint.getStatus());
+    }
+
+    @Test
+    public void testAddingFailed() {
+        final String PROCESSOR_ID = "processor-add-failed";
+
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(UNUSED, UNUSED, UNUSED);
+        Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+
+        mockBridge();
+        mockAddProcessor(PROCESSOR_ID);
+
+        Map<String, Object> jsonEndpoint = createEndpoint(identityHeader);
+
+        assertEquals("PROVISIONING", jsonEndpoint.get("status"));
+
+        Processor processor = new Processor(UNUSED);
+        processor.setStatus("failed");
+        processor.setStatus_message("It failed to create :-(");
+        mockProcessor(PROCESSOR_ID, processor);
+
+        endpointReadyChecker.execute();
+        Endpoint endpoint = resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint.get("id").toString()));
+
+        assertEquals(EndpointStatus.FAILED, endpoint.getStatus());
+    }
+
+    @Test
+    public void testDeleting() {
+        final String PROCESSOR_ID = "processor-deleting";
+
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(UNUSED, UNUSED, UNUSED);
+        Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+
+        mockBridge();
+        mockAddProcessor(PROCESSOR_ID);
+
+        Map<String, Object> jsonEndpoint = createEndpoint(identityHeader);
+
+        assertEquals("PROVISIONING", jsonEndpoint.get("status"));
+
+        Processor processor = new Processor(UNUSED);
+        processor.setStatus("ready");
+        processor.setStatus_message("It is ready!");
+        mockProcessor(PROCESSOR_ID, processor);
+
+        endpointReadyChecker.execute();
+
+        // delete it now
+        deleteEndpoint(identityHeader, jsonEndpoint.get("id").toString());
+
+        // Verify it's marked for deletion
+        Endpoint endpoint = resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint.get("id").toString()));
+        assertEquals(EndpointStatus.DELETING, endpoint.getStatus());
+
+        processor.setStatus("deleted");
+        processor.setStatus_message("What processor?");
+        endpointReadyChecker.execute();
+
+        endpoint = resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint.get("id").toString()));
+        assertNull(endpoint);
+    }
+
+    @Test
+    public void multipleEndpointsAtOnce() {
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(UNUSED, UNUSED, UNUSED);
+        Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+
+        mockBridge();
+
+        final String PROCESSOR_1 = "processor-multiple-1";
+        final String PROCESSOR_2 = "processor-multiple-2";
+        final String PROCESSOR_3 = "processor-multiple-3";
+        final String PROCESSOR_4 = "processor-multiple-4";
+        final String PROCESSOR_5 = "processor-multiple-5";
+
+        mockAddProcessor(PROCESSOR_1);
+        Map<String, Object> jsonEndpoint1 = createEndpoint(identityHeader);
+
+        mockAddProcessor(PROCESSOR_2);
+        Map<String, Object> jsonEndpoint2 = createEndpoint(identityHeader);
+
+        // We are going to delete the first 2 processors - fishing their lifecycle to have them as ready.
+        Processor processor1 = new Processor(UNUSED);
+        processor1.setStatus("ready");
+        processor1.setStatus_message("It is ready!");
+        mockProcessor(PROCESSOR_1, processor1);
+
+        Processor processor2 = new Processor(UNUSED);
+        processor2.setStatus("ready");
+        processor2.setStatus_message("It is ready!");
+        mockProcessor(PROCESSOR_2, processor2);
+
+        endpointReadyChecker.execute();
+
+        deleteEndpoint(identityHeader, jsonEndpoint1.get("id").toString());
+        processor1.setStatus("deleted");
+
+        deleteEndpoint(identityHeader, jsonEndpoint2.get("id").toString());
+        processor2.setStatus("deleted");
+
+        // Continue creating other processors
+
+        // Ready
+        mockAddProcessor(PROCESSOR_3);
+        Map<String, Object> jsonEndpoint3 = createEndpoint(identityHeader);
+        Processor processor3 = new Processor(UNUSED);
+        processor3.setStatus("ready");
+        processor3.setStatus_message("It is ready!");
+        mockProcessor(PROCESSOR_3, processor3);
+
+        // Ready
+        mockAddProcessor(PROCESSOR_4);
+        Map<String, Object> jsonEndpoint4 = createEndpoint(identityHeader);
+        Processor processor4 = new Processor(UNUSED);
+        processor4.setStatus("ready");
+        processor4.setStatus_message("It is ready!");
+        mockProcessor(PROCESSOR_4, processor4);
+
+        // Failed
+        mockAddProcessor(PROCESSOR_5);
+        Map<String, Object> jsonEndpoint5 = createEndpoint(identityHeader);
+        Processor processor5 = new Processor(UNUSED);
+        processor5.setStatus("failed");
+        processor5.setStatus_message("It is ready!");
+        mockProcessor(PROCESSOR_5, processor5);
+
+        endpointReadyChecker.execute();
+
+        // Endpoint1 - deleted
+        assertNull(resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint1.get("id").toString())));
+
+        // Endpoint2 - deleted
+        assertNull(resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint2.get("id").toString())));
+
+        // Endpoint3 - ready
+        assertEquals(
+                EndpointStatus.READY,
+                resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint3.get("id").toString())).getStatus()
+        );
+
+        // Endpoint4 - ready
+        assertEquals(
+                EndpointStatus.READY,
+                resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint4.get("id").toString())).getStatus()
+        );
+
+        // Endpoint5 - failed
+        assertEquals(
+                EndpointStatus.FAILED,
+                resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint5.get("id").toString())).getStatus()
+        );
+    }
+
+    private Map<String, Object> createEndpoint(Header identityHeader) {
+        CamelProperties properties = new CamelProperties();
+        properties.setUrl("http://200.133.110.13");
+        properties.setExtras(new HashMap<>());
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("Endpoint1");
+        endpoint.setDescription(UNUSED);
+        endpoint.setEnabled(true);
+        endpoint.setType(EndpointType.CAMEL);
+        endpoint.setSubType("slack");
+        endpoint.setProperties(properties);
+
+        return given()
+                .header(identityHeader)
+                .when()
+                .contentType(JSON)
+                .body(Json.encode(endpoint))
+                .post("/endpoints")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(Map.class);
+    }
+
+    private void deleteEndpoint(Header identityHeader, String endpointId) {
+        given()
+                .header(identityHeader)
+                .when()
+                .contentType(JSON)
+                .delete("/endpoints/" + endpointId)
+                .then()
+                .statusCode(204);
+    }
+
+    private void mockBridge() {
+        Bridge bridge = new Bridge("321", "http://some.events/", "my bridge");
+        BridgeItemList<Bridge> bridgeList = new BridgeItemList<>();
+        bridgeList.setSize(1);
+        bridgeList.setTotal(1);
+        List<Bridge> items = new ArrayList<>();
+        items.add(bridge);
+        bridgeList.setItems(items);
+
+        Mockito.when(bridgeApiService.getBridgeByName(Mockito.anyString(), Mockito.anyString())).thenReturn(bridgeList);
+    }
+
+    private void mockAddProcessor(String processorId) {
+        Processor processor = new Processor("processor");
+        processor.setId(processorId);
+
+        Mockito.when(bridgeApiService.addProcessor(
+                Mockito.anyString(),
+                Mockito.anyString(),
+                Mockito.any())
+        ).thenReturn(processor);
+    }
+
+    private void mockProcessor(String processorId, Processor processor) {
+        Mockito.when(bridgeApiService.getProcessorById(
+                Mockito.anyString(),
+                Mockito.eq(processorId),
+                Mockito.anyString()
+        )).thenReturn(processor);
+    }
+
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointReadyCheckerTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointReadyCheckerTest.java
@@ -68,14 +68,16 @@ public class EndpointReadyCheckerTest {
     }
 
     private final String UNUSED = "UNUSED";
+    private final String ORG_ACCOUNT_ID = "ENDPOINT_READY_CHECKER_ID";
 
     @Test
     public void testAddingReady() {
         final String PROCESSOR_ID = "processor-add-ready";
 
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(UNUSED, UNUSED, UNUSED);
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(ORG_ACCOUNT_ID, ORG_ACCOUNT_ID, UNUSED);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+        resourceHelpers.setupTransformationTemplate();
 
         mockBridge();
         mockAddProcessor(PROCESSOR_ID);
@@ -90,7 +92,7 @@ public class EndpointReadyCheckerTest {
         mockProcessor(PROCESSOR_ID, processor);
 
         endpointReadyChecker.execute();
-        Endpoint endpoint = resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint.get("id").toString()));
+        Endpoint endpoint = resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint.get("id").toString()));
 
         assertEquals(EndpointStatus.READY, endpoint.getStatus());
     }
@@ -99,9 +101,10 @@ public class EndpointReadyCheckerTest {
     public void testAddingFailed() {
         final String PROCESSOR_ID = "processor-add-failed";
 
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(UNUSED, UNUSED, UNUSED);
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(ORG_ACCOUNT_ID, ORG_ACCOUNT_ID, UNUSED);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+        resourceHelpers.setupTransformationTemplate();
 
         mockBridge();
         mockAddProcessor(PROCESSOR_ID);
@@ -116,7 +119,7 @@ public class EndpointReadyCheckerTest {
         mockProcessor(PROCESSOR_ID, processor);
 
         endpointReadyChecker.execute();
-        Endpoint endpoint = resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint.get("id").toString()));
+        Endpoint endpoint = resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint.get("id").toString()));
 
         assertEquals(EndpointStatus.FAILED, endpoint.getStatus());
     }
@@ -125,9 +128,10 @@ public class EndpointReadyCheckerTest {
     public void testDeleting() {
         final String PROCESSOR_ID = "processor-deleting";
 
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(UNUSED, UNUSED, UNUSED);
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(ORG_ACCOUNT_ID, ORG_ACCOUNT_ID, UNUSED);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+        resourceHelpers.setupTransformationTemplate();
 
         mockBridge();
         mockAddProcessor(PROCESSOR_ID);
@@ -147,22 +151,23 @@ public class EndpointReadyCheckerTest {
         deleteEndpoint(identityHeader, jsonEndpoint.get("id").toString());
 
         // Verify it's marked for deletion
-        Endpoint endpoint = resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint.get("id").toString()));
+        Endpoint endpoint = resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint.get("id").toString()));
         assertEquals(EndpointStatus.DELETING, endpoint.getStatus());
 
         processor.setStatus("deleted");
         processor.setStatus_message("What processor?");
         endpointReadyChecker.execute();
 
-        endpoint = resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint.get("id").toString()));
+        endpoint = resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint.get("id").toString()));
         assertNull(endpoint);
     }
 
     @Test
     public void multipleEndpointsAtOnce() {
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(UNUSED, UNUSED, UNUSED);
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(ORG_ACCOUNT_ID, ORG_ACCOUNT_ID, UNUSED);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
+        resourceHelpers.setupTransformationTemplate();
 
         mockBridge();
 
@@ -226,27 +231,27 @@ public class EndpointReadyCheckerTest {
         endpointReadyChecker.execute();
 
         // Endpoint1 - deleted
-        assertNull(resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint1.get("id").toString())));
+        assertNull(resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint1.get("id").toString())));
 
         // Endpoint2 - deleted
-        assertNull(resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint2.get("id").toString())));
+        assertNull(resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint2.get("id").toString())));
 
         // Endpoint3 - ready
         assertEquals(
                 EndpointStatus.READY,
-                resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint3.get("id").toString())).getStatus()
+                resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint3.get("id").toString())).getStatus()
         );
 
         // Endpoint4 - ready
         assertEquals(
                 EndpointStatus.READY,
-                resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint4.get("id").toString())).getStatus()
+                resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint4.get("id").toString())).getStatus()
         );
 
         // Endpoint5 - failed
         assertEquals(
                 EndpointStatus.FAILED,
-                resourceHelpers.getEndpoint(UNUSED, UUID.fromString(jsonEndpoint5.get("id").toString())).getStatus()
+                resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint5.get("id").toString())).getStatus()
         );
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointReadyCheckerTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointReadyCheckerTest.java
@@ -154,6 +154,7 @@ public class EndpointReadyCheckerTest {
         Endpoint endpoint = resourceHelpers.getEndpoint(ORG_ACCOUNT_ID, UUID.fromString(jsonEndpoint.get("id").toString()));
         assertEquals(EndpointStatus.DELETING, endpoint.getStatus());
 
+        // Update the response to deleted
         processor.setStatus("deleted");
         processor.setStatus_message("What processor?");
         endpointReadyChecker.execute();
@@ -183,7 +184,7 @@ public class EndpointReadyCheckerTest {
         mockAddProcessor(PROCESSOR_2);
         Map<String, Object> jsonEndpoint2 = createEndpoint(identityHeader);
 
-        // We are going to delete the first 2 processors - fishing their lifecycle to have them as ready.
+        // We are going to delete the first 2 processors - finishing their lifecycle to have them as ready.
         Processor processor1 = new Processor(UNUSED);
         processor1.setStatus("ready");
         processor1.setStatus_message("It is ready!");

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -16,8 +16,6 @@ import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointStatus;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.HttpType;
-import com.redhat.cloud.notifications.models.IntegrationTemplate;
-import com.redhat.cloud.notifications.models.Template;
 import com.redhat.cloud.notifications.models.WebhookProperties;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidator;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidatorTest;
@@ -41,8 +39,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -91,9 +87,6 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @Inject
     EmailSubscriptionRepository emailSubscriptionRepository;
-
-    @Inject
-    EntityManager entityManager;
 
     @Inject
     BridgeHelper bridgeHelper;
@@ -563,7 +556,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
 
-        setupTransformationTemplate();
+        resourceHelpers.setupTransformationTemplate();
 
         CamelProperties cAttr = new CamelProperties();
         cAttr.setDisableSslVerification(false);
@@ -675,22 +668,6 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         MockServerConfig.clearOpenBridgeEndpoints(bridge);
         featureFlipper.setObEnabled(false);
-    }
-
-    @Transactional
-    void setupTransformationTemplate() {
-        // Set up the transformationTemplate in the DB
-        Template template = new Template();
-        template.setName("aTemplate");
-        template.setDescription("what's this?");
-        template.setData("Li la lu");
-        entityManager.persist(template);
-
-        IntegrationTemplate gt = new IntegrationTemplate();
-        gt.setTemplateKind(IntegrationTemplate.TemplateKind.DEFAULT);
-        gt.setIntegrationType("slack");
-        gt.setTheTemplate(template);
-        entityManager.persist(gt);
     }
 
     @Test


### PR DESCRIPTION
Adding some tests for the `EndpointReadyChecker`. 
The tests covers the add (success/failed) and deleting scenarios.
