### PR TITLE
[RHCLOUD-23717] feature: limit behavior groups name to 150 characters

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -299,7 +299,7 @@ public class NotificationResource {
     @Transactional
     public Response updateBehaviorGroup(@Context SecurityContext sec,
                                         @Parameter(description = "The UUID of the behavior group to update") @PathParam("id") UUID id,
-                                        @RequestBody(description = "New parameters", required = true) @NotNull UpdateBehaviorGroupRequest request) {
+                                        @RequestBody(description = "New parameters", required = true) @NotNull @Valid UpdateBehaviorGroupRequest request) {
         String orgId = getOrgId(sec);
 
         if (request.displayName != null) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/CreateBehaviorGroupRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -27,6 +28,7 @@ public class CreateBehaviorGroupRequest {
      * Display name the behavior group will have.
      */
     @NotBlank
+    @Size(max = 150, message = "the display name cannot exceed {max} characters")
     public String displayName;
 
     /**

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.Set;
@@ -31,4 +32,16 @@ public class UpdateBehaviorGroupRequest {
      * This will effectively set the linked event types..
      */
     public Set<UUID> eventTypeIds;
+
+    /**
+     * Validates that the display name is not blank when it is provided. Since
+     * this is a potential payload for the "update" operation, clients might
+     * not even send the display name if they don't want to update it. That is
+     * why we let "null" display names go through.
+     * @return true if the display name is not null, but it is blank.
+     */
+    @AssertFalse(message = "the display name cannot be empty")
+    private boolean isDisplayNameNotNullAndBlank() {
+        return this.displayName != null && this.displayName.isBlank();
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/behaviorgroup/UpdateBehaviorGroupRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -15,6 +16,7 @@ public class UpdateBehaviorGroupRequest {
     /**
      * If not null, changes the display name of the behavior group to this value.
      */
+    @Size(max = 150, message = "the display name cannot exceed {max} characters")
     public String displayName;
 
     /**

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/UpdateBehaviorGroupRequestTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/UpdateBehaviorGroupRequestTest.java
@@ -51,4 +51,42 @@ public class UpdateBehaviorGroupRequestTest {
             Assertions.assertEquals(expectedErrorMessage, cv.getMessage(), "unexpected constraint violation returned");
         }
     }
+
+    /**
+     * Tests that when blank display names are provided to an update behavior
+     * group request, a constraint violation is raised.
+     */
+    @Test
+    void testDisplayNameBlank() {
+        final String[] invalidDisplayNames = {"", "     "};
+
+        for (final var invalidName : invalidDisplayNames) {
+            final UpdateBehaviorGroupRequest request = new UpdateBehaviorGroupRequest();
+            request.displayName = invalidName;
+
+            final var constraintViolations = validator.validate(request);
+
+            Assertions.assertEquals(1, constraintViolations.size(), "unexpected number of constraint violations received. CVs: " + constraintViolations);
+
+            for (final var cv : constraintViolations) {
+                Assertions.assertEquals("displayNameNotNullAndBlank", cv.getPropertyPath().toString(), "unexpected field raised the constraint violation");
+                Assertions.assertEquals("the display name cannot be empty", cv.getMessage(), "unexpected constraint violation returned");
+            }
+        }
+    }
+
+    /**
+     * Tests that when null display name is provided, simulating an update
+     * operation that wants to leave the display name untouched, no constraint
+     * violation is raised.
+     */
+    @Test
+    void testDisplayNameNull() {
+        final UpdateBehaviorGroupRequest request = new UpdateBehaviorGroupRequest();
+        request.displayName = null;
+
+        final var constraintViolations = validator.validate(request);
+
+        Assertions.assertEquals(0, constraintViolations.size(), "unexpected number of constraint violations received. CVs: " + constraintViolations);
+    }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/UpdateBehaviorGroupRequestTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/behaviorgroup/UpdateBehaviorGroupRequestTest.java
@@ -1,0 +1,54 @@
+package com.redhat.cloud.notifications.models.behaviorgroup;
+
+import com.redhat.cloud.notifications.routers.models.behaviorgroup.CreateBehaviorGroupRequest;
+import com.redhat.cloud.notifications.routers.models.behaviorgroup.UpdateBehaviorGroupRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Size;
+import java.lang.reflect.Field;
+
+public class UpdateBehaviorGroupRequestTest {
+
+    private static Validator validator;
+
+    /**
+     * Sets up the validator.
+     */
+    @BeforeAll
+    public static void setUp() {
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            validator = validatorFactory.getValidator();
+        }
+    }
+
+    /**
+     * Tests that a "display name too long" constraint violation is triggered
+     * if the display name exceeds the maximum length specified in the class's
+     * annotation.
+     * @throws NoSuchFieldException if the {@link CreateBehaviorGroupRequest#displayName} field cannot be found.
+     */
+    @Test
+    void testDisplayNameTooLong() throws NoSuchFieldException {
+        final Field classField = UpdateBehaviorGroupRequest.class.getDeclaredField("displayName");
+        final Size sizeClassAnnotation = classField.getAnnotation(Size.class);
+
+        final var request = new UpdateBehaviorGroupRequest();
+        request.displayName = "a".repeat(sizeClassAnnotation.max() + 1);
+
+        final var constraintViolations = validator.validate(request);
+
+        Assertions.assertEquals(1, constraintViolations.size(), "unexpected number of constraint violations received. CVs: " + constraintViolations);
+
+        for (final var cv : constraintViolations) {
+            Assertions.assertEquals("displayName", cv.getPropertyPath().toString(), "unexpected field raised the constraint violation");
+
+            final String expectedErrorMessage = String.format("the display name cannot exceed %s characters", sizeClassAnnotation.max());
+            Assertions.assertEquals(expectedErrorMessage, cv.getMessage(), "unexpected constraint violation returned");
+        }
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -1150,8 +1150,8 @@ public class NotificationResourceTest extends DbIsolatedTest {
         final Field classField = UpdateBehaviorGroupRequest.class.getDeclaredField("displayName");
         final Size sizeClassAnnotation = classField.getAnnotation(Size.class);
 
-        final UpdateBehaviorGroupRequest createBehaviorGroupRequest = new UpdateBehaviorGroupRequest();
-        createBehaviorGroupRequest.displayName = "a".repeat(sizeClassAnnotation.max() + 1);
+        final UpdateBehaviorGroupRequest updateBehaviorGroupRequest = new UpdateBehaviorGroupRequest();
+        updateBehaviorGroupRequest.displayName = "a".repeat(sizeClassAnnotation.max() + 1);
 
         final Header identityHeader = initRbacMock(accountId, orgId, "user", FULL_ACCESS);
         final String url = String.format("/notifications/behaviorGroups/%s", behaviorGroup.getId());
@@ -1160,7 +1160,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(createBehaviorGroupRequest))
+                .body(Json.encode(updateBehaviorGroupRequest))
                 .put(url)
                 .then()
                 .statusCode(400)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -1165,7 +1165,6 @@ public class NotificationResourceTest extends DbIsolatedTest {
                 .then()
                 .statusCode(400)
                 .extract()
-                .body()
                 .asString();
 
         final JsonObject responseJson = new JsonObject(response);


### PR DESCRIPTION
The front end already has that limit established, so this needs to be done in the back end as well so that direct requests are also limited in this sense.

## Links
[[RHCLOUD-23717]](https://issues.redhat.com/browse/RHCLOUD-23717)