### PR TITLE
RHCLOUD-22474 fix daily digest init date

### DIFF
--- a/aggregator/src/main/java/com/redhat/cloud/notifications/db/AggregationOrgConfigRepository.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/db/AggregationOrgConfigRepository.java
@@ -26,7 +26,7 @@ public class AggregationOrgConfigRepository {
 
         int createdEntries = entityManager.createNativeQuery(query)
             .setParameter("expectedRunningTime", defaultRunningTime)
-            .setParameter("lastRun", LocalDateTime.now(UTC).minusYears(1))
+            .setParameter("lastRun", LocalDateTime.now(UTC).minusDays(1))
             .executeUpdate();
 
         Log.infof("Default time preference must be created for %d OrgId", createdEntries);

--- a/database/src/main/resources/db/migration/V1.69.1__RHCLOUD-22474_reset_daily_digest_scheduling_table.sql
+++ b/database/src/main/resources/db/migration/V1.69.1__RHCLOUD-22474_reset_daily_digest_scheduling_table.sql
@@ -1,0 +1,1 @@
+DELETE FROM aggregation_org_config;


### PR DESCRIPTION
When a new OrgId have to be aggregted, the initialisation is one year in the past.
This date have no sens for the end user, but it is included on report email like `02 Dec 2021 - 7 policies triggered on 1 system`
