### PR TITLE
[RHCLOUD-25186] feature allow overriding default message test endpoint

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -20,7 +20,7 @@ import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.SourcesSecretable;
 import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
-import com.redhat.cloud.notifications.routers.endpoints.EndpointTestRequest;
+import com.redhat.cloud.notifications.routers.endpoints.InternalEndpointTestRequest;
 import com.redhat.cloud.notifications.routers.engine.EndpointTestService;
 import com.redhat.cloud.notifications.routers.models.EndpointPage;
 import com.redhat.cloud.notifications.routers.models.Meta;
@@ -591,7 +591,7 @@ public class EndpointResource {
             throw new NotFoundException("integration not found");
         }
 
-        final var endpointTestRequest = new EndpointTestRequest(uuid, orgId);
+        final var endpointTestRequest = new InternalEndpointTestRequest(uuid, orgId);
 
         this.endpointTestService.testEndpoint(endpointTestRequest);
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -586,7 +586,7 @@ public class EndpointResource {
             )
     })
     @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
-    public void testEndpoint(@Context SecurityContext sec, @RestPath UUID uuid, @RequestBody EndpointTestRequest requestBody) {
+    public void testEndpoint(@Context SecurityContext sec, @RestPath UUID uuid, @RequestBody @Valid final EndpointTestRequest requestBody) {
         final String orgId = SecurityContextUtil.getOrgId(sec);
 
         if (!this.endpointRepository.existsByUuidAndOrgId(uuid, orgId)) {
@@ -597,12 +597,7 @@ public class EndpointResource {
         if (requestBody == null) {
             internalEndpointTestRequest = new InternalEndpointTestRequest(uuid, null, orgId);
         } else {
-            if (requestBody.isMessageBlank()) {
-                throw new BadRequestException("the custom message cannot be empty");
-            }
-
             internalEndpointTestRequest = new InternalEndpointTestRequest(uuid, requestBody.message, orgId);
-
         }
 
         this.endpointTestService.testEndpoint(internalEndpointTestRequest);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -593,11 +593,11 @@ public class EndpointResource {
             throw new NotFoundException("integration not found");
         }
 
-        final InternalEndpointTestRequest internalEndpointTestRequest;
-        if (requestBody == null) {
-            internalEndpointTestRequest = new InternalEndpointTestRequest(uuid, null, orgId);
-        } else {
-            internalEndpointTestRequest = new InternalEndpointTestRequest(uuid, requestBody.message, orgId);
+        final InternalEndpointTestRequest internalEndpointTestRequest = new InternalEndpointTestRequest();
+        internalEndpointTestRequest.endpointUuid = uuid;
+        internalEndpointTestRequest.orgId = orgId;
+        if (requestBody != null) {
+            internalEndpointTestRequest.message = requestBody.message;
         }
 
         this.endpointTestService.testEndpoint(internalEndpointTestRequest);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/engine/EndpointTestService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/engine/EndpointTestService.java
@@ -1,7 +1,7 @@
 package com.redhat.cloud.notifications.routers.engine;
 
 import com.redhat.cloud.notifications.Constants;
-import com.redhat.cloud.notifications.routers.endpoints.EndpointTestRequest;
+import com.redhat.cloud.notifications.routers.endpoints.InternalEndpointTestRequest;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -15,10 +15,10 @@ public interface EndpointTestService {
      * Sends a request to the engine to test the provided endpoint. This
      * happens when the client wants to test their integration with a test
      * event.
-     * @param endpointTestRequest the payload of the request.
+     * @param internalEndpointTestRequest the payload of the request.
      */
     @Path(Constants.API_INTERNAL + "/endpoints/test")
     @POST
     @Retry(maxRetries = 3)
-    void testEndpoint(EndpointTestRequest endpointTestRequest);
+    void testEndpoint(InternalEndpointTestRequest internalEndpointTestRequest);
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -2306,7 +2306,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
 
         final String customTestMessage = "Hello, World!";
-        final EndpointTestRequest endpointTestRequest = new EndpointTestRequest(customTestMessage);
+        final EndpointTestRequest endpointTestRequest = new EndpointTestRequest();
+        endpointTestRequest.message = customTestMessage;
 
         // Call the endpoint under test.
         final String path = String.format("/endpoints/%s/test", createdEndpoint.getId());
@@ -2347,7 +2348,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         MockServerConfig.addMockRbacAccess(identityHeaderValue, MockServerConfig.RbacAccess.FULL_ACCESS);
 
         final String blankTestMessage = "";
-        final EndpointTestRequest endpointTestRequest = new EndpointTestRequest(blankTestMessage);
+        final EndpointTestRequest endpointTestRequest = new EndpointTestRequest();
+        endpointTestRequest.message = blankTestMessage;
 
         // Call the endpoint under test.
         final String path = String.format("/endpoints/%s/test", createdEndpoint.getId());

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -22,7 +22,7 @@ import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
 import com.redhat.cloud.notifications.models.WebhookProperties;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidator;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidatorTest;
-import com.redhat.cloud.notifications.routers.endpoints.EndpointTestRequest;
+import com.redhat.cloud.notifications.routers.endpoints.InternalEndpointTestRequest;
 import com.redhat.cloud.notifications.routers.engine.EndpointTestService;
 import com.redhat.cloud.notifications.routers.models.EndpointPage;
 import com.redhat.cloud.notifications.routers.models.RequestSystemSubscriptionProperties;
@@ -2245,10 +2245,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .statusCode(204);
 
         // Capture the sent payload to verify it.
-        final ArgumentCaptor<EndpointTestRequest> capturedPayload = ArgumentCaptor.forClass(EndpointTestRequest.class);
+        final ArgumentCaptor<InternalEndpointTestRequest> capturedPayload = ArgumentCaptor.forClass(InternalEndpointTestRequest.class);
         Mockito.verify(this.endpointTestService).testEndpoint(capturedPayload.capture());
 
-        final EndpointTestRequest sentPayload = capturedPayload.getValue();
+        final InternalEndpointTestRequest sentPayload = capturedPayload.getValue();
 
         Assertions.assertEquals(createdEndpoint.getId(), sentPayload.endpointUuid, "the sent endpoint UUID in the payload doesn't match the one from the fixture");
         Assertions.assertEquals(orgId, sentPayload.orgId, "the sent org id in the payload doesn't match the one from the fixture");

--- a/common/src/main/java/com/redhat/cloud/notifications/models/event/TestEventHelper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/event/TestEventHelper.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.events.EventWrapperCloudEvent;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 
 import java.time.Clock;
@@ -24,6 +25,8 @@ public class TestEventHelper {
      * Regular action test data.
      */
     public static final String TEST_ACTION_CONTEXT_ENDPOINT_ID = "integration-uuid";
+    public static final String TEST_ACTION_METADATA_KEY = "meta-information";
+    public static final String TEST_ACTION_METADATA_VALUE = "Meta information about the action";
     public static final String TEST_ACTION_PAYLOAD_KEY = "message";
     public static final String TEST_ACTION_PAYLOAD_VALUE = "Congratulations! The integration you created on https://console.redhat.com was successfully tested!";
     /**
@@ -36,12 +39,25 @@ public class TestEventHelper {
     public static final String TEST_CLOUD_EVENT_TYPE = "com.redhat.console.integrations.integration-test";
 
     /**
-     * Creates a test action ready to be sent to the engine. It sets the endpoint's UUID in the context.
+     * Creates a test action with a default message ready to be sent to the
+     * engine. It sets the endpoint's UUID in the context.
      * @param endpointUuid the endpoint UUID that will be set in the context.
      * @param orgId the org ID for the action.
      * @return the created action.
      */
     public static Action createTestAction(final UUID endpointUuid, final String orgId) {
+        return createTestAction(endpointUuid, TEST_ACTION_PAYLOAD_VALUE, orgId);
+    }
+
+    /**
+     * Creates a test action ready to be sent to the engine with a custom
+     * message. It sets the endpoint's UUID in the context.
+     * @param endpointUuid the endpoint UUID that will be set in the context.
+     * @param message      the custom message to be set in the action.
+     * @param orgId        the org ID for the action.
+     * @return the created action.
+     */
+    public static Action createTestAction(final UUID endpointUuid, final String message, final String orgId) {
         Action testAction = new Action();
 
         final var context = new com.redhat.cloud.notifications.ingress.Context();
@@ -51,11 +67,15 @@ public class TestEventHelper {
         /*
          * Create a test event which will be sent along with the action.
          */
-        Event testEvent = new Event();
+        final Event testEvent = new Event();
 
-        Payload payload = new Payload();
-        payload.setAdditionalProperty(TEST_ACTION_PAYLOAD_KEY, TEST_ACTION_PAYLOAD_VALUE);
+        final Metadata metadata = new Metadata();
+        metadata.setAdditionalProperty(TEST_ACTION_METADATA_KEY, TEST_ACTION_METADATA_VALUE);
 
+        final Payload payload = new Payload();
+        payload.setAdditionalProperty(TEST_ACTION_PAYLOAD_KEY, message);
+
+        testEvent.setMetadata(metadata);
         testEvent.setPayload(payload);
 
         /*

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/EndpointTestRequest.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/EndpointTestRequest.java
@@ -1,13 +1,27 @@
 package com.redhat.cloud.notifications.routers.endpoints;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 /**
  * Represents the structure of the "test endpoint" request that the user might
  * send.
  */
-public class EndpointTestRequest {
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class EndpointTestRequest {
     public String message;
 
-    public EndpointTestRequest(final String message) {
+    public EndpointTestRequest(@JsonProperty("message") final String message) {
         this.message = message;
+    }
+
+    /**
+     * Checks if the message is null or blank.
+     * @return true if the message is null or blank.
+     */
+    public boolean isMessageBlank() {
+        return this.message == null
+            || this.message.isBlank();
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/EndpointTestRequest.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/EndpointTestRequest.java
@@ -4,24 +4,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import javax.validation.constraints.NotBlank;
+
 /**
  * Represents the structure of the "test endpoint" request that the user might
  * send.
  */
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public final class EndpointTestRequest {
+    @NotBlank
     public String message;
 
     public EndpointTestRequest(@JsonProperty("message") final String message) {
         this.message = message;
-    }
-
-    /**
-     * Checks if the message is null or blank.
-     * @return true if the message is null or blank.
-     */
-    public boolean isMessageBlank() {
-        return this.message == null
-            || this.message.isBlank();
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/EndpointTestRequest.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/EndpointTestRequest.java
@@ -1,23 +1,13 @@
 package com.redhat.cloud.notifications.routers.endpoints;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import java.util.UUID;
-
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+/**
+ * Represents the structure of the "test endpoint" request that the user might
+ * send.
+ */
 public class EndpointTestRequest {
+    public String message;
 
-    @NotNull
-    public UUID endpointUuid;
-
-    @NotBlank
-    public String orgId;
-
-    public EndpointTestRequest(final UUID endpointUuid, final String orgId) {
-        this.endpointUuid = endpointUuid;
-        this.orgId = orgId;
+    public EndpointTestRequest(final String message) {
+        this.message = message;
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/EndpointTestRequest.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/EndpointTestRequest.java
@@ -1,21 +1,18 @@
 package com.redhat.cloud.notifications.routers.endpoints;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import javax.validation.constraints.NotBlank;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 
 /**
  * Represents the structure of the "test endpoint" request that the user might
  * send.
  */
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(SnakeCaseStrategy.class)
 public final class EndpointTestRequest {
+
     @NotBlank
     public String message;
-
-    public EndpointTestRequest(@JsonProperty("message") final String message) {
-        this.message = message;
-    }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/InternalEndpointTestRequest.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/InternalEndpointTestRequest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.routers.endpoints;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -27,9 +28,22 @@ public class InternalEndpointTestRequest {
         this.orgId = orgId;
     }
 
-    public InternalEndpointTestRequest(final UUID endpointUuid, final String message, final String orgId) {
+    public InternalEndpointTestRequest(
+        @JsonProperty("endpointUuid") final UUID endpointUuid,
+        @JsonProperty("message") final String message,
+        @JsonProperty("orgId") final String orgId
+    ) {
         this.endpointUuid = endpointUuid;
         this.message = message;
         this.orgId = orgId;
+    }
+
+    /**
+     * Checks if the message is null or blank.
+     * @return true if the message is null or blank.
+     */
+    public boolean isMessageBlank() {
+        return this.message == null
+            || this.message.isBlank();
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/InternalEndpointTestRequest.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/InternalEndpointTestRequest.java
@@ -1,18 +1,18 @@
 package com.redhat.cloud.notifications.routers.endpoints;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
 /**
  * Represents the internal request that will be sent from the backend to the
  * engine in order to trigger an "endpoint test".
  */
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonNaming(SnakeCaseStrategy.class)
 public class InternalEndpointTestRequest {
 
     @NotNull
@@ -22,21 +22,6 @@ public class InternalEndpointTestRequest {
 
     @NotBlank
     public String orgId;
-
-    public InternalEndpointTestRequest(final UUID endpointUuid, final String orgId) {
-        this.endpointUuid = endpointUuid;
-        this.orgId = orgId;
-    }
-
-    public InternalEndpointTestRequest(
-        @JsonProperty("endpointUuid") final UUID endpointUuid,
-        @JsonProperty("message") final String message,
-        @JsonProperty("orgId") final String orgId
-    ) {
-        this.endpointUuid = endpointUuid;
-        this.message = message;
-        this.orgId = orgId;
-    }
 
     /**
      * Checks if the message is null or blank.

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/InternalEndpointTestRequest.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/endpoints/InternalEndpointTestRequest.java
@@ -1,0 +1,35 @@
+package com.redhat.cloud.notifications.routers.endpoints;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.UUID;
+
+/**
+ * Represents the internal request that will be sent from the backend to the
+ * engine in order to trigger an "endpoint test".
+ */
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class InternalEndpointTestRequest {
+
+    @NotNull
+    public UUID endpointUuid;
+
+    public String message;
+
+    @NotBlank
+    public String orgId;
+
+    public InternalEndpointTestRequest(final UUID endpointUuid, final String orgId) {
+        this.endpointUuid = endpointUuid;
+        this.orgId = orgId;
+    }
+
+    public InternalEndpointTestRequest(final UUID endpointUuid, final String message, final String orgId) {
+        this.endpointUuid = endpointUuid;
+        this.message = message;
+        this.orgId = orgId;
+    }
+}

--- a/common/src/test/java/com/redhat/cloud/notifications/models/event/TestEventHelperTest.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/models/event/TestEventHelperTest.java
@@ -9,6 +9,7 @@ import com.redhat.cloud.notifications.ingress.Payload;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -51,6 +52,46 @@ public class TestEventHelperTest {
         final String payloadValue = (String) payload.getAdditionalProperties().get(TestEventHelper.TEST_ACTION_PAYLOAD_KEY);
 
         Assertions.assertEquals(TestEventHelper.TEST_ACTION_PAYLOAD_VALUE, payloadValue, "unexpected event payload value");
+    }
+
+    /**
+     * Tests that the action gets properly created with the expected values.
+     */
+    @Test
+    public void createTestActionCustomMessageTest() {
+        final UUID endpointUuid = UUID.randomUUID();
+        final String customMessage = "Hello, World!";
+        final String orgId = UUID.randomUUID().toString();
+
+        final Action testAction = TestEventHelper.createTestAction(endpointUuid, customMessage, orgId);
+
+        // Check that the top level values coincide.
+        Assertions.assertEquals(TestEventHelper.TEST_ACTION_BUNDLE, testAction.getBundle(), "unexpected bundle in the test action");
+        Assertions.assertEquals(TestEventHelper.TEST_ACTION_APPLICATION, testAction.getApplication(), "unexpected application in the test action");
+        Assertions.assertEquals(TestEventHelper.TEST_ACTION_EVENT_TYPE, testAction.getEventType(), "unexpected event type in the test action");
+        Assertions.assertEquals(orgId, testAction.getOrgId(), "unexpected org id in the test action");
+
+        final Context context = testAction.getContext();
+        final Map<String, Object> contextProperties = context.getAdditionalProperties();
+        Assertions.assertEquals(endpointUuid, contextProperties.get(TestEventHelper.TEST_ACTION_CONTEXT_ENDPOINT_ID), "unexpected endpoint ID received in the action's context");
+
+        // Check the events, their metadata and their payload.
+        final List<Event> events = testAction.getEvents();
+
+        final int expectedEventsCount = 1;
+        Assertions.assertEquals(expectedEventsCount, events.size(), "unexpected number of test action events");
+
+        final Event event = events.get(0);
+
+        final Payload payload = event.getPayload();
+        final Map<String, Object> payloadAdditionalProperties = payload.getAdditionalProperties();
+
+        final int expectedPayloadAdditionalPropertiesCount = 1;
+        Assertions.assertEquals(expectedPayloadAdditionalPropertiesCount, payloadAdditionalProperties.size(), "unexpected number of payload additional properties");
+
+        final String payloadValue = (String) payload.getAdditionalProperties().get(TestEventHelper.TEST_ACTION_PAYLOAD_KEY);
+
+        Assertions.assertEquals(customMessage, payloadValue, "unexpected event payload value");
     }
 
     /**

--- a/engine/src/main/java/com/redhat/cloud/notifications/routers/EndpointTestResource.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/routers/EndpointTestResource.java
@@ -37,10 +37,19 @@ public class EndpointTestResource {
     @Path("/test")
     @POST
     public void testEndpoint(@Valid final InternalEndpointTestRequest internalEndpointTestRequest) {
-        final Action testAction = TestEventHelper.createTestAction(
-            internalEndpointTestRequest.endpointUuid,
-            internalEndpointTestRequest.orgId
-        );
+        final Action testAction;
+        if (internalEndpointTestRequest.isMessageBlank()) {
+            testAction = TestEventHelper.createTestAction(
+                internalEndpointTestRequest.endpointUuid,
+                internalEndpointTestRequest.orgId
+            );
+        } else {
+            testAction = TestEventHelper.createTestAction(
+                internalEndpointTestRequest.endpointUuid,
+                internalEndpointTestRequest.message,
+                internalEndpointTestRequest.orgId
+            );
+        }
 
         final String encodedAction = Parser.encode(testAction);
         final Message<String> message = KafkaMessageWithIdBuilder.build(encodedAction);

--- a/engine/src/main/java/com/redhat/cloud/notifications/routers/EndpointTestResource.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/routers/EndpointTestResource.java
@@ -5,7 +5,7 @@ import com.redhat.cloud.notifications.events.KafkaMessageWithIdBuilder;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Parser;
 import com.redhat.cloud.notifications.models.event.TestEventHelper;
-import com.redhat.cloud.notifications.routers.endpoints.EndpointTestRequest;
+import com.redhat.cloud.notifications.routers.endpoints.InternalEndpointTestRequest;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
@@ -30,16 +30,16 @@ public class EndpointTestResource {
     /**
      * Creates a "endpoint integration test" action and sends it to the ingress
      * Kafka channel, based on the received payload.
-     * @param endpointTestRequest the payload to create the test event from.
+     * @param internalEndpointTestRequest the payload to create the test event from.
      */
     @APIResponse(responseCode = "204")
     @Consumes(APPLICATION_JSON)
     @Path("/test")
     @POST
-    public void testEndpoint(@Valid final EndpointTestRequest endpointTestRequest) {
+    public void testEndpoint(@Valid final InternalEndpointTestRequest internalEndpointTestRequest) {
         final Action testAction = TestEventHelper.createTestAction(
-            endpointTestRequest.endpointUuid,
-            endpointTestRequest.orgId
+            internalEndpointTestRequest.endpointUuid,
+            internalEndpointTestRequest.orgId
         );
 
         final String encodedAction = Parser.encode(testAction);

--- a/engine/src/test/java/com/redhat/cloud/notifications/routers/EndpointTestResourceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/routers/EndpointTestResourceTest.java
@@ -13,7 +13,7 @@ import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.event.TestEventHelper;
-import com.redhat.cloud.notifications.routers.endpoints.EndpointTestRequest;
+import com.redhat.cloud.notifications.routers.endpoints.InternalEndpointTestRequest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
@@ -49,13 +49,13 @@ public class EndpointTestResourceTest {
         final String orgId = "test-endpoint-engine-test";
         final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(EndpointType.CAMEL, "slack", true, 0);
 
-        final EndpointTestRequest endpointTestRequest = new EndpointTestRequest(createdEndpoint.getId(), orgId);
+        final InternalEndpointTestRequest internalEndpointTestRequest = new InternalEndpointTestRequest(createdEndpoint.getId(), orgId);
 
         // Call the endpoint under test.
         given()
             .when()
             .contentType(ContentType.JSON)
-            .body(Json.encode(endpointTestRequest))
+            .body(Json.encode(internalEndpointTestRequest))
             .post("/internal/endpoints/test")
             .then()
             .statusCode(204);

--- a/engine/src/test/java/com/redhat/cloud/notifications/routers/EndpointTestResourceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/routers/EndpointTestResourceTest.java
@@ -3,7 +3,6 @@ package com.redhat.cloud.notifications.routers;
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
-import com.redhat.cloud.notifications.events.ConnectorReceiver;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Event;
@@ -22,6 +21,7 @@ import io.smallrye.reactive.messaging.providers.connectors.InMemorySink;
 import org.awaitility.Awaitility;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.enterprise.inject.Any;
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.events.ConnectorReceiver.EGRESS_CHANNEL;
 import static io.restassured.RestAssured.given;
 
 @QuarkusTest
@@ -41,6 +42,11 @@ public class EndpointTestResourceTest {
 
     @Inject
     ResourceHelpers resourceHelpers;
+
+    @BeforeEach
+    void beforeEach() {
+        inMemoryConnector.sink(EGRESS_CHANNEL).clear();
+    }
 
     /**
      * Tests that when a "Test Endpoint" request is received, a "test
@@ -65,7 +71,7 @@ public class EndpointTestResourceTest {
             .statusCode(204);
 
         // We should receive the action triggered by the REST call.
-        InMemorySink<String> actionsOut = this.inMemoryConnector.sink(ConnectorReceiver.EGRESS_CHANNEL);
+        InMemorySink<String> actionsOut = this.inMemoryConnector.sink(EGRESS_CHANNEL);
 
         // Make sure that the message was received before continuing.
         Awaitility.await().until(
@@ -146,7 +152,7 @@ public class EndpointTestResourceTest {
             .statusCode(204);
 
         // We should receive the action triggered by the REST call.
-        InMemorySink<String> actionsOut = this.inMemoryConnector.sink(ConnectorReceiver.EGRESS_CHANNEL);
+        InMemorySink<String> actionsOut = this.inMemoryConnector.sink(EGRESS_CHANNEL);
 
         // Make sure that the message was received before continuing.
         Awaitility.await().until(

--- a/engine/src/test/java/com/redhat/cloud/notifications/routers/EndpointTestResourceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/routers/EndpointTestResourceTest.java
@@ -51,7 +51,9 @@ public class EndpointTestResourceTest {
         final String orgId = "test-endpoint-engine-test";
         final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(EndpointType.CAMEL, "slack", true, 0);
 
-        final InternalEndpointTestRequest internalEndpointTestRequest = new InternalEndpointTestRequest(createdEndpoint.getId(), orgId);
+        final InternalEndpointTestRequest internalEndpointTestRequest = new InternalEndpointTestRequest();
+        internalEndpointTestRequest.endpointUuid = createdEndpoint.getId();
+        internalEndpointTestRequest.orgId = orgId;
 
         // Call the endpoint under test.
         given()
@@ -129,7 +131,10 @@ public class EndpointTestResourceTest {
         final String customMessage = "Hello, World!";
         final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(EndpointType.CAMEL, "slack", true, 0);
 
-        final InternalEndpointTestRequest internalEndpointTestRequest = new InternalEndpointTestRequest(createdEndpoint.getId(), customMessage, orgId);
+        final InternalEndpointTestRequest internalEndpointTestRequest = new InternalEndpointTestRequest();
+        internalEndpointTestRequest.endpointUuid = createdEndpoint.getId();
+        internalEndpointTestRequest.message = customMessage;
+        internalEndpointTestRequest.orgId = orgId;
 
         // Call the endpoint under test.
         given()

--- a/engine/src/test/java/com/redhat/cloud/notifications/routers/EndpointTestResourceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/routers/EndpointTestResourceTest.java
@@ -141,7 +141,7 @@ public class EndpointTestResourceTest {
             .statusCode(204);
 
         // We should receive the action triggered by the REST call.
-        InMemorySink<String> actionsOut = this.inMemoryConnector.sink(FromCamelHistoryFiller.EGRESS_CHANNEL);
+        InMemorySink<String> actionsOut = this.inMemoryConnector.sink(ConnectorReceiver.EGRESS_CHANNEL);
 
         // Make sure that the message was received before continuing.
         Awaitility.await().until(


### PR DESCRIPTION
The second step on sending "test events" for integrations was to allow
sending custom messages on those events. This implements it in a way
that the client can decide whether to send a message or not. But if they
do, the message must not be blank.

## Links

[[RHCLOUD-25186]](https://issues.redhat.com/browse/RHCLOUD-25186)