### PR TITLE
Fix Slack notifications data deserialization

### DIFF
--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/slack/SlackProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/slack/SlackProcessorTest.java
@@ -39,6 +39,14 @@ public class SlackProcessorTest {
 
     private static final String WEBHOOK_URL = "https://foo.bar";
     private static final String CHANNEL = "#notifications";
+    private static final String SLACK_TEMPLATE = "{#if data.context.display_name??}" +
+            "<{data.environment_url}/insights/inventory/{data.context.inventory_id}|{data.context.display_name}> " +
+            "triggered {data.events.size()} event{#if data.events.size() > 1}s{/if}" +
+            "{#else}{data.events.size()} event{#if data.events.size() > 1}s{/if} triggered{/if} " +
+            "from {data.bundle}/{data.application}. " +
+            "<{data.environment_url}/insights/{data.application}|Open {data.application}>";
+    private static final String SLACK_EXPECTED_MSG = "<//insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
+            "triggered 1 event from rhel/policies. <//insights/policies|Open policies>";
 
     @Inject
     SlackProcessor slackProcessor;
@@ -67,13 +75,13 @@ public class SlackProcessorTest {
         verify(internalTemporarySlackService, times(1)).send(argumentCaptor.capture());
         assertEquals(WEBHOOK_URL, argumentCaptor.getValue().webhookUrl);
         assertEquals(CHANNEL, argumentCaptor.getValue().channel);
-        assertEquals("rhel/policies/policy-triggered", argumentCaptor.getValue().message);
+        assertEquals(SLACK_EXPECTED_MSG, argumentCaptor.getValue().message);
     }
 
     private void mockTemplate() {
         Template template = new Template();
         template.setName("Test template");
-        template.setData("{data.bundle}/{data.application}/{data.event_type}");
+        template.setData(SLACK_TEMPLATE);
 
         IntegrationTemplate integrationTemplate = new IntegrationTemplate();
         integrationTemplate.setTheTemplate(template);


### PR DESCRIPTION
`JsonObject#getMap` doesn't work well with Qute when fields from `context` need to be used in a template, so I replaced it with `ObjectMapper#readValue(String.class, Map.class)`.