### PR TITLE
[RHCLOUD-22355] feature: disallow endpoint deletion if processor is not in actionable state

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -379,7 +379,7 @@ public class EndpointResource {
              * user.
              * 2. Avoid unnecessarily calling RHOSE.
              *
-             * Check https://issues.redhat.com/browse/RHCLOUD-22281
+             * Check https://issues.redhat.com/browse/RHCLOUD-22355
              * for more information.
              */
             if (ep.getStatus() != EndpointStatus.READY && ep.getStatus() != EndpointStatus.FAILED) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -368,6 +368,25 @@ public class EndpointResource {
 
         Endpoint ep = endpointRepository.getEndpoint(orgId, id);
         if (isForOpenBridge(ep)) {
+            /*
+             * Before the endpoint and its processor get deleted, we need to
+             * check that the processor was in an actionable state before
+             * updating it in RHOSE.
+             *
+             * This will achieve two goals:
+             *
+             * 1. Avoid returning the RHOSE error directly to the
+             * user.
+             * 2. Avoid unnecessarily calling RHOSE.
+             *
+             * Check https://issues.redhat.com/browse/RHCLOUD-22281
+             * for more information.
+             */
+            if (ep.getStatus() != EndpointStatus.READY && ep.getStatus() != EndpointStatus.FAILED) {
+                throw new BadRequestException(
+                    "the processor associated with the endpoint is not ready to be deleted"
+                );
+            }
 
             try {
                 ep.setStatus(EndpointStatus.DELETING);


### PR DESCRIPTION
An endpoint should not be deleted unless the associated RHOSE processor is also ready to be deleted along with it.

## Links

[[RHCLOUD-22355]](https://issues.redhat.com/browse/RHCLOUD-22355)