### PR TITLE
[RHCLOUD-22513] feature: create behavior groups specifying the bundle name

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BundleRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BundleRepository.java
@@ -82,4 +82,27 @@ public class BundleRepository {
                     .getResultList();
         }
     }
+
+    /**
+     * Finds the bundle by name.
+     * @param bundleName the name to find the bundle by.
+     * @return the found bundle from the database.
+     */
+    public Bundle findByName(final String bundleName) {
+        final String findByNameQuery =
+            "SELECT " +
+                    "b " +
+            "FROM " +
+                "Bundle AS b " +
+            "WHERE " +
+                "b.name = :name";
+
+        try {
+            return this.entityManager.createQuery(findByNameQuery, Bundle.class)
+                .setParameter("name", bundleName)
+                .getSingleResult();
+        } catch (final NoResultException e) {
+            throw new NotFoundException("the provided bundle name does not exist");
+        }
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BundleRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BundleRepository.java
@@ -10,6 +10,7 @@ import javax.persistence.NoResultException;
 import javax.transaction.Transactional;
 import javax.ws.rs.NotFoundException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @ApplicationScoped
@@ -88,7 +89,7 @@ public class BundleRepository {
      * @param bundleName the name to find the bundle by.
      * @return the found bundle from the database.
      */
-    public Bundle findByName(final String bundleName) {
+    public Optional<Bundle> findByName(final String bundleName) {
         final String findByNameQuery =
             "SELECT " +
                     "b " +
@@ -98,11 +99,13 @@ public class BundleRepository {
                 "b.name = :name";
 
         try {
-            return this.entityManager.createQuery(findByNameQuery, Bundle.class)
-                .setParameter("name", bundleName)
-                .getSingleResult();
+            return Optional.of(
+                this.entityManager.createQuery(findByNameQuery, Bundle.class)
+                    .setParameter("name", bundleName)
+                    .getSingleResult()
+            );
         } catch (final NoResultException e) {
-            throw new NotFoundException("the provided bundle name does not exist");
+            return Optional.empty();
         }
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -19,7 +19,6 @@ import com.redhat.cloud.notifications.routers.models.PageLinksBuilder;
 import com.redhat.cloud.notifications.routers.models.behaviorgroup.CreateBehaviorGroupRequest;
 import com.redhat.cloud.notifications.routers.models.behaviorgroup.CreateBehaviorGroupResponse;
 import com.redhat.cloud.notifications.routers.models.behaviorgroup.UpdateBehaviorGroupRequest;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -240,7 +239,7 @@ public class NotificationResource {
         // to fetch the bundles to get the exact bundle ID. More information in
         // the request's class, or in RHCLOUD-22513.
         UUID bundleId = request.bundleId;
-        if (bundleId == null && !StringUtils.isBlank(request.bundleName)) {
+        if (bundleId == null) {
             final Optional<Bundle> bundle = this.bundleRepository.findByName(request.bundleName);
             if (bundle.isEmpty()) {
                 throw new NotFoundException("the specified bundle was not found in the database");

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -53,6 +53,7 @@ import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -240,8 +241,12 @@ public class NotificationResource {
         // the request's class, or in RHCLOUD-22513.
         UUID bundleId = request.bundleId;
         if (bundleId == null && !StringUtils.isBlank(request.bundleName)) {
-            final Bundle bundle = this.bundleRepository.findByName(request.bundleName);
-            bundleId = bundle.getId();
+            final Optional<Bundle> bundle = this.bundleRepository.findByName(request.bundleName);
+            if (bundle.isEmpty()) {
+                throw new NotFoundException("the specified bundle was not found in the database");
+            }
+
+            bundleId = bundle.get().getId();
         }
 
         BehaviorGroup behaviorGroup = new BehaviorGroup();

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -216,6 +216,17 @@ public class NotificationResource {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Creates a new behavior group. The payload requires to either specify the
+     * related bundle ID, or its name. This is due to a feature request coming
+     * from the frontend team, which was forced to fetch all bundles in order
+     * to grab their UUID, when apparently they could simply send the bundle
+     * name instead. More information in the related Jira ticket
+     * <a href="https://issues.redhat.com/browse/RHCLOUD-22513">RHCLOUD-22513</a>.
+     * @param sec the security context needed to get the account ID and the Org ID.
+     * @param request the incoming valid {@link CreateBehaviorGroupRequest}.
+     * @return the created behavior group to the client.
+     */
     @POST
     @Path("/behaviorGroups")
     @Consumes(APPLICATION_JSON)
@@ -233,11 +244,10 @@ public class NotificationResource {
         String accountId = getAccountId(sec);
         String orgId = getOrgId(sec);
 
-        // Set the bundle ID from the incoming request. If the user provided a
-        // bundle name instead, fetch the bundle ID from the database. This is
-        // to make the frontend's life easier, in the way that they won't need
-        // to fetch the bundles to get the exact bundle ID. More information in
-        // the request's class, or in RHCLOUD-22513.
+        // We know that either the ID or the name are present because the
+        // request gets validated before reaching this point, and therefore it
+        // is safe to assume that either the bundle ID or the bundle name will
+        // be present.
         UUID bundleId = request.bundleId;
         if (bundleId == null) {
             final Optional<Bundle> bundle = this.bundleRepository.findByName(request.bundleName);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
@@ -43,10 +43,11 @@ public class CreateBehaviorGroupRequest {
 
     /**
      * Validates that the bundle is identifiable.
-     * @return true if the bundle ID is null and the bundle name is blank. False otherwise.
+     * @return true if the bundle UUID is not null, or if the bundle name is
+     * not blank.
      */
     @AssertTrue(message = "either the bundle name or the bundle UUID are required")
-    private boolean isBundleUuidNullOrBundleNameBlank() {
+    private boolean isBundleUuidOrBundleNameValid() {
         return this.bundleId != null || (
             this.bundleName != null && !this.bundleName.isBlank()
             );

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
@@ -11,15 +11,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-/**
- * Expected payload for when a behavior group is to be created. In order to
- * specify which bundle it will be tied to, its UUID or internal name can be
- * specified. This is due to a request coming from the frontend team, which
- * was forced to fetch all bundles in order to grab their UUID, when apparently
- * they could simply send the bundle name instead. More information in the
- * related Jira ticket
- * <a href="https://issues.redhat.com/browse/RHCLOUD-22513">RHCLOUD-22513</a>.
- */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateBehaviorGroupRequest {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
@@ -3,20 +3,35 @@ package com.redhat.cloud.notifications.routers.models.behaviorgroup;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.apache.commons.lang3.StringUtils;
 
+import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * Expected payload for when a behavior group is to be created. In order to
+ * specify which bundle it will be tied to, its UUID or internal name can be
+ * specified. This is due to a request coming from the frontend team, which
+ * was forced to fetch all bundles in order to grab their UUID, when apparently
+ * they could simply send the bundle name instead. More information in the
+ * related Jira ticket
+ * <a href="https://issues.redhat.com/browse/RHCLOUD-22513">RHCLOUD-22513</a>.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateBehaviorGroupRequest {
     /**
      * BundleId the behavior group will be created for.
      */
-    @NotNull
     public UUID bundleId;
+
+    /**
+     * The name of the bundle.
+     */
+    public String bundleName;
 
     /**
      * Display name the behavior group will have.
@@ -35,4 +50,13 @@ public class CreateBehaviorGroupRequest {
      * the behavior group).
      */
     public Set<UUID> eventTypeIds;
+
+    /**
+     * Validates that the bundle is identifiable.
+     * @return true if the bundle ID is null and the bundle name is blank. False otherwise.
+     */
+    @AssertFalse(message = "either the bundle name or the bundle UUID are required")
+    private boolean isBundleUuidNullOrBundleNameBlank() {
+        return this.bundleId == null && StringUtils.isBlank(this.bundleName);
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
@@ -3,10 +3,9 @@ package com.redhat.cloud.notifications.routers.models.behaviorgroup;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import org.apache.commons.lang3.StringUtils;
 
-import javax.validation.constraints.AssertFalse;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotBlank;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -27,7 +26,7 @@ public class CreateBehaviorGroupRequest {
     /**
      * Display name the behavior group will have.
      */
-    @NotNull
+    @NotBlank
     public String displayName;
 
     /**
@@ -46,8 +45,10 @@ public class CreateBehaviorGroupRequest {
      * Validates that the bundle is identifiable.
      * @return true if the bundle ID is null and the bundle name is blank. False otherwise.
      */
-    @AssertFalse(message = "either the bundle name or the bundle UUID are required")
+    @AssertTrue(message = "either the bundle name or the bundle UUID are required")
     private boolean isBundleUuidNullOrBundleNameBlank() {
-        return this.bundleId == null && StringUtils.isBlank(this.bundleName);
+        return this.bundleId != null || (
+            this.bundleName != null && !this.bundleName.isBlank()
+            );
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
@@ -38,10 +38,10 @@ public class BundleRepositoryTest extends DbIsolatedTest {
     }
 
     /**
-     * Tests that a not found exception is thrown when the bundle cannot be found by its name.
+     * Tests that an empty Optional is returned when the bundle cannot be found by its name.
      */
     @Test
-    void testFindByNameBadRequest() {
+    void testFindByNameEmptyOptional() {
         Assertions.assertTrue(this.bundleRepository.findByName("made-up-name").isEmpty(), "the bundle shouldn't have been found in the database");
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-import javax.ws.rs.NotFoundException;
+import java.util.Optional;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
@@ -30,9 +30,10 @@ public class BundleRepositoryTest {
         final Bundle bundle = this.resourceHelpers.createBundle(bundleName, "test-find-by-name-display-name-bundle");
 
         // Call the function under test.
-        final Bundle result = this.bundleRepository.findByName(bundleName);
+        final Optional<Bundle> result = this.bundleRepository.findByName(bundleName);
 
-        Assertions.assertEquals(bundle.getId(), result.getId(), "unexpected bundle fetched by name from the database");
+        Assertions.assertTrue(result.isPresent(), "no bundle was fetched from the database");
+        Assertions.assertEquals(bundle.getId(), result.get().getId(), "unexpected bundle fetched by name from the database");
     }
 
     /**
@@ -40,6 +41,6 @@ public class BundleRepositoryTest {
      */
     @Test
     void testFindByNameBadRequest() {
-        Assertions.assertThrows(NotFoundException.class, () -> this.bundleRepository.findByName("made-up-name"));
+        Assertions.assertTrue(this.bundleRepository.findByName("made-up-name").isEmpty(), "the bundle shouldn't have been found in the database");
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.Bundle;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -13,7 +14,7 @@ import java.util.Optional;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class BundleRepositoryTest {
+public class BundleRepositoryTest extends DbIsolatedTest {
 
     @Inject
     BundleRepository bundleRepository;

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BundleRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.models.Bundle;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class BundleRepositoryTest {
+
+    @Inject
+    BundleRepository bundleRepository;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    /**
+     * Tests that a bundle can be successfully found by its name.
+     */
+    @Test
+    void testFindByName() {
+        final String bundleName = "test-find-by-name-bundle";
+        final Bundle bundle = this.resourceHelpers.createBundle(bundleName, "test-find-by-name-display-name-bundle");
+
+        // Call the function under test.
+        final Bundle result = this.bundleRepository.findByName(bundleName);
+
+        Assertions.assertEquals(bundle.getId(), result.getId(), "unexpected bundle fetched by name from the database");
+    }
+
+    /**
+     * Tests that a not found exception is thrown when the bundle cannot be found by its name.
+     */
+    @Test
+    void testFindByNameBadRequest() {
+        Assertions.assertThrows(NotFoundException.class, () -> this.bundleRepository.findByName("made-up-name"));
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/CreateBehaviorGroupRequestTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/CreateBehaviorGroupRequestTest.java
@@ -34,7 +34,7 @@ public class CreateBehaviorGroupRequestTest {
         requestBundleId.displayName = "valid display name";
 
         final var requestBundleName = new CreateBehaviorGroupRequest();
-        requestBundleName.bundleId = UUID.randomUUID();
+        requestBundleName.bundleName = "specified bundle name";
         requestBundleName.displayName = "valid display name";
 
         final CreateBehaviorGroupRequest[] validRequests = {requestBundleId, requestBundleName};

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/CreateBehaviorGroupRequestTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/CreateBehaviorGroupRequestTest.java
@@ -1,0 +1,115 @@
+package com.redhat.cloud.notifications.models.behaviorgroup;
+
+import com.redhat.cloud.notifications.routers.models.behaviorgroup.CreateBehaviorGroupRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.UUID;
+
+public class CreateBehaviorGroupRequestTest {
+
+    private static Validator validator;
+
+    /**
+     * Sets up the validator.
+     */
+    @BeforeAll
+    public static void setUp() {
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            validator = validatorFactory.getValidator();
+        }
+    }
+
+    /**
+     * Tests that a valid request doesn't raise any constraint violations.
+     */
+    @Test
+    void testValidRequest() {
+        final var requestBundleId = new CreateBehaviorGroupRequest();
+        requestBundleId.bundleId = UUID.randomUUID();
+        requestBundleId.displayName = "valid display name";
+
+        final var requestBundleName = new CreateBehaviorGroupRequest();
+        requestBundleName.bundleId = UUID.randomUUID();
+        requestBundleName.displayName = "valid display name";
+
+        final CreateBehaviorGroupRequest[] validRequests = {requestBundleId, requestBundleName};
+
+        for (final var request : validRequests) {
+            final var constraintViolations = validator.validate(request);
+
+            Assertions.assertEquals(0, constraintViolations.size(), "unexpected constraint violations received: " + constraintViolations);
+        }
+    }
+
+    /**
+     * Tests that a request with an invalid display name raises a constraint
+     * violation.
+     */
+    @Test
+    void testInvalidDisplayName() {
+        final String[] invalidDisplayNames = {null, "", "     "};
+
+        for (final var invalidName : invalidDisplayNames) {
+            final var request = new CreateBehaviorGroupRequest();
+            request.bundleId = UUID.randomUUID();
+            request.displayName = invalidName;
+
+            final var constraintViolations = validator.validate(request);
+
+            Assertions.assertEquals(1, constraintViolations.size(), "unexpected number of constraint violations received. CVs: " + constraintViolations);
+
+            for (final var cv : constraintViolations) {
+                Assertions.assertEquals("displayName", cv.getPropertyPath().toString(), "unexpected field raised the constraint violation");
+                Assertions.assertEquals("must not be blank", cv.getMessage(), "unexpected constraint violation returned");
+            }
+        }
+    }
+
+    /**
+     * Tests that when the bundle ID or the name is missing, a constraint
+     * violation is raised.
+     */
+    @Test
+    void testMissingBundleIdAndNames() {
+        final var request = new CreateBehaviorGroupRequest();
+        request.displayName = "test display name";
+
+        final var constraintViolations = validator.validate(request);
+
+        Assertions.assertEquals(1, constraintViolations.size(), "unexpected number of constraint violations received. CVs: " + constraintViolations);
+
+        for (final var cv : constraintViolations) {
+            Assertions.assertEquals("bundleUuidNullOrBundleNameBlank", cv.getPropertyPath().toString(), "unexpected field raised the constraint violation");
+            Assertions.assertEquals("either the bundle name or the bundle UUID are required", cv.getMessage(), "unexpected constraint violation returned");
+        }
+    }
+
+    /**
+     * Tests that when the specified bundle names are invalid, a constraint
+     * violation is raised.
+     */
+    @Test
+    void testInvalidBundleNames() {
+        final String[] invalidBundleNames = {null, "", "     "};
+
+        for (final var invalidName : invalidBundleNames) {
+            final var request = new CreateBehaviorGroupRequest();
+            request.bundleName = invalidName;
+            request.displayName = "test display name";
+
+            final var constraintViolations = validator.validate(request);
+
+            Assertions.assertEquals(1, constraintViolations.size(), "unexpected number of constraint violations received. CVs: " + constraintViolations);
+
+            for (final var cv : constraintViolations) {
+                Assertions.assertEquals("bundleUuidNullOrBundleNameBlank", cv.getPropertyPath().toString(), "unexpected field raised the constraint violation");
+                Assertions.assertEquals("either the bundle name or the bundle UUID are required", cv.getMessage(), "unexpected constraint violation returned");
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/CreateBehaviorGroupRequestTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/CreateBehaviorGroupRequestTest.java
@@ -84,7 +84,7 @@ public class CreateBehaviorGroupRequestTest {
         Assertions.assertEquals(1, constraintViolations.size(), "unexpected number of constraint violations received. CVs: " + constraintViolations);
 
         for (final var cv : constraintViolations) {
-            Assertions.assertEquals("bundleUuidNullOrBundleNameBlank", cv.getPropertyPath().toString(), "unexpected field raised the constraint violation");
+            Assertions.assertEquals("bundleUuidOrBundleNameValid", cv.getPropertyPath().toString(), "unexpected field raised the constraint violation");
             Assertions.assertEquals("either the bundle name or the bundle UUID are required", cv.getMessage(), "unexpected constraint violation returned");
         }
     }
@@ -107,7 +107,7 @@ public class CreateBehaviorGroupRequestTest {
             Assertions.assertEquals(1, constraintViolations.size(), "unexpected number of constraint violations received. CVs: " + constraintViolations);
 
             for (final var cv : constraintViolations) {
-                Assertions.assertEquals("bundleUuidNullOrBundleNameBlank", cv.getPropertyPath().toString(), "unexpected field raised the constraint violation");
+                Assertions.assertEquals("bundleUuidOrBundleNameValid", cv.getPropertyPath().toString(), "unexpected field raised the constraint violation");
                 Assertions.assertEquals("either the bundle name or the bundle UUID are required", cv.getMessage(), "unexpected constraint violation returned");
             }
         }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -972,6 +972,51 @@ public class NotificationResourceTest extends DbIsolatedTest {
         }
     }
 
+    /**
+     * Tests that a successful status code is returned when a behavior group is
+     * created by using the bundle's name instead of its UUID.
+     */
+    @Test
+    void testBehaviorGroupUsingBundleName() {
+        final Bundle bundle = helpers.createBundle(TEST_BUNDLE_NAME, "Bundle-display-name");
+
+        final CreateBehaviorGroupRequest createBehaviorGroupRequest = new CreateBehaviorGroupRequest();
+        createBehaviorGroupRequest.displayName = "behavior-group-display-name";
+        createBehaviorGroupRequest.bundleName =  bundle.getName();
+
+        final Header identityHeader = initRbacMock("tenant", "sameBehaviorGroupName", "user", FULL_ACCESS);
+
+        given()
+            .header(identityHeader)
+            .when()
+            .contentType(JSON)
+            .body(Json.encode(createBehaviorGroupRequest))
+            .post("/notifications/behaviorGroups")
+            .then()
+            .statusCode(200);
+    }
+
+    /**
+     * Tests that a bad request response is returned when attempting to create
+     * a behavior group without specifying a bundle ID or its name.
+     */
+    @Test
+    void testBadRequestBehaviorGroupInvalidBundle() {
+        final CreateBehaviorGroupRequest createBehaviorGroupRequest = new CreateBehaviorGroupRequest();
+        createBehaviorGroupRequest.displayName = "behavior-group-display-name";
+
+        final Header identityHeader = initRbacMock("tenant", "sameBehaviorGroupName", "user", FULL_ACCESS);
+
+        given()
+            .header(identityHeader)
+            .when()
+            .contentType(JSON)
+            .body(Json.encode(createBehaviorGroupRequest))
+            .post("/notifications/behaviorGroups")
+            .then()
+            .statusCode(400);
+    }
+
     private Optional<CreateBehaviorGroupResponse> createBehaviorGroup(Header identityHeader, CreateBehaviorGroupRequest request, int expectedStatusCode) {
         ValidatableResponse response = given()
                 .header(identityHeader)


### PR DESCRIPTION
The frontend team has requested us to implement a change to be able to create a behavior group by using the bundle's name, instead of its UUID. The reason behind this is that they seem to be able to provide the bundle name directly, but for the UUID, they need to fetch all the bundles to find the right one by name.

## Links

[[RHCLOUD-22513]](https://issues.redhat.com/browse/RHCLOUD-22513)