### PR TITLE
Fix daily digest trigger endpoint path

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/engine/DailyDigestService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/engine/DailyDigestService.java
@@ -16,7 +16,7 @@ public interface DailyDigestService {
      * @param triggerDailyDigestRequest the daily digest's payload with the
      *                                     desired settings.
      */
-    @Path(Constants.API_INTERNAL + "/daily-digest")
+    @Path(Constants.API_INTERNAL + "/daily-digest/trigger")
     @POST
     @Retry(maxRetries = 3)
     void triggerDailyDigest(TriggerDailyDigestRequest triggerDailyDigestRequest);


### PR DESCRIPTION
I tried to trigger a daily digest in stage and it failed with a 404.

The REST client interface didn't match this path:
https://github.com/RedHatInsights/notifications-backend/blob/f1b415363fd28c79ddf4437685ba642b2587d502/engine/src/main/java/com/redhat/cloud/notifications/routers/DailyDigestResource.java#L49