### PR TITLE
[RHCLOUD-22513] feature: find all bundles

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -96,6 +96,23 @@ public class NotificationResource {
     }
 
     @GET
+    @Path("/bundles")
+    @Produces(APPLICATION_JSON)
+    @Operation(summary = "Retrieve the collection of bundles")
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+    public Page<Bundle> getBundlesCollection(@Context final UriInfo uriInfo, @BeanParam @Valid final Query query) {
+
+        final List<Bundle> bundles = this.bundleRepository.getBundles(query);
+        final long bundlesCount = this.bundleRepository.getBundlesCount();
+
+        return new Page<>(
+            bundles,
+            PageLinksBuilder.build(uriInfo.getPath(), bundlesCount, query.getLimit().getLimit(), query.getLimit().getOffset()),
+            new Meta(bundlesCount)
+        );
+    }
+
+    @GET
     @Path("/bundles/{bundleName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve the bundle by name")

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class BundleRepositoryTest {
+
+    @Inject
+    BundleRepository bundleRepository;
+
+    @Inject
+    EntityManager entityManager;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    /**
+     * Tests that the {@link BundleRepository#getBundlesCount()} counts the number of bundles that are present in the
+     * database. For that, it first counts ones that are preloaded, creates a number of bundles, and calls the function
+     * under test to see if the numbers match.
+     */
+    @Test
+    void testCountBundles() {
+        final String query =
+            "SELECT " +
+                "count(b)" +
+            "FROM " +
+                "Bundle AS b";
+
+        final long initialBundlesCount = this.entityManager.createQuery(query, Long.class).getSingleResult();
+
+        final int bundlesToBeCreated = 5;
+        for (int i = 0; i < bundlesToBeCreated; i++) {
+            this.resourceHelpers.createBundle(
+                String.format("name-%s", i),
+                String.format("display-name-%s", i)
+            );
+        }
+
+        final long count = this.bundleRepository.getBundlesCount();
+
+        Assertions.assertEquals(initialBundlesCount + bundlesToBeCreated, count, "unexpected number of bundles counted");
+    }
+}


### PR DESCRIPTION
Lets the user query the entire collection to fetch all the available bundles that the Notifications service offers.

## Links

[[RHCLOUD-22513]](https://issues.redhat.com/browse/RHCLOUD-22513)