### PR TITLE
Fixed Edge image creation email template

### DIFF
--- a/engine/src/main/resources/templates/EdgeManagement/imageCreationBody.html
+++ b/engine/src/main/resources/templates/EdgeManagement/imageCreationBody.html
@@ -1,5 +1,5 @@
 {#include EdgeManagement/insightsEmailBody}
-{#content-title}Egde Management Image Notification - {action.timestamp.toStringFormat()}{/content-title}
+{#content-title}Edge Management - Image Notification - {action.timestamp.toStringFormat()}{/content-title}
 {#content-body}
 <tr>
     <td class="rh-body rh-multi-column">
@@ -35,7 +35,7 @@
                         Hi,
                         <br>
                         <br>
-                        A New Image it's being created {action.events[0].payload.ID}.
+                        A new image was created {action.timestamp.toTimeAgo()}. Follow this <a href="{environment.url}/edge/manage-images/{action.events[0].payload.ImageSetID}/versions/{action.events[0].payload.ImageId}/details" target="_blank">link</a> to image named {action.context.ImageName}.
                     </p>
                 </td>
             </tr>
@@ -45,6 +45,5 @@
     </td>
 </tr>
 <!-- end body section -->
-
 {/content-body}
 {/include}

--- a/engine/src/main/resources/templates/EdgeManagement/imageCreationTitle.txt
+++ b/engine/src/main/resources/templates/EdgeManagement/imageCreationTitle.txt
@@ -1,1 +1,1 @@
-Image Creation Started
+Edge Managemant - Image Creation Started - {action.timestamp.toTimeAgo()}

--- a/engine/src/main/resources/templates/EdgeManagement/imageCreationTitle.txt
+++ b/engine/src/main/resources/templates/EdgeManagement/imageCreationTitle.txt
@@ -1,1 +1,1 @@
-Edge Managemant - Image Creation Started - {action.timestamp.toTimeAgo()}
+Edge Management - Image Creation Started - {action.timestamp.toTimeAgo()}


### PR DESCRIPTION
Fixed issues with Edge image creation email template.
Fixed these issues that were listed in this [slack thread](https://coreos.slack.com/archives/C01UC7NRV19/p1664437926331259):

- no button to go to Images
- Instant email but not timestamp
- Subject doesn't mention Edge, nor timestamp
- Extra ' ' (space) before final point
- No name/link to the image name
- Sentence is not grammatically correct..
- 'Egde' typo in title

~~Currently setting this PR to draft because this PR depends on a [PR from Edge-api](https://github.com/RedHatInsights/edge-api/pull/1825) to be merged first.~~