### PR TITLE
Fix openapi error

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -618,7 +618,7 @@ public class EndpointResource {
      * @param uuid the {@link UUID} of the endpoint to test.
      * @return a "no content" response on success.
      */
-    @APIResponse(responseCode = "204")
+    @APIResponse(responseCode = "204", description = "No Content")
     @POST
     @Path("/{uuid}/test")
     @Parameters({


### PR DESCRIPTION
While working on the API docs, i noticed that we have a validation error:

```yml
/endpoints/{uuid}/test:
    post:
      tags:
        - Endpoint Resource
      operationId: EndpointResource_testEndpoint
      parameters:
        - name: uuid
          in: path
          description: The UUID of the endpoint to test
          required: true
          schema:
            type: string
      responses:
        '204': {}
        '401':
          description: Not Authorized
        '403':
          description: Not Allowed
      security:
        - SecurityScheme: []
```

```
Structural error at paths./endpoints/{uuid}/test.post.responses.204
should have required property 'description'
missingProperty: description
```