### PR TITLE
[RHCLOUD-25887] fix: "instant emails" feature flag styling

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
@@ -159,7 +159,7 @@ public class FeatureFlipper {
         Log.infof("The Advisor openShift email templates V2 are %s", advisorOpenShiftEmailTemplatesV2Enabled ? "enabled" : "disabled");
         Log.infof("The event type level for email subscription is %s", useEventTypeForSubscriptionEnabled ? "enabled" : "disabled");
         Log.infof("The Rhel Advisor daily digest is %s", rhelAdvisorDailyDigestEnabled ? "enabled" : "disabled");
-        Log.infof("Instant emails are %s", instantEmailsEnabled, "enabled", "disabled");
+        Log.infof("Instant emails are %s", instantEmailsEnabled ? "enabled" : "disabled");
         Log.infof("Sending one single email with multiple recipients is %s", sendSingleEmailForMultipleRecipientsEnabled ? "enabled" : "disabled");
     }
 


### PR DESCRIPTION
We forgot to put the conditional in a similar fashion to the rest of the feature flags, so it is a bit off. Nothing too urgent or important, but the patch is just to help maintain consistency.

## Links

[[RHCLOUD-25887]](https://issues.redhat.com/browse/RHCLOUD-25887)