### PR TITLE
[RHCLOUD-25078] feature: checked exceptions for the "SecretUtils" service

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -431,6 +431,8 @@ public class EndpointResource {
                     this.secretUtils.updateSecretsForEndpoint(dbEndpoint);
                 } catch (final SourcesException e) {
                     Log.error(e.getMessage(), e);
+
+                    throw new InternalServerErrorException("Unable to update the integration due to an internal error");
                 }
             }
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -52,6 +52,7 @@ import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -230,6 +231,8 @@ public class EndpointResource {
                 this.secretUtils.createSecretsForEndpoint(endpoint);
             } catch (final SourcesException e) {
                 Log.error(e.getMessage(), e);
+
+                throw new InternalServerErrorException("Unable to create the integration due to an internal error");
             }
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -26,6 +26,8 @@ import com.redhat.cloud.notifications.routers.models.EndpointPage;
 import com.redhat.cloud.notifications.routers.models.Meta;
 import com.redhat.cloud.notifications.routers.models.RequestSystemSubscriptionProperties;
 import com.redhat.cloud.notifications.routers.sources.SecretUtils;
+import com.redhat.cloud.notifications.routers.sources.SourcesException;
+import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonObject;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
@@ -171,7 +173,11 @@ public class EndpointResource {
         for (Endpoint endpoint: endpoints) {
             // Fetch the secrets from Sources.
             if (this.featureFlipper.isSourcesUsedAsSecretsBackend()) {
-                this.secretUtils.loadSecretsForEndpoint(endpoint);
+                try {
+                    this.secretUtils.loadSecretsForEndpoint(endpoint);
+                } catch (final SourcesException e) {
+                    Log.error(e.getMessage(), e);
+                }
             }
         }
 
@@ -220,7 +226,11 @@ public class EndpointResource {
          * for more details.
          */
         if (this.featureFlipper.isSourcesUsedAsSecretsBackend()) {
-            this.secretUtils.createSecretsForEndpoint(endpoint);
+            try {
+                this.secretUtils.createSecretsForEndpoint(endpoint);
+            } catch (final SourcesException e) {
+                Log.error(e.getMessage(), e);
+            }
         }
 
         return endpointRepository.createEndpoint(endpoint);
@@ -296,7 +306,11 @@ public class EndpointResource {
         } else {
             // Fetch the secrets from Sources.
             if (this.featureFlipper.isSourcesUsedAsSecretsBackend()) {
-                this.secretUtils.loadSecretsForEndpoint(endpoint);
+                try {
+                    this.secretUtils.loadSecretsForEndpoint(endpoint);
+                } catch (final SourcesException e) {
+                    Log.error(e.getMessage(), e);
+                }
             }
 
             return endpoint;
@@ -319,7 +333,11 @@ public class EndpointResource {
         // Clean up the secrets in Sources.
         if (this.featureFlipper.isSourcesUsedAsSecretsBackend()) {
             Endpoint ep = endpointRepository.getEndpoint(orgId, id);
-            this.secretUtils.deleteSecretsForEndpoint(ep);
+            try {
+                this.secretUtils.deleteSecretsForEndpoint(ep);
+            } catch (final SourcesException e) {
+                Log.error(e.getMessage(), e);
+            }
         }
 
         endpointRepository.deleteEndpoint(orgId, id);
@@ -406,7 +424,11 @@ public class EndpointResource {
                 databaseEndpointProps.setBasicAuthentication(incomingEndpointProps.getBasicAuthentication());
                 databaseEndpointProps.setSecretToken(incomingEndpointProps.getSecretToken());
 
-                this.secretUtils.updateSecretsForEndpoint(dbEndpoint);
+                try {
+                    this.secretUtils.updateSecretsForEndpoint(dbEndpoint);
+                } catch (final SourcesException e) {
+                    Log.error(e.getMessage(), e);
+                }
             }
         }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SecretUtilsTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SecretUtilsTest.java
@@ -13,7 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Random;
+import java.util.UUID;
 
 @QuarkusTest
 public class SecretUtilsTest {
@@ -41,9 +45,10 @@ public class SecretUtilsTest {
      * Tests that the underlying "get by id" function gets called two times: one for the basic authentication and
      * another one for the secret token. It also tests that the endpoint's properties hold the secrets from the
      * returned payload from Sources.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void getSecretsForEndpointTest() {
+    void getSecretsForEndpointTest() throws SourcesException {
         // Create a "Basic Authentication" secret mock.
         final Secret basicAuthenticationMock = new Secret();
         basicAuthenticationMock.password = BASIC_AUTH_PASSWORD;
@@ -114,9 +119,10 @@ public class SecretUtilsTest {
      * Tests that when the endpoint's properties has the "basic authentication" and the "secret token" properties set,
      * the function under test calls "create" upon Sources two times, and that the returned IDs are properly set on the
      * endpoint's properties.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void createSecretsForEndpointTest() {
+    void createSecretsForEndpointTest() throws SourcesException {
         // Set the ID for the basic authentication secret that is supposed that is created in Sources.
         final Secret basicAuthenticationMock = new Secret();
         basicAuthenticationMock.id = BASIC_AUTH_SOURCES_ID;
@@ -168,9 +174,10 @@ public class SecretUtilsTest {
      * Tests that when there is a {@code NULL} "basic authentication" object on the endpoint's properties, the function
      * under test calls "create" upon Sources just for the "secret token" secret, and that the ID for that secret is
      * properly set on the endpoint's properties.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void createSecretsForEndpointBasicAuthNullTest() {
+    void createSecretsForEndpointBasicAuthNullTest() throws SourcesException {
         // Set the ID for the secret token secret that is supposed that is created in Sources.
         final Secret secretTokenMock = new Secret();
         secretTokenMock.id = SECRET_TOKEN_SOURCES_ID;
@@ -213,9 +220,10 @@ public class SecretUtilsTest {
      * Tests that when there is a non-{@code NULL} "basic authentication" object with its fields with blank values, the
      * function under test calls "create" upon Sources just for the "secret token" secret, and that the ID for that
      * secret is properly set on the endpoint's properties.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void createSecretsForEndpointBasicAuthBlankFieldsTest() {
+    void createSecretsForEndpointBasicAuthBlankFieldsTest() throws SourcesException {
         // Set the ID for the secret token secret that is supposed that is created in Sources.
         final Secret secretTokenMock = new Secret();
         secretTokenMock.id = SECRET_TOKEN_SOURCES_ID;
@@ -262,9 +270,10 @@ public class SecretUtilsTest {
      * Tests that when there is a {@code NULL} "secret token" property on the endpoint's properties, the function under
      * test only calls "create" on Sources just for the "basic authentication", and that the returned ID is properly
      * assigned to the endpoint's properties.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void createSecretsForEndpointSecretTokenNullTest() {
+    void createSecretsForEndpointSecretTokenNullTest() throws SourcesException {
         // Set the ID for the basic authentication secret that is supposed that is created in Sources.
         final Secret basicAuthenticationMock = new Secret();
         basicAuthenticationMock.id = BASIC_AUTH_SOURCES_ID;
@@ -309,9 +318,10 @@ public class SecretUtilsTest {
      * Tests that when there is a non-{@code NULL} "secret token" property which is blank on the endpoint's properties,
      * the function under test only calls "create" on Sources just for the "basic authentication", and that the
      * returned ID is properly assigned to the endpoint's properties.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void createSecretsForEndpointSecretTokenBlankTest() {
+    void createSecretsForEndpointSecretTokenBlankTest() throws SourcesException {
         // Set the ID for the basic authentication secret that is supposed that is created in Sources.
         final Secret basicAuthenticationMock = new Secret();
         basicAuthenticationMock.id = BASIC_AUTH_SOURCES_ID;
@@ -359,9 +369,10 @@ public class SecretUtilsTest {
      * Tests that the function under test calls "update" upon Sources two times, one for the "basic authentication" and
      * another one for the "secret token". It also checks that the responses are properly marshalled into the right
      * endpoint properties.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void updateSecretsForEndpointTest() {
+    void updateSecretsForEndpointTest() throws SourcesException {
         // Create a "Basic Authentication" secret mock.
         final Secret basicAuthenticationMock = new Secret();
         basicAuthenticationMock.password = BASIC_AUTH_PASSWORD;
@@ -426,9 +437,10 @@ public class SecretUtilsTest {
     /**
      * Tests that when the user provides a {@code null} "basic authentication" and "secret token" secret for an
      * endpoint which has secrets stored in Sources, the deletion process for those secrets is triggered.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void updateSecretsForEndpointDeleteTest() {
+    void updateSecretsForEndpointDeleteTest() throws SourcesException {
         // Create an endpoint that contains the expected data by the function under test.
         final String orgId = "update-secrets-for-endpoint-delete-test-organization-id";
 
@@ -460,9 +472,10 @@ public class SecretUtilsTest {
      * Tests that when the client updates an endpoint, but there are no secrets stored in Sources, or no valid secrets
      * provided by the client, basically a NOP happens. For a valid secret we understand it as a secret token that is
      * not blank.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void updateSecretsForEndpointNopTest() {
+    void updateSecretsForEndpointNopTest() throws SourcesException {
         // Create an endpoint that contains the expected data by the function under test.
         Endpoint endpoint = new Endpoint();
         WebhookProperties webhookProperties = new WebhookProperties();
@@ -486,8 +499,14 @@ public class SecretUtilsTest {
         Mockito.verifyNoInteractions(this.sourcesServiceMock);
     }
 
+    /**
+     * Tests that when the client updates an endpoint which has no associated secrets, and the client provides a basic
+     * authentication and secret token secrets, then the secrets are created in Sources and that the references are
+     * stored in the properties.
+     * @throws SourcesException if any unexpected Sources error occurs.
+     */
     @Test
-    void updateSecretsForEndpointCreateTest() {
+    void updateSecretsForEndpointCreateTest() throws SourcesException {
         // Set the ID for the basic authentication secret that is supposed that is created in Sources.
         final Secret basicAuthenticationMock = new Secret();
         basicAuthenticationMock.id = BASIC_AUTH_SOURCES_ID;
@@ -538,9 +557,10 @@ public class SecretUtilsTest {
     /**
      * Tests that the "delete" function from the function under test gets called for both the "basic authentication"
      * and "secret token" secrets.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void deleteSecretsForEndpointTest() {
+    void deleteSecretsForEndpointTest() throws SourcesException {
         // Create an endpoint that contains the expected data by the function under test.
         final String orgId = "delete-secrets-for-endpoint-test-organization-id";
 
@@ -566,9 +586,10 @@ public class SecretUtilsTest {
     /**
      * Tests that when the "basic authentication" and "secret token" don't have associated Sources IDs, the "delete"
      * function from the function under test doesn't get called.
+     * @throws SourcesException if any unexpected Sources error occurs.
      */
     @Test
-    void deleteSecretsForEndpointZeroIdsTest() {
+    void deleteSecretsForEndpointZeroIdsTest() throws SourcesException {
         // Create an endpoint that contains the expected data by the function under test.
         Endpoint endpoint = new Endpoint();
         WebhookProperties webhookProperties = new WebhookProperties();
@@ -612,5 +633,395 @@ public class SecretUtilsTest {
         for (final var basicAuth : blankBasicAuths) {
             Assertions.assertTrue(this.secretUtils.isBasicAuthNullOrBlank(basicAuth), "the basic authentication should have been considered as blank");
         }
+    }
+
+    /**
+     * Tests that when calling the {@link SecretUtils#loadSecretsForEndpoint(Endpoint)}
+     * function, if the {@link SourcesService} throws a {@link SourcesRuntimeException},
+     * then the generated {@link SourcesException} contains the expected data.
+     */
+    @Test
+    void exceptionsAreProperlyThrownOnLoadTest() throws NoSuchMethodException {
+        // Create an endpoint fixture with both references to Sources'
+        // secrets.
+        final String orgId = "exceptions-properly-thrown-on-load";
+
+        final Endpoint endpoint = new Endpoint();
+        endpoint.setId(UUID.randomUUID());
+        endpoint.setOrgId(orgId);
+
+        final WebhookProperties webhookProperties = new WebhookProperties();
+        webhookProperties.setBasicAuthenticationSourcesId(new Random().nextLong(1, Long.MAX_VALUE));
+        webhookProperties.setSecretTokenSourcesId(new Random().nextLong(1, Long.MAX_VALUE));
+        endpoint.setProperties(webhookProperties);
+
+        // Get the method from the interface for the stubbed exception.
+        final Method method = SourcesService.class.getMethod("getById", String.class, String.class, long.class);
+
+        // Generate a mocked response object for the stubbed exception.
+        final Response response = Mockito.mock(Response.class);
+        final String responseBody = "{\"error\": \"some error occurred\"}";
+        final int statusCode = new Random().nextInt();
+        Mockito.when(response.getStatus()).thenReturn(statusCode);
+        Mockito.when(response.readEntity(String.class)).thenReturn(responseBody);
+
+        // Simulate that the source service throws the stubbed exception.
+        final SourcesRuntimeException re = new SourcesRuntimeException(method, response);
+        Mockito
+            .when(this.sourcesServiceMock.getById(Mockito.eq(orgId), Mockito.eq(this.sourcesPsk), Mockito.anyLong()))
+            .thenThrow(re);
+
+        // Call the function under test.
+        final SourcesException basicAuthEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.loadSecretsForEndpoint(endpoint)
+        );
+
+        final String expectedBasicAuthMessage = String.format(
+            "[endpoint_uuid: %s][secret_id: %s][method: %s][response_status_code: %s] Sources returned an unexpected response: %s",
+            endpoint.getId(),
+            webhookProperties.getBasicAuthenticationSourcesId(),
+            method.getName(),
+            statusCode,
+            responseBody
+        );
+
+        Assertions.assertEquals(expectedBasicAuthMessage, basicAuthEx.getMessage(), "the exception returned an unexpected message");
+
+        // Nullify the basic authentication's reference so that the function
+        // under test attempts to fetch the secret token.
+        webhookProperties.setBasicAuthenticationSourcesId(null);
+
+        // Call the function under test.
+        final SourcesException secretTokenEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.loadSecretsForEndpoint(endpoint)
+        );
+
+        final String expectedSecretTokenMessage = String.format(
+            "[endpoint_uuid: %s][secret_id: %s][method: %s][response_status_code: %s] Sources returned an unexpected response: %s",
+            endpoint.getId(),
+            webhookProperties.getSecretTokenSourcesId(),
+            method.getName(),
+            statusCode,
+            responseBody
+        );
+
+        Assertions.assertEquals(expectedSecretTokenMessage, secretTokenEx.getMessage(), "the exception returned an unexpected message");
+    }
+
+    /**
+     * Tests that when calling the {@link SecretUtils#createSecretsForEndpoint(Endpoint)}
+     * function, if the {@link SourcesService} throws a {@link SourcesRuntimeException},
+     * then the generated {@link SourcesException} contains the expected data.
+     */
+    @Test
+    void exceptionsAreProperlyThrownOnCreationTest() throws NoSuchMethodException {
+        // Create an endpoint fixture with both secrets.
+        final String orgId = "exceptions-properly-thrown-on-creation";
+
+        final Endpoint endpoint = new Endpoint();
+        endpoint.setOrgId(orgId);
+
+        final WebhookProperties webhookProperties = new WebhookProperties();
+        webhookProperties.setBasicAuthentication(new BasicAuthentication("user", "password"));
+        webhookProperties.setSecretToken("super-secret-token");
+        endpoint.setProperties(webhookProperties);
+
+        // Get the method from the interface for the stubbed exception.
+        final Method method = SourcesService.class.getMethod("create", String.class, String.class, Secret.class);
+
+        // Generate a mocked response object for the stubbed exception.
+        final Response response = Mockito.mock(Response.class);
+        final String responseBody = "{\"error\": \"some error occurred\"}";
+        final int statusCode = new Random().nextInt();
+        Mockito.when(response.getStatus()).thenReturn(statusCode);
+        Mockito.when(response.readEntity(String.class)).thenReturn(responseBody);
+
+        // Simulate that the source service throws the stubbed exception.
+        final SourcesRuntimeException re = new SourcesRuntimeException(method, response);
+        Mockito
+            .when(this.sourcesServiceMock.create(Mockito.eq(orgId), Mockito.eq(this.sourcesPsk), Mockito.any()))
+            .thenThrow(re);
+
+        // Call the function under test.
+        final SourcesException basicAuthEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.createSecretsForEndpoint(endpoint)
+        );
+
+        final String expectedMessage = String.format(
+            "[method: %s][response_status_code: %s] Sources returned an unexpected response: %s",
+            method.getName(),
+            statusCode,
+            responseBody
+        );
+
+        Assertions.assertEquals(expectedMessage, basicAuthEx.getMessage(), "the exception returned an unexpected message");
+
+        // Nullify the basic authentication so that the function under test
+        // attempts to create the secret token instead.
+        webhookProperties.setBasicAuthentication(null);
+
+        // Call the function under test.
+        final SourcesException secretTokenEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.createSecretsForEndpoint(endpoint)
+        );
+
+        Assertions.assertEquals(expectedMessage, secretTokenEx.getMessage(), "the exception returned an unexpected message");
+    }
+
+    /**
+     * Tests that when calling the {@link SecretUtils#updateSecretsForEndpoint(Endpoint)}
+     * function, if the {@link SourcesService} throws a {@link SourcesRuntimeException},
+     * then the generated {@link SourcesException} contains the expected data.
+     */
+    @Test
+    void exceptionsAreProperlyThrownOnUpdateTest() throws NoSuchMethodException {
+        // Create an endpoint fixture.
+        final String orgId = "exceptions-properly-thrown-on-creation";
+
+        final Endpoint endpoint = new Endpoint();
+        endpoint.setId(UUID.randomUUID());
+        endpoint.setOrgId(orgId);
+
+        // Get the different methods from the interface for the stubbed
+        // exceptions.
+        final Method createMethod = SourcesService.class.getMethod("create", String.class, String.class, Secret.class);
+        final Method deleteMethod = SourcesService.class.getMethod("delete", String.class, String.class, long.class);
+        final Method updateMethod = SourcesService.class.getMethod("update", String.class, String.class, long.class, Secret.class);
+
+        // Generate a mocked response object for the stubbed exceptions.
+        final Response response = Mockito.mock(Response.class);
+        final String responseBody = "{\"error\": \"some error occurred\"}";
+        final int statusCode = new Random().nextInt();
+        Mockito.when(response.getStatus()).thenReturn(statusCode);
+        Mockito.when(response.readEntity(String.class)).thenReturn(responseBody);
+
+        // Simulate that the source service throws the stubbed exception.
+        final SourcesRuntimeException createRe = new SourcesRuntimeException(createMethod, response);
+        final SourcesRuntimeException deleteRe = new SourcesRuntimeException(deleteMethod, response);
+        final SourcesRuntimeException updateRe = new SourcesRuntimeException(updateMethod, response);
+
+        // Set up the Mockito calls.
+        Mockito
+            .when(this.sourcesServiceMock.create(Mockito.eq(orgId), Mockito.eq(this.sourcesPsk), Mockito.any()))
+            .thenThrow(createRe);
+        Mockito
+            .when(this.sourcesServiceMock.update(Mockito.eq(orgId), Mockito.eq(this.sourcesPsk), Mockito.anyLong(), Mockito.any()))
+            .thenThrow(updateRe);
+        Mockito
+            .doThrow(deleteRe)
+            .when(this.sourcesServiceMock).delete(Mockito.eq(orgId), Mockito.eq(this.sourcesPsk), Mockito.anyLong());
+
+        // Set up the expected messages for the exceptions.
+        final String createExpectedMessage = String.format(
+            "[endpoint_uuid: %s][method: %s][response_status_code: %s] Sources returned an unexpected response during an endpoint update operation: %s",
+            endpoint.getId(),
+            createMethod.getName(),
+            statusCode,
+            responseBody
+        );
+
+        // Test getting an exception when a basic authentication secret is
+        // attempted to be deleted.
+        final WebhookProperties deleteBasicAuth = new WebhookProperties();
+        deleteBasicAuth.setBasicAuthentication(null);
+        deleteBasicAuth.setBasicAuthenticationSourcesId(new Random().nextLong(1, Long.MAX_VALUE));
+        endpoint.setProperties(deleteBasicAuth);
+
+        // Call the function under test.
+        final SourcesException deleteBasicAuthEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.updateSecretsForEndpoint(endpoint)
+        );
+
+        final String deleteBasicAuthExpectedMessage = String.format(
+            "[endpoint_uuid: %s][secret_id: %s][method: %s][response_status_code: %s] Sources returned an unexpected response during an endpoint update operation: %s",
+            endpoint.getId(),
+            deleteBasicAuth.getBasicAuthenticationSourcesId(),
+            deleteMethod.getName(),
+            statusCode,
+            responseBody
+        );
+
+        Assertions.assertEquals(deleteBasicAuthExpectedMessage, deleteBasicAuthEx.getMessage(), "the exception returned an unexpected message");
+
+        // Test getting an exception when a basic authentication secret is
+        // attempted to be updated.
+        final WebhookProperties updateBasicAuth = new WebhookProperties();
+        updateBasicAuth.setBasicAuthentication(new BasicAuthentication("username", "password"));
+        updateBasicAuth.setBasicAuthenticationSourcesId(new Random().nextLong(1, Long.MAX_VALUE));
+        endpoint.setProperties(updateBasicAuth);
+
+        // Call the function under test.
+        final SourcesException updateBasicAuthEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.updateSecretsForEndpoint(endpoint)
+        );
+
+        final String updateBasicAuthExpectedMessage = String.format(
+            "[endpoint_uuid: %s][secret_id: %s][method: %s][response_status_code: %s] Sources returned an unexpected response during an endpoint update operation: %s",
+            endpoint.getId(),
+            updateBasicAuth.getBasicAuthenticationSourcesId(),
+            updateMethod.getName(),
+            statusCode,
+            responseBody
+        );
+
+        Assertions.assertEquals(updateBasicAuthExpectedMessage, updateBasicAuthEx.getMessage(), "the exception returned an unexpected message");
+
+        // Test getting an exception when a basic authentication secret is
+        // attempted to be created.
+        final WebhookProperties createBasicAuth = new WebhookProperties();
+        createBasicAuth.setBasicAuthentication(new BasicAuthentication("username", "password"));
+        createBasicAuth.setBasicAuthenticationSourcesId(null);
+        endpoint.setProperties(createBasicAuth);
+
+        // Call the function under test.
+        final SourcesException createBasicAuthEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.updateSecretsForEndpoint(endpoint)
+        );
+
+        Assertions.assertEquals(createExpectedMessage, createBasicAuthEx.getMessage(), "the exception returned an unexpected message");
+
+        // Test getting an exception when a secret token is attempted to be
+        // deleted.
+        final WebhookProperties deleteSecretToken = new WebhookProperties();
+        deleteSecretToken.setSecretToken(null);
+        deleteSecretToken.setSecretTokenSourcesId(new Random().nextLong(1, Long.MAX_VALUE));
+        endpoint.setProperties(deleteSecretToken);
+
+        // Call the function under test.
+        final SourcesException deleteSecretTokenEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.updateSecretsForEndpoint(endpoint)
+        );
+
+        final String deleteSecretTokenExpectedMessage = String.format(
+            "[endpoint_uuid: %s][secret_id: %s][method: %s][response_status_code: %s] Sources returned an unexpected response during an endpoint update operation: %s",
+            endpoint.getId(),
+            deleteSecretToken.getSecretTokenSourcesId(),
+            deleteMethod.getName(),
+            statusCode,
+            responseBody
+        );
+
+        Assertions.assertEquals(deleteSecretTokenExpectedMessage, deleteSecretTokenEx.getMessage(), "the exception returned an unexpected message");
+
+        // Test getting an exception when a secret token is attempted to be
+        // deleted.
+        final WebhookProperties updateSecretToken = new WebhookProperties();
+        updateSecretToken.setSecretToken("my-super-secret-token");
+        updateSecretToken.setSecretTokenSourcesId(new Random().nextLong(1, Long.MAX_VALUE));
+        endpoint.setProperties(updateSecretToken);
+
+        // Call the function under test.
+        final SourcesException updateSecretTokenEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.updateSecretsForEndpoint(endpoint)
+        );
+
+        final String updateSecretTokenExpectedMessage = String.format(
+            "[endpoint_uuid: %s][secret_id: %s][method: %s][response_status_code: %s] Sources returned an unexpected response during an endpoint update operation: %s",
+            endpoint.getId(),
+            updateSecretToken.getSecretTokenSourcesId(),
+            updateMethod.getName(),
+            statusCode,
+            responseBody
+        );
+
+        Assertions.assertEquals(updateSecretTokenExpectedMessage, updateSecretTokenEx.getMessage(), "the exception returned an unexpected message");
+
+        // Test getting an exception when a secret token is attempted to be
+        // created.
+        final WebhookProperties createSecretToken = new WebhookProperties();
+        createSecretToken.setSecretToken("my-super-secret-token");
+        createSecretToken.setSecretTokenSourcesId(null);
+        endpoint.setProperties(createSecretToken);
+
+        // Call the function under test.
+        final SourcesException createSecretTokenEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.updateSecretsForEndpoint(endpoint)
+        );
+
+        Assertions.assertEquals(createExpectedMessage, createSecretTokenEx.getMessage(), "the exception returned an unexpected message");
+    }
+
+    /**
+     * Tests that when calling the {@link SecretUtils#deleteSecretsForEndpoint(Endpoint)}
+     * function, if the {@link SourcesService} throws a {@link SourcesRuntimeException},
+     * then the generated {@link SourcesException} contains the expected data.
+     */
+    @Test
+    void exceptionsAreProperlyThrownOnDeleteTest() throws NoSuchMethodException {
+        // Create an endpoint fixture with both secrets
+        final String orgId = "exceptions-properly-thrown-on-delete";
+
+        final Endpoint endpoint = new Endpoint();
+        endpoint.setId(UUID.randomUUID());
+        endpoint.setOrgId(orgId);
+
+        final WebhookProperties webhookProperties = new WebhookProperties();
+        webhookProperties.setBasicAuthenticationSourcesId(new Random().nextLong(1, Long.MAX_VALUE));
+        webhookProperties.setSecretTokenSourcesId(new Random().nextLong(1, Long.MAX_VALUE));
+        endpoint.setProperties(webhookProperties);
+
+        // Get the method from the interface for the stubbed exception.
+        final Method method = SourcesService.class.getMethod("delete", String.class, String.class, long.class);
+
+        // Generate a mocked response object for the stubbed exception.
+        final Response response = Mockito.mock(Response.class);
+        final String responseBody = "{\"error\": \"some error occurred\"}";
+        final int statusCode = new Random().nextInt();
+        Mockito.when(response.getStatus()).thenReturn(statusCode);
+        Mockito.when(response.readEntity(String.class)).thenReturn(responseBody);
+
+        // Simulate that the source service throws the stubbed exception.
+        final SourcesRuntimeException re = new SourcesRuntimeException(method, response);
+        Mockito
+            .doThrow(re)
+            .when(this.sourcesServiceMock).delete(Mockito.eq(orgId), Mockito.eq(this.sourcesPsk), Mockito.anyLong());
+
+        // Call the function under test.
+        final SourcesException basicAuthEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.deleteSecretsForEndpoint(endpoint)
+        );
+
+        final String expectedBasicAuthMessage = String.format(
+            "[endpoint_uuid: %s][secret_id: %s][method: %s][response_status_code: %s] Sources returned an unexpected response: %s",
+            endpoint.getId(),
+            webhookProperties.getBasicAuthenticationSourcesId(),
+            method.getName(),
+            statusCode,
+            responseBody
+        );
+
+        Assertions.assertEquals(expectedBasicAuthMessage, basicAuthEx.getMessage(), "the exception returned an unexpected message");
+
+        // Nullify the basic authentication so that the function under test
+        // attempts to create the secret token instead.
+        webhookProperties.setBasicAuthenticationSourcesId(null);
+
+        // Call the function under test.
+        final SourcesException secretTokenEx = Assertions.assertThrows(
+            SourcesException.class,
+            () -> this.secretUtils.deleteSecretsForEndpoint(endpoint)
+        );
+
+        final String expectedSecretTokenMessage = String.format(
+            "[endpoint_uuid: %s][secret_id: %s][method: %s][response_status_code: %s] Sources returned an unexpected response: %s",
+            endpoint.getId(),
+            webhookProperties.getSecretTokenSourcesId(),
+            method.getName(),
+            statusCode,
+            responseBody
+        );
+
+        Assertions.assertEquals(expectedSecretTokenMessage, secretTokenEx.getMessage(), "the exception returned an unexpected message");
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesException.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesException.java
@@ -1,0 +1,123 @@
+package com.redhat.cloud.notifications.routers.sources;
+
+import com.redhat.cloud.notifications.models.Endpoint;
+
+import javax.ws.rs.core.Response;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * A checked exception which is thrown from the {@link SecretUtils} class,
+ * to force callers to implement measurements whenever an unsuccessful response
+ * is received from Sources.
+ */
+public class SourcesException extends Exception {
+    /**
+     * The method that caused the exception.
+     */
+    private final Method method;
+
+    /**
+     * The optional endpoint UUID that might get appended to the exception's
+     * message.
+     */
+    private final Optional<UUID> endpointUuid;
+
+    /**
+     * Used to determine if the exception was thrown during an update
+     * operation. In such case, the exception's message will indicate that.
+     */
+    private final boolean isUpdateOperation;
+
+    /**
+     * The received response from Sources.
+     */
+    private final Response response;
+
+    /**
+     * The optional secret ID the that might get appended to the exception's
+     * message.
+     */
+    private final Optional<Long> secretId;
+
+    /**
+     * A basic constructor for when there is no endpoint UUID and secret
+     * UUIDs available. Used in {@link SecretUtils#createSecretsForEndpoint(Endpoint)}.
+     * @param e the {@link SourcesRuntimeException} that was thrown by the
+     *          {@link SourcesService}.
+     */
+    public SourcesException(final SourcesRuntimeException e) {
+        this.endpointUuid = Optional.empty();
+        this.isUpdateOperation = false;
+        this.method = e.getMethod();
+        this.response = e.getResponse();
+        this.secretId = Optional.empty();
+    }
+
+    /**
+     * A constructor for when the endpoint UUID is available.
+     *
+     * @param endpointUuid      the endpoint's {@link UUID} which will get
+     *                          appended to the exception's message.
+     * @param isUpdateOperation has the exception been thrown in an update
+     *                          operation? If so, this will be indicated in the
+     *                          exception's message.
+     * @param e                 the {@link SourcesRuntimeException} that was
+     *                          thrown by the {@link SourcesService}.
+     */
+    public SourcesException(final UUID endpointUuid, final boolean isUpdateOperation, final SourcesRuntimeException e) {
+        this.endpointUuid = Optional.of(endpointUuid);
+        this.isUpdateOperation = isUpdateOperation;
+        this.method = e.getMethod();
+        this.response = e.getResponse();
+        this.secretId = Optional.empty();
+    }
+
+    /**
+     * A constructor for when the endpoint's UUID and the secret's ID are
+     * available.
+     * @param endpointUuid      the endpoint's {@link UUID} which will get
+     *                          appended to the exception's message.
+     * @param secretId          the secret's ID which will get appended to the
+     *                          exception's message.
+     * @param isUpdateOperation has the exception been thrown in an update
+     *                          operation? If so, this will be indicated in the
+     *                          exception's message.
+     * @param e                 the {@link SourcesRuntimeException} that was
+     *                          thrown by the {@link SourcesService}.
+     */
+    public SourcesException(final UUID endpointUuid, final long secretId, final boolean isUpdateOperation, final SourcesRuntimeException e) {
+        this.endpointUuid = Optional.of(endpointUuid);
+        this.isUpdateOperation = isUpdateOperation;
+        this.method = e.getMethod();
+        this.response = e.getResponse();
+        this.secretId = Optional.of(secretId);
+    }
+
+    /**
+     * Returns the detail message string of this throwable.
+     *
+     * @return  the detail message string of this {@code Throwable} instance.
+     */
+    @Override
+    public String getMessage() {
+        final StringBuilder errorMessage = new StringBuilder();
+
+        this.endpointUuid.ifPresent(uuid -> errorMessage.append(String.format("[endpoint_uuid: %s]", uuid)));
+        this.secretId.ifPresent(secretId -> errorMessage.append(String.format("[secret_id: %s]", secretId)));
+
+        errorMessage.append(String.format("[method: %s]", this.method.getName()));
+        errorMessage.append(String.format("[response_status_code: %s]", this.response.getStatus()));
+
+        if (this.isUpdateOperation) {
+            errorMessage.append(" Sources returned an unexpected response during an endpoint update operation: ");
+        } else {
+            errorMessage.append(" Sources returned an unexpected response: ");
+        }
+
+        errorMessage.append(this.response.readEntity(String.class));
+
+        return errorMessage.toString();
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesRuntimeException.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesRuntimeException.java
@@ -1,0 +1,33 @@
+package com.redhat.cloud.notifications.routers.sources;
+
+import javax.ws.rs.core.Response;
+import java.lang.reflect.Method;
+
+/**
+ * A runtime exception that is thrown in {@link SourcesService} any time
+ * Sources returns an unsuccessful response.
+ */
+public class SourcesRuntimeException extends RuntimeException {
+    /**
+     * The Java method that caused the exception.
+     */
+    private final Method method;
+
+    /**
+     * The received response from Sources.
+     */
+    private final Response response;
+
+    public SourcesRuntimeException(final Method method, final Response response) {
+        this.method = method;
+        this.response = response;
+    }
+
+    public Method getMethod() {
+        return this.method;
+    }
+
+    public Response getResponse() {
+        return this.response;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesService.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesService.java
@@ -13,8 +13,8 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import java.lang.reflect.Method;
 
 /**
  * <p>REST Client for the Sources API. The OpenAPI spec is available at:</p>
@@ -106,13 +106,12 @@ public interface SourcesService {
 
     /**
      * Throws a runtime exception with the client's response for an easier debugging.
+     * @param method the method that caused the exception.
      * @param response the received response from Sources.
      * @return the {@link RuntimeException} to be thrown.
      */
     @ClientExceptionMapper
-    static RuntimeException toException(final Response response) {
-        final var errMessage = String.format("Sources responded with a %s status: %s", response.getStatus(), response.readEntity(String.class));
-
-        throw new WebApplicationException(errMessage, response);
+    static RuntimeException toException(final Method method, final Response response) {
+        return new SourcesRuntimeException(method, response);
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
@@ -13,6 +13,7 @@ import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.processors.ConnectorSender;
 import com.redhat.cloud.notifications.processors.EndpointTypeProcessor;
 import com.redhat.cloud.notifications.routers.sources.SecretUtils;
+import com.redhat.cloud.notifications.routers.sources.SourcesException;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.logging.Log;
@@ -118,7 +119,11 @@ public class EventingProcessor extends EndpointTypeProcessor {
 
         if (featureFlipper.isSourcesUsedAsSecretsBackend()) {
             // Get the basic authentication and secret token secrets from Sources.
-            secretUtils.loadSecretsForEndpoint(endpoint);
+            try {
+                this.secretUtils.loadSecretsForEndpoint(endpoint);
+            } catch (final SourcesException e) {
+                Log.error(e.getMessage(), e);
+            }
         }
         getSecretToken(properties).ifPresent(secretToken -> metaData.put(TOKEN_HEADER, secretToken));
         getBasicAuth(properties).ifPresent(basicAuth -> metaData.put("basicAuth", basicAuth));

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -153,7 +153,14 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
         });
     }
 
-    private void process(Event event, Endpoint endpoint) {
+    /**
+     * Sends the given event to the specified endpoint via an HTTP request.
+     * @param event the event to be sent.
+     * @param endpoint the endpoint to send the event to.
+     * @throws SourcesException if the endpoint's credentials cannot be fetched
+     * from Sources.
+     */
+    private void process(Event event, Endpoint endpoint) throws SourcesException {
 
         WebhookProperties properties = endpoint.getProperties(WebhookProperties.class);
 
@@ -164,11 +171,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
          * Get the basic authentication and secret token secrets from Sources.
          */
         if (this.featureFlipper.isSourcesUsedAsSecretsBackend()) {
-            try {
-                this.secretUtils.loadSecretsForEndpoint(endpoint);
-            } catch (final SourcesException e) {
-                Log.error(e.getMessage(), e);
-            }
+            this.secretUtils.loadSecretsForEndpoint(endpoint);
         }
 
         if (properties.getSecretToken() != null && !properties.getSecretToken().isBlank()) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -13,6 +13,7 @@ import com.redhat.cloud.notifications.processors.EndpointTypeProcessor;
 import com.redhat.cloud.notifications.processors.webclient.SslVerificationDisabled;
 import com.redhat.cloud.notifications.processors.webclient.SslVerificationEnabled;
 import com.redhat.cloud.notifications.routers.sources.SecretUtils;
+import com.redhat.cloud.notifications.routers.sources.SourcesException;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
@@ -163,7 +164,11 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
          * Get the basic authentication and secret token secrets from Sources.
          */
         if (this.featureFlipper.isSourcesUsedAsSecretsBackend()) {
-            this.secretUtils.loadSecretsForEndpoint(endpoint);
+            try {
+                this.secretUtils.loadSecretsForEndpoint(endpoint);
+            } catch (final SourcesException e) {
+                Log.error(e.getMessage(), e);
+            }
         }
 
         if (properties.getSecretToken() != null && !properties.getSecretToken().isBlank()) {


### PR DESCRIPTION
The checked exceptions will force the caller to explicitly deal with any errors that may occur during a Sources request call. The goal of this is to force the developer to think about which actions should be taken when the external service is reporting errors.

The reason for this change is that the "get endpoints" endpoint was reporting 404 errors when at least one endpoint had references to non-existing Sources secrets. In theory this should not happen, because we already took good care of making sure that every operation leaves the Sources references as they should in the [RHCLOUD-24435](https://issues.redhat.com/browse/RHCLOUD-24435) ticket.

However, there are a couple of "unlikely" scenarios in which this may happen:

* The secrets dissapear in Sources for any unexpected reason. One of them could be, for example, a bad data migration on their side.
* QE tests may spawn two Sources instances, and this could make some tests fail if they end up creating secrets with cross references to those instances.