### PR TITLE
[SPM-2047] refactor: update patch daily digest to new format

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregator.java
@@ -22,6 +22,7 @@ public class PatchEmailPayloadAggregator extends AbstractEmailPayloadAggregator 
     // Patch event payload
     private static final String ADVISORY_NAME = "advisory_name";
     private static final String ADVISORY_TYPE = "advisory_type";
+    private static final String SYNOPSIS = "synopsis";
 
     // Patch aggregator
     private static final String PATCH_KEY = "patch";
@@ -34,6 +35,7 @@ public class PatchEmailPayloadAggregator extends AbstractEmailPayloadAggregator 
     private static final String BUGFIX_TYPE = "bugfix";
     private static final String SECURITY_TYPE = "security";
     private static final String UNSPECIFIED_TYPE = "unspecified";
+    private static final String OTHER_TYPE = "other";
     private static final List<String> ADVISORY_TYPES = Arrays.asList(ENHANCEMENT_TYPE, BUGFIX_TYPE, SECURITY_TYPE, UNSPECIFIED_TYPE);
 
     private static final String TOTAL_ADVISORIES = "total_advisories";
@@ -42,10 +44,10 @@ public class PatchEmailPayloadAggregator extends AbstractEmailPayloadAggregator 
     public PatchEmailPayloadAggregator() {
         JsonObject patch = new JsonObject();
 
-        patch.put(ENHANCEMENT_TYPE, new JsonArray());
-        patch.put(BUGFIX_TYPE, new JsonArray());
         patch.put(SECURITY_TYPE, new JsonArray());
-        patch.put(UNSPECIFIED_TYPE, new JsonArray());
+        patch.put(BUGFIX_TYPE, new JsonArray());
+        patch.put(ENHANCEMENT_TYPE, new JsonArray());
+        patch.put(OTHER_TYPE, new JsonArray());
 
         context.put(PATCH_KEY, patch);
         context.put(TOTAL_ADVISORIES, totalAdvisories);
@@ -75,7 +77,14 @@ public class PatchEmailPayloadAggregator extends AbstractEmailPayloadAggregator 
             }
 
             String advisoryName = payload.getString(ADVISORY_NAME);
-            patch.getJsonArray(advisoryType).add(advisoryName);
+
+            // Group unspecified advisories under other type
+            if (advisoryType.equals(UNSPECIFIED_TYPE)) {
+                advisoryType = OTHER_TYPE.toString();
+            }
+
+            String synopsis = payload.getString(SYNOPSIS);
+            patch.getJsonArray(advisoryType).add(new JsonObject().put("name", advisoryName).put("synopsis", synopsis));
             totalAdvisories.incrementAndGet();
         });
     }

--- a/engine/src/main/resources/templates/Patch/dailyEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Patch/dailyEmailBodyV2.html
@@ -10,25 +10,30 @@
 {#content-title-right-part-section1}
     <a target="_blank" href="{environment.url}/insights/patch/advisories">{action.context.total_advisories}</a>
 {/content-title-right-part-section1}
+{#content-subtitle-section1}
+    There are {action.context.total_advisories} new advisories affecting your systems.
+{/content-subtitle-section1}
 {#content-body-section1}
-    <p>
-        Here is your Patch advisories summary affecting your systems.
-    </p>
-
     {#for key in action.context.patch.keySet()}
         {#if action.context.patch.get(key).size() > 0}
             <p>
                 <table class="rh-data-table rh-m-bordered">
                     <thead>
                         <tr>
-                          <th style="text-transform: capitalize">{key} advisories</th>
+                          <th>
+                            <span style="text-transform: capitalize">{key}</span> advisories
+                        </th>
+                          <th>Synopsis</th>
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody class="rh-body-table">
                         {#for advisory in action.context.patch.get(key)}
                             <tr>
-                                <td>
-                                    <a class="rh-url" href="{environment.url}/insights/patch/advisories/{advisory}">{advisory}</a>
+                                <td style="width: 40%">
+                                    <a class="rh-url" href="{environment.url}/insights/patch/advisories/{advisory["name"]}">{advisory["name"]}</a>
+                                </td>
+                                <td style="width: 60%">
+                                    {advisory["synopsis"]}
                                 </td>
                             </tr>
                         {/for}
@@ -39,6 +44,6 @@
     {/for}
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/insights/patch/advisories">Go to Advisories</a>
+    <a target="_blank" href="{environment.url}/insights/patch/advisories">Open Advisories in Insights</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/PatchTestHelpers.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,11 +20,12 @@ import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 public class PatchTestHelpers {
 
     private static final String ADVISORY_NAME = "advisory_name";
+    private static final String SYNOPSIS = "synopsis";
     private static final String ADVISORY_TYPE = "advisory_type";
     private static final String UNIQUE_HOSTS_CNT = "unique_system_count";
     private static final String ADVISORIES_KEY = "advisories";
 
-    public static EmailAggregation createEmailAggregation(String bundle, String application, String advisoryName, String advisoryType, String inventory_id) {
+    public static EmailAggregation createEmailAggregation(String bundle, String application, String advisoryName, String synopsis, String advisoryType, String inventory_id) {
         EmailAggregation aggregation = new EmailAggregation();
         aggregation.setBundleName(bundle);
         aggregation.setApplicationName(application);
@@ -45,6 +47,7 @@ public class PatchTestHelpers {
                         .withPayload(
                                 new Payload.PayloadBuilder()
                                         .withAdditionalProperty(ADVISORY_NAME, advisoryName)
+                                        .withAdditionalProperty(SYNOPSIS, synopsis)
                                         .withAdditionalProperty(ADVISORY_TYPE, advisoryType)
                                         .build()
                         )
@@ -79,6 +82,7 @@ public class PatchTestHelpers {
                 .withPayload(
                         new Payload.PayloadBuilder()
                                 .withAdditionalProperty(ADVISORY_NAME, "RH-1")
+                                .withAdditionalProperty(SYNOPSIS, "synopsis")
                                 .withAdditionalProperty(ADVISORY_TYPE, "ENHANCEMENT")
                                 .build()
                 )
@@ -88,6 +92,7 @@ public class PatchTestHelpers {
                         .withPayload(
                                 new Payload.PayloadBuilder()
                                         .withAdditionalProperty(ADVISORY_NAME, "RH-2")
+                                        .withAdditionalProperty(SYNOPSIS, "synopsis")
                                         .withAdditionalProperty(ADVISORY_TYPE, "BUGFIX")
                                         .build()
                         )
@@ -97,6 +102,7 @@ public class PatchTestHelpers {
                         .withPayload(
                                 new Payload.PayloadBuilder()
                                         .withAdditionalProperty(ADVISORY_NAME, "RH-3")
+                                        .withAdditionalProperty(SYNOPSIS, "synopsis")
                                         .withAdditionalProperty(ADVISORY_TYPE, "UNKNOWN")
                                         .build()
                         )
@@ -109,9 +115,9 @@ public class PatchTestHelpers {
         return aggregation;
     }
 
-    public static ArrayList<String> getAdvisoriesByType(PatchEmailPayloadAggregator aggregator, String advisoryType) {
+    public static ArrayList<LinkedHashMap<String, String>> getAdvisoriesByType(PatchEmailPayloadAggregator aggregator, String advisoryType) {
         Map<String, Object> patch = (Map<String, Object>) ((Map<String, Object>) aggregator.getContext()).get("patch");
-        return (ArrayList<String>) patch.get(advisoryType);
+        return (ArrayList<LinkedHashMap<String, String>>) patch.get(advisoryType);
     }
 
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregatorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
@@ -19,6 +20,8 @@ public class PatchEmailPayloadAggregatorTest {
     private final String enhancement = "enhancement";
     private final String bugfix = "bugfix";
     private final String security = "security";
+    private final String unspecified = "unspecified";
+    private final String other = "other";
 
     @BeforeEach
     void setUp() {
@@ -32,7 +35,7 @@ public class PatchEmailPayloadAggregatorTest {
 
     @Test
     void shouldSetOrgId() {
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory", bugfix, "inventoryId"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory", "test synopsis", bugfix, "inventoryId"));
         Assertions.assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
     }
 
@@ -41,35 +44,49 @@ public class PatchEmailPayloadAggregatorTest {
         LocalDateTime startTime = LocalDateTime.of(2021, 4, 22, 13, 15, 33);
         LocalDateTime endTime = LocalDateTime.of(2021, 4, 22, 14, 15, 33);
 
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_1", security, "host-01"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_2", enhancement, "host-01"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_3", enhancement, "host-02"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_4", bugfix, "host-03"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_1", "test synopsis", security, "host-01"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_2", "test synopsis", enhancement, "host-01"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_3", "test synopsis", enhancement, "host-02"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_4", "test synopsis", bugfix, "host-03"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_5", "test synopsis", unspecified, "host-04"));
 
-        ArrayList<String> secAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, security);
+        ArrayList<LinkedHashMap<String, String>> secAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, security);
         Assertions.assertEquals(1, secAdvs.size());
-        Assertions.assertTrue(secAdvs.get(0).equals("advisory_1"));
+        Assertions.assertTrue(secAdvs.get(0).get("name").equals("advisory_1"));
+        Assertions.assertTrue(secAdvs.get(0).get("synopsis").equals("test synopsis"));
 
-        ArrayList<String> enhAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, enhancement);
+        ArrayList<LinkedHashMap<String, String>> enhAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, enhancement);
         Assertions.assertEquals(2, enhAdvs.size());
-        Assertions.assertTrue(enhAdvs.get(0).equals("advisory_2"));
-        Assertions.assertTrue(enhAdvs.get(1).equals("advisory_3"));
+        Assertions.assertTrue(enhAdvs.get(0).get("name").equals("advisory_2"));
+        Assertions.assertTrue(enhAdvs.get(0).get("synopsis").equals("test synopsis"));
+        Assertions.assertTrue(enhAdvs.get(1).get("name").equals("advisory_3"));
+        Assertions.assertTrue(enhAdvs.get(1).get("synopsis").equals("test synopsis"));
 
-        ArrayList<String> fixAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, bugfix);
+        ArrayList<LinkedHashMap<String, String>> fixAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, bugfix);
         Assertions.assertEquals(1, fixAdvs.size());
-        Assertions.assertTrue(fixAdvs.get(0).equals("advisory_4"));
+        Assertions.assertTrue(fixAdvs.get(0).get("name").equals("advisory_4"));
+        Assertions.assertTrue(fixAdvs.get(0).get("synopsis").equals("test synopsis"));
+
+        ArrayList<LinkedHashMap<String, String>> otherAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, other);
+        Assertions.assertEquals(1, otherAdvs.size());
+        Assertions.assertTrue(otherAdvs.get(0).get("name").equals("advisory_5"));
+        Assertions.assertTrue(otherAdvs.get(0).get("synopsis").equals("test synopsis"));
 
         Map<String, Object> patch = aggregator.getContext();
         patch.put("start_time", startTime.toString());
         patch.put("end_time", endTime.toString());
+
+        //System.out.println(JsonObject.mapFrom(patch).toString());
     }
 
     @Test
     void validatePayloadMultipleEvents() {
         aggregator.aggregate(PatchTestHelpers.createEmailAggregationMultipleEvents(bundle, application));
-        ArrayList<String> enhAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, enhancement);
-        Assertions.assertTrue(enhAdvs.get(0).equals("RH-1"));
-        ArrayList<String> fixAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, bugfix);
-        Assertions.assertTrue(fixAdvs.get(0).equals("RH-2"));
+        ArrayList<LinkedHashMap<String, String>> enhAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, enhancement);
+        Assertions.assertTrue(enhAdvs.get(0).get("name").equals("RH-1"));
+        Assertions.assertTrue(enhAdvs.get(0).get("synopsis").equals("synopsis"));
+        ArrayList<LinkedHashMap<String, String>> fixAdvs = PatchTestHelpers.getAdvisoriesByType(aggregator, bugfix);
+        Assertions.assertTrue(fixAdvs.get(0).get("name").equals("RH-2"));
+        Assertions.assertTrue(fixAdvs.get(0).get("synopsis").equals("synopsis"));
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestPatchTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestPatchTemplate.java
@@ -88,10 +88,10 @@ public class TestPatchTemplate extends EmailTemplatesInDbHelper {
         String enhancement = "enhancement";
         String bugfix = "bugfix";
         String security = "security";
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_1", security, "host-01"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_2", enhancement, "host-01"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_3", enhancement, "host-02"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_4", bugfix, "host-03"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_1", "synopsis", security, "host-01"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_2", "synopsis", enhancement, "host-01"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_3", "synopsis", enhancement, "host-02"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(bundle, application, "advisory_4", "synopsis", bugfix, "host-03"));
         aggregator.setStartTime(LocalDateTime.now());
         aggregator.setEndTimeKey(LocalDateTime.now());
 
@@ -102,7 +102,7 @@ public class TestPatchTemplate extends EmailTemplatesInDbHelper {
             featureFlipper.setPatchEmailTemplatesV2Enabled(true);
             migrate();
             result = generateAggregatedEmailBody(aggregator.getContext());
-            assertTrue(result.contains("Here is your Patch advisories summary affecting your systems"));
+            assertTrue(result.contains("There are 4 new advisories affecting your systems."));
             assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
         });
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/secured/TestPatchDailyDigest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/secured/TestPatchDailyDigest.java
@@ -22,11 +22,11 @@ public class TestPatchDailyDigest extends EmailTemplatesInDbHelper {
     @Test
     void testSecureTemplate() {
         PatchEmailPayloadAggregator aggregator = new PatchEmailPayloadAggregator();
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_1", security, "host-01"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_2", enhancement, "host-01"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_3", enhancement, "host-02"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_4", bugfix, "host-03"));
-        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_5", bugfix, "host-04"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_1", "synopsis", security, "host-01"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_2", "synopsis", enhancement, "host-01"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_3", "synopsis", enhancement, "host-02"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_4", "synopsis", bugfix, "host-03"));
+        aggregator.aggregate(PatchTestHelpers.createEmailAggregation(getBundle(), getApp(), "advisory_5", "synopsis", bugfix, "host-04"));
 
         statelessSessionFactory.withSession(statelessSession -> {
             String resultSubject = generateAggregatedEmailSubject(aggregator.getContext());


### PR DESCRIPTION
Changes:
- Added synopsis field to aggregator
- Order of advisory types in emails
- Included synopsis column in emails
- Group `unspecified` advisories under `other` group