### PR TITLE
RHCLOUD-23850 Add QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT env var

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -176,6 +176,8 @@ objects:
           value: "8000"
         - name: QUARKUS_LOG_CATEGORY__COM_REDHAT_CLOUD_NOTIFICATIONS__LEVEL
           value: ${NOTIFICATIONS_LOG_LEVEL}
+        - name: QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT
+          value: ${QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT}
         - name: QUARKUS_LOG_CLOUDWATCH_ENABLED
           value: ${CLOUDWATCH_ENABLED}
         - name: QUARKUS_LOG_CLOUDWATCH_LOG_STREAM_NAME
@@ -305,6 +307,9 @@ parameters:
 - name: OB_READY_CHECK_PERIOD
   description: Period between two executions of the EndpointReadyChecker
   value: "off"
+- name: QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT
+  description: Amount of time to allow the CloudWatch client to complete the execution of an API call expressed with the ISO-8601 duration format PnDTnHnMn.nS.
+  value: PT30S
 - name: QUARKUS_REST_CLIENT_OB_URL
   description: URL of the OpenBridge fleet manager
   value: "http://addMe"

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -168,6 +168,8 @@ objects:
           value: "8000"
         - name: QUARKUS_LOG_CATEGORY__COM_REDHAT_CLOUD_NOTIFICATIONS__LEVEL
           value: ${NOTIFICATIONS_LOG_LEVEL}
+        - name: QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT
+          value: ${QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT}
         - name: QUARKUS_LOG_CLOUDWATCH_BATCH_PERIOD
           value: ${QUARKUS_LOG_CLOUDWATCH_BATCH_PERIOD}
         - name: QUARKUS_LOG_CLOUDWATCH_BATCH_SIZE
@@ -310,6 +312,9 @@ parameters:
 - name: OB_ERROR_CHECK_PERIOD
   description: Period between two executions of the FromOpenBridgeHistoryFiller scheduled job
   value: 10s
+- name: QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT
+  description: Amount of time to allow the CloudWatch client to complete the execution of an API call expressed with the ISO-8601 duration format PnDTnHnMn.nS.
+  value: PT30S
 - name: QUARKUS_LOG_CLOUDWATCH_BATCH_PERIOD
   description: Period between two batch executions. Defaults to 5s.
   value: 5s


### PR DESCRIPTION
See the description of https://github.com/quarkiverse/quarkus-logging-cloudwatch/pull/375 for more information about the new env var.

After this PR, if we send log entries to CloudWatch and the remote server does not respond within 30 seconds, our request will be canceled with a timeout to prevent the accumulation of log entries in the app memory. The cancelation will be logged as an error and reported in Sentry.