### PR TITLE
Display warning on apps forcing emails

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
@@ -160,9 +160,13 @@ public class UserConfigResource {
             BundleSettingsValue bundleSettingsValue = new BundleSettingsValue();
             bundleSettingsValue.displayName = bundle.getDisplayName();
             settingsValues.bundles.put(bundle.getName(), bundleSettingsValue);
+
+            List<Application> applicationsWithForcedEmails = applicationRepository.getApplicationsWithForcedEmail(bundle.getId(), orgId);
+
             for (Application application : applicationRepository.getApplications(bundle.getName())) {
                 ApplicationSettingsValue applicationSettingsValue = new ApplicationSettingsValue();
                 applicationSettingsValue.displayName = application.getDisplayName();
+                applicationSettingsValue.hasForcedEmail = applicationsWithForcedEmails.contains(application);
                 for (EmailSubscriptionType emailSubscriptionType : EmailSubscriptionType.values()) {
                     // TODO NOTIF-450 How do we deal with a failure here? What kind of response should be sent to the UI when the engine is down?
                     boolean supported = templateEngineClient.isSubscriptionTypeSupported(bundle.getName(), application.getName(), emailSubscriptionType);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/SettingsValueJsonForm.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/SettingsValueJsonForm.java
@@ -88,7 +88,9 @@ public class SettingsValueJsonForm {
                             field.label = "Instant notification";
                             field.description = "Immediate email for each triggered application event. See notification settings for configuration.";
                             field.checkedWarning = "Opting into this notification may result in a large number of emails";
-                            field.infoMessage = "You may still receive forced notifications for this service";
+                            if (applicationSettingsValue.hasForcedEmail) {
+                                field.infoMessage = "You may still receive forced notifications for this service";
+                            }
                             break;
                         default:
                             return;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/SettingsValues.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/SettingsValues.java
@@ -25,6 +25,7 @@ public class SettingsValues {
         @JsonIgnore
         public String displayName;
         public Map<EmailSubscriptionType, Boolean> notifications = new HashMap<>();
+        public boolean hasForcedEmail;
     }
 
 


### PR DESCRIPTION
Follow up to https://github.com/RedHatInsights/notifications-backend/pull/1702 to only show the message about "forced emails" in applications that have forced emails