### PR TITLE
[RHCLOUD-23515] Update email template in db from file system

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
@@ -56,7 +56,7 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_USER)
+    @RolesAllowed(RBAC_INTERNAL_ADMIN)
     public Template createTemplate(@NotNull @Valid Template template) {
         return templateRepository.createTemplate(template);
     }
@@ -81,7 +81,7 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_USER)
+    @RolesAllowed(RBAC_INTERNAL_ADMIN)
     public Response updateTemplate(@RestPath UUID templateId, Template template) {
         boolean updated = templateRepository.updateTemplate(templateId, template);
         if (updated) {
@@ -94,7 +94,7 @@ public class TemplateResource {
     @DELETE
     @Path("/{templateId}")
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_USER)
+    @RolesAllowed(RBAC_INTERNAL_ADMIN)
     public boolean deleteTemplate(@RestPath UUID templateId) {
         return templateRepository.deleteTemplate(templateId);
     }
@@ -104,7 +104,7 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_USER)
+    @RolesAllowed(RBAC_INTERNAL_ADMIN)
     public InstantEmailTemplate createInstantEmailTemplate(@NotNull @Valid InstantEmailTemplate template) {
         return templateRepository.createInstantEmailTemplate(template);
     }
@@ -141,7 +141,7 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_USER)
+    @RolesAllowed(RBAC_INTERNAL_ADMIN)
     public Response updateInstantEmailTemplate(@RestPath UUID templateId, @NotNull @Valid InstantEmailTemplate template) {
         boolean updated = templateRepository.updateInstantEmailTemplate(templateId, template);
         if (updated) {
@@ -154,7 +154,7 @@ public class TemplateResource {
     @DELETE
     @Path("/email/instant/{templateId}")
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_USER)
+    @RolesAllowed(RBAC_INTERNAL_ADMIN)
     public boolean deleteInstantEmailTemplate(@RestPath UUID templateId) {
         return templateRepository.deleteInstantEmailTemplate(templateId);
     }
@@ -164,7 +164,7 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_USER)
+    @RolesAllowed(RBAC_INTERNAL_ADMIN)
     public AggregationEmailTemplate createAggregationEmailTemplate(@NotNull @Valid AggregationEmailTemplate template) {
         return templateRepository.createAggregationEmailTemplate(template);
     }
@@ -198,7 +198,7 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_USER)
+    @RolesAllowed(RBAC_INTERNAL_ADMIN)
     public Response updateAggregationEmailTemplate(@RestPath UUID templateId, @NotNull @Valid AggregationEmailTemplate template) {
         boolean updated = templateRepository.updateAggregationEmailTemplate(templateId, template);
         if (updated) {
@@ -211,7 +211,7 @@ public class TemplateResource {
     @DELETE
     @Path("/email/aggregation/{templateId}")
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_USER)
+    @RolesAllowed(RBAC_INTERNAL_ADMIN)
     public boolean deleteAggregationEmailTemplate(@RestPath UUID templateId) {
         return templateRepository.deleteAggregationEmailTemplate(templateId);
     }

--- a/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
@@ -123,8 +123,6 @@ public class FeatureFlipper {
     @ConfigProperty(name = "notifications.use-event-type-for-subscription.enabled", defaultValue = "false")
     boolean useEventTypeForSubscriptionEnabled;
 
-    @ConfigProperty(name = "notifications.inject-email-templates-to-db-on-startup.enabled", defaultValue = "false")
-    boolean injectEmailTemplateToDbOnStartupEnabled;
 
     void logFeaturesStatusAtStartup(@Observes StartupEvent event) {
         Log.infof("=== %s startup status ===", FeatureFlipper.class.getSimpleName());
@@ -156,7 +154,6 @@ public class FeatureFlipper {
         Log.infof("The Advisor's email templates V2 are %s", advisorEmailTemplatesV2Enabled ? "enabled" : "disabled");
         Log.infof("The Advisor openShift email templates V2 are %s", advisorOpenShiftEmailTemplatesV2Enabled ? "enabled" : "disabled");
         Log.infof("The event type level for email subscription is %s", useEventTypeForSubscriptionEnabled ? "enabled" : "disabled");
-        Log.infof("The email template injection on startup is %s", injectEmailTemplateToDbOnStartupEnabled ? "enabled" : "disabled");
     }
 
     public boolean isEnforceBehaviorGroupNameUnicity() {
@@ -399,10 +396,6 @@ public class FeatureFlipper {
     public void setUseEventTypeForSubscriptionEnabled(boolean useEventTypeForSubscriptionEnabled) {
         checkTestLaunchMode();
         this.useEventTypeForSubscriptionEnabled = useEventTypeForSubscriptionEnabled;
-    }
-
-    public boolean isInjectEmailTemplateToDbOnStartupEnabled() {
-        return injectEmailTemplateToDbOnStartupEnabled;
     }
 
     /**

--- a/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
@@ -123,6 +123,8 @@ public class FeatureFlipper {
     @ConfigProperty(name = "notifications.use-event-type-for-subscription.enabled", defaultValue = "false")
     boolean useEventTypeForSubscriptionEnabled;
 
+    @ConfigProperty(name = "notifications.inject-email-templates-to-db-on-startup.enabled", defaultValue = "false")
+    boolean injectEmailTemplateToDbOnStartupEnabled;
 
     void logFeaturesStatusAtStartup(@Observes StartupEvent event) {
         Log.infof("=== %s startup status ===", FeatureFlipper.class.getSimpleName());
@@ -154,6 +156,7 @@ public class FeatureFlipper {
         Log.infof("The Advisor's email templates V2 are %s", advisorEmailTemplatesV2Enabled ? "enabled" : "disabled");
         Log.infof("The Advisor openShift email templates V2 are %s", advisorOpenShiftEmailTemplatesV2Enabled ? "enabled" : "disabled");
         Log.infof("The event type level for email subscription is %s", useEventTypeForSubscriptionEnabled ? "enabled" : "disabled");
+        Log.infof("The email template injection on startup is %s", injectEmailTemplateToDbOnStartupEnabled ? "enabled" : "disabled");
     }
 
     public boolean isEnforceBehaviorGroupNameUnicity() {
@@ -396,6 +399,10 @@ public class FeatureFlipper {
     public void setUseEventTypeForSubscriptionEnabled(boolean useEventTypeForSubscriptionEnabled) {
         checkTestLaunchMode();
         this.useEventTypeForSubscriptionEnabled = useEventTypeForSubscriptionEnabled;
+    }
+
+    public boolean isInjectEmailTemplateToDbOnStartupEnabled() {
+        return injectEmailTemplateToDbOnStartupEnabled;
     }
 
     /**

--- a/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
@@ -27,8 +27,10 @@ public class RunOnEngineStartup {
         startupUtils.logExternalServiceUrl("quarkus.rest-client.rbac-s2s.url");
         if (featureFlipper.isInjectEmailTemplateToDbOnStartupEnabled()) {
             List<String> warnings = emailTemplateMigrationService.migrate();
-            Log.warn("Email template migration ended with warnings, please check the logs for more details");
-            warnings.stream().forEach(t -> Log.info(t));
+            if (!warnings.isEmpty()) {
+                Log.warn("Email template migration ended with warnings, please check the logs for more details");
+                warnings.stream().forEach(t -> Log.info(t));
+            }
         }
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
@@ -25,8 +25,9 @@ public class RunOnEngineStartup {
         startupUtils.initAccessLogFilter();
         startupUtils.logGitProperties();
         startupUtils.logExternalServiceUrl("quarkus.rest-client.rbac-s2s.url");
-        if (featureFlipper.isUseTemplatesFromDb()) {
+        if (featureFlipper.isInjectEmailTemplateToDbOnStartupEnabled()) {
             List<String> warnings = emailTemplateMigrationService.migrate();
+            Log.warn("Email template migration ended with warnings, please check the logs for more details");
             warnings.stream().forEach(t -> Log.info(t));
         }
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications;
 
-import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.templates.EmailTemplateMigrationService;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.Startup;
@@ -16,9 +15,6 @@ public class RunOnEngineStartup {
 
     @Inject
     EmailTemplateMigrationService emailTemplateMigrationService;
-
-    @Inject
-    FeatureFlipper featureFlipper;
 
     @PostConstruct
     void postConstruct() {

--- a/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
@@ -1,9 +1,12 @@
 package com.redhat.cloud.notifications;
 
+import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.templates.EmailTemplateMigrationService;
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.Startup;
-
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import java.util.List;
 
 @Startup
 public class RunOnEngineStartup {
@@ -11,10 +14,20 @@ public class RunOnEngineStartup {
     @Inject
     StartupUtils startupUtils;
 
+    @Inject
+    EmailTemplateMigrationService emailTemplateMigrationService;
+
+    @Inject
+    FeatureFlipper featureFlipper;
+
     @PostConstruct
     void postConstruct() {
         startupUtils.initAccessLogFilter();
         startupUtils.logGitProperties();
         startupUtils.logExternalServiceUrl("quarkus.rest-client.rbac-s2s.url");
+        if (featureFlipper.isUseTemplatesFromDb()) {
+            List<String> warnings = emailTemplateMigrationService.migrate();
+            warnings.stream().forEach(t -> Log.info(t));
+        }
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/RunOnEngineStartup.java
@@ -25,12 +25,11 @@ public class RunOnEngineStartup {
         startupUtils.initAccessLogFilter();
         startupUtils.logGitProperties();
         startupUtils.logExternalServiceUrl("quarkus.rest-client.rbac-s2s.url");
-        if (featureFlipper.isInjectEmailTemplateToDbOnStartupEnabled()) {
-            List<String> warnings = emailTemplateMigrationService.migrate();
-            if (!warnings.isEmpty()) {
-                Log.warn("Email template migration ended with warnings, please check the logs for more details");
-                warnings.stream().forEach(t -> Log.info(t));
-            }
+
+        List<String> warnings = emailTemplateMigrationService.migrate();
+        if (!warnings.isEmpty()) {
+            Log.warn("Email template migration ended with warnings, please check the logs for more details");
+            warnings.stream().forEach(t -> Log.info(t));
         }
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -402,37 +402,37 @@ public class EmailTemplateMigrationService {
                 warnings, "application-services", "rhosak", List.of("disruption"),
                 "Rhosak/serviceDisruptionTitle", "txt", "Rhosak service disruption email title",
                 "Rhosak/serviceDisruptionBody", "html", "Rhosak service disruption email body",
-                featureFlipper.isRosakEmailTemplatesV2Enabled()
+                featureFlipper.isRhosakEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("instance-created"),
                 "Rhosak/instanceCreatedTitle", "txt", "Rhosak instance created email title",
                 "Rhosak/instanceCreatedBody", "html", "Rhosak instance created email body",
-                featureFlipper.isRosakEmailTemplatesV2Enabled()
+                featureFlipper.isRhosakEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("instance-deleted"),
                 "Rhosak/instanceDeletedTitle", "txt", "Rhosak instance deleted email title",
                 "Rhosak/instanceDeletedBody", "html", "Rhosak instance deleted email body",
-                featureFlipper.isRosakEmailTemplatesV2Enabled()
+                featureFlipper.isRhosakEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("action-required"),
                 "Rhosak/actionRequiredTitle", "txt", "Rhosak action required email title",
                 "Rhosak/actionRequiredBody", "html", "Rhosak action required email body",
-                featureFlipper.isRosakEmailTemplatesV2Enabled()
+                featureFlipper.isRhosakEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("scheduled-upgrade"),
                 "Rhosak/scheduledUpgradeTitle", "txt", "Rhosak scheduled upgrade email title",
                 "Rhosak/scheduledUpgradeBody", "html", "Rhosak scheduled upgrade email body",
-                featureFlipper.isRosakEmailTemplatesV2Enabled()
+                featureFlipper.isRhosakEmailTemplatesV2Enabled()
         );
         createDailyEmailTemplate(
                 warnings, "application-services", "rhosak",
                 "Rhosak/dailyRhosakEmailsTitle", "txt", "Rhosak daily email title",
                 "Rhosak/dailyRhosakEmailsBody", "html", "Rhosak daily email body",
-                featureFlipper.isRosakEmailTemplatesV2Enabled()
+                featureFlipper.isRhosakEmailTemplatesV2Enabled()
         );
 
         /*

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.templates;
 
+import com.cronutils.utils.StringUtils;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.EventType;
@@ -40,6 +42,9 @@ public class EmailTemplateMigrationService {
     @Inject
     EntityManager entityManager;
 
+    @Inject
+    FeatureFlipper featureFlipper;
+
     /*
      * Templates from resources may evolve after the first migration to DB templates, before we enable DB templates
      * everywhere in notifications. This endpoint can be used to delete all DB templates before we trigger another
@@ -68,22 +73,26 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "rhel", "advisor", List.of(DEACTIVATED_RECOMMENDATION),
                 "Advisor/deactivatedRecommendationInstantEmailTitle", "txt", "Advisor deactivated recommendation email title",
-                "Advisor/deactivatedRecommendationInstantEmailBody", "html", "Advisor deactivated recommendation email body"
+                "Advisor/deactivatedRecommendationInstantEmailBody", "html", "Advisor deactivated recommendation email body",
+                featureFlipper.isAdvisorEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "rhel", "advisor", List.of(NEW_RECOMMENDATION),
                 "Advisor/newRecommendationInstantEmailTitle", "txt", "Advisor new recommendation email title",
-                "Advisor/newRecommendationInstantEmailBody", "html", "Advisor new recommendation email body"
+                "Advisor/newRecommendationInstantEmailBody", "html", "Advisor new recommendation email body",
+                featureFlipper.isAdvisorEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "rhel", "advisor", List.of(RESOLVED_RECOMMENDATION),
                 "Advisor/resolvedRecommendationInstantEmailTitle", "txt", "Advisor resolved recommendation email title",
-                "Advisor/resolvedRecommendationInstantEmailBody", "html", "Advisor resolved recommendation email body"
+                "Advisor/resolvedRecommendationInstantEmailBody", "html", "Advisor resolved recommendation email body",
+                featureFlipper.isAdvisorEmailTemplatesV2Enabled()
         );
         createDailyEmailTemplate(
                 warnings, "rhel", "advisor",
                 "Advisor/dailyEmailTitle", "txt", "Advisor daily email title",
-                "Advisor/dailyEmailBody", "html", "Advisor daily email body"
+                "Advisor/dailyEmailBody", "html", "Advisor daily email body",
+                featureFlipper.isAdvisorEmailTemplatesV2Enabled()
         );
 
         /*
@@ -93,7 +102,8 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "openshift", "advisor", List.of("new-recommendation"),
                 "AdvisorOpenshift/newRecommendationInstantEmailTitle", "txt", "AdvisorOpenshift new recommendation email title",
-                "AdvisorOpenshift/newRecommendationInstantEmailBody", "html", "AdvisorOpenshift new recommendation email body"
+                "AdvisorOpenshift/newRecommendationInstantEmailBody", "html", "AdvisorOpenshift new recommendation email body",
+                featureFlipper.isAdvisorEmailTemplatesV2Enabled()
         );
 
         /*
@@ -103,7 +113,8 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "ansible", "reports", List.of("report-available"),
                 "Ansible/instantEmailTitle", "txt", "Ansible instant email title",
-                "Ansible/instantEmailBody", "html", "Ansible instant email body"
+                "Ansible/instantEmailBody", "html", "Ansible instant email body",
+                featureFlipper.isAnsibleEmailTemplatesV2Enabled()
         );
 
         /*
@@ -113,32 +124,20 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "rhel", "compliance", List.of("compliance-below-threshold"),
                 "Compliance/complianceBelowThresholdEmailTitle", "txt", "Compliance below threshold email title",
-                "Compliance/complianceBelowThresholdEmailBody", "html", "Compliance below threshold email body"
+                "Compliance/complianceBelowThresholdEmailBody", "html", "Compliance below threshold email body",
+                featureFlipper.isComplianceEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "rhel", "compliance", List.of("report-upload-failed"),
                 "Compliance/reportUploadFailedEmailTitle", "txt", "Compliance report upload failed email title",
-                "Compliance/reportUploadFailedEmailBody", "html", "Compliance report upload failed email body"
+                "Compliance/reportUploadFailedEmailBody", "html", "Compliance report upload failed email body",
+                featureFlipper.isComplianceEmailTemplatesV2Enabled()
         );
         createDailyEmailTemplate(
                 warnings, "rhel", "compliance",
                 "Compliance/dailyEmailTitle", "txt", "Compliance daily email title",
-                "Compliance/dailyEmailBody", "html", "Compliance daily email body"
-        );
-
-        /*
-         * Former src/main/resources/templates/Integrations folder.
-         */
-        getOrCreateTemplate(warnings, "Integrations/insightsEmailBody", "html", "Integrations Insights email body");
-        createInstantEmailTemplate(
-                warnings, "console", "integrations", List.of(INTEGRATION_FAILED_EVENT_TYPE),
-                "Integrations/failedIntegrationTitle", "txt", "Integrations failed integration email title",
-                "Integrations/failedIntegrationBody", "txt", "Integrations failed integration email body"
-        );
-        createInstantEmailTemplate(
-                warnings, "console", "integrations", List.of(INTEGRATION_DISABLED_EVENT_TYPE),
-                "Integrations/integrationDisabledTitle", "txt", "Integrations disabled integration email title",
-                "Integrations/integrationDisabledBody", "html", "Integrations disabled integration email body"
+                "Compliance/dailyEmailBody", "html", "Compliance daily email body",
+                featureFlipper.isComplianceEmailTemplatesV2Enabled()
         );
 
         /*
@@ -148,37 +147,44 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "openshift", "cost-management", List.of("missing-cost-model"),
                 "CostManagement/MissingCostModelEmailTitle", "txt", "Cost Management missing cost model email title",
-                "CostManagement/MissingCostModelEmailBody", "html", "Cost Management missing cost model email body"
+                "CostManagement/MissingCostModelEmailBody", "html", "Cost Management missing cost model email body",
+                featureFlipper.isCostManagementEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "openshift", "cost-management", List.of("cost-model-create"),
                 "CostManagement/CostModelCreateEmailTitle", "txt", "Cost Management cost model create email title",
-                "CostManagement/CostModelCreateEmailBody", "html", "Cost Management cost model create email body"
+                "CostManagement/CostModelCreateEmailBody", "html", "Cost Management cost model create email body",
+                featureFlipper.isCostManagementEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "openshift", "cost-management", List.of("cost-model-update"),
                 "CostManagement/CostModelUpdateEmailTitle", "txt", "Cost Management cost model update email title",
-                "CostManagement/CostModelUpdateEmailBody", "html", "Cost Management cost model update email body"
+                "CostManagement/CostModelUpdateEmailBody", "html", "Cost Management cost model update email body",
+                featureFlipper.isCostManagementEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "openshift", "cost-management", List.of("cost-model-remove"),
                 "CostManagement/CostModelRemoveEmailTitle", "txt", "Cost Management cost model remove email title",
-                "CostManagement/CostModelRemoveEmailBody", "html", "Cost Management cost model remove email body"
+                "CostManagement/CostModelRemoveEmailBody", "html", "Cost Management cost model remove email body",
+                featureFlipper.isCostManagementEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "openshift", "cost-management", List.of("cm-operator-stale"),
                 "CostManagement/CmOperatorStaleEmailTitle", "txt", "Cost Management operator stale email title",
-                "CostManagement/CmOperatorStaleEmailBody", "html", "Cost Management operator stale email body"
+                "CostManagement/CmOperatorStaleEmailBody", "html", "Cost Management operator stale email body",
+                featureFlipper.isCostManagementEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "openshift", "cost-management", List.of("cm-operator-data-processed"),
                 "CostManagement/CmOperatorDataProcessedEmailTitle", "txt", "Cost Management operator data processed email title",
-                "CostManagement/CmOperatorDataProcessedEmailBody", "html", "Cost Management operator data processed email body"
+                "CostManagement/CmOperatorDataProcessedEmailBody", "html", "Cost Management operator data processed email body",
+                featureFlipper.isCostManagementEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "openshift", "cost-management", List.of("cm-operator-data-received"),
                 "CostManagement/CmOperatorDataReceivedEmailTitle", "txt", "Cost Management operator data received email title",
-                "CostManagement/CmOperatorDataReceivedEmailBody", "html", "Cost Management operator data received email body"
+                "CostManagement/CmOperatorDataReceivedEmailBody", "html", "Cost Management operator data received email body",
+                featureFlipper.isCostManagementEmailTemplatesV2Enabled()
         );
 
         /*
@@ -188,12 +194,14 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "rhel", "drift", List.of("drift-baseline-detected"),
                 "Drift/newBaselineDriftInstantEmailTitle", "txt", "Drift new baseline drift email title",
-                "Drift/newBaselineDriftInstantEmailBody", "html", "Drift new baseline drift email body"
+                "Drift/newBaselineDriftInstantEmailBody", "html", "Drift new baseline drift email body",
+                featureFlipper.isDriftEmailTemplatesV2Enabled()
         );
         createDailyEmailTemplate(
                 warnings, "rhel", "drift",
                 "Drift/dailyEmailTitle", "txt", "Drift daily email title",
-                "Drift/dailyEmailBody", "html", "Drift daily email body"
+                "Drift/dailyEmailBody", "html", "Drift daily email body",
+                featureFlipper.isDriftEmailTemplatesV2Enabled()
         );
 
         /*
@@ -203,12 +211,14 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "rhel", "edge-management", List.of("image-creation"),
                 "EdgeManagement/imageCreationTitle", "txt", "EdgeManagement image creation email title",
-                "EdgeManagement/imageCreationBody", "html", "EdgeManagement image creation email body"
+                "EdgeManagement/imageCreationBody", "html", "EdgeManagement image creation email body",
+                featureFlipper.isEdgeManagementEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "rhel", "edge-management", List.of("update-devices"),
                 "EdgeManagement/updateDeviceTitle", "txt", "EdgeManagement update devices email title",
-                "EdgeManagement/updateDeviceBody", "html", "EdgeManagement update devices email body"
+                "EdgeManagement/updateDeviceBody", "html", "EdgeManagement update devices email body",
+                featureFlipper.isEdgeManagementEmailTemplatesV2Enabled()
         );
 
         /*
@@ -218,12 +228,31 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "rhel", "inventory", List.of("validation-error"),
                 "Inventory/validationErrorEmailTitle", "txt", "Inventory instant email title",
-                "Inventory/validationErrorEmailBody", "html", "Inventory instant email body"
+                "Inventory/validationErrorEmailBody", "html", "Inventory instant email body",
+                featureFlipper.isInventoryEmailTemplatesV2Enabled()
         );
         createDailyEmailTemplate(
-                warnings, "rhel", "Inventory",
+                warnings, "rhel", "inventory",
                 "Inventory/dailyEmailTitle", "txt", "Inventory daily email title",
-                "Inventory/dailyEmailBody", "html", "Inventory daily email body"
+                "Inventory/dailyEmailBody", "html", "Inventory daily email body",
+                featureFlipper.isInventoryEmailTemplatesV2Enabled()
+        );
+
+        /*
+         * Former src/main/resources/templates/Integrations folder.
+         */
+        getOrCreateTemplate(warnings, "Integrations/insightsEmailBody", "html", "Integrations Insights email body");
+        createInstantEmailTemplate(
+            warnings, "console", "integrations", List.of(INTEGRATION_FAILED_EVENT_TYPE),
+            "Integrations/failedIntegrationTitle", "txt", "Integrations failed integration email title",
+            "Integrations/failedIntegrationBody", "txt", "Integrations failed integration email body",
+            featureFlipper.isIntegrationsEmailTemplatesV2Enabled()
+        );
+        createInstantEmailTemplate(
+            warnings, "console", "integrations", List.of(INTEGRATION_DISABLED_EVENT_TYPE),
+            "Integrations/integrationDisabledTitle", "txt", "Integrations disabled integration email title",
+            "Integrations/integrationDisabledBody", "html", "Integrations disabled integration email body",
+            featureFlipper.isIntegrationsEmailTemplatesV2Enabled()
         );
 
         /*
@@ -233,7 +262,8 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "rhel", "malware-detection", List.of("detected-malware"),
                 "MalwareDetection/detectedMalwareInstantEmailTitle", "txt", "Malware Detection detected malware email title",
-                "MalwareDetection/detectedMalwareInstantEmailBody", "html", "Malware Detection detected malware email body"
+                "MalwareDetection/detectedMalwareInstantEmailBody", "html", "Malware Detection detected malware email body",
+                featureFlipper.isMalwareEmailTemplatesV2Enabled()
         );
 
         /*
@@ -243,12 +273,14 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "rhel", "patch", List.of("new-advisory"),
                 "Patch/newAdvisoriesInstantEmailTitle", "txt", "Patch instant advisories email title",
-                "Patch/newAdvisoriesInstantEmailBody", "html", "Patch instant advisories email body"
+                "Patch/newAdvisoriesInstantEmailBody", "html", "Patch instant advisories email body",
+                featureFlipper.isPatchEmailTemplatesV2Enabled()
         );
         createDailyEmailTemplate(
                 warnings, "rhel", "patch",
                 "Patch/dailyEmailTitle", "txt", "Patch daily email title",
-                "Patch/dailyEmailBody", "html", "Patch daily email body"
+                "Patch/dailyEmailBody", "html", "Patch daily email body",
+                featureFlipper.isPatchEmailTemplatesV2Enabled()
         );
 
         /*
@@ -258,12 +290,14 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "rhel", "policies", List.of("policy-triggered"),
                 "Policies/instantEmailTitle", "txt", "Policies instant email title",
-                "Policies/instantEmailBody", "html", "Policies instant email body"
+                "Policies/instantEmailBody", "html", "Policies instant email body",
+                featureFlipper.isPoliciesEmailTemplatesV2Enabled()
         );
         createDailyEmailTemplate(
                 warnings, "rhel", "policies",
                 "Policies/dailyEmailTitle", "txt", "Policies daily email title",
-                "Policies/dailyEmailBody", "html", "Policies daily email body"
+                "Policies/dailyEmailBody", "html", "Policies daily email body",
+                featureFlipper.isPoliciesEmailTemplatesV2Enabled()
         );
 
         /*
@@ -273,67 +307,80 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("rh-new-role-available"),
                 "Rbac/systemRoleAvailableEmailTitle", "txt", "Rbac system role available email title",
-                "Rbac/systemRoleAvailableEmailBody", "html", "Rbac system role available email body"
+                "Rbac/systemRoleAvailableEmailBody", "html", "Rbac system role available email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("rh-platform-default-role-updated"),
                 "Rbac/platformRoleUpdatedEmailTitle", "txt", "Rbac platform role updated email title",
-                "Rbac/platformRoleUpdatedEmailBody", "html", "Rbac platform role updated email body"
+                "Rbac/platformRoleUpdatedEmailBody", "html", "Rbac platform role updated email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("rh-non-platform-default-role-updated"),
                 "Rbac/nonPlatformRoleUpdatedEmailTitle", "txt", "Rbac non platform role updated email title",
-                "Rbac/nonPlatformRoleUpdatedEmailBody", "html", "Rbac non platform role updated email body"
+                "Rbac/nonPlatformRoleUpdatedEmailBody", "html", "Rbac non platform role updated email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("custom-role-created"),
                 "Rbac/customRoleCreatedEmailTitle", "txt", "Rbac custom role created email title",
-                "Rbac/customRoleCreatedEmailBody", "html", "Rbac custom role created email body"
+                "Rbac/customRoleCreatedEmailBody", "html", "Rbac custom role created email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("custom-role-updated"),
                 "Rbac/customRoleUpdatedEmailTitle", "txt", "Rbac custom role updated email title",
-                "Rbac/customRoleUpdatedEmailBody", "html", "Rbac custom role updated email body"
+                "Rbac/customRoleUpdatedEmailBody", "html", "Rbac custom role updated email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("custom-role-deleted"),
                 "Rbac/customRoleDeletedEmailTitle", "txt", "Rbac custom role deleted email title",
-                "Rbac/customRoleDeletedEmailBody", "html", "Rbac custom role deleted email body"
+                "Rbac/customRoleDeletedEmailBody", "html", "Rbac custom role deleted email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("rh-new-role-added-to-default-access"),
                 "Rbac/roleAddedToPlatformGroupEmailTitle", "txt", "Rbac role added to platform group email title",
-                "Rbac/roleAddedToPlatformGroupEmailBody", "html", "Rbac role added to platform group email body"
+                "Rbac/roleAddedToPlatformGroupEmailBody", "html", "Rbac role added to platform group email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("rh-role-removed-from-default-access"),
                 "Rbac/roleRemovedFromPlatformGroupEmailTitle", "txt", "Rbac role removed from platform group email title",
-                "Rbac/roleRemovedFromPlatformGroupEmailBody", "html", "Rbac role removed from platform group email body"
+                "Rbac/roleRemovedFromPlatformGroupEmailBody", "html", "Rbac role removed from platform group email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("custom-default-access-updated"),
                 "Rbac/customPlatformGroupUpdatedEmailTitle", "txt", "Rbac custom platform group updated email title",
-                "Rbac/customPlatformGroupUpdatedEmailBody", "html", "Rbac custom platform group updated email body"
+                "Rbac/customPlatformGroupUpdatedEmailBody", "html", "Rbac custom platform group updated email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("group-created"),
                 "Rbac/customGroupCreatedEmailTitle", "txt", "Rbac custom group created email title",
-                "Rbac/customGroupCreatedEmailBody", "html", "Rbac custom group created email body"
+                "Rbac/customGroupCreatedEmailBody", "html", "Rbac custom group created email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("group-updated"),
                 "Rbac/customGroupUpdatedEmailTitle", "txt", "Rbac custom group updated email title",
-                "Rbac/customGroupUpdatedEmailBody", "html", "Rbac custom group updated email body"
+                "Rbac/customGroupUpdatedEmailBody", "html", "Rbac custom group updated email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("group-deleted"),
                 "Rbac/customGroupDeletedEmailTitle", "txt", "Rbac custom group deleted email title",
-                "Rbac/customGroupDeletedEmailBody", "html", "Rbac custom group deleted email body"
+                "Rbac/customGroupDeletedEmailBody", "html", "Rbac custom group deleted email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("platform-default-group-turned-into-custom"),
                 "Rbac/platformGroupToCustomEmailTitle", "txt", "Rbac platform group to custom email title",
-                "Rbac/platformGroupToCustomEmailBody", "html", "Rbac platform group to custom email body"
+                "Rbac/platformGroupToCustomEmailBody", "html", "Rbac platform group to custom email body",
+                featureFlipper.isRbacEmailTemplatesV2Enabled()
         );
 
         /*
@@ -343,7 +390,8 @@ public class EmailTemplateMigrationService {
         createDailyEmailTemplate(
                 warnings, "rhel", "resource-optimization",
                 "ResourceOptimization/dailyEmailTitle", "txt", "Resource Optimization daily email title",
-                "ResourceOptimization/dailyEmailBody", "html", "Resource Optimization daily email body"
+                "ResourceOptimization/dailyEmailBody", "html", "Resource Optimization daily email body",
+                featureFlipper.isResourceOptimizationManagementEmailTemplatesV2Enabled()
         );
 
         /*
@@ -353,32 +401,38 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("disruption"),
                 "Rhosak/serviceDisruptionTitle", "txt", "Rhosak service disruption email title",
-                "Rhosak/serviceDisruptionBody", "html", "Rhosak service disruption email body"
+                "Rhosak/serviceDisruptionBody", "html", "Rhosak service disruption email body",
+                featureFlipper.isRosakEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("instance-created"),
                 "Rhosak/instanceCreatedTitle", "txt", "Rhosak instance created email title",
-                "Rhosak/instanceCreatedBody", "html", "Rhosak instance created email body"
+                "Rhosak/instanceCreatedBody", "html", "Rhosak instance created email body",
+                featureFlipper.isRosakEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("instance-deleted"),
                 "Rhosak/instanceDeletedTitle", "txt", "Rhosak instance deleted email title",
-                "Rhosak/instanceDeletedBody", "html", "Rhosak instance deleted email body"
+                "Rhosak/instanceDeletedBody", "html", "Rhosak instance deleted email body",
+                featureFlipper.isRosakEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("action-required"),
                 "Rhosak/actionRequiredTitle", "txt", "Rhosak action required email title",
-                "Rhosak/actionRequiredBody", "html", "Rhosak action required email body"
+                "Rhosak/actionRequiredBody", "html", "Rhosak action required email body",
+                featureFlipper.isRosakEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("scheduled-upgrade"),
                 "Rhosak/scheduledUpgradeTitle", "txt", "Rhosak scheduled upgrade email title",
-                "Rhosak/scheduledUpgradeBody", "html", "Rhosak scheduled upgrade email body"
+                "Rhosak/scheduledUpgradeBody", "html", "Rhosak scheduled upgrade email body",
+                featureFlipper.isRosakEmailTemplatesV2Enabled()
         );
         createDailyEmailTemplate(
                 warnings, "application-services", "rhosak",
                 "Rhosak/dailyRhosakEmailsTitle", "txt", "Rhosak daily email title",
-                "Rhosak/dailyRhosakEmailsBody", "html", "Rhosak daily email body"
+                "Rhosak/dailyRhosakEmailsBody", "html", "Rhosak daily email body",
+                featureFlipper.isRosakEmailTemplatesV2Enabled()
         );
 
         /*
@@ -388,7 +442,8 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "console", "sources", List.of("availability-status"),
                 "Sources/availabilityStatusEmailTitle", "txt", "Sources availability status email title",
-                "Sources/availabilityStatusEmailBody", "html", "Sources availability status email body"
+                "Sources/availabilityStatusEmailBody", "html", "Sources availability status email body",
+                featureFlipper.isSourcesEmailTemplatesV2Enabled()
         );
 
         /*
@@ -398,28 +453,35 @@ public class EmailTemplateMigrationService {
         createInstantEmailTemplate(
                 warnings, "rhel", "vulnerability", List.of("any-cve-known-exploit"),
                 "Vulnerability/anyCveKnownExploitTitle", "txt", "Vulnerability any CVE known exploit email title",
-                "Vulnerability/anyCveKnownExploitBody", "html", "Vulnerability any CVE known exploit email body"
+                "Vulnerability/anyCveKnownExploitBody", "html", "Vulnerability any CVE known exploit email body",
+                featureFlipper.isVulnerabilityEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "rhel", "vulnerability", List.of("new-cve-severity"),
                 "Vulnerability/newCveCritSeverityEmailTitle", "txt", "Vulnerability new CVE crit severity email title",
-                "Vulnerability/newCveCritSeverityEmailBody", "html", "Vulnerability new CVE crit severity email body"
+                "Vulnerability/newCveCritSeverityEmailBody", "html", "Vulnerability new CVE crit severity email body",
+                featureFlipper.isVulnerabilityEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "rhel", "vulnerability", List.of("new-cve-cvss"),
                 "Vulnerability/newCveHighCvssEmailTitle", "txt", "Vulnerability new CVE high cvss email title",
-                "Vulnerability/newCveHighCvssEmailBody", "html", "Vulnerability new CVE high cvss email body"
+                "Vulnerability/newCveHighCvssEmailBody", "html", "Vulnerability new CVE high cvss email body",
+                featureFlipper.isVulnerabilityEmailTemplatesV2Enabled()
         );
         createInstantEmailTemplate(
                 warnings, "rhel", "vulnerability", List.of("new-cve-security-rule"),
                 "Vulnerability/newCveSecurityRuleTitle", "txt", "Vulnerability new CVE security rule email title",
-                "Vulnerability/newCveSecurityRuleBody", "html", "Vulnerability new CVE security rule email body"
+                "Vulnerability/newCveSecurityRuleBody", "html", "Vulnerability new CVE security rule email body",
+                featureFlipper.isVulnerabilityEmailTemplatesV2Enabled()
         );
         createDailyEmailTemplate(
                 warnings, "rhel", "vulnerability",
                 "Vulnerability/dailyEmailTitle", "txt", "Vulnerability daily email title",
-                "Vulnerability/dailyEmailBody", "html", "Vulnerability daily email body"
+                "Vulnerability/dailyEmailBody", "html", "Vulnerability daily email body",
+                featureFlipper.isVulnerabilityEmailTemplatesV2Enabled()
         );
+
+        getOrCreateTemplate(warnings, "Common/insightsEmailBody", "html", "Advisor Insights email body");
 
         Log.debug("Migration ended");
 
@@ -431,11 +493,18 @@ public class EmailTemplateMigrationService {
      * Existing templates are never updated by this migration service.
      */
     Template getOrCreateTemplate(List<String> warnings, String name, String extension, String description) {
+        String templateFromFS = loadResourceTemplate(name, extension);
         try {
+            boolean hasBeenUpdated = false;
             Template template = entityManager.createQuery("FROM Template WHERE name = :name", Template.class)
                     .setParameter("name", name)
                     .getSingleResult();
-            warnings.add(String.format("Template found in DB: %s", name));
+            if (!template.getData().equals(templateFromFS)) {
+                template.setData(templateFromFS);
+                template = entityManager.merge(template);
+                hasBeenUpdated = true;
+            }
+            Log.infof("Template found in DB: %s" + (hasBeenUpdated ? " has been updated" : StringUtils.EMPTY), name);
             return template;
         } catch (NoResultException e) {
             Log.infof("Creating template: %s", name);
@@ -469,8 +538,12 @@ public class EmailTemplateMigrationService {
      */
     private void createInstantEmailTemplate(List<String> warnings, String bundleName, String appName, List<String> eventTypeNames,
             String subjectTemplateName, String subjectTemplateExtension, String subjectTemplateDescription,
-            String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription) {
+            String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription, boolean useTemplateV2) {
 
+        if (useTemplateV2) {
+            subjectTemplateName += "V2";
+            bodyTemplateName += "V2";
+        }
         for (String eventTypeName : eventTypeNames) {
             Optional<EventType> eventType = findEventType(warnings, bundleName, appName, eventTypeName);
             if (eventType.isPresent()) {
@@ -527,8 +600,12 @@ public class EmailTemplateMigrationService {
      */
     private void createDailyEmailTemplate(List<String> warnings, String bundleName, String appName,
                                           String subjectTemplateName, String subjectTemplateExtension, String subjectTemplateDescription,
-                                          String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription) {
+                                          String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription, boolean useTemplateV2) {
 
+        if (useTemplateV2) {
+            subjectTemplateName += "V2";
+            bodyTemplateName += "V2";
+        }
         Optional<Application> app = findApplication(warnings, bundleName, appName);
         if (app.isPresent()) {
             if (aggregationEmailTemplateExists(app.get())) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -69,7 +69,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Advisor folder.
          */
-        getOrCreateTemplate(warnings, "Advisor/insightsEmailBody", "html", "Advisor Insights email body");
+        getOrCreateTemplate("Advisor/insightsEmailBody", "html", "Advisor Insights email body");
         createInstantEmailTemplate(
                 warnings, "rhel", "advisor", List.of(DEACTIVATED_RECOMMENDATION),
                 "Advisor/deactivatedRecommendationInstantEmailTitle", "txt", "Advisor deactivated recommendation email title",
@@ -98,18 +98,18 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/AdvisorOpenshift folder.
          */
-        getOrCreateTemplate(warnings, "AdvisorOpenshift/insightsEmailBody", "html", "AdvisorOpenshift Insights email body");
+        getOrCreateTemplate("AdvisorOpenshift/insightsEmailBody", "html", "AdvisorOpenshift Insights email body");
         createInstantEmailTemplate(
                 warnings, "openshift", "advisor", List.of("new-recommendation"),
                 "AdvisorOpenshift/newRecommendationInstantEmailTitle", "txt", "AdvisorOpenshift new recommendation email title",
                 "AdvisorOpenshift/newRecommendationInstantEmailBody", "html", "AdvisorOpenshift new recommendation email body",
-                featureFlipper.isAdvisorEmailTemplatesV2Enabled()
+                featureFlipper.isAdvisorOpenShiftEmailTemplatesV2Enabled()
         );
 
         /*
          * Former src/main/resources/templates/Ansible folder.
          */
-        getOrCreateTemplate(warnings, "Ansible/insightsEmailBody", "html", "Ansible Insights email body");
+        getOrCreateTemplate("Ansible/insightsEmailBody", "html", "Ansible Insights email body");
         createInstantEmailTemplate(
                 warnings, "ansible", "reports", List.of("report-available"),
                 "Ansible/instantEmailTitle", "txt", "Ansible instant email title",
@@ -120,7 +120,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Compliance folder.
          */
-        getOrCreateTemplate(warnings, "Compliance/insightsEmailBody", "html", "Compliance Insights email body");
+        getOrCreateTemplate("Compliance/insightsEmailBody", "html", "Compliance Insights email body");
         createInstantEmailTemplate(
                 warnings, "rhel", "compliance", List.of("compliance-below-threshold"),
                 "Compliance/complianceBelowThresholdEmailTitle", "txt", "Compliance below threshold email title",
@@ -143,7 +143,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/CostManagement folder.
          */
-        getOrCreateTemplate(warnings, "CostManagement/insightsEmailBody", "html", "Cost Management Insights email body");
+        getOrCreateTemplate("CostManagement/insightsEmailBody", "html", "Cost Management Insights email body");
         createInstantEmailTemplate(
                 warnings, "openshift", "cost-management", List.of("missing-cost-model"),
                 "CostManagement/MissingCostModelEmailTitle", "txt", "Cost Management missing cost model email title",
@@ -190,7 +190,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Drift folder.
          */
-        getOrCreateTemplate(warnings, "Drift/insightsEmailBody", "html", "Drift Insights email body");
+        getOrCreateTemplate("Drift/insightsEmailBody", "html", "Drift Insights email body");
         createInstantEmailTemplate(
                 warnings, "rhel", "drift", List.of("drift-baseline-detected"),
                 "Drift/newBaselineDriftInstantEmailTitle", "txt", "Drift new baseline drift email title",
@@ -207,7 +207,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/EdgeManagement folder.
          */
-        getOrCreateTemplate(warnings, "EdgeManagement/insightsEmailBody", "html", "EdgeManagement Insights email body");
+        getOrCreateTemplate("EdgeManagement/insightsEmailBody", "html", "EdgeManagement Insights email body");
         createInstantEmailTemplate(
                 warnings, "rhel", "edge-management", List.of("image-creation"),
                 "EdgeManagement/imageCreationTitle", "txt", "EdgeManagement image creation email title",
@@ -224,7 +224,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Inventory folder.
          */
-        getOrCreateTemplate(warnings, "Inventory/insightsEmailBody", "html", "Inventory Insights email body");
+        getOrCreateTemplate("Inventory/insightsEmailBody", "html", "Inventory Insights email body");
         createInstantEmailTemplate(
                 warnings, "rhel", "inventory", List.of("validation-error"),
                 "Inventory/validationErrorEmailTitle", "txt", "Inventory instant email title",
@@ -241,7 +241,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Integrations folder.
          */
-        getOrCreateTemplate(warnings, "Integrations/insightsEmailBody", "html", "Integrations Insights email body");
+        getOrCreateTemplate("Integrations/insightsEmailBody", "html", "Integrations Insights email body");
         createInstantEmailTemplate(
             warnings, "console", "integrations", List.of(INTEGRATION_FAILED_EVENT_TYPE),
             "Integrations/failedIntegrationTitle", "txt", "Integrations failed integration email title",
@@ -258,7 +258,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/MalwareDetection folder.
          */
-        getOrCreateTemplate(warnings, "MalwareDetection/insightsEmailBody", "html", "Malware Detection Insights email body");
+        getOrCreateTemplate("MalwareDetection/insightsEmailBody", "html", "Malware Detection Insights email body");
         createInstantEmailTemplate(
                 warnings, "rhel", "malware-detection", List.of("detected-malware"),
                 "MalwareDetection/detectedMalwareInstantEmailTitle", "txt", "Malware Detection detected malware email title",
@@ -269,7 +269,7 @@ public class EmailTemplateMigrationService {
         /*
         * Former src/main/resources/templates/Patch folder.
          */
-        getOrCreateTemplate(warnings, "Patch/insightsEmailBody", "html", "Patch Insights email body");
+        getOrCreateTemplate("Patch/insightsEmailBody", "html", "Patch Insights email body");
         createInstantEmailTemplate(
                 warnings, "rhel", "patch", List.of("new-advisory"),
                 "Patch/newAdvisoriesInstantEmailTitle", "txt", "Patch instant advisories email title",
@@ -286,7 +286,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Policies folder.
          */
-        getOrCreateTemplate(warnings, "Policies/insightsEmailBody", "html", "Policies Insights email body");
+        getOrCreateTemplate("Policies/insightsEmailBody", "html", "Policies Insights email body");
         createInstantEmailTemplate(
                 warnings, "rhel", "policies", List.of("policy-triggered"),
                 "Policies/instantEmailTitle", "txt", "Policies instant email title",
@@ -303,7 +303,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Rbac folder.
          */
-        getOrCreateTemplate(warnings, "Rbac/insightsEmailBody", "html", "Rbac Insights email body");
+        getOrCreateTemplate("Rbac/insightsEmailBody", "html", "Rbac Insights email body");
         createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("rh-new-role-available"),
                 "Rbac/systemRoleAvailableEmailTitle", "txt", "Rbac system role available email title",
@@ -386,7 +386,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/ResourceOptimization folder.
          */
-        getOrCreateTemplate(warnings, "ResourceOptimization/insightsEmailBody", "html", "Resource Optimization Insights email body");
+        getOrCreateTemplate("ResourceOptimization/insightsEmailBody", "html", "Resource Optimization Insights email body");
         createDailyEmailTemplate(
                 warnings, "rhel", "resource-optimization",
                 "ResourceOptimization/dailyEmailTitle", "txt", "Resource Optimization daily email title",
@@ -397,7 +397,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Rhosak folder.
          */
-        getOrCreateTemplate(warnings, "Rhosak/rhosakEmailBody", "html", "Rhosak email body");
+        getOrCreateTemplate("Rhosak/rhosakEmailBody", "html", "Rhosak email body");
         createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("disruption"),
                 "Rhosak/serviceDisruptionTitle", "txt", "Rhosak service disruption email title",
@@ -438,7 +438,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Sources folder.
          */
-        getOrCreateTemplate(warnings, "Sources/insightsEmailBody", "html", "Sources Insights email body");
+        getOrCreateTemplate("Sources/insightsEmailBody", "html", "Sources Insights email body");
         createInstantEmailTemplate(
                 warnings, "console", "sources", List.of("availability-status"),
                 "Sources/availabilityStatusEmailTitle", "txt", "Sources availability status email title",
@@ -449,7 +449,7 @@ public class EmailTemplateMigrationService {
         /*
          * Former src/main/resources/templates/Vulnerability folder.
          */
-        getOrCreateTemplate(warnings, "Vulnerability/insightsEmailBody", "html", "Vulnerability Insights email body");
+        getOrCreateTemplate("Vulnerability/insightsEmailBody", "html", "Vulnerability Insights email body");
         createInstantEmailTemplate(
                 warnings, "rhel", "vulnerability", List.of("any-cve-known-exploit"),
                 "Vulnerability/anyCveKnownExploitTitle", "txt", "Vulnerability any CVE known exploit email title",
@@ -481,7 +481,7 @@ public class EmailTemplateMigrationService {
                 featureFlipper.isVulnerabilityEmailTemplatesV2Enabled()
         );
 
-        getOrCreateTemplate(warnings, "Common/insightsEmailBody", "html", "Advisor Insights email body");
+        getOrCreateTemplate("Common/insightsEmailBody", "html", "Common Insights email body");
 
         Log.debug("Migration ended");
 
@@ -492,7 +492,7 @@ public class EmailTemplateMigrationService {
      * Creates a template only if it does not already exist in the DB.
      * Existing templates are never updated by this migration service.
      */
-    Template getOrCreateTemplate(List<String> warnings, String name, String extension, String description) {
+    Template getOrCreateTemplate(String name, String extension, String description) {
         String templateFromFS = loadResourceTemplate(name, extension);
         try {
             boolean hasBeenUpdated = false;
@@ -501,7 +501,6 @@ public class EmailTemplateMigrationService {
                     .getSingleResult();
             if (!template.getData().equals(templateFromFS)) {
                 template.setData(templateFromFS);
-                template = entityManager.merge(template);
                 hasBeenUpdated = true;
             }
             Log.infof("Template found in DB: %s" + (hasBeenUpdated ? " has been updated" : StringUtils.EMPTY), name);
@@ -511,7 +510,7 @@ public class EmailTemplateMigrationService {
             Template template = new Template();
             template.setName(name);
             template.setDescription(description);
-            template.setData(loadResourceTemplate(name, extension));
+            template.setData(templateFromFS);
             entityManager.persist(template);
             return template;
         }
@@ -550,8 +549,8 @@ public class EmailTemplateMigrationService {
                 if (instantEmailTemplateExists(eventType.get())) {
                     warnings.add(String.format("Instant email template found in DB for event type: %s/%s/%s", bundleName, appName, eventTypeName));
                 } else {
-                    Template subjectTemplate = getOrCreateTemplate(warnings, subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
-                    Template bodyTemplate = getOrCreateTemplate(warnings, bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
+                    Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
+                    Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
 
                     Log.infof("Creating instant email template for event type: %s/%s/%s", bundleName, appName, eventTypeName);
 
@@ -611,8 +610,8 @@ public class EmailTemplateMigrationService {
             if (aggregationEmailTemplateExists(app.get())) {
                 warnings.add(String.format("Aggregation email template found in DB for application: %s/%s", bundleName, appName));
             } else {
-                Template subjectTemplate = getOrCreateTemplate(warnings, subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
-                Template bodyTemplate = getOrCreateTemplate(warnings, bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
+                Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
+                Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
 
                 Log.infof("Creating daily email template for application: %s/%s", bundleName, appName);
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -191,9 +191,9 @@ public class ResourceHelpers {
     }
 
     @Transactional
-    public void deleteAllEmailTemplates() {
-        entityManager.createQuery("DELETE FROM InstantEmailTemplate").executeUpdate();
-        entityManager.createQuery("DELETE FROM AggregationEmailTemplate").executeUpdate();
+    public void deleteEmailTemplatesById(UUID templateId) {
+        entityManager.createQuery("DELETE FROM InstantEmailTemplate WHERE id = :id").setParameter("id", templateId).executeUpdate();
+        entityManager.createQuery("DELETE FROM AggregationEmailTemplate WHERE id = :id").setParameter("id", templateId).executeUpdate();
     }
 
     @Transactional

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
@@ -67,7 +67,7 @@ public class TemplateRepositoryTest {
             assertIsEmailSubscriptionSupported(false, false, false, false, false, false);
 
             // Then we link an instant email template with event-type-1 (which is a child entity of app-1).
-            resourceHelpers.createInstantEmailTemplate(eventType1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
+            InstantEmailTemplate createdInstanceEmailTemplate = resourceHelpers.createInstantEmailTemplate(eventType1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
 
             /*
              * Expectations:
@@ -77,7 +77,7 @@ public class TemplateRepositoryTest {
             assertIsEmailSubscriptionSupported(true, false, false, false, false, false);
 
             // Then we link an aggregation (DAILY) email template with event-type2 (which is a child entity of app-2).
-            resourceHelpers.createAggregationEmailTemplate(app2.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
+            AggregationEmailTemplate createdTemplate = resourceHelpers.createAggregationEmailTemplate(app2.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
 
             /*
              * Expectations:
@@ -87,7 +87,8 @@ public class TemplateRepositoryTest {
              */
             assertIsEmailSubscriptionSupported(true, false, false, true, false, false);
 
-            resourceHelpers.deleteAllEmailTemplates();
+            resourceHelpers.deleteEmailTemplatesById(createdTemplate.getId());
+            resourceHelpers.deleteEmailTemplatesById(createdInstanceEmailTemplate.getId());
         });
     }
 
@@ -114,7 +115,7 @@ public class TemplateRepositoryTest {
             assertIsEmailAggregationSupported(false, false);
 
             // Then we link an aggregation (DAILY) email template with app-1.
-            resourceHelpers.createAggregationEmailTemplate(app1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
+            AggregationEmailTemplate createdTemplate = resourceHelpers.createAggregationEmailTemplate(app1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
 
             /*
              * Expectations:
@@ -122,8 +123,7 @@ public class TemplateRepositoryTest {
              * - app-2 should still not support email aggregation
              */
             assertIsEmailAggregationSupported(true, false);
-
-            resourceHelpers.deleteAllEmailTemplates();
+            resourceHelpers.deleteEmailTemplatesById(createdTemplate.getId());
         });
     }
 
@@ -140,7 +140,7 @@ public class TemplateRepositoryTest {
             assertTrue(templateRepository.findInstantEmailTemplate(eventType2.getId()).isEmpty());
 
             // Then we link an instant email template with event-type-1...
-            resourceHelpers.createInstantEmailTemplate(eventType1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
+            InstantEmailTemplate createdTemplate = resourceHelpers.createInstantEmailTemplate(eventType1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
             // ... and retrieve it from the DB using the repository.
             Optional<InstantEmailTemplate> instantTemplate = templateRepository.findInstantEmailTemplate(eventType1.getId());
 
@@ -151,7 +151,7 @@ public class TemplateRepositoryTest {
             // event-type-2 should still not be linked to any instant email template.
             assertTrue(templateRepository.findInstantEmailTemplate(eventType2.getId()).isEmpty());
 
-            resourceHelpers.deleteAllEmailTemplates();
+            resourceHelpers.deleteEmailTemplatesById(createdTemplate.getId());
         });
     }
 
@@ -163,7 +163,7 @@ public class TemplateRepositoryTest {
             assertTrue(templateRepository.findAggregationEmailTemplate(bundle.getName(), app2.getName(), DAILY).isEmpty());
 
             // Then we link an aggregation email template with app-1...
-            resourceHelpers.createAggregationEmailTemplate(app1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
+            AggregationEmailTemplate createdTemplate = resourceHelpers.createAggregationEmailTemplate(app1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
             // ... and retrieve it from the DB using the repository.
             Optional<AggregationEmailTemplate> aggregationTemplate = templateRepository.findAggregationEmailTemplate(bundle.getName(), app1.getName(), DAILY);
 
@@ -174,7 +174,7 @@ public class TemplateRepositoryTest {
             // app-2 should still not be linked to any aggregation email template.
             assertTrue(templateRepository.findAggregationEmailTemplate(bundle.getName(), app2.getName(), DAILY).isEmpty());
 
-            resourceHelpers.deleteAllEmailTemplates();
+            resourceHelpers.deleteEmailTemplatesById(createdTemplate.getId());
         });
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorWithMigratedTemplateTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorWithMigratedTemplateTest.java
@@ -21,21 +21,17 @@ import com.redhat.cloud.notifications.recipients.itservice.pojo.response.Persona
 import com.redhat.cloud.notifications.templates.EmailTemplateFactory;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.QuarkusTestProfile;
-import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.vertx.core.json.JsonObject;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
@@ -45,9 +41,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @QuarkusTest
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @QuarkusTestResource(TestLifecycleManager.class)
-@TestProfile(EmailSubscriptionTypeProcessorWithMigratedTemplateTest.EnvVarTestSetup.class)
 public class EmailSubscriptionTypeProcessorWithMigratedTemplateTest {
 
     @Inject
@@ -126,8 +120,6 @@ public class EmailSubscriptionTypeProcessorWithMigratedTemplateTest {
 
         // Display name
         assertTrue(bodyRequest.contains("My test machine"), "Body should contain the display_name");
-
-        assertTrue(bodyRequest.contains(TestHelpers.HCC_LOGO_TARGET));
 
         return bodyRequest;
     }
@@ -209,18 +201,9 @@ public class EmailSubscriptionTypeProcessorWithMigratedTemplateTest {
     }
 
     List<EventType> getEventTypes() {
-        String query = "From EventType";
+        String query = "From EventType where name= :name";
         return entityManager.createQuery(query, EventType.class)
+            .setParameter("name", "policy-triggered")
             .getResultList();
-    }
-
-    public static class EnvVarTestSetup implements QuarkusTestProfile {
-        @Override
-        public Map<String, String> getConfigOverrides() {
-            return Map.of("notifications.use-templates-from-db", "true",
-                "notifications.inject-email-templates-to-db-on-startup.enabled", "true",
-                "notifications.use-policies-email-templates-v2.enabled", "true"
-                );
-        }
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorWithMigratedTemplateTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorWithMigratedTemplateTest.java
@@ -1,0 +1,232 @@
+package com.redhat.cloud.notifications.processors.email;
+
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.db.StatelessSessionFactory;
+import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.models.EmailSubscriptionProperties;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.Event;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.processors.webhooks.WebhookTypeProcessor;
+import com.redhat.cloud.notifications.recipients.itservice.ITUserService;
+import com.redhat.cloud.notifications.recipients.itservice.pojo.request.ITUserRequest;
+import com.redhat.cloud.notifications.recipients.itservice.pojo.response.AccountRelationship;
+import com.redhat.cloud.notifications.recipients.itservice.pojo.response.Authentication;
+import com.redhat.cloud.notifications.recipients.itservice.pojo.response.ITUserResponse;
+import com.redhat.cloud.notifications.recipients.itservice.pojo.response.PersonalInformation;
+import com.redhat.cloud.notifications.templates.EmailTemplateFactory;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.vertx.core.json.JsonObject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static com.redhat.cloud.notifications.models.EmailSubscriptionType.INSTANT;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@QuarkusTestResource(TestLifecycleManager.class)
+@TestProfile(EmailSubscriptionTypeProcessorWithMigratedTemplateTest.EnvVarTestSetup.class)
+public class EmailSubscriptionTypeProcessorWithMigratedTemplateTest {
+
+    @Inject
+    EmailSubscriptionTypeProcessor emailProcessor;
+
+    @Inject
+    EntityManager entityManager;
+
+    @Inject
+    StatelessSessionFactory statelessSessionFactory;
+
+    @InjectMock
+    @RestClient
+    ITUserService itUserService;
+
+    @InjectSpy
+    EmailTemplateFactory emailTemplateFactory;
+
+    @InjectMock
+    WebhookTypeProcessor webhookSender;
+
+    @InjectSpy
+    TemplateRepository templateRepository;
+
+    @Inject
+    FeatureFlipper featureFlipper;
+
+    String commonTest() {
+        mockGetUsers(8);
+
+        final String tenant = "instant-email-tenant";
+        final String[] usernames = {"username-1"};
+        String bundle = "rhel";
+        String application = "policies";
+
+        for (String username : usernames) {
+            subscribe(DEFAULT_ORG_ID, username, bundle, application);
+        }
+
+        final List<String> bodyRequests = new ArrayList<>();
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            bodyRequests.add(String.valueOf(args[3])); // The fourth argument is email Payload
+            return null;
+        }).when(webhookSender)
+            .doHttpRequest(any(), any(), any(), any(), anyString(), anyString(), anyBoolean());
+
+        Action emailActionMessage = TestHelpers.createPoliciesAction(tenant, bundle, application, "My test machine");
+        List<EventType> events =  getEventTypes();
+
+        Event event = new Event();
+        event.setEventType(events.get(0));
+        event.setAction(emailActionMessage);
+
+        EmailSubscriptionProperties properties = new EmailSubscriptionProperties();
+
+        Endpoint ep = new Endpoint();
+        ep.setType(EndpointType.EMAIL_SUBSCRIPTION);
+        ep.setName("positive feeling");
+        ep.setDescription("needle in the haystack");
+        ep.setEnabled(true);
+        ep.setProperties(properties);
+        try {
+            statelessSessionFactory.withSession(statelessSession -> {
+                emailProcessor.process(event, List.of(ep));
+            });
+
+            assertEquals(1, bodyRequests.size());
+            JsonObject email = new JsonObject(bodyRequests.get(0));
+            String bodyRequest = email.getJsonArray("emails").getJsonObject(0).getString("body");
+
+            assertTrue(bodyRequest.contains(TestHelpers.policyId1), "Body should contain policy id" + TestHelpers.policyId1);
+            assertTrue(bodyRequest.contains(TestHelpers.policyName1), "Body should contain policy name" + TestHelpers.policyName1);
+
+            assertTrue(bodyRequest.contains(TestHelpers.policyId2), "Body should contain policy id" + TestHelpers.policyId2);
+            assertTrue(bodyRequest.contains(TestHelpers.policyName2), "Body should contain policy name" + TestHelpers.policyName2);
+
+            // Display name
+            assertTrue(bodyRequest.contains("My test machine"), "Body should contain the display_name");
+
+            assertTrue(bodyRequest.contains(TestHelpers.HCC_LOGO_TARGET));
+
+            return bodyRequest;
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e);
+        }
+        return null;
+    }
+
+    @Test
+    void testEmailSubscriptionInstantFromFileSystem() {
+        featureFlipper.setUseTemplatesFromDb(false);
+        commonTest();
+        verify(emailTemplateFactory, times(2)).get(anyString(), anyString());
+        verify(templateRepository, times(0)).findInstantEmailTemplate(any(UUID.class));
+    }
+
+    @Test
+    void testEmailSubscriptionInstantFromDatabase() {
+        featureFlipper.setUseTemplatesFromDb(true);
+        String renderedEmailFromDb = commonTest();
+        verify(emailTemplateFactory, times(0)).get(anyString(), anyString());
+        verify(templateRepository, times(1)).findInstantEmailTemplate(any(UUID.class));
+
+        featureFlipper.setUseTemplatesFromDb(false);
+        String renderedEmailFromFs = commonTest();
+        assertEquals(renderedEmailFromDb, renderedEmailFromFs);
+    }
+
+    private void mockGetUsers(int elements) {
+        MockedUserAnswer answer = new MockedUserAnswer(elements);
+        Mockito.when(itUserService.getUsers(Mockito.any(ITUserRequest.class)
+        )).then(invocationOnMock -> answer.mockedUserAnswer());
+    }
+
+    static class MockedUserAnswer {
+
+        private final int expectedElements;
+
+        MockedUserAnswer(int expectedElements) {
+            this.expectedElements = expectedElements;
+        }
+
+        List<ITUserResponse> mockedUserAnswer() {
+
+            List<ITUserResponse> users = new ArrayList<>();
+            for (int i = 0; i < expectedElements; ++i) {
+                ITUserResponse user = new ITUserResponse();
+
+                user.authentications = new ArrayList<>();
+                user.authentications.add(new Authentication());
+                user.authentications.get(0).principal = String.format("username-%d", i);
+
+                com.redhat.cloud.notifications.recipients.itservice.pojo.response.Email email = new com.redhat.cloud.notifications.recipients.itservice.pojo.response.Email();
+                email.address = String.format("username-%d@foobardotcom", i);
+                user.accountRelationships = new ArrayList<>();
+                user.accountRelationships.add(new AccountRelationship());
+                user.accountRelationships.get(0).emails = List.of(email);
+
+                user.personalInformation = new PersonalInformation();
+                user.personalInformation.firstName = "foo";
+                user.personalInformation.lastNames = "bar";
+
+                users.add(user);
+            }
+
+            return users;
+        }
+    }
+
+    @Transactional
+    void subscribe(String orgId, String username, String bundleName, String applicationName) {
+        String query = "INSERT INTO endpoint_email_subscriptions(org_id, user_id, application_id, subscription_type) " +
+                "SELECT :orgId, :userId, a.id, :subscriptionType " +
+                "FROM applications a, bundles b WHERE a.bundle_id = b.id AND a.name = :applicationName AND b.name = :bundleName " +
+                "ON CONFLICT (org_id, user_id, application_id, subscription_type) DO NOTHING";
+        entityManager.createNativeQuery(query)
+                .setParameter("orgId", orgId)
+                .setParameter("userId", username)
+                .setParameter("bundleName", bundleName)
+                .setParameter("applicationName", applicationName)
+                .setParameter("subscriptionType", INSTANT.name())
+                .executeUpdate();
+    }
+
+    List<EventType> getEventTypes() {
+        String query = "From EventType";
+        return entityManager.createQuery(query, EventType.class)
+            .getResultList();
+    }
+
+    public static class EnvVarTestSetup implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("notifications.use-templates-from-db", "true",
+                "notifications.use-policies-email-templates-v2.enabled", "true"
+                );
+        }
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
@@ -203,6 +203,7 @@ public class EmailTemplateMigrationServiceTest {
             findAndCompileInstantEmailTemplate(updateDevices.getId());
             // App: Inventory
             findAndCompileInstantEmailTemplate(inventoryValidationError.getId());
+            findAndCompileAggregationEmailTemplate(rhel.getName(), inventory.getName(), DAILY);
             // App: malware-detection
             findAndCompileInstantEmailTemplate(detectedMalware.getId());
             assertTrue(templateRepository.findAggregationEmailTemplate(rhel.getName(), malwareDetection.getName(), DAILY).isEmpty());

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
@@ -86,6 +86,9 @@ public class EmailTemplateMigrationServiceTest {
         Application edgeManagement = resourceHelpers.createApp(rhel.getId(), "edge-management");
         EventType imageCreation = resourceHelpers.createEventType(edgeManagement.getId(), "image-creation");
         EventType updateDevices = resourceHelpers.createEventType(edgeManagement.getId(), "update-devices");
+        // App: inventory
+        Application inventoryManagement = resourceHelpers.createApp(rhel.getId(), "inventory");
+        EventType inventoryValidationError = resourceHelpers.createEventType(inventoryManagement.getId(), "validation-error");
         // App: malware-detection
         Application malwareDetection = resourceHelpers.createApp(rhel.getId(), "malware-detection");
         EventType detectedMalware = resourceHelpers.createEventType(malwareDetection.getId(), "detected-malware");
@@ -198,6 +201,8 @@ public class EmailTemplateMigrationServiceTest {
             // App: edge-management
             findAndCompileInstantEmailTemplate(imageCreation.getId());
             findAndCompileInstantEmailTemplate(updateDevices.getId());
+            // App: Inventory
+            findAndCompileInstantEmailTemplate(inventoryValidationError.getId());
             // App: malware-detection
             findAndCompileInstantEmailTemplate(detectedMalware.getId());
             assertTrue(templateRepository.findAggregationEmailTemplate(rhel.getName(), malwareDetection.getName(), DAILY).isEmpty());

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
@@ -87,8 +87,8 @@ public class EmailTemplateMigrationServiceTest {
         EventType imageCreation = resourceHelpers.createEventType(edgeManagement.getId(), "image-creation");
         EventType updateDevices = resourceHelpers.createEventType(edgeManagement.getId(), "update-devices");
         // App: inventory
-        Application inventoryManagement = resourceHelpers.createApp(rhel.getId(), "inventory");
-        EventType inventoryValidationError = resourceHelpers.createEventType(inventoryManagement.getId(), "validation-error");
+        Application inventory = resourceHelpers.createApp(rhel.getId(), "inventory");
+        EventType inventoryValidationError = resourceHelpers.createEventType(inventory.getId(), "validation-error");
         // App: malware-detection
         Application malwareDetection = resourceHelpers.createApp(rhel.getId(), "malware-detection");
         EventType detectedMalware = resourceHelpers.createEventType(malwareDetection.getId(), "detected-malware");


### PR DESCRIPTION
Be able to create/update email templates from file system, when engine starts.
Restrict write access to Template API to internal admin only for the moment. 