### PR TITLE
Making IT service optional

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -121,9 +121,9 @@ objects:
             secretKeyRef:
               name: backoffice
               key: token
-        - name: QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE
-          value: /mnt/secrets/clientkeystore.jks
-        - name: QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_PASSWORD
+        - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE
+          value: ${IT_SERVICE_TO_SERVICE_KEY_STORE}
+        - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: it-services
@@ -431,3 +431,6 @@ parameters:
   value: "false"
 - name: NOTIFICATIONS_USE_EVENT_TYPE_FOR_SUBSCRIPTION_ENABLED
   value: "false"
+- name: IT_SERVICE_TO_SERVICE_KEY_STORE
+  description: "Key store for secured connection if communicating with IT. It should be set to file:/mnt/secrets/clientkeystore.jks"
+  value: ""

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -76,10 +76,7 @@ quarkus.rest-client.rbac-s2s.connect-timeout=2000
 quarkus.rest-client.rbac-s2s.read-timeout=120000
 
 # IT User service
-# these entries are needed because of a bug in quarkus: https://github.com/quarkusio/quarkus/issues/8384
-%prod.quarkus.rest-client.it-s2s.url=FILL_ME
-%prod.quarkus.rest-client.it-s2s.key-store=file:${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE:FILL_ME}
-%prod.quarkus.rest-client.it-s2s.key-store-password=${QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_PASSWORD:FILL_ME}
+quarkus.rest-client.it-s2s.url=https://ci.cloud.redhat.com
 
 # Used for service to service communication
 rbac.service-to-service.application=notifications


### PR DESCRIPTION
I'm removing the it keystore from `QUARKUS_HTTP_SSL_CERTIFICATE_KEY_STORE_FILE` (global keystore for http) because we might have to use a new one from clowdapp.

I'm setting it specifically for the ITservice.