### PR TITLE
Add ENV_BASE_URL environment variable

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -84,6 +84,8 @@ objects:
           successThreshold: 1
           failureThreshold: 3
         env:
+        - name: ENV_BASE_URL
+          value: ${ENV_BASE_URL}
         - name: ENV_NAME
           value: ${ENV_NAME}
         - name: MP_MESSAGING_INCOMING_AGGREGATION_THROTTLED_UNPROCESSED_RECORD_MAX_AGE_MS


### PR DESCRIPTION
Slack and email links are incorrect on stage because of that missing env var.