### PR TITLE
Fix test when running locally

### DIFF
--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
@@ -119,7 +119,7 @@ class EmailAggregatorTest {
         verify(emailAggregationRepository, times(1)).getEmailAggregation(any(EmailAggregationKey.class), any(LocalDateTime.class), any(LocalDateTime.class), anyInt(), anyInt());
         verify(emailAggregationRepository, times(1)).getEmailAggregation(any(EmailAggregationKey.class), any(LocalDateTime.class), any(LocalDateTime.class), eq(0), eq(emailAggregator.aggregationMaxPageSize));
         statelessSessionFactory.withSession(statelessSession -> {
-            emailAggregationRepository.purgeOldAggregation(aggregationKey, LocalDateTime.now());
+            emailAggregationRepository.purgeOldAggregation(aggregationKey, LocalDateTime.now(ZoneOffset.UTC));
         });
         reset(emailAggregationRepository); // just reset mockito counter
 


### PR DESCRIPTION
 It was missing the UTC offset when calling a local time