### PR TITLE
[RHCLOUD-23993] feature: turn Sources ClowdApp into an optional dependency

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -15,7 +15,8 @@ objects:
     dependencies:
     - notifications-engine
     - rbac
-    - sources-api
+    optionalDependencies:
+    - sources-api # https://issues.redhat.com/browse/RHCLOUD-23993
     database:
       name: notifications-backend
       version: 13

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -16,7 +16,8 @@ objects:
     - ingress
     - notifications-backend
     - rbac
-    - sources-api
+    optionalDependencies:
+    - sources-api # https://issues.redhat.com/browse/RHCLOUD-23993
     database:
       sharedDbAppName: notifications-backend
     kafkaTopics:


### PR DESCRIPTION
Another team needs to run Notifications without Sources, and they can't do that if Sources is listed as a mandatory dependency.

## Links

[[RHCLOUD-23993]](https://issues.redhat.com/browse/RHCLOUD-23993)