### PR TITLE
RHCLOUD-23546 Add temporary internal endpoint to delete behavior groups

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/BehaviorGroupCleanupResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/BehaviorGroupCleanupResource.java
@@ -1,0 +1,67 @@
+package com.redhat.cloud.notifications.routers.internal;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
+import io.quarkus.logging.Log;
+import org.jboss.resteasy.reactive.RestPath;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import java.time.Duration;
+
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+
+/*
+ * /!\ WARNING /!\
+ * USE THIS REST RESOURCE WITH EXTREME CAUTION
+ * /!\ WARNING /!\
+ */
+// TODO Remove this class ASAP!
+@RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)
+@Path(API_INTERNAL + "/behavior-group-cleanup")
+public class BehaviorGroupCleanupResource {
+
+    private static final Object DUMMY_CACHE_VALUE = new Object();
+
+    private final Cache<String, Object> cache = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(1L))
+            .build();
+
+    @Inject
+    EntityManager entityManager;
+
+    @PUT
+    @Path("/{orgId}/initiate")
+    public void initiate(@RestPath String orgId) {
+        Log.warnf("If you are not sure of what you are doing, STOP NOW! " +
+                "Behavior groups cleanup is enabled for 1 minute for orgId=%s. " +
+                "Nothing has been deleted yet from the DB. " +
+                "Call the confirmation endpoint to delete all behavior groups from orgId=%s.", orgId, orgId);
+        cache.put(orgId, DUMMY_CACHE_VALUE);
+    }
+
+    @PUT
+    @Path("/{orgId}/confirm")
+    @Transactional
+    public Response confirm(@RestPath String orgId) {
+        if (cache.getIfPresent(orgId) == null) {
+            Log.warnf("Confirmation endpoint of behavior group cleanup was called without prior initialization for orgId=%s", orgId);
+            return Response.status(400).build();
+        } else {
+            Log.warnf("Behavior groups cleanup has been confirmed for orgId=%s", orgId);
+            cache.invalidate(orgId);
+            long count = entityManager.createQuery("DELETE FROM BehaviorGroup WHERE orgId = :orgId")
+                    .setParameter("orgId", orgId)
+                    .executeUpdate();
+            Log.warnf("%d behavior groups from orgId=%s were deleted from the DB", orgId, count);
+            return Response.ok().entity(count).build();
+        }
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/BehaviorGroupCleanupResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/BehaviorGroupCleanupResource.java
@@ -39,12 +39,14 @@ public class BehaviorGroupCleanupResource {
 
     @PUT
     @Path("/{orgId}/initiate")
-    public void initiate(@RestPath String orgId) {
-        Log.warnf("If you are not sure of what you are doing, STOP NOW! " +
+    public String initiate(@RestPath String orgId) {
+        String msg = String.format("If you are not sure of what you are doing, STOP NOW! " +
                 "Behavior groups cleanup is enabled for 1 minute for orgId=%s. " +
                 "Nothing has been deleted yet from the DB. " +
                 "Call the confirmation endpoint to delete all behavior groups from orgId=%s.", orgId, orgId);
+        Log.warn(msg);
         cache.put(orgId, DUMMY_CACHE_VALUE);
+        return msg;
     }
 
     @PUT

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/BehaviorGroupCleanupResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/BehaviorGroupCleanupResourceTest.java
@@ -1,0 +1,109 @@
+package com.redhat.cloud.notifications.routers.internal;
+
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.models.Bundle;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.Header;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class BehaviorGroupCleanupResourceTest extends DbIsolatedTest {
+
+    @ConfigProperty(name = "internal.admin-role")
+    String adminRole;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @Test
+    void testConfirmWithoutInitiate() {
+        Header header = TestHelpers.createTurnpikeIdentityHeader("admin", adminRole);
+        given()
+                .header(header)
+                .pathParam("orgId", "foo")
+                .when()
+                .put("/internal/behavior-group-cleanup/{orgId}/confirm")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void testInitiateThenConfirm() {
+        Bundle bundle = resourceHelpers.createBundle("bundle", "Bundle");
+        resourceHelpers.createBehaviorGroup("account-1", "org-1", "Behavior group 1", bundle.getId());
+        resourceHelpers.createBehaviorGroup("account-1", "org-1", "Behavior group 2", bundle.getId());
+        resourceHelpers.createBehaviorGroup("account-2", "org-2", "Behavior group 3", bundle.getId());
+
+        Header header = TestHelpers.createTurnpikeIdentityHeader("admin", adminRole);
+
+        given()
+                .header(header)
+                .pathParam("orgId", "org-1")
+                .when()
+                .put("/internal/behavior-group-cleanup/{orgId}/initiate")
+                .then()
+                .statusCode(204);
+
+        String count = given()
+                .header(header)
+                .pathParam("orgId", "org-1")
+                .when()
+                .put("/internal/behavior-group-cleanup/{orgId}/confirm")
+                .then()
+                .statusCode(200)
+                .extract().asString();
+        assertEquals("2", count);
+
+        given()
+                .header(header)
+                .pathParam("orgId", "org-2")
+                .when()
+                .put("/internal/behavior-group-cleanup/{orgId}/initiate")
+                .then()
+                .statusCode(204);
+
+        count = given()
+                .header(header)
+                .pathParam("orgId", "org-2")
+                .when()
+                .put("/internal/behavior-group-cleanup/{orgId}/confirm")
+                .then()
+                .statusCode(200)
+                .extract().asString();
+        assertEquals("1", count);
+    }
+
+    @Test
+    void testInitiateThenWaitOneMinuteThenConfirm() throws InterruptedException {
+        Header header = TestHelpers.createTurnpikeIdentityHeader("admin", adminRole);
+
+        given()
+                .header(header)
+                .pathParam("orgId", "foo")
+                .when()
+                .put("/internal/behavior-group-cleanup/{orgId}/initiate")
+                .then()
+                .statusCode(204);
+
+        Thread.sleep(61000);
+
+        given()
+                .header(header)
+                .pathParam("orgId", "foo")
+                .when()
+                .put("/internal/behavior-group-cleanup/{orgId}/confirm")
+                .then()
+                .statusCode(400);
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/BehaviorGroupCleanupResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/BehaviorGroupCleanupResourceTest.java
@@ -15,6 +15,7 @@ import javax.inject.Inject;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
@@ -47,13 +48,15 @@ public class BehaviorGroupCleanupResourceTest extends DbIsolatedTest {
 
         Header header = TestHelpers.createTurnpikeIdentityHeader("admin", adminRole);
 
-        given()
+        String responseBody = given()
                 .header(header)
                 .pathParam("orgId", "org-1")
                 .when()
                 .put("/internal/behavior-group-cleanup/{orgId}/initiate")
                 .then()
-                .statusCode(204);
+                .statusCode(200)
+                .extract().asString();
+        assertTrue(responseBody.startsWith("If you are not sure of what you are doing, STOP NOW!"));
 
         String count = given()
                 .header(header)
@@ -71,7 +74,7 @@ public class BehaviorGroupCleanupResourceTest extends DbIsolatedTest {
                 .when()
                 .put("/internal/behavior-group-cleanup/{orgId}/initiate")
                 .then()
-                .statusCode(204);
+                .statusCode(200);
 
         count = given()
                 .header(header)
@@ -94,7 +97,7 @@ public class BehaviorGroupCleanupResourceTest extends DbIsolatedTest {
                 .when()
                 .put("/internal/behavior-group-cleanup/{orgId}/initiate")
                 .then()
-                .statusCode(204);
+                .statusCode(200);
 
         Thread.sleep(61000);
 


### PR DESCRIPTION
This PR introduces an internal endpoint that will be used to delete all behavior groups from a few internal accounts that will not be disclosed here.