### PR TITLE
Initial write-up of Advisor daily digest notification aggregator

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -307,7 +307,7 @@ parameters:
   value: "false"
 - name: RHEL_ADVISOR_DAILY_DIGEST_ENABLED
   description: Is the daily digest enabled for the rhel/advisor app?
-  value: false
+  value: "false"
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -147,6 +147,8 @@ objects:
           value: ${RECIPIENT_PROVIDER_RBAC_ELEMENTS_PER_PAGE}
         - name: RECIPIENT_PROVIDER_USE_IT_IMPL
           value: ${RECIPIENT_PROVIDER_USE_IT_IMPL}
+        - name: RHEL_ADVISOR_DAILY_DIGEST_ENABLED
+          value: ${RHEL_ADVISOR_DAILY_DIGEST_ENABLED}
         - name: QUARKUS_CACHE_CAFFEINE_RBAC_RECIPIENT_USERS_PROVIDER_GET_USERS_EXPIRE_AFTER_WRITE
           value: ${RBAC_USERS_RETENTION_DELAY}
         - name: QUARKUS_CACHE_CAFFEINE_RBAC_RECIPIENT_USERS_PROVIDER_GET_GROUP_USERS_EXPIRE_AFTER_WRITE
@@ -303,6 +305,9 @@ parameters:
 - name: RECIPIENT_PROVIDER_USE_IT_IMPL
   description: Temporary recipients retrieval switch between RBAC and IT
   value: "false"
+- name: RHEL_ADVISOR_DAILY_DIGEST_ENABLED
+  description: Is the daily digest enabled for the rhel/advisor app?
+  value: false
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -9,7 +9,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-
 /*
  * Events are of the form:
  * {
@@ -88,36 +87,31 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
     private static final String EVENT_TYPE_KEY = "event_type";
     private static final String EVENTS_KEY = "events";
     private static final String PAYLOAD_KEY = "payload";
-    private static final String INVENTORY_ID = "inventory_id";
-    private static final String PAYLOAD_RULE_ID = "rule_id";
-    private static final String PAYLOAD_RULE_DESCRIPTION = "rule_description";
-    private static final String PAYLOAD_RULE_TOTAL_RISK = "total_risk";
-    private static final String PAYLOAD_RULE_HAS_INCIDENT = "has_incident";
-    private static final String PAYLOAD_RULE_URL = "rule_url";
 
-    // Advisor event payloads
-    private static final String NEW_RECOMMENDATION = "new_recommendation";
-    private static final String RESOLVED_RECOMMENDATION = "resolved_recommendation";
-    private static final String DEACTIVATED_RECOMMENDATION = "deactivated_recommendation";
+    public static final String PAYLOAD_RULE_ID = "rule_id";
+    public static final String PAYLOAD_RULE_DESCRIPTION = "rule_description";
+    public static final String PAYLOAD_RULE_TOTAL_RISK = "total_risk";
+    public static final String PAYLOAD_RULE_HAS_INCIDENT = "has_incident";
+    public static final String PAYLOAD_RULE_URL = "rule_url";
 
     // Advisor events aggregator data contents
-    private static final String ADVISOR_KEY = "advisor";
-    private static final String NEW_RECOMMENDATIONS = "new_recommendations";
-    private static final String RESOLVED_RECOMMENDATIONS = "resolved_recommendations";
-    private static final String DEACTIVATED_RECOMMENDATIONS = "deactivated_recommendations";
-    private static final String CONTENT_RULE_DESCRIPTION = "description";
-    private static final String CONTENT_RULE_TOTAL_RISK = "total_risk";
-    private static final String CONTENT_RULE_HAS_INCIDENT = "has_incident";
-    private static final String CONTENT_RULE_URL = "url";
-    private static final String CONTENT_SYSTEM_COUNT = "systems";
+    public static final String ADVISOR_KEY = "advisor";
+    public static final String NEW_RECOMMENDATIONS = "new_recommendations";
+    public static final String RESOLVED_RECOMMENDATIONS = "resolved_recommendations";
+    public static final String DEACTIVATED_RECOMMENDATIONS = "deactivated_recommendations";
+    public static final String CONTENT_RULE_DESCRIPTION = "description";
+    public static final String CONTENT_RULE_TOTAL_RISK = "total_risk";
+    public static final String CONTENT_RULE_HAS_INCIDENT = "has_incident";
+    public static final String CONTENT_RULE_URL = "url";
+    public static final String CONTENT_SYSTEM_COUNT = "systems";
 
     // Advisor event types
-    private static final String NEW_RECOMMENDATION_EVENT = "new-recommendation";
-    private static final String RESOLVED_RECOMMENDATION_EVENT = "resolved-recommendation";
-    private static final String DEACTIVATED_RULE_EVENT = "deactivated-rule";
+    public static final String NEW_RECOMMENDATION = "new-recommendation";
+    public static final String RESOLVED_RECOMMENDATION = "resolved-recommendation";
+    public static final String DEACTIVATED_RECOMMENDATION = "deactivated-recommendation";
     private static final Set<String> EVENT_TYPES = new HashSet<>(Arrays.asList(
-        NEW_RECOMMENDATION_EVENT, RESOLVED_RECOMMENDATION_EVENT,
-        DEACTIVATED_RULE_EVENT
+            NEW_RECOMMENDATION, RESOLVED_RECOMMENDATION,
+            DEACTIVATED_RECOMMENDATION
     ));
 
     // Advisor final payload helpers
@@ -137,7 +131,6 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
     @Override
     void processEmailAggregation(EmailAggregation notification) {
         JsonObject notifPayload = notification.getPayload();
-        JsonObject advisor = context.getJsonObject(ADVISOR_KEY);
         String eventType = notifPayload.getString(EVENT_TYPE_KEY);
         /* Major assumption: that there is at most one event per day from each
          * rule,system pair - i.e. that the tuple (day, rule, system) is

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -61,7 +61,7 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
     // Advisor event payloads
     private static final String NEW_RECOMMENDATION = "new_recommendation";
     private static final String RESOLVED_RECOMMENDATION = "resolved_recommendation";
-    private static final String DEACTIVATED_RECOMMENDATION = "resolved_recommendation";
+    private static final String DEACTIVATED_RECOMMENDATION = "deactivated_recommendation";
 
     // Advisor events aggregator data contents
     private static final String ADVISOR_KEY = "advisor";

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -10,6 +10,41 @@ import java.util.Map;
 import java.util.Set;
 
 
+/*
+ * Events are of the form:
+ * {
+   "bundle":"rhel",
+   "application":"advisor",
+   "event_type":"new-recommendation",
+   "timestamp":"2022-11-30T17:30:20.773398",
+   "account_id":"5758117",
+   "org_id":"7806094",
+   "context":{
+      "inventory_id":"6ad30f3e-0497-4e74-99f1-b3f9a6120a6f",
+      "hostname":"my-computer-jmartine",
+      "display_name":"my-computer-jmartine",
+      "rhel_version":"8.4",
+      "host_url":"https://console.redhat.com/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f",
+      "tags":[]
+   },
+   "events":[
+      {
+         "metadata":{},
+         "payload":{
+            "rule_id":"insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE",
+            "rule_description":"System is not able to get the latest recommendations and may miss bug fixes when the Insights Client Core egg file is outdated",
+            "total_risk":"2",
+            "publish_date":"2021-03-13T18:44:00+00:00",
+            "rule_url":"https://console.redhat.com/insights/advisor/recommendations/insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE/",
+            "reboot_required":false,
+            "has_incident":false,
+            "report_url":"https://console.redhat.com/insights/advisor/recommendations/insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f"
+         }
+      }
+   ]
+}
+ */
+
 public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregator {
 
     // Notification common
@@ -18,17 +53,26 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
     private static final String PAYLOAD_KEY = "payload";
     private static final String INVENTORY_ID = "inventory_id";
     private static final String PAYLOAD_RULE_ID = "rule_id";
+    private static final String PAYLOAD_RULE_DESCRIPTION = "rule_description";
+    private static final String PAYLOAD_RULE_TOTAL_RISK = "total_risk";
+    private static final String PAYLOAD_RULE_HAS_INCIDENT = "has_incident";
+    private static final String PAYLOAD_RULE_URL = "rule_url";
 
     // Advisor event payloads
     private static final String NEW_RECOMMENDATION = "new_recommendation";
     private static final String RESOLVED_RECOMMENDATION = "resolved_recommendation";
     private static final String DEACTIVATED_RECOMMENDATION = "resolved_recommendation";
 
-    // Advisor events aggregator
+    // Advisor events aggregator data contents
     private static final String ADVISOR_KEY = "advisor";
     private static final String NEW_RECOMMENDATIONS = "new_recommendations";
     private static final String RESOLVED_RECOMMENDATIONS = "resolved_recommendations";
     private static final String DEACTIVATED_RECOMMENDATIONS = "deactivated_recommendations";
+    private static final String CONTENT_RULE_DESCRIPTION = "description";
+    private static final String CONTENT_RULE_TOTAL_RISK = "total_risk";
+    private static final String CONTENT_RULE_HAS_INCIDENT = "has_incident";
+    private static final String CONTENT_RULE_URL = "url";
+    private static final String CONTENT_SYSTEM_COUNT = "systems";
 
     // Advisor event types
     private static final String NEW_RECOMMENDATION_EVENT = "new-recommendation";
@@ -40,9 +84,9 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
     ));
 
     // Advisor final payload helpers
-    private final Map<String, Set<String>> newRecommendations = new HashMap<>();
-    private final Map<String, Set<String>> resolvedRecommendations = new HashMap<>();
-    private final Set<String> deactivatedRecommendations = new HashSet<>();
+    private final Map<String, Map<String, Object>> newRecommendations = new HashMap<>();
+    private final Map<String, Map<String, Object>> resolvedRecommendations = new HashMap<>();
+    private final Map<String, Map<String, String>> deactivatedRecommendations = new HashMap<>();
 
     public AdvisorEmailPayloadAggregator() {
         JsonObject advisor = new JsonObject();
@@ -58,7 +102,13 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
         JsonObject notifPayload = notification.getPayload();
         JsonObject advisor = context.getJsonObject(ADVISOR_KEY);
         String eventType = notifPayload.getString(EVENT_TYPE_KEY);
-        String inventoryId = notifPayload.getJsonObject("context").getString(INVENTORY_ID);
+        /* Major assumption: that there is at most one event per day from each
+         * rule,system pair - i.e. that the tuple (day, rule, system) is
+         * unique for new, and resolved, events.  This is generally true,
+         * because a rule would have to be new twice or resolved twice - i.e.
+         * new, then resolved, then occur again - on the same system in order
+         * for this to not be wrong.  This means we don't need to remember the
+         * inventory ID of each system impacted by or resolving a rule. */
 
         if (!EVENT_TYPES.contains(eventType)) {
             return;
@@ -68,18 +118,43 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
             JsonObject event = (JsonObject) eventObject;
             JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
             String ruleId = payload.getString(PAYLOAD_RULE_ID);
+            String ruleDescription = payload.getString(PAYLOAD_RULE_DESCRIPTION);
+            String ruleRisk = payload.getString(PAYLOAD_RULE_TOTAL_RISK);
+            String ruleIncident = payload.getString(PAYLOAD_RULE_HAS_INCIDENT);
+            String ruleURL = payload.getString(PAYLOAD_RULE_URL);
 
             switch (eventType) {
-                case COMPLIANCE:
-                    newRecommendations.computeIfAbsent(
-                        ruleId, key -> new HashSet<String>()
-                    ).add(inventoryId);
+                case NEW_RECOMMENDATION:
+                    systemCount = newRecommendations.computeIfAbsent(
+                        ruleId, key -> new HashMap<>(Map.of(
+                            CONTENT_RULE_DESCRIPTION, ruleDescription,
+                            CONTENT_RULE_HAS_INCIDENT, ruleIncident,
+                            CONTENT_RULE_TOTAL_RISK, ruleRisk,
+                            CONTENT_RULE_URL, ruleURL,
+                            CONTENT_SYSTEM_COUNT, 0
+                        ))
+                    ).get(CONTENT_SYSTEM_COUNT);
+                    newRecommendations.set(CONTENT_SYSTEM_COUNT, systemCount + 1);
                 case RESOLVED_RECOMMENDATION:
-                    resolvedRecommendations.computeIfAbsent(
-                        ruleId, key -> new HashSet<String>()
-                    ).add(inventoryId);
+                    systemCount = resolvedRecommendations.computeIfAbsent(
+                        ruleId, key -> new HashMap<>(Map.of(
+                            CONTENT_RULE_DESCRIPTION, ruleDescription,
+                            CONTENT_RULE_HAS_INCIDENT, ruleIncident,
+                            CONTENT_RULE_TOTAL_RISK, ruleRisk,
+                            CONTENT_RULE_URL, ruleURL,
+                            CONTENT_SYSTEM_COUNT, 0
+                        ))
+                    ).get(CONTENT_SYSTEM_COUNT);
+                    resolvedRecommendations.set(CONTENT_SYSTEM_COUNT, systemCount + 1);
                 case DEACTIVATED_RECOMMENDATION:
-                    deactivatedRecommendations.add(ruleId);
+                    deactivatedRecommendations.computeIfAbsent(
+                        ruleId, key -> new HashMap<>(Map.of(
+                            CONTENT_RULE_DESCRIPTION, ruleDescription,
+                            CONTENT_RULE_HAS_INCIDENT, ruleIncident,
+                            CONTENT_RULE_TOTAL_RISK, ruleRisk,
+                            CONTENT_RULE_URL, ruleURL
+                        ))
+                    );
                 default:
                     break;
             }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -45,7 +45,7 @@ import java.util.Set;
 }
  */
 
-public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregator {
+public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
 
     // Notification common
     private static final String EVENT_TYPE_KEY = "event_type";
@@ -88,7 +88,7 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
     private final Map<String, Map<String, Object>> resolvedRecommendations = new HashMap<>();
     private final Map<String, Map<String, String>> deactivatedRecommendations = new HashMap<>();
 
-    public AdvisorEmailPayloadAggregator() {
+    public AdvisorEmailAggregator() {
         JsonObject advisor = new JsonObject();
         advisor.put(NEW_RECOMMENDATIONS, newRecommendations);
         advisor.put(RESOLVED_RECOMMENDATIONS, resolvedRecommendations);
@@ -135,7 +135,7 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
                         ))
                     );
                     ruleData.put(
-                        CONTENT_SYSTEM_COUNT, (Integer) ruleDat.get(CONTENT_SYSTEM_COUNT) + 1
+                        CONTENT_SYSTEM_COUNT, (Integer) ruleData.get(CONTENT_SYSTEM_COUNT) + 1
                     );
                     break;
                 case RESOLVED_RECOMMENDATION:
@@ -148,7 +148,9 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
                             CONTENT_SYSTEM_COUNT, 0
                         ))
                     );
-                    resolvedRecommendations.set(CONTENT_SYSTEM_COUNT, systemCount + 1);
+                    ruleData.put(
+                        CONTENT_SYSTEM_COUNT, (Integer) ruleData.get(CONTENT_SYSTEM_COUNT) + 1
+                    );
                     break;
                 case DEACTIVATED_RECOMMENDATION:
                     deactivatedRecommendations.computeIfAbsent(

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -4,8 +4,8 @@ import com.redhat.cloud.notifications.models.EmailAggregation;
 import io.vertx.core.json.JsonObject;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -43,6 +43,43 @@ import java.util.Set;
       }
    ]
 }
+ *
+ * Output should be of the form:
+ * {
+    "new_recommendations": {
+        "product_eol_check|NGINX_EOL_ERROR": {
+            "description": "Red Hat has discontinued support services as well as software maintenance services for the End-Of-Life nginx",
+            "total_risk": 4,
+            "has_incident": false,
+            "url": "https://console.redhat.com/insights/advisor/recommendations/product_eol_check|NGINX_EOL_ERROR",
+            "affected_systems": 33
+        },
+        "container_rhel_version_privileged|CONTAINER_RHEL_VERSION_PRIVILEGED": {
+            "description": "A privileged container running on a different RHEL version host is not compatible",
+            "total_risk": 4,
+            "has_incident": true,
+            "url": "https://console.redhat.com/insights/advisor/recommendations/container_rhel_version_privileged|CONTAINER_RHEL_VERSION_PRIVILEGED",
+            "affected_systems": 3
+        }
+    },
+    "resolved_recommendations": {
+        "auditd_daemon_log_file_oversize|AUDIT_DAEMON_LOG_FILE_OVERSIZE": {
+            "description": "The auditd service gets suspended when the size of the log file is over \"max_log_file\"",
+            "total_risk": 2,
+            "has_incident": true,
+            "url": "https://console.redhat.com/insights/advisor/recommendations/audit_daemon_log_file_oversize|AUDIT_DAEMON_LOG_FILE_OVERSIZE",
+            "affected_systems": 1
+        }
+    },
+    "deactivated_recommendations": {
+        "el6_to_el7_upgrade|RHEL6_TO_RHEL7_UPGRADE_AVAILABLE_V4": {
+            "description": "RHEL 6 system is eligible for an in-place upgrade to RHEL 7 using the Leapp utility",
+            "has_incident": false,
+            "url": "https://console.redhat.com/insights/advisor/recommendations/el6_to_el7_upgrade|RHEL6_TO_RHEL7_UPGRADE_AVAILABLE_V4",
+            "total_risk": 3
+        }
+    }
+}
  */
 
 public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -88,27 +88,22 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
     public static final String RESOLVED_RECOMMENDATION = "resolved-recommendation";
     public static final String DEACTIVATED_RECOMMENDATION = "deactivated-recommendation";
 
-    // Notification common
-    private static final String EVENT_TYPE_KEY = "event_type";
-    private static final String EVENTS_KEY = "events";
-    private static final String PAYLOAD_KEY = "payload";
-
-    public static final String PAYLOAD_RULE_ID = "rule_id";
-    public static final String PAYLOAD_RULE_DESCRIPTION = "rule_description";
-    public static final String PAYLOAD_RULE_TOTAL_RISK = "total_risk";
-    public static final String PAYLOAD_RULE_HAS_INCIDENT = "has_incident";
-    public static final String PAYLOAD_RULE_URL = "rule_url";
-
     // Advisor events aggregator data contents
     public static final String ADVISOR_KEY = "advisor";
     public static final String NEW_RECOMMENDATIONS = "new_recommendations";
     public static final String RESOLVED_RECOMMENDATIONS = "resolved_recommendations";
     public static final String DEACTIVATED_RECOMMENDATIONS = "deactivated_recommendations";
-    public static final String CONTENT_RULE_DESCRIPTION = "description";
-    public static final String CONTENT_RULE_TOTAL_RISK = "total_risk";
-    public static final String CONTENT_RULE_HAS_INCIDENT = "has_incident";
-    public static final String CONTENT_RULE_URL = "url";
+    public static final String RULE_ID = "rule_id";
+    public static final String RULE_DESCRIPTION = "rule_description";
+    public static final String TOTAL_RISK = "total_risk";
+    public static final String HAS_INCIDENT = "has_incident";
+    public static final String RULE_URL = "rule_url";
     public static final String CONTENT_SYSTEM_COUNT = "systems";
+
+    // Notification common
+    private static final String EVENT_TYPE_KEY = "event_type";
+    private static final String EVENTS_KEY = "events";
+    private static final String PAYLOAD_KEY = "payload";
 
     private static final Set<String> EVENT_TYPES = new HashSet<>(Arrays.asList(
             NEW_RECOMMENDATION, RESOLVED_RECOMMENDATION,
@@ -148,21 +143,21 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
         notifPayload.getJsonArray(EVENTS_KEY).stream().forEach(eventObject -> {
             JsonObject event = (JsonObject) eventObject;
             JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
-            String ruleId = payload.getString(PAYLOAD_RULE_ID);
-            String ruleDescription = payload.getString(PAYLOAD_RULE_DESCRIPTION);
-            String ruleRisk = payload.getString(PAYLOAD_RULE_TOTAL_RISK);
-            String ruleIncident = payload.getString(PAYLOAD_RULE_HAS_INCIDENT);
-            String ruleURL = payload.getString(PAYLOAD_RULE_URL);
+            String ruleId = payload.getString(RULE_ID);
+            String ruleDescription = payload.getString(RULE_DESCRIPTION);
+            String ruleRisk = payload.getString(TOTAL_RISK);
+            String ruleIncident = payload.getString(HAS_INCIDENT);
+            String ruleURL = payload.getString(RULE_URL);
             Map<String, Object> ruleData;
 
             switch (eventType) {
                 case NEW_RECOMMENDATION:
                     ruleData = newRecommendations.computeIfAbsent(
                         ruleId, key -> new HashMap<>(Map.of(
-                            CONTENT_RULE_DESCRIPTION, ruleDescription,
-                            CONTENT_RULE_HAS_INCIDENT, ruleIncident,
-                            CONTENT_RULE_TOTAL_RISK, ruleRisk,
-                            CONTENT_RULE_URL, ruleURL,
+                            RULE_DESCRIPTION, ruleDescription,
+                            HAS_INCIDENT, ruleIncident,
+                            TOTAL_RISK, ruleRisk,
+                            RULE_URL, ruleURL,
                             CONTENT_SYSTEM_COUNT, 0
                         ))
                     );
@@ -173,10 +168,10 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
                 case RESOLVED_RECOMMENDATION:
                     ruleData = resolvedRecommendations.computeIfAbsent(
                         ruleId, key -> new HashMap<>(Map.of(
-                            CONTENT_RULE_DESCRIPTION, ruleDescription,
-                            CONTENT_RULE_HAS_INCIDENT, ruleIncident,
-                            CONTENT_RULE_TOTAL_RISK, ruleRisk,
-                            CONTENT_RULE_URL, ruleURL,
+                            RULE_DESCRIPTION, ruleDescription,
+                            HAS_INCIDENT, ruleIncident,
+                            TOTAL_RISK, ruleRisk,
+                            RULE_URL, ruleURL,
                             CONTENT_SYSTEM_COUNT, 0
                         ))
                     );
@@ -187,10 +182,10 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
                 case DEACTIVATED_RECOMMENDATION:
                     deactivatedRecommendations.computeIfAbsent(
                         ruleId, key -> new HashMap<>(Map.of(
-                            CONTENT_RULE_DESCRIPTION, ruleDescription,
-                            CONTENT_RULE_HAS_INCIDENT, ruleIncident,
-                            CONTENT_RULE_TOTAL_RISK, ruleRisk,
-                            CONTENT_RULE_URL, ruleURL
+                            RULE_DESCRIPTION, ruleDescription,
+                            HAS_INCIDENT, ruleIncident,
+                            TOTAL_RISK, ruleRisk,
+                            RULE_URL, ruleURL
                         ))
                     );
                     break;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -125,7 +125,7 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
 
             switch (eventType) {
                 case NEW_RECOMMENDATION:
-                    systemCount = newRecommendations.computeIfAbsent(
+                    Map<String, Object> ruleData = newRecommendations.computeIfAbsent(
                         ruleId, key -> new HashMap<>(Map.of(
                             CONTENT_RULE_DESCRIPTION, ruleDescription,
                             CONTENT_RULE_HAS_INCIDENT, ruleIncident,
@@ -133,10 +133,13 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
                             CONTENT_RULE_URL, ruleURL,
                             CONTENT_SYSTEM_COUNT, 0
                         ))
-                    ).get(CONTENT_SYSTEM_COUNT);
-                    newRecommendations.set(CONTENT_SYSTEM_COUNT, systemCount + 1);
+                    );
+                    ruleData.put(
+                        CONTENT_SYSTEM_COUNT, (Integer) ruleDat.get(CONTENT_SYSTEM_COUNT) + 1
+                    );
+                    break;
                 case RESOLVED_RECOMMENDATION:
-                    systemCount = resolvedRecommendations.computeIfAbsent(
+                    Map<String, Object> ruleData = resolvedRecommendations.computeIfAbsent(
                         ruleId, key -> new HashMap<>(Map.of(
                             CONTENT_RULE_DESCRIPTION, ruleDescription,
                             CONTENT_RULE_HAS_INCIDENT, ruleIncident,
@@ -144,8 +147,9 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
                             CONTENT_RULE_URL, ruleURL,
                             CONTENT_SYSTEM_COUNT, 0
                         ))
-                    ).get(CONTENT_SYSTEM_COUNT);
+                    );
                     resolvedRecommendations.set(CONTENT_SYSTEM_COUNT, systemCount + 1);
+                    break;
                 case DEACTIVATED_RECOMMENDATION:
                     deactivatedRecommendations.computeIfAbsent(
                         ruleId, key -> new HashMap<>(Map.of(
@@ -155,6 +159,7 @@ public class AdvisorEmailPayloadAggregator extends AbstractEmailPayloadAggregato
                             CONTENT_RULE_URL, ruleURL
                         ))
                     );
+                    break;
                 default:
                     break;
             }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -74,10 +74,9 @@ public class AdvisorDailyDigestEmailPayloadAggregator extends AbstractEmailPaylo
                     ruleId, key -> new HashSet<String>()
                 ).add(inventoryId);
             } else if (eventType.equals(RESOLVED_RECOMMENDATION)) {
-                if (! resolvedRecommendations.contains(ruleId)) {
-                    resolvedRecommendations.put(ruleId, new HashSet<String>());
-                }
-                resolvedRecommendations.get(ruleId).add(inventoryId);
+                resolvedRecommendations.computeIfAbsent(
+                    ruleId, key -> new HashSet<String>()
+                ).add(inventoryId);
             } else if (eventType.equals(DEACTIVATED_RECOMMENDATION)) {
                 deactivatedRecommendations.add(ruleId);
             }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -122,10 +122,11 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
             String ruleRisk = payload.getString(PAYLOAD_RULE_TOTAL_RISK);
             String ruleIncident = payload.getString(PAYLOAD_RULE_HAS_INCIDENT);
             String ruleURL = payload.getString(PAYLOAD_RULE_URL);
+            Map<String, Object> ruleData;
 
             switch (eventType) {
                 case NEW_RECOMMENDATION:
-                    Map<String, Object> ruleData = newRecommendations.computeIfAbsent(
+                    ruleData = newRecommendations.computeIfAbsent(
                         ruleId, key -> new HashMap<>(Map.of(
                             CONTENT_RULE_DESCRIPTION, ruleDescription,
                             CONTENT_RULE_HAS_INCIDENT, ruleIncident,
@@ -139,7 +140,7 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
                     );
                     break;
                 case RESOLVED_RECOMMENDATION:
-                    Map<String, Object> ruleData = resolvedRecommendations.computeIfAbsent(
+                    ruleData = resolvedRecommendations.computeIfAbsent(
                         ruleId, key -> new HashMap<>(Map.of(
                             CONTENT_RULE_DESCRIPTION, ruleDescription,
                             CONTENT_RULE_HAS_INCIDENT, ruleIncident,

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -1,0 +1,85 @@
+package com.redhat.cloud.notifications.processors.email.aggregators;
+
+import com.redhat.cloud.notifications.models.EmailAggregation;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Set;
+
+public class AdvisorDailyDigestEmailPayloadAggregator extends AbstractEmailPayloadAggregator {
+
+    // Notification common
+    private static final String EVENT_TYPE_KEY = "event_type";
+    private static final String EVENTS_KEY = "events";
+    private static final String PAYLOAD_KEY = "payload";
+    private static final String INVENTORY_ID = "inventory_id";
+    private static final String PAYLOAD_RULE_ID = "rule_id";
+
+    // Advisor event payloads
+    private static final String NEW_RECOMMENDATION = "new_recommendation";
+    private static final String RESOLVED_RECOMMENDATION = "resolved_recommendation";
+    private static final String DEACTIVATED_RECOMMENDATION = "resolved_recommendation";
+
+    // Advisor events aggregator
+    private static final String ADVISOR_KEY = "advisor";
+    private static final String NEW_RECOMMENDATIONS = "new_recommendations";
+    private static final String RESOLVED_RECOMMENDATIONS = "resolved_recommendations";
+    private static final String DEACTIVATED_RECOMMENDATIONS = "deactivated_recommendations";
+
+    // Advisor event types
+    private static final String NEW_RECOMMENDATION_EVENT = "new-recommendation";
+    private static final String RESOLVED_RECOMMENDATION_EVENT = "resolved-recommendation";
+    private static final String DEACTIVATED_RULE_EVENT = "deactivated-rule";
+    private static final Set<String> EVENT_TYPES = new HashSet<>(Arrays.asList(
+        NEW_RECOMMENDATION_EVENT, RESOLVED_RECOMMENDATION_EVENT,
+        DEACTIVATED_RULE_EVENT
+    ));
+
+    // Advisor final payload helpers
+    private final HashMap<String, HashSet<String>> newRecommendations = new HashMap<String, HashSet<>>();
+    private final HashMap<String, HashSet<String>> resolvedRecommendations = new HashSet<String, HashSet<>>();
+    private final HashSet<String> deactivatedRecommendations = new HashSet<>();
+
+    public AdvisorDailyDigestEmailPayloadAggregator() {
+        JsonObject advisor = new JsonObject();
+
+        context.put(ADVISOR_KEY, advisor);
+    }
+
+    @Override
+    void processEmailAggregation(EmailAggregation notification) {
+        JsonObject notifPayload = notification.getPayload();
+        JsonObject advisor = context.getJsonObject(ADVISOR_KEY);
+        String eventType = notifPayload.getString(EVENT_TYPE_KEY);
+        String inventoryId = notification.getContext().getString(INVENTORY_ID);
+
+        if (!EVENT_TYPES.contains(eventType)) {
+            return;
+        }
+
+        notifPayload.getJsonArray(EVENTS_KEY).stream().forEach(eventObject -> {
+            JsonObject event = (JsonObject) eventObject;
+            JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
+            String ruleId = payload.getString(PAYLOAD_RULE_ID);
+
+            if (eventType == NEW_RECOMMENDATION) {
+                if (! newRecommendations.contains(ruleId)) {
+                    newRecommendations.put(ruleId, new HashSet<String>());
+                }
+                newRecommendations.get(ruleId).add(inventoryId);
+            } else if (eventType == RESOLVED_RECOMMENDATION) {
+                if (! resolvedRecommendations.contains(ruleId)) {
+                    resolvedRecommendations.put(ruleId, new HashSet<String>());
+                }
+                resolvedRecommendations.get(ruleId).add(inventoryId);
+            } else if (eventType == DEACTIVATED_RECOMMENDATION) {
+                deactivatedRecommendations.add(ruleId);
+            }
+        });
+        advisor.put(NEW_RECOMMENDATIONS, newRecommendations);
+        advisor.put(RESOLVED_RECOMMENDATIONS, newRecommendations);
+        advisor.put(DEACTIVATED_RECOMMENDATIONS, newRecommendations);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregator.java
@@ -83,6 +83,11 @@ import java.util.Set;
 
 public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
 
+    // Advisor event types
+    public static final String NEW_RECOMMENDATION = "new-recommendation";
+    public static final String RESOLVED_RECOMMENDATION = "resolved-recommendation";
+    public static final String DEACTIVATED_RECOMMENDATION = "deactivated-recommendation";
+
     // Notification common
     private static final String EVENT_TYPE_KEY = "event_type";
     private static final String EVENTS_KEY = "events";
@@ -105,10 +110,6 @@ public class AdvisorEmailAggregator extends AbstractEmailPayloadAggregator {
     public static final String CONTENT_RULE_URL = "url";
     public static final String CONTENT_SYSTEM_COUNT = "systems";
 
-    // Advisor event types
-    public static final String NEW_RECOMMENDATION = "new-recommendation";
-    public static final String RESOLVED_RECOMMENDATION = "resolved-recommendation";
-    public static final String DEACTIVATED_RECOMMENDATION = "deactivated-recommendation";
     private static final Set<String> EVENT_TYPES = new HashSet<>(Arrays.asList(
             NEW_RECOMMENDATION, RESOLVED_RECOMMENDATION,
             DEACTIVATED_RECOMMENDATION

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
@@ -40,7 +40,7 @@ public class EmailPayloadAggregatorFactory {
             case RHEL:
                 switch (application) {
                     case ADVISOR:
-                        return new AdvisorEmailPayloadAggregator();
+                        return new AdvisorEmailAggregator();
                     case COMPLIANCE:
                         return new ComplianceEmailAggregator();
                     case DRIFT:

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
@@ -6,6 +6,7 @@ public class EmailPayloadAggregatorFactory {
 
     private static final String RHEL = "rhel";
     private static final String APPLICATION_SERVICES = "application-services";
+    private static final String ADVISOR = "advisor";
     private static final String POLICIES = "policies";
     private static final String COMPLIANCE = "compliance";
     private static final String DRIFT = "drift";
@@ -38,6 +39,8 @@ public class EmailPayloadAggregatorFactory {
                 break;
             case RHEL:
                 switch (application) {
+                    case ADVISOR:
+                        return new AdvisorEmailPayloadAggregator();
                     case COMPLIANCE:
                         return new ComplianceEmailAggregator();
                     case DRIFT:

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
@@ -16,7 +16,8 @@ public class Advisor implements EmailTemplate {
                 return Templates.resolvedRecommendationInstantEmailTitle();
             } else if (eventType.equals("deactivated-recommendation")) {
                 return Templates.deactivatedRecommendationInstantEmailTitle();
-            }
+        } else if (type == EmailSubscriptionType.DAILY) {
+            return Templates.dailyEmailTitle();
         }
 
         throw new UnsupportedOperationException(String.format(
@@ -35,6 +36,8 @@ public class Advisor implements EmailTemplate {
             } else if (eventType.equals("deactivated-recommendation")) {
                 return Templates.deactivatedRecommendationInstantEmailBody();
             }
+        } else if (type == EmailSubscriptionType.DAILY) {
+            return Templates.dailyEmailBody();
         }
 
         throw new UnsupportedOperationException(String.format(
@@ -45,12 +48,19 @@ public class Advisor implements EmailTemplate {
 
     @Override
     public boolean isSupported(String eventType, EmailSubscriptionType type) {
-        return (eventType.equals("new-recommendation") || eventType.equals("resolved-recommendation") || eventType.equals("deactivated-recommendation")) && type == EmailSubscriptionType.INSTANT;
+        return (
+            type == EmailSubscriptionType.DAILY ||
+            type == EmailSubscriptionType.INSTANT && (
+                eventType.equals("new-recommendation") ||
+                eventType.equals("resolved-recommendation") ||
+                eventType.equals("deactivated-recommendation")
+            )
+        );
     }
 
     @Override
     public boolean isEmailSubscriptionSupported(EmailSubscriptionType type) {
-        return type == EmailSubscriptionType.INSTANT;
+        return type == EmailSubscriptionType.INSTANT || type == EmailSubscriptionType.DAILY;
     }
 
     @CheckedTemplate(requireTypeSafeExpressions = false)
@@ -67,6 +77,10 @@ public class Advisor implements EmailTemplate {
         public static native TemplateInstance deactivatedRecommendationInstantEmailTitle();
 
         public static native TemplateInstance deactivatedRecommendationInstantEmailBody();
+
+        public static native TemplateInstance dailyEmailTitle();
+
+        public static native TemplateInstance dailyEmailBody();
     }
 
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
@@ -16,6 +16,7 @@ public class Advisor implements EmailTemplate {
                 return Templates.resolvedRecommendationInstantEmailTitle();
             } else if (eventType.equals("deactivated-recommendation")) {
                 return Templates.deactivatedRecommendationInstantEmailTitle();
+            }
         } else if (type == EmailSubscriptionType.DAILY) {
             return Templates.dailyEmailTitle();
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
@@ -55,8 +55,7 @@ public class Advisor implements EmailTemplate {
                 eventType.equals("new-recommendation") ||
                 eventType.equals("resolved-recommendation") ||
                 eventType.equals("deactivated-recommendation")
-            )
-        );
+            ));
     }
 
     @Override

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
@@ -4,17 +4,21 @@ import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.DEACTIVATED_RECOMMENDATION;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.NEW_RECOMMENDATION;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RESOLVED_RECOMMENDATION;
+
 // Name needs to be "Advisor" to read templates from resources/templates/Advisor
 public class Advisor implements EmailTemplate {
 
     @Override
     public TemplateInstance getTitle(String eventType, EmailSubscriptionType type) {
         if (type == EmailSubscriptionType.INSTANT) {
-            if (eventType.equals("new-recommendation")) {
+            if (eventType.equals(NEW_RECOMMENDATION)) {
                 return Templates.newRecommendationInstantEmailTitle();
-            } else if (eventType.equals("resolved-recommendation")) {
+            } else if (eventType.equals(RESOLVED_RECOMMENDATION)) {
                 return Templates.resolvedRecommendationInstantEmailTitle();
-            } else if (eventType.equals("deactivated-recommendation")) {
+            } else if (eventType.equals(DEACTIVATED_RECOMMENDATION)) {
                 return Templates.deactivatedRecommendationInstantEmailTitle();
             }
         } else if (type == EmailSubscriptionType.DAILY) {
@@ -30,11 +34,11 @@ public class Advisor implements EmailTemplate {
     @Override
     public TemplateInstance getBody(String eventType, EmailSubscriptionType type) {
         if (type == EmailSubscriptionType.INSTANT) {
-            if (eventType.equals("new-recommendation")) {
+            if (eventType.equals(NEW_RECOMMENDATION)) {
                 return Templates.newRecommendationInstantEmailBody();
-            } else if (eventType.equals("resolved-recommendation")) {
+            } else if (eventType.equals(RESOLVED_RECOMMENDATION)) {
                 return Templates.resolvedRecommendationInstantEmailBody();
-            } else if (eventType.equals("deactivated-recommendation")) {
+            } else if (eventType.equals(DEACTIVATED_RECOMMENDATION)) {
                 return Templates.deactivatedRecommendationInstantEmailBody();
             }
         } else if (type == EmailSubscriptionType.DAILY) {
@@ -52,9 +56,9 @@ public class Advisor implements EmailTemplate {
         return (
             type == EmailSubscriptionType.DAILY ||
             type == EmailSubscriptionType.INSTANT && (
-                eventType.equals("new-recommendation") ||
-                eventType.equals("resolved-recommendation") ||
-                eventType.equals("deactivated-recommendation")
+                eventType.equals(NEW_RECOMMENDATION) ||
+                eventType.equals(RESOLVED_RECOMMENDATION) ||
+                eventType.equals(DEACTIVATED_RECOMMENDATION)
             ));
     }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/Advisor.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.templates;
 import com.redhat.cloud.notifications.models.EmailSubscriptionType;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.DEACTIVATED_RECOMMENDATION;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.NEW_RECOMMENDATION;
@@ -54,7 +55,7 @@ public class Advisor implements EmailTemplate {
     @Override
     public boolean isSupported(String eventType, EmailSubscriptionType type) {
         return (
-            type == EmailSubscriptionType.DAILY ||
+            type == EmailSubscriptionType.DAILY && isDailyDigestEnabled() ||
             type == EmailSubscriptionType.INSTANT && (
                 eventType.equals(NEW_RECOMMENDATION) ||
                 eventType.equals(RESOLVED_RECOMMENDATION) ||
@@ -64,7 +65,15 @@ public class Advisor implements EmailTemplate {
 
     @Override
     public boolean isEmailSubscriptionSupported(EmailSubscriptionType type) {
-        return type == EmailSubscriptionType.INSTANT || type == EmailSubscriptionType.DAILY;
+        return type == EmailSubscriptionType.INSTANT || type == EmailSubscriptionType.DAILY && isDailyDigestEnabled();
+    }
+
+    /*
+     * This is a feature flag meant to disable the daily digest on prod until it has been fully validated on stage.
+     * TODO Remove this as soon as the daily digest is enabled on prod.
+     */
+    private boolean isDailyDigestEnabled() {
+        return ConfigProvider.getConfig().getOptionalValue("rhel.advisor.daily-digest.enabled", boolean.class).orElse(false);
     }
 
     @CheckedTemplate(requireTypeSafeExpressions = false)

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -27,6 +27,9 @@ import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.events.FromCamelHistoryFiller.INTEGRATION_FAILED_EVENT_TYPE;
 import static com.redhat.cloud.notifications.events.IntegrationDisabledNotifier.INTEGRATION_DISABLED_EVENT_TYPE;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.DEACTIVATED_RECOMMENDATION;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.NEW_RECOMMENDATION;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RESOLVED_RECOMMENDATION;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -63,17 +66,17 @@ public class EmailTemplateMigrationService {
          */
         getOrCreateTemplate(warnings, "Advisor/insightsEmailBody", "html", "Advisor Insights email body");
         createInstantEmailTemplate(
-                warnings, "rhel", "advisor", List.of("deactivated-recommendation"),
+                warnings, "rhel", "advisor", List.of(DEACTIVATED_RECOMMENDATION),
                 "Advisor/deactivatedRecommendationInstantEmailTitle", "txt", "Advisor deactivated recommendation email title",
                 "Advisor/deactivatedRecommendationInstantEmailBody", "html", "Advisor deactivated recommendation email body"
         );
         createInstantEmailTemplate(
-                warnings, "rhel", "advisor", List.of("new-recommendation"),
+                warnings, "rhel", "advisor", List.of(NEW_RECOMMENDATION),
                 "Advisor/newRecommendationInstantEmailTitle", "txt", "Advisor new recommendation email title",
                 "Advisor/newRecommendationInstantEmailBody", "html", "Advisor new recommendation email body"
         );
         createInstantEmailTemplate(
-                warnings, "rhel", "advisor", List.of("resolved-recommendation"),
+                warnings, "rhel", "advisor", List.of(RESOLVED_RECOMMENDATION),
                 "Advisor/resolvedRecommendationInstantEmailTitle", "txt", "Advisor resolved recommendation email title",
                 "Advisor/resolvedRecommendationInstantEmailBody", "html", "Advisor resolved recommendation email body"
         );

--- a/engine/src/main/resources/templates/Advisor/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Advisor/dailyEmailBody.html
@@ -111,7 +111,7 @@
             {#for recommendation in action.context.new_recommendations.keySet()}
               <tr style="border-bottom: thin lightgrey solid">
                 <td style="padding: 0.5em; width: 60%; word-wrap: anywhere;">
-                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.new_recommendations.get(recommendation).description}</a>
+                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.new_recommendations.get(recommendation).rule_description}</a>
                   {#if action.context.new_recommendations.get(recommendation).has_incident}
                     <span style="border-radius: 1em; border: thin black solid; background-color: #fac8c8; padding: 0 0.5em;">Incident</span>
                   {/if}
@@ -157,7 +157,7 @@
             {#for recommendation in action.context.resolved_recommendations.keySet()}
               <tr style="border-bottom: thin lightgrey solid">
                 <td style="padding: 0.5em; width: 60%; word-wrap: anywhere;">
-                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.resolved_recommendations.get(recommendation).description}</a>
+                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.resolved_recommendations.get(recommendation).rule_description}</a>
                   {#if action.context.resolved_recommendations.get(recommendation).has_incident}
                     <span style="border-radius: 1em; border: thin black solid; background-color: #fac8c8; padding: 0 0.5em;">Incident</span>
                   {/if}
@@ -202,7 +202,7 @@
             {#for recommendation in action.context.deactivated_recommendations.keySet()}
               <tr style="border-bottom: thin lightgrey solid">
                 <td style="padding: 0.5em; width: 60%; word-wrap: anywhere;">
-                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.deactivated_recommendations.get(recommendation).description}</a>
+                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.deactivated_recommendations.get(recommendation).rule_description}</a>
                   {#if action.context.deactivated_recommendations.get(recommendation).has_incident}
                     <span style="border-radius: 1em; border: thin black solid; background-color: #fac8c8; padding: 0 0.5em;">Incident</span>
                   {/if}

--- a/engine/src/main/resources/templates/Advisor/dailyEmailBody.html
+++ b/engine/src/main/resources/templates/Advisor/dailyEmailBody.html
@@ -90,7 +90,7 @@
 </tr>
 
 <!-- List of new recommendations section -->
-{#if action.context.new_recommendations.orEmpty.size > 0}
+{#if action.context.advisor.new_recommendations.orEmpty.size > 0}
 <tr>
   <td class="rh-body">
     <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
@@ -108,23 +108,23 @@
             </tr>
             </thead>
             <tbody style="background-color: white;">
-            {#for recommendation in action.context.new_recommendations.keySet()}
+            {#for recommendation in action.context.advisor.new_recommendations.keySet()}
               <tr style="border-bottom: thin lightgrey solid">
                 <td style="padding: 0.5em; width: 60%; word-wrap: anywhere;">
-                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.new_recommendations.get(recommendation).rule_description}</a>
-                  {#if action.context.new_recommendations.get(recommendation).has_incident}
+                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.advisor.new_recommendations.get(recommendation).rule_description}</a>
+                  {#if action.context.advisor.new_recommendations.get(recommendation).has_incident}
                     <span style="border-radius: 1em; border: thin black solid; background-color: #fac8c8; padding: 0 0.5em;">Incident</span>
                   {/if}
                 </td>
                 <td class="rh-severity" style="padding: 0.5em; width: 20%">
-                  {#switch action.context.new_recommendations.get(recommendation).total_risk}
+                  {#switch action.context.advisor.new_recommendations.get(recommendation).total_risk}
                     {#case 1}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low.png" alt="Low severity" width="55" border="0">
                     {#case 2}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate.png" alt="Moderate severity" width="85" border="0">
                     {#case 3}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important.png" alt="Important severity" width="86" border="0">
                     {#case 4}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical.png" alt="Critical severity" width="70" border="0">
                   {/switch}
                 </td>
-                <td style="padding: 0.5em; width: 20%">{action.context.new_recommendations.get(recommendation).affected_systems}</td>
+                <td style="padding: 0.5em; width: 20%">{action.context.advisor.new_recommendations.get(recommendation).systems}</td>
               </tr>
             {/for}
             </tbody>
@@ -136,7 +136,7 @@
 {/if}
 
 <!-- List of resolved recommendations section -->
-{#if action.context.resolved_recommendations.orEmpty.size > 0}
+{#if action.context.advisor.resolved_recommendations.orEmpty.size > 0}
 <tr>
   <td class="rh-body">
     <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
@@ -154,23 +154,23 @@
             </tr>
             </thead>
             <tbody style="background-color: white;">
-            {#for recommendation in action.context.resolved_recommendations.keySet()}
+            {#for recommendation in action.context.advisor.resolved_recommendations.keySet()}
               <tr style="border-bottom: thin lightgrey solid">
                 <td style="padding: 0.5em; width: 60%; word-wrap: anywhere;">
-                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.resolved_recommendations.get(recommendation).rule_description}</a>
-                  {#if action.context.resolved_recommendations.get(recommendation).has_incident}
+                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.advisor.resolved_recommendations.get(recommendation).rule_description}</a>
+                  {#if action.context.advisor.resolved_recommendations.get(recommendation).has_incident}
                     <span style="border-radius: 1em; border: thin black solid; background-color: #fac8c8; padding: 0 0.5em;">Incident</span>
                   {/if}
                 </td>
                 <td class="rh-severity" style="padding: 0.5em; width: 20%">
-                  {#switch action.context.resolved_recommendations.get(recommendation).total_risk}
+                  {#switch action.context.advisor.resolved_recommendations.get(recommendation).total_risk}
                     {#case 1}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low.png" alt="Low severity" width="55" border="0">
                     {#case 2}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate.png" alt="Moderate severity" width="85" border="0">
                     {#case 3}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important.png" alt="Important severity" width="86" border="0">
                     {#case 4}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical.png" alt="Critical severity" width="70" border="0">
                   {/switch}
                 </td>
-                <td style="padding: 0.5em; width: 20%">{action.context.resolved_recommendations.get(recommendation).affected_systems}</td>
+                <td style="padding: 0.5em; width: 20%">{action.context.advisor.resolved_recommendations.get(recommendation).systems}</td>
               </tr>
             {/for}
             </tbody>
@@ -182,7 +182,7 @@
 {/if}
 
 <!-- List of deactivated recommendations section -->
-{#if action.context.deactivated_recommendations.orEmpty.size > 0}
+{#if action.context.advisor.deactivated_recommendations.orEmpty.size > 0}
 <tr>
   <td class="rh-body">
     <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
@@ -199,16 +199,16 @@
             </tr>
             </thead>
             <tbody style="background-color: white;">
-            {#for recommendation in action.context.deactivated_recommendations.keySet()}
+            {#for recommendation in action.context.advisor.deactivated_recommendations.keySet()}
               <tr style="border-bottom: thin lightgrey solid">
                 <td style="padding: 0.5em; width: 60%; word-wrap: anywhere;">
-                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.deactivated_recommendations.get(recommendation).rule_description}</a>
-                  {#if action.context.deactivated_recommendations.get(recommendation).has_incident}
+                  <a target="_blank" href="{environment.url}/insights/advisor/recommendations/{recommendation}">{action.context.advisor.deactivated_recommendations.get(recommendation).rule_description}</a>
+                  {#if action.context.advisor.deactivated_recommendations.get(recommendation).has_incident}
                     <span style="border-radius: 1em; border: thin black solid; background-color: #fac8c8; padding: 0 0.5em;">Incident</span>
                   {/if}
                 </td>
                 <td class="rh-severity" style="padding: 0.5em; width: 40%">
-                  {#switch action.context.deactivated_recommendations.get(recommendation).total_risk}
+                  {#switch action.context.advisor.deactivated_recommendations.get(recommendation).total_risk}
                     {#case 1}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low.png" alt="Low severity" width="55" border="0">
                     {#case 2}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate.png" alt="Moderate severity" width="85" border="0">
                     {#case 3}<img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important.png" alt="Important severity" width="86" border="0">

--- a/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
@@ -1,0 +1,136 @@
+package com.redhat.cloud.notifications;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.transformers.BaseTransformer;
+import io.vertx.core.json.JsonObject;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
+/*
+ * Create a structure of the form:
+ * {
+   "bundle":"rhel",
+   "application":"advisor",
+   "event_type":"new-recommendation",
+   "timestamp":"2022-11-30T17:30:20.773398",
+   "account_id":"5758117",
+   "org_id":"7806094",
+   "context":{
+      "inventory_id":"6ad30f3e-0497-4e74-99f1-b3f9a6120a6f",
+      "hostname":"my-computer-jmartine",
+      "display_name":"my-computer-jmartine",
+      "rhel_version":"8.4",
+      "host_url":"https://console.redhat.com/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f",
+      "tags":[
+
+      ]
+   },
+   "events":[
+      {
+         "metadata":{},
+         "payload":{
+            "rule_id":"insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE",
+            "rule_description":"System is not able to get the latest recommendations and may miss bug fixes when the Insights Client Core egg file is outdated",
+            "total_risk":"2",
+            "publish_date":"2021-03-13T18:44:00+00:00",
+            "rule_url":"https://console.redhat.com/insights/advisor/recommendations/insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE/",
+            "reboot_required":false,
+            "has_incident":false,
+            "report_url":"https://console.redhat.com/insights/advisor/recommendations/insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f"
+         }
+      }
+   ]
+}
+ */
+
+public class AdvisorTestHelpers {
+
+    public static BaseTransformer baseTransformer = new BaseTransformer();
+
+    public static final String EVENT_METADATA = "metadata";
+    public static final String EVENT_PAYLOAD = "payload";
+    public static final String EVENT_PAYLOAD_RULE_ID = "rule_id";
+    public static final String EVENT_PAYLOAD_DESCRIPTION = "rule_description";
+    public static final String EVENT_PAYLOAD_TOTAL_RISK = "total_risk";
+    public static final String EVENT_PAYLOAD_URL = "total_risk";
+    public static final String EVENT_PAYLOAD_PUBLISH_DATE = "publish_date";
+    public static final String EVENT_PAYLOAD_REBOOT_REQUIRED = "reboot_required";
+    public static final String EVENT_PAYLOAD_REPORT_URL = "report_url";
+
+    public static Event createEvent(
+        String rule_id, String description, String rule_url,
+        boolean has_incident, Integer total_risk,
+    ) {
+        /* Add events via emailActionMessage.setEvents */
+        /* Fill in the important fields from the arguments, and make up
+         * everything else. */
+        event = new Event.EventBuilder()
+            .withMetadata(new Metadata.MetadataBuilder().build())
+            .withPayload(new Payload.PayloadBuilder()
+                /* Supplied data */
+                .withAdditionalProperty(EVENT_PAYLOAD_RULE_ID, rule_id)
+                .withAdditionalProperty(EVENT_PAYLOAD_DESCRIPTION, description)
+                .withAdditionalProperty(EVENT_PAYLOAD_TOTAL_RISK, total_risk.toString())
+                .withAdditionalProperty(EVENT_PAYLOAD_HAS_INCIDENT, has_incident)
+                .withAdditionalProperty(EVENT_PAYLOAD_URL, rule_url)
+                /* Made up data */
+                .withAdditionalProperty(EVENT_PAYLOAD_PUBLISH_DATE, "2021-03-13T18:44:00+00:00")
+                .withAdditionalProperty(EVENT_PAYLOAD_REBOOT_REQUIRED, false)
+                .withAdditionalProperty(EVENT_PAYLOAD_REPORT_URL, rule_url)
+                .build()
+            ).build();
+        return event;
+    }
+
+    public static Action createAction(
+        String bundle, String application, String eventType
+        String inventoryId, String inventoryName
+    ) {
+        Action emailActionMessage = new Action();
+        emailActionMessage.setBundle(bundle);
+        emailActionMessage.setApplication(application);
+        emailActionMessage.setTimestamp(LocalDateTime.now());
+        emailActionMessage.setEventType(eventType);
+
+        emailActionMessage.setContext(
+            new Context.ContextBuilder()
+            .withAdditionalProperty("inventory_id", inventoryId)
+            .withAdditionalProperty("system_check_in", LocalDateTime.now())
+            .withAdditionalProperty("display_name", inventoryName)
+            .withAdditionalProperty("tags", List.of())
+            .build()
+        );
+
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+        return emailActionMessage;
+    }
+
+    public static EmailAggregation createEmailAggregation(
+        Action emailActionMessage
+    ) {
+        /* General process:
+         * - Create an action with createAction
+         * - Add one or more events to the action with
+         *   setEvents(List.of(createEvent(...)))
+         * - Create the Aggregation with createEmailAggregation, based on the
+         *   action.
+         */
+        EmailAggregation aggregation = new EmailAggregation();
+        aggregation.setBundleName(emailActionMessage.bundle);
+        aggregation.setApplicationName(emailActionMessage.application);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
+
+        JsonObject payload = baseTransformer.toJsonObject(emailActionMessage);
+        aggregation.setPayload(payload);
+
+        return aggregation;
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
@@ -91,7 +91,7 @@ public class AdvisorTestHelpers {
     }
 
     public static Action createAction(
-        String bundle, String application, String eventType
+        String bundle, String application, String eventType,
         String inventoryId, String inventoryName
     ) {
         Action emailActionMessage = new Action();

--- a/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
@@ -67,7 +67,7 @@ public class AdvisorTestHelpers {
 
     public static Event createEvent(
         String rule_id, String description, String rule_url,
-        boolean has_incident, Integer total_risk,
+        boolean has_incident, Integer total_risk
     ) {
         /* Add events via emailActionMessage.setEvents */
         /* Fill in the important fields from the arguments, and make up

--- a/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
@@ -13,11 +13,11 @@ import java.util.List;
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_DESCRIPTION;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_HAS_INCIDENT;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_ID;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_TOTAL_RISK;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_URL;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.HAS_INCIDENT;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RULE_DESCRIPTION;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RULE_ID;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RULE_URL;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.TOTAL_RISK;
 
 /*
  * Create a structure of the form:
@@ -92,11 +92,11 @@ public class AdvisorTestHelpers {
                         .withMetadata(new Metadata.MetadataBuilder().build())
                         .withPayload(new Payload.PayloadBuilder()
                                 /* Supplied data */
-                                .withAdditionalProperty(PAYLOAD_RULE_ID, rule.get(PAYLOAD_RULE_ID))
-                                .withAdditionalProperty(PAYLOAD_RULE_DESCRIPTION, rule.get(PAYLOAD_RULE_DESCRIPTION))
-                                .withAdditionalProperty(PAYLOAD_RULE_TOTAL_RISK, rule.get(PAYLOAD_RULE_TOTAL_RISK))
-                                .withAdditionalProperty(PAYLOAD_RULE_HAS_INCIDENT, rule.get(PAYLOAD_RULE_HAS_INCIDENT))
-                                .withAdditionalProperty(PAYLOAD_RULE_URL, rule.get(PAYLOAD_RULE_URL))
+                                .withAdditionalProperty(RULE_ID, rule.get(RULE_ID))
+                                .withAdditionalProperty(RULE_DESCRIPTION, rule.get(RULE_DESCRIPTION))
+                                .withAdditionalProperty(TOTAL_RISK, rule.get(TOTAL_RISK))
+                                .withAdditionalProperty(HAS_INCIDENT, rule.get(HAS_INCIDENT))
+                                .withAdditionalProperty(RULE_URL, rule.get(RULE_URL))
                                 /* Made up data */
                                 .withAdditionalProperty(EVENT_PAYLOAD_PUBLISH_DATE, "2021-03-13T18:44:00+00:00")
                                 .withAdditionalProperty(EVENT_PAYLOAD_REBOOT_REQUIRED, false)

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregatorTest.java
@@ -1,0 +1,127 @@
+package com.redhat.cloud.notifications.processors.email.aggregators;
+
+import com.redhat.cloud.notifications.AdvisorTestHelpers;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Event;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
+/*
+ * Aggregated data should be of the form:
+ * {
+    "new_recommendations": {
+        "product_eol_check|NGINX_EOL_ERROR": {
+            "description": "Red Hat has discontinued support services as well as software maintenance services for the End-Of-Life nginx",
+            "total_risk": 4,
+            "has_incident": false,
+            "url": "https://console.redhat.com/insights/advisor/recommendations/product_eol_check|NGINX_EOL_ERROR",
+            "affected_systems": 33
+        },
+        "container_rhel_version_privileged|CONTAINER_RHEL_VERSION_PRIVILEGED": {
+            "description": "A privileged container running on a different RHEL version host is not compatible",
+            "total_risk": 4,
+            "has_incident": true,
+            "url": "https://console.redhat.com/insights/advisor/recommendations/container_rhel_version_privileged|CONTAINER_RHEL_VERSION_PRIVILEGED",
+            "affected_systems": 3
+        }
+    },
+    "resolved_recommendations": {
+        "auditd_daemon_log_file_oversize|AUDIT_DAEMON_LOG_FILE_OVERSIZE": {
+            "description": "The auditd service gets suspended when the size of the log file is over \"max_log_file\"",
+            "total_risk": 2,
+            "has_incident": true,
+            "url": "https://console.redhat.com/insights/advisor/recommendations/audit_daemon_log_file_oversize|AUDIT_DAEMON_LOG_FILE_OVERSIZE",
+            "affected_systems": 1
+        }
+    },
+    "deactivated_recommendations": {
+        "el6_to_el7_upgrade|RHEL6_TO_RHEL7_UPGRADE_AVAILABLE_V4": {
+            "description": "RHEL 6 system is eligible for an in-place upgrade to RHEL 7 using the Leapp utility",
+            "has_incident": false,
+            "url": "https://console.redhat.com/insights/advisor/recommendations/el6_to_el7_upgrade|RHEL6_TO_RHEL7_UPGRADE_AVAILABLE_V4",
+            "total_risk": 3
+        }
+    }
+}
+ */
+class AdvisorEmailAggregatorTest {
+
+    public static final String BUNDLE_RHEL = "rhel";
+    public static final String BUNDLE_OPENSHIFT = "openshift";
+    public static final String APPLICATION_ADVISOR = "advisor";
+    public static final String TEST_INVENTORY_ID = "00112233-4455-6677-8899-AABBCCDDEE01";
+    public static final String TEST_INVENTORY_NAME = "system01.example.org";
+    public static final String TEST_RULE_1_ID = "test|Active_rule";
+    public static final String TEST_RULE_1_DESCRIPTION = "Active rule";
+    public static final String TEST_RULE_1_URL = "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule";
+    public static final boolean TEST_RULE_1_IMPACTING = false;
+    public static final Integer TEST_RULE_1_TOTAL_RISK = 1;
+    /* From Advisor test data - but here we don't care about whether this is
+     * actually acked in the ruleset.  If we got a notification for it, we
+     * aggregate it. */
+    public static final String TEST_RULE_3_ID = "test|Acked_rule";
+    public static final String TEST_RULE_3_DESCRIPTION = "Acked rule";
+    public static final String TEST_RULE_3_URL = "https://console.redhat.com/insights/advisor/recommendations/test|Acked_rule";
+    public static final boolean TEST_RULE_3_IMPACTING = false;
+    public static final Integer TEST_RULE_3_TOTAL_RISK = 1;
+
+    private AdvisorEmailAggregator aggregator;
+    private Action rhelAdvisorAction;
+    private Action openshiftAdvisorAction;
+    private Event eventActiveRule;
+
+    @BeforeClass
+    void setUpTestData() {
+        rhelAdvisorAction = AdvisorTestHelpers.createAction(
+            BUNDLE_RHEL, APPLICATION_ADVISOR, TEST_INVENTORY_ID, TEST_INVENTORY_NAME
+        );
+        openshiftAdvisorAction = AdvisorTestHelpers.createAction(
+            BUNDLE_OPENSHIFT, APPLICATION_ADVISOR, TEST_INVENTORY_ID, TEST_INVENTORY_NAME
+        );
+        eventActiveRule = AdvisorTestHelpers.createEvent(
+            TEST_RULE_ID, TEST_RULE_DESCRIPTION, TEST_RULE_URL,
+            TEST_RULE_IMPACTING, TEST_RULE_TOTAL_RISK
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        aggregator = new AdvisorEmailAggregator();
+    }
+
+    @Test
+    void emptyAggregatorHasNoOrgId() {
+        Assertions.assertNull(aggregator.getOrgId(), "Empty aggregator has no orgId");
+    }
+
+    @Test
+    void shouldSetOrgId() {
+        oneMessage = AdvisorTestHelpers.createEmailAggregation(emailActionMessage);
+        aggregator.aggregate(oneMessage);
+        Assertions.assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
+    }
+
+    @Test
+    void validatePayload() {
+        oneMessage = AdvisorTestHelpers.createEmailAggregation(emailActionMessage);
+        oneMessage.setEvents(List.of(eventActiveRule));
+        aggregator.aggregate(oneMessage);
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject Advisor = JsonObject.mapFrom(context).getJsonObject("Advisor");
+        System.out.println(Advisor.toString());
+
+        Assertions.assertFalse(Advisor.containsKey("foo"));
+        Assertions.assertEquals(Advisor.getJsonArray("report-upload-failed").size(), 2);
+        Assertions.assertEquals(Advisor.getJsonArray("Advisor-below-threshold").size(), 2);
+        Assertions.assertEquals(Advisor.getJsonArray("Advisor-below-threshold").size(), 2);
+        // Assertions.assertEquals(Advisor.getJsonArray("system-not-reporting").size(), 2);
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregatorTest.java
@@ -7,22 +7,18 @@ import java.util.Map;
 
 import static com.redhat.cloud.notifications.AdvisorTestHelpers.createEmailAggregation;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.ADVISOR_KEY;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.CONTENT_RULE_DESCRIPTION;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.CONTENT_RULE_HAS_INCIDENT;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.CONTENT_RULE_TOTAL_RISK;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.CONTENT_RULE_URL;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.CONTENT_SYSTEM_COUNT;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.DEACTIVATED_RECOMMENDATION;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.DEACTIVATED_RECOMMENDATIONS;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.HAS_INCIDENT;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.NEW_RECOMMENDATION;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.NEW_RECOMMENDATIONS;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_DESCRIPTION;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_HAS_INCIDENT;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_ID;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_TOTAL_RISK;
-import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.PAYLOAD_RULE_URL;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RESOLVED_RECOMMENDATION;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RESOLVED_RECOMMENDATIONS;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RULE_DESCRIPTION;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RULE_ID;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RULE_URL;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.TOTAL_RISK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -67,46 +63,46 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class AdvisorEmailAggregatorTest {
 
     private static final Map<String, String> TEST_RULE_1 = Map.of(
-            PAYLOAD_RULE_ID, "test|Active_rule_1",
-            PAYLOAD_RULE_DESCRIPTION, "Active rule 1",
-            PAYLOAD_RULE_TOTAL_RISK, "3",
-            PAYLOAD_RULE_HAS_INCIDENT, "true",
-            PAYLOAD_RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_1"
+            RULE_ID, "test|Active_rule_1",
+            RULE_DESCRIPTION, "Active rule 1",
+            TOTAL_RISK, "3",
+            HAS_INCIDENT, "true",
+            RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_1"
     );
     private static final Map<String, String> TEST_RULE_2 = Map.of(
-            PAYLOAD_RULE_ID, "test|Active_rule_2",
-            PAYLOAD_RULE_DESCRIPTION, "Active rule 2",
-            PAYLOAD_RULE_TOTAL_RISK, "0",
-            PAYLOAD_RULE_HAS_INCIDENT, "false",
-            PAYLOAD_RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_2"
+            RULE_ID, "test|Active_rule_2",
+            RULE_DESCRIPTION, "Active rule 2",
+            TOTAL_RISK, "0",
+            HAS_INCIDENT, "false",
+            RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_2"
     );
     private static final Map<String, String> TEST_RULE_3 = Map.of(
-            PAYLOAD_RULE_ID, "test|Active_rule_3",
-            PAYLOAD_RULE_DESCRIPTION, "Active rule 3",
-            PAYLOAD_RULE_TOTAL_RISK, "0",
-            PAYLOAD_RULE_HAS_INCIDENT, "false",
-            PAYLOAD_RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_3"
+            RULE_ID, "test|Active_rule_3",
+            RULE_DESCRIPTION, "Active rule 3",
+            TOTAL_RISK, "0",
+            HAS_INCIDENT, "false",
+            RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_3"
     );
     private static final Map<String, String> TEST_RULE_4 = Map.of(
-            PAYLOAD_RULE_ID, "test|Active_rule_4",
-            PAYLOAD_RULE_DESCRIPTION, "Active rule 4",
-            PAYLOAD_RULE_TOTAL_RISK, "10",
-            PAYLOAD_RULE_HAS_INCIDENT, "true",
-            PAYLOAD_RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_4"
+            RULE_ID, "test|Active_rule_4",
+            RULE_DESCRIPTION, "Active rule 4",
+            TOTAL_RISK, "10",
+            HAS_INCIDENT, "true",
+            RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_4"
     );
     private static final Map<String, String> TEST_RULE_5 = Map.of(
-            PAYLOAD_RULE_ID, "test|Active_rule_5",
-            PAYLOAD_RULE_DESCRIPTION, "Active rule 5",
-            PAYLOAD_RULE_TOTAL_RISK, "4",
-            PAYLOAD_RULE_HAS_INCIDENT, "true",
-            PAYLOAD_RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_5"
+            RULE_ID, "test|Active_rule_5",
+            RULE_DESCRIPTION, "Active rule 5",
+            TOTAL_RISK, "4",
+            HAS_INCIDENT, "true",
+            RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_5"
     );
     private static final Map<String, String> TEST_RULE_6 = Map.of(
-            PAYLOAD_RULE_ID, "test|Active_rule_6",
-            PAYLOAD_RULE_DESCRIPTION, "Active rule 6",
-            PAYLOAD_RULE_TOTAL_RISK, "2",
-            PAYLOAD_RULE_HAS_INCIDENT, "false",
-            PAYLOAD_RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_6"
+            RULE_ID, "test|Active_rule_6",
+            RULE_DESCRIPTION, "Active rule 6",
+            TOTAL_RISK, "2",
+            HAS_INCIDENT, "false",
+            RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_6"
     );
 
     @Test
@@ -131,52 +127,52 @@ class AdvisorEmailAggregatorTest {
         Map<String, Map<String, Object>> newRecommendations = advisor.getJsonObject(NEW_RECOMMENDATIONS).mapTo(Map.class);
         assertEquals(2, newRecommendations.entrySet().size());
 
-        Map<String, Object> rule1 = newRecommendations.get(TEST_RULE_1.get(PAYLOAD_RULE_ID));
-        assertEquals(TEST_RULE_1.get(PAYLOAD_RULE_DESCRIPTION), rule1.get(CONTENT_RULE_DESCRIPTION));
-        assertEquals(TEST_RULE_1.get(PAYLOAD_RULE_HAS_INCIDENT), rule1.get(CONTENT_RULE_HAS_INCIDENT));
-        assertEquals(TEST_RULE_1.get(PAYLOAD_RULE_TOTAL_RISK), rule1.get(CONTENT_RULE_TOTAL_RISK));
-        assertEquals(TEST_RULE_1.get(PAYLOAD_RULE_URL), rule1.get(CONTENT_RULE_URL));
-        assertEquals(4, rule1.get(CONTENT_SYSTEM_COUNT));
+        Map<String, Object> aggregatedRule1 = newRecommendations.get(TEST_RULE_1.get(RULE_ID));
+        assertEquals(TEST_RULE_1.get(RULE_DESCRIPTION), aggregatedRule1.get(RULE_DESCRIPTION));
+        assertEquals(TEST_RULE_1.get(HAS_INCIDENT), aggregatedRule1.get(HAS_INCIDENT));
+        assertEquals(TEST_RULE_1.get(TOTAL_RISK), aggregatedRule1.get(TOTAL_RISK));
+        assertEquals(TEST_RULE_1.get(RULE_URL), aggregatedRule1.get(RULE_URL));
+        assertEquals(4, aggregatedRule1.get(CONTENT_SYSTEM_COUNT));
 
-        Map<String, Object> rule2 = newRecommendations.get(TEST_RULE_2.get(PAYLOAD_RULE_ID));
-        assertEquals(TEST_RULE_2.get(PAYLOAD_RULE_DESCRIPTION), rule2.get(CONTENT_RULE_DESCRIPTION));
-        assertEquals(TEST_RULE_2.get(PAYLOAD_RULE_HAS_INCIDENT), rule2.get(CONTENT_RULE_HAS_INCIDENT));
-        assertEquals(TEST_RULE_2.get(PAYLOAD_RULE_TOTAL_RISK), rule2.get(CONTENT_RULE_TOTAL_RISK));
-        assertEquals(TEST_RULE_2.get(PAYLOAD_RULE_URL), rule2.get(CONTENT_RULE_URL));
-        assertEquals(1, rule2.get(CONTENT_SYSTEM_COUNT));
+        Map<String, Object> aggregatedRule2 = newRecommendations.get(TEST_RULE_2.get(RULE_ID));
+        assertEquals(TEST_RULE_2.get(RULE_DESCRIPTION), aggregatedRule2.get(RULE_DESCRIPTION));
+        assertEquals(TEST_RULE_2.get(HAS_INCIDENT), aggregatedRule2.get(HAS_INCIDENT));
+        assertEquals(TEST_RULE_2.get(TOTAL_RISK), aggregatedRule2.get(TOTAL_RISK));
+        assertEquals(TEST_RULE_2.get(RULE_URL), aggregatedRule2.get(RULE_URL));
+        assertEquals(1, aggregatedRule2.get(CONTENT_SYSTEM_COUNT));
 
         Map<String, Map<String, Object>> resolvedRecommendations = advisor.getJsonObject(RESOLVED_RECOMMENDATIONS).mapTo(Map.class);
         assertEquals(2, resolvedRecommendations.size());
 
-        Map<String, Object> rule3 = resolvedRecommendations.get(TEST_RULE_3.get(PAYLOAD_RULE_ID));
-        assertEquals(TEST_RULE_3.get(PAYLOAD_RULE_DESCRIPTION), rule3.get(CONTENT_RULE_DESCRIPTION));
-        assertEquals(TEST_RULE_3.get(PAYLOAD_RULE_HAS_INCIDENT), rule3.get(CONTENT_RULE_HAS_INCIDENT));
-        assertEquals(TEST_RULE_3.get(PAYLOAD_RULE_TOTAL_RISK), rule3.get(CONTENT_RULE_TOTAL_RISK));
-        assertEquals(TEST_RULE_3.get(PAYLOAD_RULE_URL), rule3.get(CONTENT_RULE_URL));
-        assertEquals(11, rule3.get(CONTENT_SYSTEM_COUNT));
+        Map<String, Object> aggregatedRule3 = resolvedRecommendations.get(TEST_RULE_3.get(RULE_ID));
+        assertEquals(TEST_RULE_3.get(RULE_DESCRIPTION), aggregatedRule3.get(RULE_DESCRIPTION));
+        assertEquals(TEST_RULE_3.get(HAS_INCIDENT), aggregatedRule3.get(HAS_INCIDENT));
+        assertEquals(TEST_RULE_3.get(TOTAL_RISK), aggregatedRule3.get(TOTAL_RISK));
+        assertEquals(TEST_RULE_3.get(RULE_URL), aggregatedRule3.get(RULE_URL));
+        assertEquals(11, aggregatedRule3.get(CONTENT_SYSTEM_COUNT));
 
-        Map<String, Object> rule4 = resolvedRecommendations.get(TEST_RULE_4.get(PAYLOAD_RULE_ID));
-        assertEquals(TEST_RULE_4.get(PAYLOAD_RULE_DESCRIPTION), rule4.get(CONTENT_RULE_DESCRIPTION));
-        assertEquals(TEST_RULE_4.get(PAYLOAD_RULE_HAS_INCIDENT), rule4.get(CONTENT_RULE_HAS_INCIDENT));
-        assertEquals(TEST_RULE_4.get(PAYLOAD_RULE_TOTAL_RISK), rule4.get(CONTENT_RULE_TOTAL_RISK));
-        assertEquals(TEST_RULE_4.get(PAYLOAD_RULE_URL), rule4.get(CONTENT_RULE_URL));
-        assertEquals(1, rule4.get(CONTENT_SYSTEM_COUNT));
+        Map<String, Object> aggregatedRule4 = resolvedRecommendations.get(TEST_RULE_4.get(RULE_ID));
+        assertEquals(TEST_RULE_4.get(RULE_DESCRIPTION), aggregatedRule4.get(RULE_DESCRIPTION));
+        assertEquals(TEST_RULE_4.get(HAS_INCIDENT), aggregatedRule4.get(HAS_INCIDENT));
+        assertEquals(TEST_RULE_4.get(TOTAL_RISK), aggregatedRule4.get(TOTAL_RISK));
+        assertEquals(TEST_RULE_4.get(RULE_URL), aggregatedRule4.get(RULE_URL));
+        assertEquals(1, aggregatedRule4.get(CONTENT_SYSTEM_COUNT));
 
         Map<String, Map<String, Object>> deactivatedRecommendations = advisor.getJsonObject(DEACTIVATED_RECOMMENDATIONS).mapTo(Map.class);
         assertEquals(2, deactivatedRecommendations.size());
 
-        Map<String, Object> rule5 = deactivatedRecommendations.get(TEST_RULE_5.get(PAYLOAD_RULE_ID));
-        assertEquals(TEST_RULE_5.get(PAYLOAD_RULE_DESCRIPTION), rule5.get(CONTENT_RULE_DESCRIPTION));
-        assertEquals(TEST_RULE_5.get(PAYLOAD_RULE_HAS_INCIDENT), rule5.get(CONTENT_RULE_HAS_INCIDENT));
-        assertEquals(TEST_RULE_5.get(PAYLOAD_RULE_TOTAL_RISK), rule5.get(CONTENT_RULE_TOTAL_RISK));
-        assertEquals(TEST_RULE_5.get(PAYLOAD_RULE_URL), rule5.get(CONTENT_RULE_URL));
-        assertNull(rule5.get(CONTENT_SYSTEM_COUNT));
+        Map<String, Object> aggregatedRule5 = deactivatedRecommendations.get(TEST_RULE_5.get(RULE_ID));
+        assertEquals(TEST_RULE_5.get(RULE_DESCRIPTION), aggregatedRule5.get(RULE_DESCRIPTION));
+        assertEquals(TEST_RULE_5.get(HAS_INCIDENT), aggregatedRule5.get(HAS_INCIDENT));
+        assertEquals(TEST_RULE_5.get(TOTAL_RISK), aggregatedRule5.get(TOTAL_RISK));
+        assertEquals(TEST_RULE_5.get(RULE_URL), aggregatedRule5.get(RULE_URL));
+        assertNull(aggregatedRule5.get(CONTENT_SYSTEM_COUNT));
 
-        Map<String, Object> rule6 = deactivatedRecommendations.get(TEST_RULE_6.get(PAYLOAD_RULE_ID));
-        assertEquals(TEST_RULE_6.get(PAYLOAD_RULE_DESCRIPTION), rule6.get(CONTENT_RULE_DESCRIPTION));
-        assertEquals(TEST_RULE_6.get(PAYLOAD_RULE_HAS_INCIDENT), rule6.get(CONTENT_RULE_HAS_INCIDENT));
-        assertEquals(TEST_RULE_6.get(PAYLOAD_RULE_TOTAL_RISK), rule6.get(CONTENT_RULE_TOTAL_RISK));
-        assertEquals(TEST_RULE_6.get(PAYLOAD_RULE_URL), rule6.get(CONTENT_RULE_URL));
-        assertNull(rule6.get(CONTENT_SYSTEM_COUNT));
+        Map<String, Object> aggregatedRule6 = deactivatedRecommendations.get(TEST_RULE_6.get(RULE_ID));
+        assertEquals(TEST_RULE_6.get(RULE_DESCRIPTION), aggregatedRule6.get(RULE_DESCRIPTION));
+        assertEquals(TEST_RULE_6.get(HAS_INCIDENT), aggregatedRule6.get(HAS_INCIDENT));
+        assertEquals(TEST_RULE_6.get(TOTAL_RISK), aggregatedRule6.get(TOTAL_RISK));
+        assertEquals(TEST_RULE_6.get(RULE_URL), aggregatedRule6.get(RULE_URL));
+        assertNull(aggregatedRule6.get(CONTENT_SYSTEM_COUNT));
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregatorTest.java
@@ -60,44 +60,44 @@ import static org.junit.jupiter.api.Assertions.assertNull;
     }
 }
  */
-class AdvisorEmailAggregatorTest {
+public class AdvisorEmailAggregatorTest {
 
-    private static final Map<String, String> TEST_RULE_1 = Map.of(
+    public static final Map<String, String> TEST_RULE_1 = Map.of(
             RULE_ID, "test|Active_rule_1",
             RULE_DESCRIPTION, "Active rule 1",
             TOTAL_RISK, "3",
             HAS_INCIDENT, "true",
             RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_1"
     );
-    private static final Map<String, String> TEST_RULE_2 = Map.of(
+    public static final Map<String, String> TEST_RULE_2 = Map.of(
             RULE_ID, "test|Active_rule_2",
             RULE_DESCRIPTION, "Active rule 2",
             TOTAL_RISK, "0",
             HAS_INCIDENT, "false",
             RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_2"
     );
-    private static final Map<String, String> TEST_RULE_3 = Map.of(
+    public static final Map<String, String> TEST_RULE_3 = Map.of(
             RULE_ID, "test|Active_rule_3",
             RULE_DESCRIPTION, "Active rule 3",
             TOTAL_RISK, "0",
             HAS_INCIDENT, "false",
             RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_3"
     );
-    private static final Map<String, String> TEST_RULE_4 = Map.of(
+    public static final Map<String, String> TEST_RULE_4 = Map.of(
             RULE_ID, "test|Active_rule_4",
             RULE_DESCRIPTION, "Active rule 4",
             TOTAL_RISK, "10",
             HAS_INCIDENT, "true",
             RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_4"
     );
-    private static final Map<String, String> TEST_RULE_5 = Map.of(
+    public static final Map<String, String> TEST_RULE_5 = Map.of(
             RULE_ID, "test|Active_rule_5",
             RULE_DESCRIPTION, "Active rule 5",
             TOTAL_RISK, "4",
             HAS_INCIDENT, "true",
             RULE_URL, "https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_5"
     );
-    private static final Map<String, String> TEST_RULE_6 = Map.of(
+    public static final Map<String, String> TEST_RULE_6 = Map.of(
             RULE_ID, "test|Active_rule_6",
             RULE_DESCRIPTION, "Active rule 6",
             TOTAL_RISK, "2",

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
@@ -15,6 +15,9 @@ import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.DAILY;
 import static com.redhat.cloud.notifications.models.EmailSubscriptionType.INSTANT;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.DEACTIVATED_RECOMMENDATION;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.NEW_RECOMMENDATION;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RESOLVED_RECOMMENDATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -25,13 +28,13 @@ public class TestAdvisorTemplate {
 
     private final Advisor advisor = new Advisor();
 
-    @ValueSource(strings = {"new-recommendation", "resolved-recommendation", "deactivated-recommendation" })
+    @ValueSource(strings = { NEW_RECOMMENDATION, RESOLVED_RECOMMENDATION, DEACTIVATED_RECOMMENDATION })
     @ParameterizedTest
     void shouldSupportDailyEmailSubscriptionType(String eventType) {
         assertTrue(advisor.isSupported(eventType, DAILY));
     }
 
-    @ValueSource(strings = {"new-recommendation", "resolved-recommendation", "deactivated-recommendation" })
+    @ValueSource(strings = { NEW_RECOMMENDATION, RESOLVED_RECOMMENDATION, DEACTIVATED_RECOMMENDATION })
     @ParameterizedTest
     void shouldSupportNewResolvedAndDeactivatedRecommendations(String eventType) {
         assertTrue(advisor.isSupported(eventType, INSTANT));

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
@@ -25,9 +25,10 @@ public class TestAdvisorTemplate {
 
     private final Advisor advisor = new Advisor();
 
-    @Test
-    void shouldNotSupportDailyEmailSubscriptionType() {
-        assertFalse(advisor.isSupported("some-recommendation", DAILY));
+    @ValueSource(strings = {"new-recommendation", "resolved-recommendation", "deactivated-recommendation" })
+    @ParameterizedTest
+    void shouldSupportDailyEmailSubscriptionType(String eventType) {
+        assertTrue(advisor.isSupported(eventType, DAILY));
     }
 
     @ValueSource(strings = {"new-recommendation", "resolved-recommendation", "deactivated-recommendation" })
@@ -77,8 +78,8 @@ public class TestAdvisorTemplate {
     }
 
     @Test
-    void shouldNotSupportDailyubscriptionType() {
-        assertFalse(advisor.isEmailSubscriptionSupported(DAILY));
+    void shouldSupportDailySubscriptionType() {
+        assertTrue(advisor.isEmailSubscriptionSupported(DAILY));
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator;
 import com.redhat.cloud.notifications.templates.models.Environment;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -32,6 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestAdvisorTemplate {
 
     private final Advisor advisor = new Advisor();
+
+    @BeforeAll
+    static void beforeAll() {
+        // TODO Remove this as soon as the daily digest is enabled on prod.
+        System.setProperty("rhel.advisor.daily-digest.enabled", "true");
+    }
 
     @ValueSource(strings = { NEW_RECOMMENDATION, RESOLVED_RECOMMENDATION, DEACTIVATED_RECOMMENDATION })
     @ParameterizedTest

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
@@ -22,6 +22,8 @@ import static com.redhat.cloud.notifications.processors.email.aggregators.Adviso
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.NEW_RECOMMENDATION;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.RESOLVED_RECOMMENDATION;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregatorTest.TEST_RULE_1;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregatorTest.TEST_RULE_2;
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregatorTest.TEST_RULE_3;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -67,6 +69,8 @@ public class TestAdvisorTemplate {
     public void testDailyEmailBody() {
         AdvisorEmailAggregator aggregator = new AdvisorEmailAggregator();
         aggregator.aggregate(createEmailAggregation(NEW_RECOMMENDATION, TEST_RULE_1));
+        aggregator.aggregate(createEmailAggregation(RESOLVED_RECOMMENDATION, TEST_RULE_2));
+        aggregator.aggregate(createEmailAggregation(DEACTIVATED_RECOMMENDATION, TEST_RULE_3));
 
         Map<String, Object> context = aggregator.getContext();
         context.put("start_time", LocalDateTime.now().toString());
@@ -81,9 +85,9 @@ public class TestAdvisorTemplate {
                 .data("user", Map.of("firstName", "John", "lastName", "Doe"))
                 .render();
 
-        System.out.println(result);
-
-        assertTrue(result.contains("If you want to see more details"));
+        assertTrue(result.contains("New recommendations"));
+        assertTrue(result.contains("Resolved recommendations"));
+        assertTrue(result.contains("Deactivated recommendations"));
     }
 
     @Test


### PR DESCRIPTION
Advisor will produce a daily digest including:

* Number of new recommendations
* Number of resolved recommendations
* Number of deactivated recommendations
* The list of new recommendations, with the count of systems newly affected
* The list of resolved recommendations, with the count of systems previously affected
* The list of deactivated recommendations

This aggregator attempts to gather this information from the events over the last 24 hours.

Signed-off-by: Paul Wayper <paulway@redhat.com>