### PR TITLE
[RHCLOUD-23167] feature: return the "meta" information for the behavior group collection

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -42,6 +42,37 @@ public class BehaviorGroupRepository {
     @Inject
     FeatureFlipper featureFlipper;
 
+    /**
+     * Counts all the behavior groups by their org id and event type id.
+     * @param orgId the org id to filter with.
+     * @param eventTypeId the event type id to filter with.
+     * @return the number of behaviour groups.
+     */
+    public long countByEventTypeId(final String orgId, final UUID eventTypeId) {
+        final EventType eventType = this.entityManager.find(EventType.class, eventTypeId);
+        if (eventType == null) {
+            throw new NotFoundException("Event type not found");
+        }
+
+        final String query =
+            "SELECT " +
+                "count(bg) " +
+            "FROM " +
+                "BehaviorGroup AS bg " +
+            "JOIN " +
+                "bg.behaviors b " +
+            "WHERE " +
+                "(bg.orgId = :orgId OR bg.orgId IS NULL) " +
+            "AND " +
+                "b.eventType.id = :eventTypeId";
+
+        return this.entityManager
+            .createQuery(query, Long.class)
+            .setParameter("eventTypeId", eventTypeId)
+            .setParameter("orgId", orgId)
+            .getSingleResult();
+    }
+
     public BehaviorGroup createFull(String accountId, String orgId, @Valid BehaviorGroup behaviorGroup, List<UUID> endpoints, Set<UUID> eventTypes) {
         BehaviorGroup saved = create(accountId, orgId, behaviorGroup);
         if (endpoints != null) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -189,9 +189,22 @@ public class NotificationResource {
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve the behavior groups linked to an event type.")
     @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public List<BehaviorGroup> getLinkedBehaviorGroups(@Context SecurityContext sec, @PathParam("eventTypeId") UUID eventTypeId, @BeanParam @Valid Query query) {
+    public Page<BehaviorGroup> getLinkedBehaviorGroups(
+            @Context SecurityContext sec,
+            @PathParam("eventTypeId") UUID eventTypeId,
+            @BeanParam @Valid Query query,
+            @Context UriInfo uriInfo
+    ) {
         String orgId = getOrgId(sec);
-        return behaviorGroupRepository.findBehaviorGroupsByEventTypeId(orgId, eventTypeId, query);
+
+        final List<BehaviorGroup> behaviorGroups = this.behaviorGroupRepository.findBehaviorGroupsByEventTypeId(orgId, eventTypeId, query);
+        final long behaviorGroupCount = this.behaviorGroupRepository.countByEventTypeId(orgId, eventTypeId);
+
+        return new Page<>(
+            behaviorGroups,
+            PageLinksBuilder.build(uriInfo.getPath(), behaviorGroupCount, query.getLimit().getLimit(), query.getLimit().getOffset()),
+            new Meta(behaviorGroupCount)
+        );
     }
 
     @GET

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -87,8 +87,7 @@ public class NotificationResource {
         public List<BehaviorGroup> getLinkedBehaviorGroups(
                 @Context SecurityContext sec,
                 @PathParam("eventTypeId") UUID eventTypeId,
-                @BeanParam @Valid Query query,
-                @Context UriInfo uriInfo
+                @BeanParam @Valid Query query
         ) {
             String orgId = getOrgId(sec);
 
@@ -116,7 +115,7 @@ public class NotificationResource {
 
             return new Page<>(
                     behaviorGroups,
-                    PageLinksBuilder.build(uriInfo.getPath(), behaviorGroupCount, query.getLimit().getLimit(), query.getLimit().getOffset()),
+                    PageLinksBuilder.build(uriInfo.getPath(), behaviorGroupCount, query),
                     new Meta(behaviorGroupCount)
             );
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -79,12 +79,47 @@ public class NotificationResource {
 
     @Path(Constants.API_NOTIFICATIONS_V_1_0 + "/notifications")
     public static class V1 extends NotificationResource {
+        @GET
+        @Path("/eventTypes/{eventTypeId}/behaviorGroups")
+        @Produces(APPLICATION_JSON)
+        @Operation(summary = "Retrieve the behavior groups linked to an event type.")
+        @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+        public List<BehaviorGroup> getLinkedBehaviorGroups(
+                @Context SecurityContext sec,
+                @PathParam("eventTypeId") UUID eventTypeId,
+                @BeanParam @Valid Query query,
+                @Context UriInfo uriInfo
+        ) {
+            String orgId = getOrgId(sec);
 
+            return behaviorGroupRepository.findBehaviorGroupsByEventTypeId(orgId, eventTypeId, query);
+        }
     }
 
     @Path(Constants.API_NOTIFICATIONS_V_2_0 + "/notifications")
     public static class V2 extends NotificationResource {
+        @GET
+        @Path("/eventTypes/{eventTypeId}/behaviorGroups")
+        @Produces(APPLICATION_JSON)
+        @Operation(summary = "Retrieve the behavior groups linked to an event type.")
+        @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+        public Page<BehaviorGroup> getLinkedBehaviorGroups(
+                @Context SecurityContext sec,
+                @PathParam("eventTypeId") UUID eventTypeId,
+                @BeanParam @Valid Query query,
+                @Context UriInfo uriInfo
+        ) {
+            String orgId = getOrgId(sec);
 
+            final List<BehaviorGroup> behaviorGroups = this.behaviorGroupRepository.findBehaviorGroupsByEventTypeId(orgId, eventTypeId, query);
+            final long behaviorGroupCount = this.behaviorGroupRepository.countByEventTypeId(orgId, eventTypeId);
+
+            return new Page<>(
+                    behaviorGroups,
+                    PageLinksBuilder.build(uriInfo.getPath(), behaviorGroupCount, query.getLimit().getLimit(), query.getLimit().getOffset()),
+                    new Meta(behaviorGroupCount)
+            );
+        }
     }
 
     @GET
@@ -182,29 +217,6 @@ public class NotificationResource {
     public List<BehaviorGroup> getBehaviorGroupsAffectedByRemovalOfEndpoint(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         String orgId = getOrgId(sec);
         return behaviorGroupRepository.findBehaviorGroupsByEndpointId(orgId, endpointId);
-    }
-
-    @GET
-    @Path("/eventTypes/{eventTypeId}/behaviorGroups")
-    @Produces(APPLICATION_JSON)
-    @Operation(summary = "Retrieve the behavior groups linked to an event type.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public Page<BehaviorGroup> getLinkedBehaviorGroups(
-            @Context SecurityContext sec,
-            @PathParam("eventTypeId") UUID eventTypeId,
-            @BeanParam @Valid Query query,
-            @Context UriInfo uriInfo
-    ) {
-        String orgId = getOrgId(sec);
-
-        final List<BehaviorGroup> behaviorGroups = this.behaviorGroupRepository.findBehaviorGroupsByEventTypeId(orgId, eventTypeId, query);
-        final long behaviorGroupCount = this.behaviorGroupRepository.countByEventTypeId(orgId, eventTypeId);
-
-        return new Page<>(
-            behaviorGroups,
-            PageLinksBuilder.build(uriInfo.getPath(), behaviorGroupCount, query.getLimit().getLimit(), query.getLimit().getOffset()),
-            new Meta(behaviorGroupCount)
-        );
     }
 
     @GET

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -711,6 +711,10 @@ public class LifecycleITest extends DbIsolatedTest {
         // Check the "last" link.
         final String expectedLastValue = String.format("/api/notifications/v2.0/notifications/eventTypes/%s/behaviorGroups?limit=20&offset=0", eventTypeId);
         assertEquals(expectedLastValue, links.getString("last"), "the \"last\" link element contains an unexpected value");
+
+        // Check the "meta" object.
+        final JsonObject meta = responseBodyJson.getJsonObject("meta");
+        assertEquals(expectedBehaviorGroupIds.length, meta.getNumber("count"), "the \"meta\" \"count\" element contains an unexpected number");
     }
 
     private void retry(Supplier<Boolean> checkEndpointHistoryResult) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -659,7 +659,10 @@ public class LifecycleITest extends DbIsolatedTest {
                 .contentType(JSON)
                 .extract().body().asString();
 
-        JsonArray jsonBehaviorGroups = new JsonArray(responseBody);
+        // The response body contains the meta information about the history collection. We need to access the
+        // "data" array to access the elements.
+        final JsonObject responseBodyJson = new JsonObject(responseBody);
+        final JsonArray jsonBehaviorGroups = responseBodyJson.getJsonArray("data");
         assertEquals(expectedBehaviorGroupIds.length, jsonBehaviorGroups.size());
 
         for (String behaviorGroupId : expectedBehaviorGroupIds) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -687,8 +687,9 @@ public class LifecycleITest extends DbIsolatedTest {
                 .contentType(JSON)
                 .extract().body().asString();
 
-        // The response body contains the meta information about the history collection. We need to access the
-        // "data" array to access the elements.
+        // The response body contains the meta information about the collection
+        // of behavior groups. We need to access the "data" array to access the
+        // elements.
         final JsonObject responseBodyJson = new JsonObject(responseBody);
         final JsonArray jsonBehaviorGroups = responseBodyJson.getJsonArray("data");
         assertEquals(expectedBehaviorGroupIds.length, jsonBehaviorGroups.size());

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -699,6 +699,18 @@ public class LifecycleITest extends DbIsolatedTest {
                 fail("One of the expected behavior groups is not linked to the event type");
             }
         }
+
+        // Check the "meta" and "links" elements.
+        final JsonObject links = responseBodyJson.getJsonObject("links");
+        assertNotNull(links, "the \"links\" element is missing from the paged response");
+
+        // Check the "first" link.
+        final String expectedFirstValue = String.format("/api/notifications/v2.0/notifications/eventTypes/%s/behaviorGroups?limit=20&offset=0", eventTypeId);
+        assertEquals(expectedFirstValue, links.getString("first"), "the \"first\" link element contains an unexpected value");
+
+        // Check the "last" link.
+        final String expectedLastValue = String.format("/api/notifications/v2.0/notifications/eventTypes/%s/behaviorGroups?limit=20&offset=0", eventTypeId);
+        assertEquals(expectedLastValue, links.getString("last"), "the \"last\" link element contains an unexpected value");
     }
 
     private void retry(Supplier<Boolean> checkEndpointHistoryResult) {


### PR DESCRIPTION
This information was missing from the collection's response, and QE reported it, so this is why we are including it in the responses from now on.

## Links

[[RHCLOUD-23167]](https://issues.redhat.com/browse/RHCLOUD-21880)