### PR TITLE
[RHCLOUD-22207] feature: SonarQube analysis script

### DIFF
--- a/.rhcicd/sonarqube/Dockerfile
+++ b/.rhcicd/sonarqube/Dockerfile
@@ -1,5 +1,5 @@
-# Image available at https://images.paas.redhat.com/repository/alm/ubi9-java17-runtime.
-FROM images.paas.redhat.com/alm/ubi9-java17-runtime:mr39
+# Image available at https://catalog.redhat.com/software/containers/ubi9/openjdk-17-runtime.
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime
 
 # Switch to the root user to be able to install the required packages.
 USER root

--- a/.rhcicd/sonarqube/Dockerfile
+++ b/.rhcicd/sonarqube/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir --parents "/var/cache/yum/metadata" \
          -noprompt \
          -storepass "${cacerts_keystore_password}" \
          -trustcacerts \
-    && rm ${rh_it_root_ca_file}
+    && rm "${rh_it_root_ca_file}"
 
 # Go back to the default, unprivileged user.
 USER default

--- a/.rhcicd/sonarqube/Dockerfile
+++ b/.rhcicd/sonarqube/Dockerfile
@@ -1,0 +1,33 @@
+# Image available at https://images.paas.redhat.com/repository/alm/ubi9-java17-runtime.
+FROM images.paas.redhat.com/alm/ubi9-java17-runtime:mr39
+
+# Switch to the root user to be able to install the required packages.
+USER root
+
+# The argument that holds Red Hat IT's custom certificate's location.
+ARG rh_it_root_ca_cert_url
+
+# 1. Install the UUID package which is required for the scripts.
+# 2. Import Red Hat IT's custom self signed certificate in the general
+#    "cacerts" file.
+# 3. Remove the certificate file.
+RUN mkdir --parents "/var/cache/yum/metadata" \
+    && microdnf install --assumeyes uuid-1.6.2-55.el9.x86_64 \
+    && microdnf clean all \
+    && readonly rh_it_root_ca_file="$(mktemp)" \
+    && curl --output "${rh_it_root_ca_file}" --insecure "${rh_it_root_ca_cert_url}" \
+    && keytool \
+         -alias "RH-IT-Root-CA" \
+         -cacerts \
+         -file "${rh_it_root_ca_file}" \
+         -importcert \
+         -noprompt \
+         -storepass "changeit" \
+         -trustcacerts \
+    && rm ${rh_it_root_ca_file}
+
+# Go back to the default, unprivileged user.
+USER default
+
+# Copy the repository contents.
+COPY --chown=default:default . /home/default

--- a/.rhcicd/sonarqube/Dockerfile
+++ b/.rhcicd/sonarqube/Dockerfile
@@ -4,25 +4,34 @@ FROM registry.access.redhat.com/ubi9/openjdk-17-runtime
 # Switch to the root user to be able to install the required packages.
 USER root
 
+# This argument holds the new password for the "cacerts" keystore.
+ARG cacerts_keystore_password
 # The argument that holds Red Hat IT's custom certificate's location.
 ARG rh_it_root_ca_cert_url
 
 # 1. Install the UUID package which is required for the scripts.
-# 2. Import Red Hat IT's custom self signed certificate in the general
+# 2. Change the default "cacert" keystore's password to a custom one for more
+#    security.
+# 3. Import Red Hat IT's custom self signed certificate in the general
 #    "cacerts" file.
-# 3. Remove the certificate file.
+# 4. Remove the certificate file.
 RUN mkdir --parents "/var/cache/yum/metadata" \
     && microdnf install --assumeyes uuid-1.6.2-55.el9.x86_64 \
     && microdnf clean all \
     && readonly rh_it_root_ca_file="$(mktemp)" \
     && curl --output "${rh_it_root_ca_file}" --insecure "${rh_it_root_ca_cert_url}" \
     && keytool \
+        -cacerts \
+        -new "${cacerts_keystore_password}" \
+        -storepasswd \
+        -storepass "changeit" \
+    && keytool \
          -alias "RH-IT-Root-CA" \
          -cacerts \
          -file "${rh_it_root_ca_file}" \
          -importcert \
          -noprompt \
-         -storepass "changeit" \
+         -storepass "${cacerts_keystore_password}" \
          -trustcacerts \
     && rm ${rh_it_root_ca_file}
 

--- a/.rhcicd/sonarqube/scanner/scan_code.bash
+++ b/.rhcicd/sonarqube/scanner/scan_code.bash
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#
+# Bash safety options:
+#   - e is for exiting immediately when a command exits with a non-zero status.
+#   - u is for treating unset variables as an error when substituting.
+#   - x is for printing all the commands as they're executed.
+#   - o pipefail is for taking into account the exit status of the commands that run on pipelines.
+#
+set -euxo pipefail
+
+#
+# On the master branch there is no need to give the pull request details.
+#
+if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "master" ]; then
+  ./mvnw sonar:sonar \
+    -Dsonar.host.url="${SONARQUBE_HOST_URL}" \
+    -Dsonar.exclusions="**/*.sql" \
+    -Dsonar.projectKey="com.redhat.console.notifications.backend" \
+    -Dsonar.projectVersion="${COMMIT_SHORT}" \
+    -Dsonar.sourceEncoding="UTF-8" \
+    -Dsonar.token="${SONARQUBE_TOKEN}"
+else
+  ./mvnw sonar:sonar \
+    -Dsonar.host.url="${SONARQUBE_HOST_URL}" \
+    -Dsonar.exclusions="**/*.sql" \
+    -Dsonar.projectKey="com.redhat.console.notifications.backend" \
+    -Dsonar.projectVersion="${COMMIT_SHORT}" \
+    -Dsonar.pullrequest.base="master" \
+    -Dsonar.pullrequest.branch="${GIT_BRANCH}" \
+    -Dsonar.pullrequest.key="${GITHUB_PULL_REQUEST_ID}" \
+    -Dsonar.sourceEncoding="UTF-8" \
+    -Dsonar.token="${SONARQUBE_TOKEN}"
+fi

--- a/.rhcicd/sonarqube/sonarqube.bash
+++ b/.rhcicd/sonarqube/sonarqube.bash
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+#
+# Bash safety options:
+#   - e is for exiting immediately when a command exits with a non-zero status.
+#   - u is for treating unset variables as an error when substituting.
+#   - x is for printing all the commands as they're executed.
+#   - o pipefail is for taking into account the exit status of the commands that run on pipelines.
+#
+set -euxo pipefail
+
+#
+# Get the commit SHA to give the scanner a unique "project version" setting.
+#
+readonly COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
+
+#
+# Build the Docker image.
+#
+docker build \
+  --build-arg rh_it_root_ca_cert_url="${RH_IT_ROOT_CA_CERT_URL}" \
+  --file .rhcicd/sonarqube/Dockerfile \
+  --tag notifications-sonarqube:latest \
+  .
+
+#
+# Should we be running on master, then skip passing the information regarding
+# the pull request.
+#
+if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "master" ]; then
+  docker run \
+    --env COMMIT_SHORT="${COMMIT_SHORT}" \
+    --env GIT_BRANCH="${GIT_BRANCH}" \
+    --env RH_IT_ROOT_CA_CERT_URL="${RH_IT_ROOT_CA_CERT_URL}" \
+    --env SONARQUBE_HOST_URL="${SONARQUBE_HOST_URL}" \
+    --env SONARQUBE_TOKEN="${SONARQUBE_TOKEN}" \
+    --rm \
+    notifications-sonarqube:latest \
+    bash .rhcicd/sonarqube/scanner/scan_code.bash
+else
+  docker run \
+    --env COMMIT_SHORT="${COMMIT_SHORT}" \
+    --env GIT_BRANCH="${GIT_BRANCH}" \
+    --env GITHUB_PULL_REQUEST_ID="${ghprbPullId}" \
+    --env RH_IT_ROOT_CA_CERT_URL="${RH_IT_ROOT_CA_CERT_URL}" \
+    --env SONARQUBE_HOST_URL="${SONARQUBE_HOST_URL}" \
+    --env SONARQUBE_TOKEN="${SONARQUBE_TOKEN}" \
+    --rm \
+    notifications-sonarqube:latest \
+    bash .rhcicd/sonarqube/scanner/scan_code.bash
+fi
+
+# Need to make a dummy results file to make the Jenkins tests pass.
+mkdir -p artifacts
+cat << EOF > artifacts/junit-dummy.xml
+<testsuite tests="1">
+  <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF

--- a/.rhcicd/sonarqube/sonarqube.bash
+++ b/.rhcicd/sonarqube/sonarqube.bash
@@ -18,6 +18,7 @@ readonly COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 # Build the Docker image.
 #
 docker build \
+  --build-arg cacerts_keystore_password="${CACERTS_KEYSTORE_PASSWORD}" \
   --build-arg rh_it_root_ca_cert_url="${RH_IT_ROOT_CA_CERT_URL}" \
   --file .rhcicd/sonarqube/Dockerfile \
   --tag notifications-sonarqube:latest \

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
         <quarkus.platform.version>2.16.6.Final</quarkus.platform.version>
         <redhat.event-schemas.version>1.4.5</redhat.event-schemas.version>
 
+        <sonar.maven.plugin.version>3.9.1.2184</sonar.maven.plugin.version>
+
     </properties>
 
     <dependencyManagement>
@@ -232,6 +234,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar.maven.plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,0 @@
-# must be unique in a given SonarQube instance
-sonar.projectKey=console.redhat.com:notifications-backend
-sonar.java.binaries=.


### PR DESCRIPTION
The script is intended to be run in order to analyze the code base. It will run for PR checks, and also every time we merge something to master.

The "sonarqube-project.properties" file is removed because the SonarQube Scanner's Maven plugin doesn't honor it.

## Links

[[RHCLOUD-22207]](https://issues.redhat.com/browse/RHCLOUD-22207)