### PR TITLE
Adds Cache for CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Prepare cache key
+        id: cache-key
+        shell: bash
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+      - name: Cache Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          # The cache key is changed every month to prevent unlimited growth.
+          key: maven-cache-${{ steps.cache-key.outputs.date }}
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/yarn
+          # The cache key is changed every month to prevent unlimited growth.
+          key: yarn-cache-${{ steps.cache-key.outputs.date }}
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,13 +40,15 @@ jobs:
         id: cache-key
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
-      - name: Cache Maven dependencies
+      - if: matrix.language == 'java'
+        name: Cache Maven dependencies
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           # The cache key is changed every month to prevent unlimited growth.
           key: maven-cache-${{ steps.cache-key.outputs.date }}
-      - name: Cache Yarn dependencies
+      - if: matrix.language == 'javascript'
+        name: Cache Yarn dependencies
         uses: actions/cache@v3
         with:
           path: ~/.cache/yarn


### PR DESCRIPTION
I noticed CodeQL download all dependencies on every run.
Adding a cache for java and javascript (depending what is being run)