### PR TITLE
[RHCLOUD-24718] fix: the engine crashloops in the ephemeral environment

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -417,3 +417,6 @@ parameters:
   value: "true"
 - name: NOTIFICATIONS_USE_TEMPLATES_FROM_DB
   value: "true"
+- name: NOTIFICATIONS_SLACK_CAMEL_LOG_RETRY_ATTEMPTED
+  description: Specifies whether the redelivery retries should be logged.
+  value: "true"


### PR DESCRIPTION
Due to the parameter not being defined in the "parameters" section of the ClowdApp, Clowder didn't replace it when deploying the engine, which caused the engine to fail and restart because of the missing parameter.

## Links

[[RHCLOUD-24718]](https://issues.redhat.com/browse/RHCLOUD-24718)