### PR TITLE
[RHCLOUD-24236] manage user rights on template api

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
@@ -28,6 +28,10 @@ public class TemplateRepository {
 
     @Transactional
     public Template createTemplate(Template template) {
+        if (template.getApplicationId() != null) {
+            Application app = findApplication(template.getApplicationId());
+            template.setApplication(app);
+        }
         entityManager.persist(template);
         return template;
     }
@@ -285,7 +289,7 @@ public class TemplateRepository {
         return rowCount > 0;
     }
 
-    private EventType findEventType(UUID id) {
+    public EventType findEventType(UUID id) {
         EventType eventType = entityManager.find(EventType.class, id);
         if (eventType == null) {
             throw new NotFoundException("Event type not found");

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/SecurityContextUtil.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/SecurityContextUtil.java
@@ -55,6 +55,9 @@ public class SecurityContextUtil {
         if (securityContext.isUserInRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
             return;
         }
+        if (applicationId == null) {
+            throw new ForbiddenException("Common templates can only be managed by administrators");
+        }
 
         List<InternalRoleAccess> internalRoleAccessList = internalRoleAccessRepository.getByApplication(applicationId);
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
@@ -123,7 +123,7 @@ public class TemplateResource {
         if (!sec.isUserInRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
             Template templateFromDb = templateRepository.findTemplateById(templateId);
             if (null == templateFromDb.getApplication()) {
-                throw new ForbiddenException();
+                throw new ForbiddenException("Common templates can only be deleted by administrators");
             }
             securityContextUtil.hasPermissionForApplication(sec, templateFromDb.getApplication().getId());
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
@@ -98,7 +98,7 @@ public class TemplateResource {
         if (!sec.isUserInRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
             Template templateFromDb = templateRepository.findTemplateById(templateId);
             if (null == templateFromDb.getApplication() || null == template.getApplicationId()) {
-                throw new ForbiddenException();
+                throw new ForbiddenException("Common templates can only be updated by administrators");
             }
             // check if user have permissions to update existing template
             securityContextUtil.hasPermissionForApplication(sec, templateFromDb.getApplication().getId());

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
@@ -1,12 +1,16 @@
 package com.redhat.cloud.notifications.routers.internal;
 
+import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
 import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
 import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
+import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.InstantEmailTemplate;
 import com.redhat.cloud.notifications.models.Template;
+import com.redhat.cloud.notifications.routers.SecurityContextUtil;
 import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateRequest;
 import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateResponse;
 import com.redhat.cloud.notifications.templates.TemplateEngineClient;
+import io.quarkus.security.ForbiddenException;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -29,7 +33,9 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
 
 import java.util.List;
 import java.util.UUID;
@@ -46,6 +52,9 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 public class TemplateResource {
 
     @Inject
+    SecurityContextUtil securityContextUtil;
+
+    @Inject
     TemplateRepository templateRepository;
 
     @Inject
@@ -56,8 +65,10 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_ADMIN)
-    public Template createTemplate(@NotNull @Valid Template template) {
+    @RolesAllowed(RBAC_INTERNAL_USER)
+    public Template createTemplate(@Context SecurityContext sec, @NotNull @Valid Template template) {
+        // Common templates don't have any applicationId, only internal admins can manage them
+        securityContextUtil.hasPermissionForApplication(sec, template.getApplicationId());
         return templateRepository.createTemplate(template);
     }
 
@@ -81,8 +92,19 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_ADMIN)
-    public Response updateTemplate(@RestPath UUID templateId, Template template) {
+    @RolesAllowed(RBAC_INTERNAL_USER)
+    public Response updateTemplate(@Context SecurityContext sec, @RestPath UUID templateId, Template template) {
+        Template templateFromDb = templateRepository.findTemplateById(templateId);
+        // Common templates don't have any applicationId, only internal admins can manage them
+        if (!sec.isUserInRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
+            if (null == templateFromDb.getApplication() || null == template.getApplicationId()) {
+                throw new ForbiddenException();
+            }
+            // check if user have permissions to update existing template
+            securityContextUtil.hasPermissionForApplication(sec, templateFromDb.getApplication().getId());
+            // if user change template application, he must have permissions on the new App
+            securityContextUtil.hasPermissionForApplication(sec, template.getApplicationId());
+        }
         boolean updated = templateRepository.updateTemplate(templateId, template);
         if (updated) {
             return Response.ok().build();
@@ -93,9 +115,18 @@ public class TemplateResource {
 
     @DELETE
     @Path("/{templateId}")
+    @Produces(TEXT_PLAIN)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_ADMIN)
-    public boolean deleteTemplate(@RestPath UUID templateId) {
+    @RolesAllowed(RBAC_INTERNAL_USER)
+    public boolean deleteTemplate(@Context SecurityContext sec, @RestPath UUID templateId) {
+        Template templateFromDb = templateRepository.findTemplateById(templateId);
+        // Common templates don't have any applicationId, only internal admins can manage them
+        if (!sec.isUserInRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
+            if (null == templateFromDb.getApplication()) {
+                throw new ForbiddenException();
+            }
+            securityContextUtil.hasPermissionForApplication(sec, templateFromDb.getApplication().getId());
+        }
         return templateRepository.deleteTemplate(templateId);
     }
 
@@ -104,8 +135,14 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_ADMIN)
-    public InstantEmailTemplate createInstantEmailTemplate(@NotNull @Valid InstantEmailTemplate template) {
+    @RolesAllowed(RBAC_INTERNAL_USER)
+    public InstantEmailTemplate createInstantEmailTemplate(@Context SecurityContext sec, @NotNull @Valid InstantEmailTemplate template) {
+        if (null != template.getEventTypeId()) {
+            EventType eventType = templateRepository.findEventType(template.getEventTypeId());
+            if (null != eventType) {
+                securityContextUtil.hasPermissionForApplication(sec, eventType.getApplicationId());
+            }
+        }
         return templateRepository.createInstantEmailTemplate(template);
     }
 
@@ -141,8 +178,25 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_ADMIN)
-    public Response updateInstantEmailTemplate(@RestPath UUID templateId, @NotNull @Valid InstantEmailTemplate template) {
+    @RolesAllowed(RBAC_INTERNAL_USER)
+    public Response updateInstantEmailTemplate(@Context SecurityContext sec, @RestPath UUID templateId, @NotNull @Valid InstantEmailTemplate template) {
+        // check if user can link existing instant email template to the new event type
+        if (null != template.getEventTypeId()) {
+            EventType eventType = templateRepository.findEventType(template.getEventTypeId());
+            if (null != eventType) {
+                securityContextUtil.hasPermissionForApplication(sec, eventType.getApplicationId());
+            }
+        }
+
+        // check if user have permission to update existing instant email template
+        InstantEmailTemplate instantEmailTemplate = templateRepository.findInstantEmailTemplateById(templateId);
+        if (null != instantEmailTemplate && null != instantEmailTemplate.getEventTypeId()) {
+            EventType eventType = templateRepository.findEventType(instantEmailTemplate.getEventTypeId());
+            if (null != eventType) {
+                securityContextUtil.hasPermissionForApplication(sec, eventType.getApplicationId());
+            }
+        }
+
         boolean updated = templateRepository.updateInstantEmailTemplate(templateId, template);
         if (updated) {
             return Response.ok().build();
@@ -153,9 +207,17 @@ public class TemplateResource {
 
     @DELETE
     @Path("/email/instant/{templateId}")
+    @Produces(TEXT_PLAIN)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_ADMIN)
-    public boolean deleteInstantEmailTemplate(@RestPath UUID templateId) {
+    @RolesAllowed(RBAC_INTERNAL_USER)
+    public boolean deleteInstantEmailTemplate(@Context SecurityContext sec, @RestPath UUID templateId) {
+        InstantEmailTemplate instantEmailTemplate = templateRepository.findInstantEmailTemplateById(templateId);
+        if (null != instantEmailTemplate && null != instantEmailTemplate.getEventTypeId()) {
+            EventType eventType = templateRepository.findEventType(instantEmailTemplate.getEventTypeId());
+            if (null != eventType) {
+                securityContextUtil.hasPermissionForApplication(sec, eventType.getApplicationId());
+            }
+        }
         return templateRepository.deleteInstantEmailTemplate(templateId);
     }
 
@@ -164,8 +226,11 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_ADMIN)
-    public AggregationEmailTemplate createAggregationEmailTemplate(@NotNull @Valid AggregationEmailTemplate template) {
+    @RolesAllowed(RBAC_INTERNAL_USER)
+    public AggregationEmailTemplate createAggregationEmailTemplate(@Context SecurityContext sec, @NotNull @Valid AggregationEmailTemplate template) {
+        if (null != template.getApplicationId()) {
+            securityContextUtil.hasPermissionForApplication(sec, template.getApplicationId());
+        }
         return templateRepository.createAggregationEmailTemplate(template);
     }
 
@@ -198,8 +263,19 @@ public class TemplateResource {
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_ADMIN)
-    public Response updateAggregationEmailTemplate(@RestPath UUID templateId, @NotNull @Valid AggregationEmailTemplate template) {
+    @RolesAllowed(RBAC_INTERNAL_USER)
+    public Response updateAggregationEmailTemplate(@Context SecurityContext sec, @RestPath UUID templateId, @NotNull @Valid AggregationEmailTemplate template) {
+        AggregationEmailTemplate templateFromDb = templateRepository.findAggregationEmailTemplateById(templateId);
+        if (null != templateFromDb.getApplicationId()) {
+            // check if user have permissions to update existing template
+            securityContextUtil.hasPermissionForApplication(sec, templateFromDb.getApplication().getId());
+        }
+
+        if (null != template.getApplicationId()) {
+            // if user change template application, he must have permissions on the new App
+            securityContextUtil.hasPermissionForApplication(sec, template.getApplicationId());
+        }
+
         boolean updated = templateRepository.updateAggregationEmailTemplate(templateId, template);
         if (updated) {
             return Response.ok().build();
@@ -210,9 +286,15 @@ public class TemplateResource {
 
     @DELETE
     @Path("/email/aggregation/{templateId}")
+    @Produces(TEXT_PLAIN)
     @Transactional
-    @RolesAllowed(RBAC_INTERNAL_ADMIN)
-    public boolean deleteAggregationEmailTemplate(@RestPath UUID templateId) {
+    @RolesAllowed(RBAC_INTERNAL_USER)
+    public boolean deleteAggregationEmailTemplate(@Context SecurityContext sec, @RestPath UUID templateId) {
+        AggregationEmailTemplate aggregationEmailTemplate = templateRepository.findAggregationEmailTemplateById(templateId);
+        if (null != aggregationEmailTemplate.getApplication()) {
+            securityContextUtil.hasPermissionForApplication(sec, aggregationEmailTemplate.getApplication().getId());
+        }
+
         return templateRepository.deleteAggregationEmailTemplate(templateId);
     }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
@@ -119,9 +119,9 @@ public class TemplateResource {
     @Transactional
     @RolesAllowed(RBAC_INTERNAL_USER)
     public boolean deleteTemplate(@Context SecurityContext sec, @RestPath UUID templateId) {
-        Template templateFromDb = templateRepository.findTemplateById(templateId);
         // Common templates don't have any applicationId, only internal admins can manage them
         if (!sec.isUserInRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
+            Template templateFromDb = templateRepository.findTemplateById(templateId);
             if (null == templateFromDb.getApplication()) {
                 throw new ForbiddenException();
             }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/TemplateResource.java
@@ -94,9 +94,9 @@ public class TemplateResource {
     @Transactional
     @RolesAllowed(RBAC_INTERNAL_USER)
     public Response updateTemplate(@Context SecurityContext sec, @RestPath UUID templateId, Template template) {
-        Template templateFromDb = templateRepository.findTemplateById(templateId);
         // Common templates don't have any applicationId, only internal admins can manage them
         if (!sec.isUserInRole(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)) {
+            Template templateFromDb = templateRepository.findTemplateById(templateId);
             if (null == templateFromDb.getApplication() || null == template.getApplicationId()) {
                 throw new ForbiddenException();
             }

--- a/backend/src/test/java/com/redhat/cloud/notifications/CrudTestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/CrudTestHelpers.java
@@ -636,7 +636,7 @@ public abstract class CrudTestHelpers {
         return new JsonArray(responseBody);
     }
 
-    public static void updateTemplate(Header header, String templateId, Template updatedTemplate) {
+    public static void updateTemplate(Header header, String templateId, Template updatedTemplate, int expectedStatusCode) {
         given()
                 .basePath(API_INTERNAL)
                 .header(header)
@@ -645,7 +645,7 @@ public abstract class CrudTestHelpers {
                 .body(Json.encode(updatedTemplate))
                 .when().put("/templates/{templateId}")
                 .then()
-                .statusCode(200)
+                .statusCode(expectedStatusCode)
                 .contentType(TEXT);
 
         // Let's check that the template fields have been correctly updated.
@@ -676,7 +676,7 @@ public abstract class CrudTestHelpers {
                 .body(Json.encode(emailTemplate))
                 .when().post("/templates/email/instant")
                 .then()
-                .statusCode(200)
+                .statusCode(expectedStatusCode)
                 .contentType(familyOf(expectedStatusCode) == SUCCESSFUL ? is(JSON_UTF8) : any(String.class))
                 .extract().asString();
 
@@ -745,18 +745,20 @@ public abstract class CrudTestHelpers {
         }
     }
 
-    public static void deleteInstantEmailTemplate(Header header, String templateId) {
+    public static void deleteInstantEmailTemplate(Header header, String templateId, int expectedStatusCode) {
         given()
                 .basePath(API_INTERNAL)
                 .header(header)
                 .pathParam("templateId", templateId)
                 .when().delete("/templates/email/instant/{templateId}")
                 .then()
-                .statusCode(200)
+                .statusCode(expectedStatusCode)
                 .contentType(TEXT);
 
-        // Let's check that the template no longer exists.
-        getInstantEmailTemplate(header, templateId, /* Not used */ null, 404);
+        if (familyOf(expectedStatusCode) == SUCCESSFUL) {
+            // Let's check that the template no longer exists.
+            getInstantEmailTemplate(header, templateId, /* Not used */ null, 404);
+        }
     }
 
     public static JsonArray getAllInstantEmailTemplates(Header header) {
@@ -815,7 +817,7 @@ public abstract class CrudTestHelpers {
         return null;
     }
 
-    public static void updateInstantEmailTemplate(Header header, String templateId, InstantEmailTemplate updatedEmailTemplate) {
+    public static void updateInstantEmailTemplate(Header header, String templateId, InstantEmailTemplate updatedEmailTemplate, int expectedStatusCode) {
         given()
                 .basePath(API_INTERNAL)
                 .header(header)
@@ -824,11 +826,13 @@ public abstract class CrudTestHelpers {
                 .body(Json.encode(updatedEmailTemplate))
                 .when().put("/templates/email/instant/{templateId}")
                 .then()
-                .statusCode(200)
+                .statusCode(expectedStatusCode)
                 .contentType(TEXT);
 
-        // Let's check that the instant email template fields have been correctly updated.
-        getInstantEmailTemplate(header, templateId, updatedEmailTemplate, 200);
+        if (familyOf(expectedStatusCode) == SUCCESSFUL) {
+            // Let's check that the instant email template fields have been correctly updated.
+            getInstantEmailTemplate(header, templateId, updatedEmailTemplate, 200);
+        }
     }
 
     public static Optional<JsonObject> createAggregationEmailTemplate(Header header, AggregationEmailTemplate emailTemplate, int expectedStatusCode) {
@@ -839,7 +843,7 @@ public abstract class CrudTestHelpers {
                 .body(Json.encode(emailTemplate))
                 .when().post("/templates/email/aggregation")
                 .then()
-                .statusCode(200)
+                .statusCode(expectedStatusCode)
                 .contentType(familyOf(expectedStatusCode) == SUCCESSFUL ? is(JSON_UTF8) : any(String.class))
                 .extract().asString();
 
@@ -908,18 +912,20 @@ public abstract class CrudTestHelpers {
         }
     }
 
-    public static void deleteAggregationEmailTemplate(Header header, String templateId) {
+    public static void deleteAggregationEmailTemplate(Header header, String templateId, int expectedStatusCode) {
         given()
                 .basePath(API_INTERNAL)
                 .header(header)
                 .pathParam("templateId", templateId)
                 .when().delete("/templates/email/aggregation/{templateId}")
                 .then()
-                .statusCode(200)
+                .statusCode(expectedStatusCode)
                 .contentType(TEXT);
 
-        // Let's check that the template no longer exists.
-        getAggregationEmailTemplate(header, templateId, /* Not used */ null, 404);
+        if (familyOf(expectedStatusCode) == SUCCESSFUL) {
+            // Let's check that the template no longer exists.
+            getAggregationEmailTemplate(header, templateId, /* Not used */ null, 404);
+        }
     }
 
     public static JsonArray getAllAggregationEmailTemplates(Header header) {
@@ -964,7 +970,7 @@ public abstract class CrudTestHelpers {
         return jsonEmailTemplates;
     }
 
-    public static void updateAggregationEmailTemplate(Header header, String templateId, AggregationEmailTemplate updatedEmailTemplate) {
+    public static void updateAggregationEmailTemplate(Header header, String templateId, AggregationEmailTemplate updatedEmailTemplate, int expectedStatusCode) {
         given()
                 .basePath(API_INTERNAL)
                 .header(header)
@@ -973,10 +979,12 @@ public abstract class CrudTestHelpers {
                 .body(Json.encode(updatedEmailTemplate))
                 .when().put("/templates/email/aggregation/{templateId}")
                 .then()
-                .statusCode(200)
+                .statusCode(expectedStatusCode)
                 .contentType(TEXT);
 
-        // Let's check that the aggregation email template fields have been correctly updated.
-        getAggregationEmailTemplate(header, templateId, updatedEmailTemplate, 200);
+        if (familyOf(expectedStatusCode) == SUCCESSFUL) {
+            // Let's check that the aggregation email template fields have been correctly updated.
+            getAggregationEmailTemplate(header, templateId, updatedEmailTemplate, 200);
+        }
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Template.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Template.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.persistence.Entity;
@@ -36,6 +37,7 @@ public class Template extends CreationUpdateTimestamped {
     @NotNull
     private String data;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "application_id")
     private Application application;

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Template.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Template.java
@@ -3,9 +3,13 @@ package com.redhat.cloud.notifications.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.Objects;
@@ -13,7 +17,6 @@ import java.util.UUID;
 
 import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
 
-// TODO NOTIF-484 Add templates ownership and restrict access to the templates.
 @Entity
 @Table(name = "template")
 public class Template extends CreationUpdateTimestamped {
@@ -32,6 +35,13 @@ public class Template extends CreationUpdateTimestamped {
 
     @NotNull
     private String data;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "application_id")
+    private Application application;
+
+    @Transient
+    private UUID applicationId;
 
     public UUID getId() {
         return id;
@@ -63,6 +73,25 @@ public class Template extends CreationUpdateTimestamped {
 
     public void setData(String data) {
         this.data = data;
+    }
+
+    public Application getApplication() {
+        return application;
+    }
+
+    public void setApplication(Application application) {
+        this.application = application;
+    }
+
+    public UUID getApplicationId() {
+        if (applicationId == null && application != null) {
+            applicationId = application.getId();
+        }
+        return applicationId;
+    }
+
+    public void setApplicationId(UUID applicationId) {
+        this.applicationId = applicationId;
     }
 
     @Override

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Template.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Template.java
@@ -36,7 +36,7 @@ public class Template extends CreationUpdateTimestamped {
     @NotNull
     private String data;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "application_id")
     private Application application;
 

--- a/database/src/main/resources/db/migration/V1.73.0__RHCLOUD-24236_add_application_fk_to_templates.sql
+++ b/database/src/main/resources/db/migration/V1.73.0__RHCLOUD-24236_add_application_fk_to_templates.sql
@@ -1,0 +1,3 @@
+ALTER TABLE template
+    add column application_id UUID,
+    add constraint fk_generic_template_app_id FOREIGN KEY (application_id) REFERENCES applications (id) ON DELETE CASCADE;

--- a/database/src/main/resources/db/migration/V1.73.0__RHCLOUD-24236_add_application_fk_to_templates.sql
+++ b/database/src/main/resources/db/migration/V1.73.0__RHCLOUD-24236_add_application_fk_to_templates.sql
@@ -1,3 +1,0 @@
-ALTER TABLE template
-    add column application_id UUID,
-    add constraint fk_generic_template_app_id FOREIGN KEY (application_id) REFERENCES applications (id) ON DELETE CASCADE;

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -66,7 +66,7 @@ public class EmailTemplateMigrationService {
 
         Log.debug("Migration starting");
         if (featureFlipper.isUseSecuredEmailTemplates()) {
-            getOrCreateTemplate("Secure/Common/insightsEmailBody", "html", "Common Insights email body");
+            getOrCreateTemplate("Secure/Common/insightsEmailBody", "html", "Common Insights email body", Optional.empty());
             if (featureFlipper.isRhelAdvisorDailyDigestEnabled()) {
                 createDailyEmailTemplate(
                     warnings, "rhel", "advisor",
@@ -119,7 +119,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Advisor folder.
              */
-            getOrCreateTemplate("Advisor/insightsEmailBody", "html", "Advisor Insights email body");
+            getOrCreateTemplate("Advisor/insightsEmailBody", "html", "Advisor Insights email body", findApplication(warnings, "rhel", "advisor"));
             createInstantEmailTemplate(
                 warnings, "rhel", "advisor", List.of(DEACTIVATED_RECOMMENDATION),
                 "Advisor/deactivatedRecommendationInstantEmailTitle", "txt", "Advisor deactivated recommendation email title",
@@ -150,7 +150,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/AdvisorOpenshift folder.
              */
-            getOrCreateTemplate("AdvisorOpenshift/insightsEmailBody", "html", "AdvisorOpenshift Insights email body");
+            getOrCreateTemplate("AdvisorOpenshift/insightsEmailBody", "html", "AdvisorOpenshift Insights email body", findApplication(warnings, "openshift", "advisor"));
             createInstantEmailTemplate(
                 warnings, "openshift", "advisor", List.of("new-recommendation"),
                 "AdvisorOpenshift/newRecommendationInstantEmailTitle", "txt", "AdvisorOpenshift new recommendation email title",
@@ -161,7 +161,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Ansible folder.
              */
-            getOrCreateTemplate("Ansible/insightsEmailBody", "html", "Ansible Insights email body");
+            getOrCreateTemplate("Ansible/insightsEmailBody", "html", "Ansible Insights email body", findApplication(warnings, "ansible", "reports"));
             createInstantEmailTemplate(
                 warnings, "ansible", "reports", List.of("report-available"),
                 "Ansible/instantEmailTitle", "txt", "Ansible instant email title",
@@ -172,7 +172,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Compliance folder.
              */
-            getOrCreateTemplate("Compliance/insightsEmailBody", "html", "Compliance Insights email body");
+            getOrCreateTemplate("Compliance/insightsEmailBody", "html", "Compliance Insights email body", findApplication(warnings, "rhel", "compliance"));
             createInstantEmailTemplate(
                 warnings, "rhel", "compliance", List.of("compliance-below-threshold"),
                 "Compliance/complianceBelowThresholdEmailTitle", "txt", "Compliance below threshold email title",
@@ -195,7 +195,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/CostManagement folder.
              */
-            getOrCreateTemplate("CostManagement/insightsEmailBody", "html", "Cost Management Insights email body");
+            getOrCreateTemplate("CostManagement/insightsEmailBody", "html", "Cost Management Insights email body", findApplication(warnings, "openshift", "cost-management"));
             createInstantEmailTemplate(
                 warnings, "openshift", "cost-management", List.of("missing-cost-model"),
                 "CostManagement/MissingCostModelEmailTitle", "txt", "Cost Management missing cost model email title",
@@ -242,7 +242,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Drift folder.
              */
-            getOrCreateTemplate("Drift/insightsEmailBody", "html", "Drift Insights email body");
+            getOrCreateTemplate("Drift/insightsEmailBody", "html", "Drift Insights email body", findApplication(warnings, "rhel", "drift"));
             createInstantEmailTemplate(
                 warnings, "rhel", "drift", List.of("drift-baseline-detected"),
                 "Drift/newBaselineDriftInstantEmailTitle", "txt", "Drift new baseline drift email title",
@@ -259,7 +259,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/EdgeManagement folder.
              */
-            getOrCreateTemplate("EdgeManagement/insightsEmailBody", "html", "EdgeManagement Insights email body");
+            getOrCreateTemplate("EdgeManagement/insightsEmailBody", "html", "EdgeManagement Insights email body", findApplication(warnings, "rhel", "edge-management"));
             createInstantEmailTemplate(
                 warnings, "rhel", "edge-management", List.of("image-creation"),
                 "EdgeManagement/imageCreationTitle", "txt", "EdgeManagement image creation email title",
@@ -276,7 +276,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Inventory folder.
              */
-            getOrCreateTemplate("Inventory/insightsEmailBody", "html", "Inventory Insights email body");
+            getOrCreateTemplate("Inventory/insightsEmailBody", "html", "Inventory Insights email body", findApplication(warnings, "rhel", "inventory"));
             createInstantEmailTemplate(
                 warnings, "rhel", "inventory", List.of("validation-error"),
                 "Inventory/validationErrorEmailTitle", "txt", "Inventory instant email title",
@@ -293,7 +293,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Integrations folder.
              */
-            getOrCreateTemplate("Integrations/insightsEmailBody", "html", "Integrations Insights email body");
+            getOrCreateTemplate("Integrations/insightsEmailBody", "html", "Integrations Insights email body", findApplication(warnings, "console", "integrations"));
             createInstantEmailTemplate(
                 warnings, "console", "integrations", List.of(INTEGRATION_FAILED_EVENT_TYPE),
                 "Integrations/failedIntegrationTitle", "txt", "Integrations failed integration email title",
@@ -310,7 +310,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/MalwareDetection folder.
              */
-            getOrCreateTemplate("MalwareDetection/insightsEmailBody", "html", "Malware Detection Insights email body");
+            getOrCreateTemplate("MalwareDetection/insightsEmailBody", "html", "Malware Detection Insights email body", findApplication(warnings, "rhel", "malware-detection"));
             createInstantEmailTemplate(
                 warnings, "rhel", "malware-detection", List.of("detected-malware"),
                 "MalwareDetection/detectedMalwareInstantEmailTitle", "txt", "Malware Detection detected malware email title",
@@ -321,7 +321,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Patch folder.
              */
-            getOrCreateTemplate("Patch/insightsEmailBody", "html", "Patch Insights email body");
+            getOrCreateTemplate("Patch/insightsEmailBody", "html", "Patch Insights email body", findApplication(warnings, "rhel", "patch"));
             createInstantEmailTemplate(
                 warnings, "rhel", "patch", List.of("new-advisory"),
                 "Patch/newAdvisoriesInstantEmailTitle", "txt", "Patch instant advisories email title",
@@ -338,7 +338,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Policies folder.
              */
-            getOrCreateTemplate("Policies/insightsEmailBody", "html", "Policies Insights email body");
+            getOrCreateTemplate("Policies/insightsEmailBody", "html", "Policies Insights email body", findApplication(warnings, "rhel", "policies"));
             createInstantEmailTemplate(
                 warnings, "rhel", "policies", List.of("policy-triggered"),
                 "Policies/instantEmailTitle", "txt", "Policies instant email title",
@@ -355,7 +355,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Rbac folder.
              */
-            getOrCreateTemplate("Rbac/insightsEmailBody", "html", "Rbac Insights email body");
+            getOrCreateTemplate("Rbac/insightsEmailBody", "html", "Rbac Insights email body", findApplication(warnings, "console", "rbac"));
             createInstantEmailTemplate(
                 warnings, "console", "rbac", List.of("rh-new-role-available"),
                 "Rbac/systemRoleAvailableEmailTitle", "txt", "Rbac system role available email title",
@@ -438,7 +438,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/ResourceOptimization folder.
              */
-            getOrCreateTemplate("ResourceOptimization/insightsEmailBody", "html", "Resource Optimization Insights email body");
+            getOrCreateTemplate("ResourceOptimization/insightsEmailBody", "html", "Resource Optimization Insights email body", findApplication(warnings, "rhel", "resource-optimization"));
             createDailyEmailTemplate(
                 warnings, "rhel", "resource-optimization",
                 "ResourceOptimization/dailyEmailTitle", "txt", "Resource Optimization daily email title",
@@ -449,7 +449,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Rhosak folder.
              */
-            getOrCreateTemplate("Rhosak/rhosakEmailBody", "html", "Rhosak email body");
+            getOrCreateTemplate("Rhosak/rhosakEmailBody", "html", "Rhosak email body", findApplication(warnings, "application-services", "rhosak"));
             createInstantEmailTemplate(
                 warnings, "application-services", "rhosak", List.of("disruption"),
                 "Rhosak/serviceDisruptionTitle", "txt", "Rhosak service disruption email title",
@@ -490,7 +490,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Sources folder.
              */
-            getOrCreateTemplate("Sources/insightsEmailBody", "html", "Sources Insights email body");
+            getOrCreateTemplate("Sources/insightsEmailBody", "html", "Sources Insights email body", findApplication(warnings, "console", "sources"));
             createInstantEmailTemplate(
                 warnings, "console", "sources", List.of("availability-status"),
                 "Sources/availabilityStatusEmailTitle", "txt", "Sources availability status email title",
@@ -501,7 +501,7 @@ public class EmailTemplateMigrationService {
             /*
              * Former src/main/resources/templates/Vulnerability folder.
              */
-            getOrCreateTemplate("Vulnerability/insightsEmailBody", "html", "Vulnerability Insights email body");
+            getOrCreateTemplate("Vulnerability/insightsEmailBody", "html", "Vulnerability Insights email body", findApplication(warnings, "rhel", "vulnerability"));
             createInstantEmailTemplate(
                 warnings, "rhel", "vulnerability", List.of("any-cve-known-exploit"),
                 "Vulnerability/anyCveKnownExploitTitle", "txt", "Vulnerability any CVE known exploit email title",
@@ -533,7 +533,7 @@ public class EmailTemplateMigrationService {
                 featureFlipper.isVulnerabilityEmailTemplatesV2Enabled()
             );
 
-            getOrCreateTemplate("Common/insightsEmailBody", "html", "Common Insights email body");
+            getOrCreateTemplate("Common/insightsEmailBody", "html", "Common Insights email body", Optional.empty());
         }
         Log.debug("Migration ended");
 
@@ -544,7 +544,7 @@ public class EmailTemplateMigrationService {
      * Creates a template only if it does not already exist in the DB.
      * Existing templates are never updated by this migration service.
      */
-    Template getOrCreateTemplate(String name, String extension, String description) {
+    Template getOrCreateTemplate(String name, String extension, String description, Optional<Application> application) {
         String templateFromFS = loadResourceTemplate(name, extension);
         if (name.contains("V2")) {
             name = name.replace("V2", "");
@@ -558,6 +558,9 @@ public class EmailTemplateMigrationService {
                 template.setData(templateFromFS);
                 hasBeenUpdated = true;
             }
+            if (application.isPresent()) {
+                template.setApplication(application.get());
+            }
             Log.infof("Template found in DB: %s" + (hasBeenUpdated ? " has been updated" : StringUtils.EMPTY), name);
             return template;
         } catch (NoResultException e) {
@@ -566,6 +569,9 @@ public class EmailTemplateMigrationService {
             template.setName(name);
             template.setDescription(description);
             template.setData(templateFromFS);
+            if (application.isPresent()) {
+                template.setApplication(application.get());
+            }
             entityManager.persist(template);
             return template;
         }
@@ -600,8 +606,8 @@ public class EmailTemplateMigrationService {
         }
         for (String eventTypeName : eventTypeNames) {
             Optional<EventType> eventType = findEventType(warnings, bundleName, appName, eventTypeName);
-            Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
-            Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
+            Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription, Optional.of(eventType.get().getApplication()));
+            Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription, Optional.of(eventType.get().getApplication()));
             if (eventType.isPresent()) {
                 if (!instantEmailTemplateExists(eventType.get())) {
                     Log.infof("Creating instant email template for event type: %s/%s/%s", bundleName, appName, eventTypeName);
@@ -667,8 +673,8 @@ public class EmailTemplateMigrationService {
         }
         Optional<Application> app = findApplication(warnings, bundleName, appName);
         if (app.isPresent()) {
-            Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription);
-            Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription);
+            Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription, app);
+            Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription, app);
             if (!aggregationEmailTemplateExists(app.get())) {
                 Log.infof("Creating daily email template for application: %s/%s", bundleName, appName);
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -606,9 +606,9 @@ public class EmailTemplateMigrationService {
         }
         for (String eventTypeName : eventTypeNames) {
             Optional<EventType> eventType = findEventType(warnings, bundleName, appName, eventTypeName);
-            Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription, Optional.of(eventType.get().getApplication()));
-            Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription, Optional.of(eventType.get().getApplication()));
             if (eventType.isPresent()) {
+                Template subjectTemplate = getOrCreateTemplate(subjectTemplateName, subjectTemplateExtension, subjectTemplateDescription, Optional.of(eventType.get().getApplication()));
+                Template bodyTemplate = getOrCreateTemplate(bodyTemplateName, bodyTemplateExtension, bodyTemplateDescription, Optional.of(eventType.get().getApplication()));
                 if (!instantEmailTemplateExists(eventType.get())) {
                     Log.infof("Creating instant email template for event type: %s/%s/%s", bundleName, appName, eventTypeName);
 


### PR DESCRIPTION
Implementing user rights checks with following rules:
- A common template don't need to belong to any application. Only internal admins can manage them.
- A template linked to an application can only be created/updated/deleted by an internal user with this application admin role.

- An instant template can use any templates of any application
- An instant template without event type can be created/updated/deleted by any internal user
- An instant template with event type can only be created/updated/deleted by an internal user with this application admin role.

- An aggregation template can use any templates of any application
- An aggregation template without application can be created/updated/deleted by any internal user
- An aggregation template with an application can only be created/updated/deleted by an internal user with this application admin role.