### PR TITLE
[RHCLOUD-23752] refactor: specify the environment's URL via an environment variable

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -217,6 +217,9 @@ parameters:
 - name: CPU_REQUEST
   description: CPU request
   value: 500m
+- name: ENV_BASE_URL
+  default: https://console.redhat.com
+  description: The environment's base URL
 - name: ENV_NAME
   description: ClowdEnvironment name (ephemeral, stage, prod)
   required: true

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/models/Environment.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/models/Environment.java
@@ -10,19 +10,14 @@ public class Environment {
     @ConfigProperty(name = "env.name", defaultValue = "local-dev")
     String environment;
 
+    @ConfigProperty(name = "env.base.url", defaultValue = "/")
+    String url;
+
     public String name() {
         return this.environment;
     }
 
     public String url() {
-
-        switch (environment) {
-            case "prod":
-                return "https://console.redhat.com";
-            case "stage":
-                return "https://console.stage.redhat.com";
-            default:
-                return "/";
-        }
+        return this.url;
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/models/EnvironmentTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/models/EnvironmentTest.java
@@ -1,29 +1,34 @@
 package com.redhat.cloud.notifications.templates.models;
 
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import javax.inject.Inject;
 
+@QuarkusTest
 public class EnvironmentTest {
 
+    @Inject
+    Environment environment;
+
+    /**
+     * Tests that the default value for the "Environment" is "local-dev".
+     */
     @Test
-    public void url() {
-        Environment environment = new Environment();
+    void testEnvironmentDefaultValue() {
+        final String expectedValue = "local-dev";
 
-        environment.environment = "prod";
-        assertEquals("https://console.redhat.com", environment.url());
-        assertEquals("prod", environment.name());
+        Assertions.assertEquals(expectedValue, this.environment.name(), "unexpected default value for the environment's name");
+    }
 
-        environment.environment = "stage";
-        assertEquals("https://console.stage.redhat.com", environment.url());
-        assertEquals("stage", environment.name());
+    /**
+     * Tests that the default value for the "URL" is "/".
+     */
+    @Test
+    void testUrlDefaultValue() {
+        final String expectedValue = "/";
 
-        environment.environment = "ephemeral";
-        assertEquals("/", environment.url());
-        assertEquals("ephemeral", environment.name());
-
-        environment.environment = "anything-else";
-        assertEquals("/", environment.url());
-        assertEquals("anything-else", environment.name());
+        Assertions.assertEquals(expectedValue, this.environment.url(), "unexpected default value for the environment's URL");
     }
 }


### PR DESCRIPTION
The idea behind this change is to allow developers to customize the environment's URL that is used across notifications. By doing this all the notifications can use the specified URL instead of relying on the hard coded values.

## Links

[[RHCLOUD-23752]](https://issues.redhat.com/browse/RHCLOUD-23752)