### PR TITLE
RHCLOUD-25673 Better deal with channel_not_found Slack error

### DIFF
--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExceptionProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExceptionProcessor.java
@@ -39,7 +39,7 @@ public class ExceptionProcessor implements Processor {
         exchange.setProperty(SUCCESSFUL, false);
         exchange.setProperty(OUTCOME, t.getMessage());
 
-        log(t, exchange);
+        process(t, exchange);
 
         producerTemplate.send("direct:" + CONNECTOR_TO_ENGINE, exchange);
     }
@@ -71,7 +71,7 @@ public class ExceptionProcessor implements Processor {
         return exchange.getProperty(TARGET_URL, String.class);
     }
 
-    protected void log(Throwable t, Exchange exchange) {
+    protected void process(Throwable t, Exchange exchange) {
         logDefault(t, exchange);
     }
 }

--- a/connector-common/src/test/java/com/redhat/cloud/notifications/connector/ConnectorRoutesTest.java
+++ b/connector-common/src/test/java/com/redhat/cloud/notifications/connector/ConnectorRoutesTest.java
@@ -38,13 +38,13 @@ import static org.mockserver.verify.VerificationTimes.atLeast;
 public abstract class ConnectorRoutesTest extends CamelQuarkusTestSupport {
 
     private static final String KAFKA_SOURCE_MOCK = "direct:kafka-source-mock";
-    private static final String REMOTE_SERVER_PATH = "/some/path";
+    protected static final String REMOTE_SERVER_PATH = "/some/path";
 
     @Inject
-    ConnectorConfig connectorConfig;
+    protected ConnectorConfig connectorConfig;
 
     @Inject
-    MicrometerAssertionHelper micrometerAssertionHelper;
+    protected MicrometerAssertionHelper micrometerAssertionHelper;
 
     @Override
     public boolean isUseRouteBuilder() {
@@ -151,7 +151,7 @@ public abstract class ConnectorRoutesTest extends CamelQuarkusTestSupport {
         micrometerAssertionHelper.assertCounterIncrement(connectorConfig.getRedeliveryCounterName(), 2);
     }
 
-    private void saveRoutesMetrics(String... routeIds) {
+    protected void saveRoutesMetrics(String... routeIds) {
         for (String routeId : routeIds) {
             micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest("CamelExchangesFailuresHandled", "routeId", routeId);
             micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest("CamelExchangesSucceeded", "routeId", routeId);
@@ -159,13 +159,13 @@ public abstract class ConnectorRoutesTest extends CamelQuarkusTestSupport {
         }
     }
 
-    private void checkRouteMetrics(String routeId, double expectedFailuresHandledIncrement, double expectedSucceededIncrement, double expectedTotalIncrement) {
+    protected void checkRouteMetrics(String routeId, double expectedFailuresHandledIncrement, double expectedSucceededIncrement, double expectedTotalIncrement) {
         micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesFailuresHandled",  "routeId", routeId, expectedFailuresHandledIncrement);
         micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesSucceeded", "routeId", routeId, expectedSucceededIncrement);
         micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesTotal", "routeId", routeId, expectedTotalIncrement);
     }
 
-    private void mockKafkaSourceEndpoint() throws Exception {
+    protected void mockKafkaSourceEndpoint() throws Exception {
         adviceWith(ENGINE_TO_CONNECTOR, context(), new AdviceWithRouteBuilder() {
             @Override
             public void configure() {
@@ -174,7 +174,7 @@ public abstract class ConnectorRoutesTest extends CamelQuarkusTestSupport {
         });
     }
 
-    private MockEndpoint mockRemoteServerEndpoint() throws Exception {
+    protected MockEndpoint mockRemoteServerEndpoint() throws Exception {
         adviceWith(connectorConfig.getConnectorName(), context(), new AdviceWithRouteBuilder() {
             @Override
             public void configure() throws Exception {
@@ -184,21 +184,21 @@ public abstract class ConnectorRoutesTest extends CamelQuarkusTestSupport {
         return getMockEndpoint(getMockEndpointUri());
     }
 
-    private String mockRemoteServer500() {
+    protected String mockRemoteServer500() {
         getClient()
                 .when(request().withMethod("POST").withPath(REMOTE_SERVER_PATH))
                 .respond(new HttpResponse().withStatusCode(500).withBody("My custom internal error"));
         return getMockServerUrl() + REMOTE_SERVER_PATH;
     }
 
-    private String mockRemoteServerNetworkFailure() {
+    protected String mockRemoteServerNetworkFailure() {
         getClient()
                 .when(request().withMethod("POST").withPath(REMOTE_SERVER_PATH))
                 .error(error().withDropConnection(true));
         return getMockServerUrl() + REMOTE_SERVER_PATH;
     }
 
-    private MockEndpoint mockKafkaSinkEndpoint() throws Exception {
+    protected MockEndpoint mockKafkaSinkEndpoint() throws Exception {
         adviceWith(CONNECTOR_TO_ENGINE, context(), new AdviceWithRouteBuilder() {
             @Override
             public void configure() throws Exception {
@@ -212,7 +212,7 @@ public abstract class ConnectorRoutesTest extends CamelQuarkusTestSupport {
         return kafkaEndpoint;
     }
 
-    private String sendMessageToKafkaSource(JsonObject notification) {
+    protected String sendMessageToKafkaSource(JsonObject notification) {
 
         String cloudEventId = UUID.randomUUID().toString();
 
@@ -227,7 +227,7 @@ public abstract class ConnectorRoutesTest extends CamelQuarkusTestSupport {
         return cloudEventId;
     }
 
-    private static void assertKafkaSinkIsSatisfied(String cloudEventId, JsonObject notification, MockEndpoint kafkaSinkMockEndpoint, boolean expectedSuccessful, String... expectedOutcomeStarts) throws InterruptedException {
+    protected static void assertKafkaSinkIsSatisfied(String cloudEventId, JsonObject notification, MockEndpoint kafkaSinkMockEndpoint, boolean expectedSuccessful, String... expectedOutcomeStarts) throws InterruptedException {
 
         kafkaSinkMockEndpoint.assertIsSatisfied();
 

--- a/connector-google-chat/src/main/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatExceptionProcessor.java
+++ b/connector-google-chat/src/main/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatExceptionProcessor.java
@@ -15,8 +15,7 @@ public class GoogleChatExceptionProcessor extends ExceptionProcessor {
 
     @Override
     protected void process(Throwable t, Exchange exchange) {
-        if (t instanceof HttpOperationFailedException) {
-            HttpOperationFailedException e = (HttpOperationFailedException) t;
+        if (t instanceof HttpOperationFailedException e) {
             Log.errorf(
                     HTTP_LOG_MSG,
                     getRouteId(exchange),

--- a/connector-google-chat/src/main/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatExceptionProcessor.java
+++ b/connector-google-chat/src/main/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatExceptionProcessor.java
@@ -14,16 +14,17 @@ public class GoogleChatExceptionProcessor extends ExceptionProcessor {
             "with status code [%d] and body [%s]";
 
     @Override
-    protected void log(Throwable t, Exchange exchange) {
+    protected void process(Throwable t, Exchange exchange) {
         if (t instanceof HttpOperationFailedException) {
+            HttpOperationFailedException e = (HttpOperationFailedException) t;
             Log.errorf(
                     HTTP_LOG_MSG,
                     getRouteId(exchange),
                     getOrgId(exchange),
                     getExchangeId(exchange),
                     getTargetUrl(exchange),
-                    ((HttpOperationFailedException) t).getStatusCode(),
-                    ((HttpOperationFailedException) t).getResponseBody()
+                    e.getStatusCode(),
+                    e.getResponseBody()
             );
         } else {
             logDefault(t, exchange);

--- a/connector-microsoft-teams/src/main/java/com/redhat/cloud/notifications/connector/microsoft/teams/TeamsExceptionProcessor.java
+++ b/connector-microsoft-teams/src/main/java/com/redhat/cloud/notifications/connector/microsoft/teams/TeamsExceptionProcessor.java
@@ -14,7 +14,7 @@ public class TeamsExceptionProcessor extends ExceptionProcessor {
             "with status code [%d] and body [%s]";
 
     @Override
-    protected void log(Throwable t, Exchange exchange) {
+    protected void process(Throwable t, Exchange exchange) {
         if (t instanceof HttpOperationFailedException) {
             Log.errorf(
                     HTTP_LOG_MSG,

--- a/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackExceptionProcessor.java
+++ b/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackExceptionProcessor.java
@@ -2,20 +2,44 @@ package com.redhat.cloud.notifications.connector.slack;
 
 import com.redhat.cloud.notifications.connector.ExceptionProcessor;
 import io.quarkus.logging.Log;
+import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
+import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static com.redhat.cloud.notifications.connector.slack.ExchangeProperty.CHANNEL;
+import static org.jboss.logging.Logger.Level.DEBUG;
+import static org.jboss.logging.Logger.Level.ERROR;
 
 @ApplicationScoped
 public class SlackExceptionProcessor extends ExceptionProcessor {
 
+    private static final Pattern CHANNEL_NOT_FOUND_PATTERN = Pattern.compile(".+code=404.+body=channel_not_found.+");
     private static final String LOG_MSG = "Message sending failed on %s: [orgId=%s, historyId=%s, webhookUrl=%s, channel=%s]";
 
     @Override
-    protected void log(Throwable t, Exchange exchange) {
-        Log.errorf(
+    protected void process(Throwable t, Exchange exchange) {
+        if (t instanceof CamelExchangeException) {
+            CamelExchangeException e = (CamelExchangeException) t;
+            Matcher matcher = CHANNEL_NOT_FOUND_PATTERN.matcher(e.getMessage());
+            if (matcher.matches()) {
+                // TODO Disable the integration using the 'integration-disabled' event type.
+                log(DEBUG, t, exchange);
+            } else {
+                log(ERROR, t, exchange);
+            }
+        } else {
+            log(ERROR, t, exchange);
+        }
+    }
+
+    private void log(Logger.Level level, Throwable t, Exchange exchange) {
+        Log.logf(
+                level,
                 t,
                 LOG_MSG,
                 getRouteId(exchange),

--- a/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackExceptionProcessor.java
+++ b/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackExceptionProcessor.java
@@ -23,8 +23,7 @@ public class SlackExceptionProcessor extends ExceptionProcessor {
 
     @Override
     protected void process(Throwable t, Exchange exchange) {
-        if (t instanceof CamelExchangeException) {
-            CamelExchangeException e = (CamelExchangeException) t;
+        if (t instanceof CamelExchangeException e) {
             Matcher matcher = CHANNEL_NOT_FOUND_PATTERN.matcher(e.getMessage());
             if (matcher.matches()) {
                 // TODO Disable the integration using the 'integration-disabled' event type.

--- a/connector-slack/src/main/resources/application.properties
+++ b/connector-slack/src/main/resources/application.properties
@@ -32,3 +32,5 @@ camel.context.name=notifications-connector-slack
 
 mp.messaging.tocamel.topic=platform.notifications.tocamel
 mp.messaging.fromcamel.topic=platform.notifications.fromcamel
+
+%test.quarkus.log.category."com.redhat.cloud.notifications".level=DEBUG

--- a/connector-slack/src/test/java/com/redhat/cloud/notifications/connector/slack/SlackConnectorRoutesTest.java
+++ b/connector-slack/src/test/java/com/redhat/cloud/notifications/connector/slack/SlackConnectorRoutesTest.java
@@ -5,12 +5,21 @@ import com.redhat.cloud.notifications.connector.TestLifecycleManager;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.json.JsonObject;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Test;
 
 import java.net.URLEncoder;
 import java.util.UUID;
 
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getClient;
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static com.redhat.cloud.notifications.connector.ConnectorToEngineRouteBuilder.CONNECTOR_TO_ENGINE;
+import static com.redhat.cloud.notifications.connector.ConnectorToEngineRouteBuilder.SUCCESS;
+import static com.redhat.cloud.notifications.connector.EngineToConnectorRouteBuilder.ENGINE_TO_CONNECTOR;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
@@ -43,5 +52,32 @@ public class SlackConnectorRoutesTest extends ConnectorRoutesTest {
     @Override
     protected boolean isConnectorRouteFailureHandled() {
         return false;
+    }
+
+    @Test
+    void test404ChannelNotFound() throws Exception {
+
+        mockKafkaSourceEndpoint(); // This is the entry point of the connector.
+        String remoteServerPath = mock404ChannelNotFound();
+        MockEndpoint kafkaSinkMockEndpoint = mockKafkaSinkEndpoint(); // This is where the return message to the engine is sent.
+
+        JsonObject notification = buildNotification(remoteServerPath);
+
+        String cloudEventId = sendMessageToKafkaSource(notification);
+
+        assertKafkaSinkIsSatisfied(cloudEventId, notification, kafkaSinkMockEndpoint, false, "Error POSTing to Slack API");
+
+        checkRouteMetrics(ENGINE_TO_CONNECTOR, 1, 1, 1);
+        checkRouteMetrics(connectorConfig.getConnectorName(), 0, 0, 1);
+        checkRouteMetrics(SUCCESS, 0, 0, 0);
+        checkRouteMetrics(CONNECTOR_TO_ENGINE, 0, 1, 1);
+        micrometerAssertionHelper.assertCounterIncrement(connectorConfig.getRedeliveryCounterName(), 0);
+    }
+
+    private String mock404ChannelNotFound() {
+        getClient()
+                .when(request().withMethod("POST").withPath(REMOTE_SERVER_PATH))
+                .respond(response().withStatusCode(404).withBody("channel_not_found"));
+        return getMockServerUrl() + REMOTE_SERVER_PATH;
     }
 }


### PR DESCRIPTION
This PR changes the log level from `ERROR` to `DEBUG` when a `404 channel_not_found` exception is thrown in the Slack connector. Because of that change, we will no longer receive alerts in Sentry.

It does not change the notification status returned to the `engine` through Kafka. That notification is still marked as failed.