### PR TITLE
[RHCLOUD-23848] feature: limit and order the returned rules for Advisor aggregations

### DIFF
--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/AdvisorEmailAggregatorTest.java
@@ -1,9 +1,19 @@
 package com.redhat.cloud.notifications.processors.email.aggregators;
 
+import com.redhat.cloud.notifications.AdvisorTestHelpers;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.AdvisorTestHelpers.createEmailAggregation;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.ADVISOR_KEY;
@@ -174,5 +184,207 @@ public class AdvisorEmailAggregatorTest {
         assertEquals(TEST_RULE_6.get(TOTAL_RISK), aggregatedRule6.get(TOTAL_RISK));
         assertEquals(TEST_RULE_6.get(RULE_URL), aggregatedRule6.get(RULE_URL));
         assertNull(aggregatedRule6.get(CONTENT_SYSTEM_COUNT));
+    }
+
+    /**
+     * Tests if the aggregator aggregates the provided rules in the highest
+     * "total risk" order, that the number of stored rules in the aggregator
+     * respects the limit, and that the rules are not altered, just transformed.
+     */
+    @Test
+    void testAggregatedInRightOrder() {
+        // Copy the fixture maps to modify the "testRisk" without risking to
+        // affect any other test.
+        final Map<String, String> testRule1 = new HashMap<>(TEST_RULE_1);
+        final Map<String, String> testRule2 = new HashMap<>(TEST_RULE_2);
+        final Map<String, String> testRule3 = new HashMap<>(TEST_RULE_3);
+        final Map<String, String> testRule4 = new HashMap<>(TEST_RULE_4);
+        final Map<String, String> testRule5 = new HashMap<>(TEST_RULE_5);
+
+        testRule1.put(TOTAL_RISK, "45");
+        testRule2.put(TOTAL_RISK, "50");
+        testRule3.put(TOTAL_RISK, "20");
+        testRule4.put(TOTAL_RISK, "65");
+        testRule5.put(TOTAL_RISK, "16");
+
+        // Create a large set of random test rules.
+        final List<Map<String, String>> testRuleCollection = new ArrayList<>(25);
+        final Random random = new Random();
+        for (int i = 0; i < 20; i++) {
+            testRuleCollection.add(
+                Map.of(
+                    RULE_ID, UUID.randomUUID().toString(),
+                    RULE_DESCRIPTION, UUID.randomUUID().toString(),
+                    TOTAL_RISK, String.valueOf(random.nextInt(15)),
+                    HAS_INCIDENT, String.valueOf(random.nextBoolean()),
+                    RULE_URL, UUID.randomUUID().toString()
+                )
+            );
+        }
+
+        // Include the five rules that should stand out and be considered as
+        // the most critical ones.
+        testRuleCollection.add(testRule1);
+        testRuleCollection.add(testRule2);
+        testRuleCollection.add(testRule3);
+        testRuleCollection.add(testRule4);
+        testRuleCollection.add(testRule5);
+
+        // Create the aggregator which will hold all the test rules.
+        final AdvisorEmailAggregator advisorEmailAggregator = new AdvisorEmailAggregator();
+
+        // Shuffle the collection so that we end up with a random order for the
+        // collection of rules.
+        Collections.shuffle(testRuleCollection);
+
+        // Create the new recommendations based off the
+        for (final Map<String, String> testRule : testRuleCollection) {
+            advisorEmailAggregator.aggregate(
+                AdvisorTestHelpers.createEmailAggregation(NEW_RECOMMENDATION, testRule)
+            );
+        }
+
+        // Shuffle the collection so that we end up with a random order for the
+        // collection of rules.
+        Collections.shuffle(testRuleCollection);
+
+        for (final Map<String, String> testRule : testRuleCollection) {
+            advisorEmailAggregator.aggregate(
+                AdvisorTestHelpers.createEmailAggregation(RESOLVED_RECOMMENDATION, testRule)
+            );
+        }
+
+        // Shuffle the collection so that we end up with a random order for the
+        // collection of rules.
+        Collections.shuffle(testRuleCollection);
+
+        for (final Map<String, String> testRule : testRuleCollection) {
+            advisorEmailAggregator.aggregate(
+                AdvisorTestHelpers.createEmailAggregation(DEACTIVATED_RECOMMENDATION, testRule)
+            );
+        }
+
+        // Grab the resulting JSON.
+        final JsonObject resultingAdvisor = JsonObject.mapFrom(advisorEmailAggregator.getContext()).getJsonObject(ADVISOR_KEY);
+
+        final Map<String, Map<String, Object>> newRecommendations = resultingAdvisor.getJsonObject(NEW_RECOMMENDATIONS).mapTo(Map.class);
+        final Map<String, Map<String, Object>> resolvedRecommendations = resultingAdvisor.getJsonObject(RESOLVED_RECOMMENDATIONS).mapTo(Map.class);
+        final Map<String, Map<String, Object>> deactivatedRecommendations = resultingAdvisor.getJsonObject(DEACTIVATED_RECOMMENDATIONS).mapTo(Map.class);
+
+        // The number of rules returned should be the maximum set in the
+        // advisor's class.
+        Assertions.assertEquals(AdvisorEmailAggregator.MAXIMUM_NUMBER_RETURNED_EVENTS, newRecommendations.size(), "unexpected number of resulting rules for the new recommendations");
+        Assertions.assertEquals(AdvisorEmailAggregator.MAXIMUM_NUMBER_RETURNED_EVENTS, resolvedRecommendations.size(), "unexpected number of resulting rules for the resolved recommendations");
+        Assertions.assertEquals(AdvisorEmailAggregator.MAXIMUM_NUMBER_RETURNED_EVENTS, deactivatedRecommendations.size(), "unexpected number of resulting rules for the deactivated recommendations");
+
+        // Add the test rules in the expected order that should be received,
+        // sorted by total risk in descending order.
+        final List<Map<String, String>> testRules = new ArrayList<>(AdvisorEmailAggregator.MAXIMUM_NUMBER_RETURNED_EVENTS);
+        testRules.add(testRule4);
+        testRules.add(testRule2);
+        testRules.add(testRule1);
+        testRules.add(testRule3);
+        testRules.add(testRule5);
+
+        // Test that the new recommendations are equivalent to the test rules
+        // and that they are in the correct order.
+        final List<Map.Entry<String, Map<String, Object>>> newRecommendationsCollection = new ArrayList<>(newRecommendations.entrySet());
+        this.assertRulesAreEqualAndCorrectOrder(testRules, newRecommendationsCollection);
+
+        // Test that the resolved recommendations are equivalent to the test
+        // rules and that they are in the correct order.
+        final List<Map.Entry<String, Map<String, Object>>> resolvedRecommendationsCollection = new ArrayList<>(resolvedRecommendations.entrySet());
+        this.assertRulesAreEqualAndCorrectOrder(testRules, resolvedRecommendationsCollection);
+
+        // Test that the deactivated recommendations are equivalent to the test
+        // rules and that they are in the correct order.
+        final List<Map.Entry<String, Map<String, Object>>> deactivatedRecommendationsCollection = new ArrayList<>(deactivatedRecommendations.entrySet());
+        this.assertRulesAreEqualAndCorrectOrder(testRules, deactivatedRecommendationsCollection);
+    }
+
+    /**
+     * Tests that the map sorting and limiting function returns an ordered map
+     * of a limited number of items.
+     */
+    @Test
+    void testSortAndLimitMapByRisk() {
+        final Map<String, Map<String, Object>> mapToSort = Map.of(
+                "a", Map.of(TOTAL_RISK, "52"),
+                "b", Map.of(TOTAL_RISK, "1"),
+                "c", Map.of(TOTAL_RISK, "11"),
+                "h", Map.of(TOTAL_RISK, "35"),
+                "j", Map.of(TOTAL_RISK, "41"),
+                "g", Map.of(TOTAL_RISK, "100"),
+                "z", Map.of(TOTAL_RISK, "100")
+        );
+
+        final AdvisorEmailAggregator aggregator = new AdvisorEmailAggregator();
+
+        // Call the function under test.
+        final Map<String, Map<String, Object>> result = aggregator.sortAndLimitMapByRisk(mapToSort);
+
+        Assertions.assertEquals(AdvisorEmailAggregator.MAXIMUM_NUMBER_RETURNED_EVENTS, result.size(), "unexpected number of events returned. It didn't respect the specified maximum");
+
+        // We use a list and not a set because the Set doesn't guarantee the
+        // insertion order, and therefore the "expectedKeys" cannot be easily
+        // generated with a "Set.of".
+        final List<String> expectedKeys = List.of("g", "z", "a", "j", "h");
+        final List<String> gotKeys = new ArrayList<>(result.keySet());
+
+        // Still, the assertion could fail if two elements contain the same
+        // "total risk" value, so we catch the first failure in case that order
+        // is flipped. In case that it fails again, then we're sure that the
+        // order is incorrect.
+        try {
+            Assertions.assertIterableEquals(expectedKeys, gotKeys);
+        } catch (final AssertionFailedError e) {
+            final List<String> secondExpectedKeys = List.of("z", "g", "a", "j", "h");
+
+            try {
+                Assertions.assertIterableEquals(secondExpectedKeys, gotKeys);
+            } catch (final AssertionFailedError e2) {
+                Assertions.fail(
+                    String.format(
+                        "unexpected order of keys received. Expected '%s' or '%s', got '%s'",
+                            expectedKeys,
+                            secondExpectedKeys,
+                            gotKeys
+                    )
+                );
+            }
+        }
+
+        final List<String> expectedRisks = List.of("100", "100", "52", "41", "35");
+        final List<String> gotRisks = result
+                .values()
+                .stream()
+                .map(stringObjectMap -> (String) stringObjectMap.get(TOTAL_RISK))
+                .collect(Collectors.toList());
+
+        Assertions.assertIterableEquals(expectedRisks, gotRisks);
+    }
+
+    /**
+     * Asserts that the provided list of expected rules and the generated rules
+     * by the aggregator are equivalent, and are in the correct order.
+     * @param expectedRules the list of expected rules to be checked against.
+     * @param gotRules the list of rules extracted from the aggregator.
+     */
+    private void assertRulesAreEqualAndCorrectOrder(final List<Map<String, String>> expectedRules, final List<Map.Entry<String, Map<String, Object>>> gotRules) {
+        for (int i = 0; i < AdvisorEmailAggregator.MAXIMUM_NUMBER_RETURNED_EVENTS; i++) {
+            final Map<String, String> expectedRule = expectedRules.get(i);
+            final Map.Entry<String, Map<String, Object>> gotRule = gotRules.get(i);
+
+            final String potentialErrorMessage = String.format("expected map '%s', got '%s'", expectedRule, gotRule);
+
+            Assertions.assertEquals(expectedRule.get(RULE_ID), gotRule.getKey(), "unexpected rule ID. " + potentialErrorMessage);
+
+            final Map<String, Object> aggregatedRule = gotRule.getValue();
+
+            Assertions.assertEquals(expectedRule.get(RULE_DESCRIPTION), aggregatedRule.get(RULE_DESCRIPTION), "unexpected rule description. " + potentialErrorMessage);
+            Assertions.assertEquals(expectedRule.get(HAS_INCIDENT), aggregatedRule.get(HAS_INCIDENT), "unexpected rule incident. " + potentialErrorMessage);
+            Assertions.assertEquals(expectedRule.get(TOTAL_RISK), aggregatedRule.get(TOTAL_RISK), "unexpected rule total risk. " + potentialErrorMessage);
+            Assertions.assertEquals(expectedRule.get(RULE_URL), aggregatedRule.get(RULE_URL), "unexpected rule url. " + potentialErrorMessage);
+        }
     }
 }


### PR DESCRIPTION
The Advisor team requested that the aggregation emails should only return the 5 most critical rules received that day, instead of all of the rules that might have been triggered.

## Links
[[RHCLOUD-23848]](https://issues.redhat.com/browse/RHCLOUD-23848)