### PR TITLE
refactor: allow specifying the full URL for the BOP host

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -149,7 +149,7 @@ objects:
         - name: PROCESSOR_EMAIL_BOP_ENV
           value: ${BACKOFFICE_CLIENT_ENV}
         - name: PROCESSOR_EMAIL_BOP_URL
-          value: ${BACKOFFICE_SCHEME}://${BACKOFFICE_HOST}/v1/sendEmails
+          value: ${BACKOFFICE_SCHEME}://${BACKOFFICE_HOST}:${BACKOFFICE_PORT}/v1/sendEmails
         - name: PROCESSOR_EMAIL_NO_REPLY
           value: ${PROCESSOR_EMAIL_NO_REPLY}
         - name: QUARKUS_REST_CLIENT_RBAC_S2S_READ_TIMEOUT
@@ -257,6 +257,9 @@ parameters:
 - name: BACKOFFICE_SCHEME
   description: The scheme for the backoffice host's URL
   value: https
+- name: BACKOFFICE_PORT
+  description: The port for the backoffice host's URL
+  value: 443
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
   value: "false"

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -149,7 +149,7 @@ objects:
         - name: PROCESSOR_EMAIL_BOP_ENV
           value: ${BACKOFFICE_CLIENT_ENV}
         - name: PROCESSOR_EMAIL_BOP_URL
-          value: https://${BACKOFFICE_HOST}/v1/sendEmails
+          value: ${BACKOFFICE_URL}/v1/sendEmails
         - name: PROCESSOR_EMAIL_NO_REPLY
           value: ${PROCESSOR_EMAIL_NO_REPLY}
         - name: QUARKUS_REST_CLIENT_RBAC_S2S_READ_TIMEOUT
@@ -251,9 +251,9 @@ parameters:
 - name: BACKOFFICE_CLIENT_ENV
   description: Back-office client environment
   value: qa
-- name: BACKOFFICE_HOST
-  description: backoffice URL
-  value: backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
+- name: BACKOFFICE_URL
+  description: The full url for the backoffice proxy
+  value: https://backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
   value: "false"

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -149,7 +149,7 @@ objects:
         - name: PROCESSOR_EMAIL_BOP_ENV
           value: ${BACKOFFICE_CLIENT_ENV}
         - name: PROCESSOR_EMAIL_BOP_URL
-          value: ${BACKOFFICE_URL}/v1/sendEmails
+          value: ${BACKOFFICE_SCHEME}://${BACKOFFICE_HOST}/v1/sendEmails
         - name: PROCESSOR_EMAIL_NO_REPLY
           value: ${PROCESSOR_EMAIL_NO_REPLY}
         - name: QUARKUS_REST_CLIENT_RBAC_S2S_READ_TIMEOUT
@@ -251,9 +251,12 @@ parameters:
 - name: BACKOFFICE_CLIENT_ENV
   description: Back-office client environment
   value: qa
-- name: BACKOFFICE_URL
-  description: The full url for the backoffice proxy
-  value: https://backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
+- name: BACKOFFICE_HOST
+  description: backoffice URL
+  value: backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
+- name: BACKOFFICE_SCHEME
+  description: The scheme for the backoffice host's URL
+  value: https
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
   value: "false"

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -259,7 +259,7 @@ parameters:
   value: https
 - name: BACKOFFICE_PORT
   description: The port for the backoffice host's URL
-  value: 443
+  value: "443"
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
   value: "false"


### PR DESCRIPTION
This will help us adapt the service to environments that don't have the BOP implemented with the HTTPS protocol.