### PR TITLE
Remove broken graph from Grafana

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
@@ -694,111 +694,6 @@ data:
           }
         },
         {
-          "aliasColors": {
-            "total": "green",
-            "used": "yellow"
-          },
-          "bars": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 6,
-            "y": 6
-          },
-          "hiddenSeries": false,
-          "id": 211,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": false,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "9.3.8",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "skSy3ZB7k"
-              },
-              "exemplar": true,
-              "expr": "sum(increase(rbac_users{job=\"notifications-engine-service\"}[5m]))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "total",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "skSy3ZB7k"
-              },
-              "exemplar": true,
-              "expr": "sum(increase(email_processor_recipients_resolved{job=\"notifications-engine-service\"}[5m]))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "used",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Users fetched by account",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:471",
-              "decimals": -1,
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:472",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -3634,7 +3529,7 @@ data:
       "timezone": "",
       "title": "Notifications Dashboard",
       "uid": "KQIVyFuMk",
-      "version": 10,
+      "version": 18,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
The removed graph:
- was broken
- didn't make any sense
- was not critical enough to be included in the Grafana dashboard

We can always access the data directly from Prometheus.