### PR TITLE
Fix event type sort field

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -36,7 +36,7 @@ import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseS
 public class EventType {
 
     public static final Map<String, String> SORT_FIELDS = Map.of(
-            "name", "name",
+            "name", "e.name",
             "display_name", "e.displayName",
             "application", "e.application.displayName",
             // NOTIF-674 Remove these entries after the frontend has been updated


### PR DESCRIPTION
This should fix the following bug found by @Mishrasubha while calling `GET /eventTypes` with the `name` sort param:
> ERROR: column reference "name" is ambiguous