### PR TITLE
Casts to Number instead of Integer (or Long)

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/events/CamelHistoryFillerHelper.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/CamelHistoryFillerHelper.java
@@ -40,7 +40,7 @@ public class CamelHistoryFillerHelper {
 
         NotificationStatus status = result ? NotificationStatus.SUCCESS : NotificationStatus.FAILED_EXTERNAL;
 
-        Integer duration = (Integer) jo.getOrDefault("duration", 0);
+        Number duration = (Number) jo.getOrDefault("duration", 0);
 
         NotificationHistory history = new NotificationHistory();
 


### PR DESCRIPTION
 We found an issue when the duration was too big, the deserialization method uses Long when the number is too big to fit an Integer.

Without the fix the updated tests fails with:
```
2023-01-04 12:21:17,746 INFO  [com.red.clo.not.eve.FromCamelHistoryFiller] (executor-thread-0) Processing return from camel: {"id":"e3c90a94-751b-4ce1-b345-b85d825795a4","source":"demo-log","data":"{\"duration\":2415706709,\"details\":{\"target\":\"1.2.3.4\",\"type\":\"com.redhat.console.notification.toCamel.tower\"},\"finishTime\":1639476503209,\"outcome\":null,\"successful\":true}","content-type":"application/json","specversion":"1.0","time":"2021-12-14T10:08:23.217Z","type":"com.redhat.cloud.notifications.history"}
2023-01-04 12:21:17,865 INFO  [com.red.clo.not.eve.FromCamelHistoryFiller] (executor-thread-0) |  Update Fail: java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer (java.lang.Long and java.lang.Integer are in module java.base of loader 'bootstrap')
	at com.redhat.cloud.notifications.events.CamelHistoryFillerHelper.updateHistoryItem(CamelHistoryFillerHelper.java:43)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.redhat.cloud.notifications.events.CamelHistoryFillerHelper.updateHistoryItem(CamelHistoryFillerHelper.java:26)
```