### PR TITLE
[RHCLOUD-21842] feature: limit the maximum allowed number of behavior group creations

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -81,7 +81,9 @@ public class BehaviorGroupRepository {
 
     @Transactional
     BehaviorGroup create(String accountId, String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {
-        if (!this.isAllowedToCreateMoreBehaviorGroups(orgId)) {
+        // The organization ID might be null if a system behavior group is being
+        // created, that is why the check is only forced for actual tenants.
+        if (orgId != null && !orgId.isBlank() && !this.isAllowedToCreateMoreBehaviorGroups(orgId)) {
             throw new BadRequestException("behavior group creation limit reached. Please consider deleting unused behavior groups before creating more.");
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -29,6 +29,11 @@ import static org.hibernate.jpa.QueryHints.HINT_PASS_DISTINCT_THROUGH;
 @ApplicationScoped
 public class BehaviorGroupRepository {
 
+    /**
+     * Represents the maximum number of behavior groups that can be created for
+     * a tenant. Comes from ticket <a href="https://issues.redhat.com/browse/RHCLOUD-21842">RHCLOUD-21842</a>.
+     */
+    public static final long MAXIMUM_NUMBER_BEHAVIOR_GROUPS = 64;
     private static final ZoneId UTC = ZoneId.of("UTC");
 
     @Inject
@@ -76,6 +81,10 @@ public class BehaviorGroupRepository {
 
     @Transactional
     BehaviorGroup create(String accountId, String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {
+        if (!this.isAllowedToCreateMoreBehaviorGroups(accountId, orgId)) {
+            throw new BadRequestException("behavior group creation limit reached. Please consider deleting unused behavior groups before creating more.");
+        }
+
         checkBehaviorGroupDisplayNameDuplicate(orgId, behaviorGroup, isDefaultBehaviorGroup);
 
         behaviorGroup.setAccountId(accountId);
@@ -554,5 +563,31 @@ public class BehaviorGroupRepository {
                 }
             }
         }
+    }
+
+    /**
+     * Checks if it is allowed to create more behavior groups for the given tenant.
+     * @param accountNumber the account number to filter the behavior groups by.
+     * @param orgId the account number to filter the behavior groups by.
+     * @return true if the number of behavior groups of the tenant is lower than the allowed
+     * {@link BehaviorGroupRepository#MAXIMUM_NUMBER_BEHAVIOR_GROUPS}.
+     */
+    private boolean isAllowedToCreateMoreBehaviorGroups(final String accountNumber, final String orgId) {
+        final String countQuery =
+            "SELECT " +
+                "COUNT(bg) " +
+            "FROM " +
+                "BehaviorGroup AS bg " +
+            "WHERE " +
+                "(bg.accountId = :account_number OR bg.accountId IS NULL) " +
+            "AND " +
+                "bg.orgId = :org_id";
+
+        final long count = this.entityManager.createQuery(countQuery, Long.class)
+            .setParameter("account_number", accountNumber)
+            .setParameter("org_id", orgId)
+            .getSingleResult();
+
+        return count < MAXIMUM_NUMBER_BEHAVIOR_GROUPS;
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -81,7 +81,7 @@ public class BehaviorGroupRepository {
 
     @Transactional
     BehaviorGroup create(String accountId, String orgId, BehaviorGroup behaviorGroup, boolean isDefaultBehaviorGroup) {
-        if (!this.isAllowedToCreateMoreBehaviorGroups(accountId, orgId)) {
+        if (!this.isAllowedToCreateMoreBehaviorGroups(orgId)) {
             throw new BadRequestException("behavior group creation limit reached. Please consider deleting unused behavior groups before creating more.");
         }
 
@@ -567,24 +567,21 @@ public class BehaviorGroupRepository {
 
     /**
      * Checks if it is allowed to create more behavior groups for the given tenant.
-     * @param accountNumber the account number to filter the behavior groups by.
+     *
      * @param orgId the account number to filter the behavior groups by.
      * @return true if the number of behavior groups of the tenant is lower than the allowed
      * {@link BehaviorGroupRepository#MAXIMUM_NUMBER_BEHAVIOR_GROUPS}.
      */
-    private boolean isAllowedToCreateMoreBehaviorGroups(final String accountNumber, final String orgId) {
+    private boolean isAllowedToCreateMoreBehaviorGroups(final String orgId) {
         final String countQuery =
             "SELECT " +
                 "COUNT(bg) " +
             "FROM " +
                 "BehaviorGroup AS bg " +
             "WHERE " +
-                "(bg.accountId = :account_number OR bg.accountId IS NULL) " +
-            "AND " +
                 "bg.orgId = :org_id";
 
         final long count = this.entityManager.createQuery(countQuery, Long.class)
-            .setParameter("account_number", accountNumber)
             .setParameter("org_id", orgId)
             .getSingleResult();
 


### PR DESCRIPTION
QE has spotted that after a few thousand behavior groups that get created, the frontend's performance degrades. However, having a customer with more than 15 behavior groups configured is going to be a rare case.

That is why we are limiting the number of behavior groups that can be created, since we assume that if more need to be created, there will highly likely be old ones that are not used, and therefore need to be deleted first.

## Links

[[RHCLOUD-21842]](https://issues.redhat.com/browse/RHCLOUD-21842)