### PR TITLE
RHCLOUD-26020 Return history from Camel through Kafka

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -105,7 +105,7 @@
             <version>${apache.commons.csv.version}</version>
         </dependency>
 
-        <!-- Slack through Camel -->
+        <!-- Integrations through Camel -->
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-core</artifactId>
@@ -130,7 +130,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-bean</artifactId>
         </dependency>
-        <!-- Teams through Camel -->
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-kafka</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-http</artifactId>

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelCommonExceptionHandler.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelCommonExceptionHandler.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 
 import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.OUTCOME;
 import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.SUCCESSFUL;
+import static com.redhat.cloud.notifications.processors.camel.ReturnRouteBuilder.RETURN_ROUTE_NAME;
 import static org.apache.camel.LoggingLevel.ERROR;
 import static org.apache.camel.LoggingLevel.INFO;
 import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.direct;
@@ -66,7 +67,7 @@ public abstract class CamelCommonExceptionHandler extends RouteBuilder {
             .end()
             .setProperty(SUCCESSFUL, constant(false))
             .setProperty(OUTCOME, simple("${exception.message}"))
-            .to(direct("return"));
+            .to(direct(RETURN_ROUTE_NAME));
 
         /*
          * Simply logs more details than what Camel provides by default in case of HTTP error.
@@ -81,7 +82,7 @@ public abstract class CamelCommonExceptionHandler extends RouteBuilder {
             .end()
             .setProperty(SUCCESSFUL, constant(false))
             .setProperty(OUTCOME, simple("${exception.message}"))
-            .to(direct("return"));
+            .to(direct(RETURN_ROUTE_NAME));
 
         /*
          * Simply logs more details than what Camel provides by default.
@@ -96,6 +97,6 @@ public abstract class CamelCommonExceptionHandler extends RouteBuilder {
             .end()
             .setProperty(SUCCESSFUL, constant(false))
             .setProperty(OUTCOME, simple("${exception.message}"))
-            .to(direct("return"));
+            .to(direct(RETURN_ROUTE_NAME));
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
@@ -11,7 +11,6 @@ import com.redhat.cloud.notifications.models.Environment;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.IntegrationTemplate;
 import com.redhat.cloud.notifications.models.NotificationHistory;
-import com.redhat.cloud.notifications.models.NotificationStatus;
 import com.redhat.cloud.notifications.processors.EndpointTypeProcessor;
 import com.redhat.cloud.notifications.templates.TemplateService;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
@@ -26,6 +25,8 @@ import java.util.UUID;
 import static com.redhat.cloud.notifications.events.EndpointProcessor.DELAYED_EXCEPTION_MSG;
 import static com.redhat.cloud.notifications.models.IntegrationTemplate.TemplateKind.ORG;
 import static com.redhat.cloud.notifications.models.NotificationHistory.getHistoryStub;
+import static com.redhat.cloud.notifications.models.NotificationStatus.FAILED_INTERNAL;
+import static com.redhat.cloud.notifications.models.NotificationStatus.PROCESSING;
 
 public abstract class CamelProcessor extends EndpointTypeProcessor {
 
@@ -76,9 +77,9 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
         NotificationHistory history = getHistoryStub(endpoint, event, 0L, historyId);
         try {
             sendNotification(event, endpoint, historyId);
-            history.setStatus(NotificationStatus.SUCCESS);
+            history.setStatus(PROCESSING);
         } catch (Exception e) {
-            history.setStatus(NotificationStatus.FAILED_INTERNAL);
+            history.setStatus(FAILED_INTERNAL);
             history.setDetails(Map.of("failure", e.getMessage()));
             Log.infof(e, "Sending %s notification through Camel failed [eventId=%s, historyId=%s]", getIntegrationName(), event.getId(), historyId);
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/ExchangeProperty.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/ExchangeProperty.java
@@ -1,0 +1,13 @@
+package com.redhat.cloud.notifications.processors.camel;
+
+public class ExchangeProperty {
+
+    public static final String HISTORY_ID = "historyId";
+    public static final String ORG_ID = "orgId";
+    public static final String OUTCOME = "outcome";
+    public static final String SOURCE = "source";
+    public static final String START_TIME = "startTime";
+    public static final String SUCCESSFUL = "successful";
+    public static final String TYPE = "type";
+    public static final String WEBHOOK_URL = "webhookUrl";
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/OutgoingCloudEventBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/OutgoingCloudEventBuilder.java
@@ -1,0 +1,51 @@
+package com.redhat.cloud.notifications.processors.camel;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.util.json.JsonObject;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.HISTORY_ID;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.OUTCOME;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.SOURCE;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.START_TIME;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.SUCCESSFUL;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.TYPE;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.WEBHOOK_URL;
+
+@ApplicationScoped
+public class OutgoingCloudEventBuilder implements Processor {
+
+    public static final String CE_SPEC_VERSION = "1.0";
+    public static final String CE_TYPE = "com.redhat.console.notifications.history";
+
+    public void process(Exchange exchange) throws Exception {
+
+        Message in = exchange.getIn();
+
+        JsonObject details = new JsonObject();
+        details.put("type", exchange.getProperty(TYPE, String.class));
+        details.put("target", exchange.getProperty(WEBHOOK_URL, String.class));
+        details.put("outcome", exchange.getProperty(OUTCOME, String.class));
+
+        JsonObject data = new JsonObject();
+        data.put("successful", exchange.getProperty(SUCCESSFUL, Boolean.class));
+        data.put("duration", System.currentTimeMillis() - exchange.getProperty(START_TIME, Long.class));
+        data.put("details", details);
+
+        JsonObject outgoingCloudEvent = new JsonObject();
+        outgoingCloudEvent.put("type", CE_TYPE);
+        outgoingCloudEvent.put("specversion", CE_SPEC_VERSION);
+        outgoingCloudEvent.put("source", exchange.getProperty(SOURCE, String.class));
+        outgoingCloudEvent.put("id", exchange.getProperty(HISTORY_ID, String.class));
+        outgoingCloudEvent.put("time", LocalDateTime.now(ZoneOffset.UTC).toString());
+        // TODO The serialization to JSON shouldn't be needed here. Migrate this later!
+        outgoingCloudEvent.put("data", data.toJson());
+
+        in.setBody(outgoingCloudEvent.toJson());
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/ReturnRouteBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/ReturnRouteBuilder.java
@@ -1,0 +1,25 @@
+package com.redhat.cloud.notifications.processors.camel;
+
+import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class ReturnRouteBuilder extends EndpointRouteBuilder {
+
+    @ConfigProperty(name = "notifications.camel.kafka-return-topic")
+    String kafkaReturnTopic;
+
+    @Inject
+    OutgoingCloudEventBuilder outgoingCloudEventBuilder;
+
+    @Override
+    public void configure() {
+        from(direct("return"))
+                .routeId("return")
+                .process(outgoingCloudEventBuilder)
+                .to(kafka(kafkaReturnTopic));
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/ReturnRouteBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/ReturnRouteBuilder.java
@@ -9,6 +9,8 @@ import javax.inject.Inject;
 @ApplicationScoped
 public class ReturnRouteBuilder extends EndpointRouteBuilder {
 
+    public static final String RETURN_ROUTE_NAME = "return";
+
     @ConfigProperty(name = "notifications.camel.kafka-return-topic")
     String kafkaReturnTopic;
 
@@ -17,8 +19,8 @@ public class ReturnRouteBuilder extends EndpointRouteBuilder {
 
     @Override
     public void configure() {
-        from(direct("return"))
-                .routeId("return")
+        from(direct(RETURN_ROUTE_NAME))
+                .routeId(RETURN_ROUTE_NAME)
                 .process(outgoingCloudEventBuilder)
                 .to(kafka(kafkaReturnTopic));
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatNotificationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatNotificationProcessor.java
@@ -14,4 +14,9 @@ public class GoogleChatNotificationProcessor extends CamelNotificationProcessor 
     protected String getIntegrationName() {
         return "Google Chat";
     }
+
+    @Override
+    public String getSource() {
+        return "googlechat";
+    }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatRouteBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatRouteBuilder.java
@@ -9,6 +9,7 @@ import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.models.HttpType.POST;
 import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.OUTCOME;
 import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.SUCCESSFUL;
+import static com.redhat.cloud.notifications.processors.camel.ReturnRouteBuilder.RETURN_ROUTE_NAME;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.camel.Exchange.CONTENT_TYPE;
@@ -59,6 +60,6 @@ public class GoogleChatRouteBuilder extends CamelCommonExceptionHandler {
                 .toD(URLDecoder.decode("${exchangeProperty.webhookUrl}", UTF_8), maxEndpointCacheSize)
                 .setProperty(SUCCESSFUL, constant(true))
                 .setProperty(OUTCOME, simple("Event ${exchangeProperty.historyId} sent successfully"))
-                .to(direct("return"));
+                .to(direct(RETURN_ROUTE_NAME));
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatRouteBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatRouteBuilder.java
@@ -4,13 +4,16 @@ import com.redhat.cloud.notifications.processors.camel.CamelCommonExceptionHandl
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.models.HttpType.POST;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.OUTCOME;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.SUCCESSFUL;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.camel.Exchange.CONTENT_TYPE;
 import static org.apache.camel.Exchange.HTTP_METHOD;
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.direct;
 
 @ApplicationScoped
 public class GoogleChatRouteBuilder extends CamelCommonExceptionHandler {
@@ -53,6 +56,9 @@ public class GoogleChatRouteBuilder extends CamelCommonExceptionHandler {
                  * That involve to split Urls parameters, surround each value by `RAW()` instruction, then concat all those to rebuild endpoint url.
                  * To avoid all those steps, we decode the full url, then Camel will encode it to send the expected format to Google servers.
                  */
-                .toD(URLDecoder.decode("${exchangeProperty.webhookUrl}", StandardCharsets.UTF_8), maxEndpointCacheSize);
+                .toD(URLDecoder.decode("${exchangeProperty.webhookUrl}", UTF_8), maxEndpointCacheSize)
+                .setProperty(SUCCESSFUL, constant(true))
+                .setProperty(OUTCOME, simple("Event ${exchangeProperty.historyId} sent successfully"))
+                .to(direct("return"));
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackNotificationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackNotificationProcessor.java
@@ -31,6 +31,11 @@ public class SlackNotificationProcessor extends CamelNotificationProcessor {
         exchange.setProperty("channel", slackNotification.channel);
     }
 
+    @Override
+    public String getSource() {
+        return "slack";
+    }
+
     private SlackNotification getSlackNotification(final String exchangeBody) throws JsonProcessingException {
         return objectMapper.readValue(exchangeBody, SlackNotification.class);
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRouteBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRouteBuilder.java
@@ -5,7 +5,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.OUTCOME;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.SUCCESSFUL;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.direct;
 
 @ApplicationScoped
 public class SlackRouteBuilder extends CamelCommonExceptionHandler {
@@ -38,6 +41,9 @@ public class SlackRouteBuilder extends CamelCommonExceptionHandler {
         from(SLACK_DIRECT_ENDPOINT)
                 .routeId(SLACK_OUTGOING_ROUTE)
                 .process(slackNotificationProcessor)
-                .toD("slack:${exchangeProperty.channel}?webhookUrl=${exchangeProperty.webhookUrl}", maxEndpointCacheSize);
+                .toD("slack:${exchangeProperty.channel}?webhookUrl=${exchangeProperty.webhookUrl}", maxEndpointCacheSize)
+                .setProperty(SUCCESSFUL, constant(true))
+                .setProperty(OUTCOME, simple("Event ${exchangeProperty.historyId} sent successfully"))
+                .to(direct("return"));
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRouteBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRouteBuilder.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.OUTCOME;
 import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.SUCCESSFUL;
+import static com.redhat.cloud.notifications.processors.camel.ReturnRouteBuilder.RETURN_ROUTE_NAME;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.direct;
 
@@ -44,6 +45,6 @@ public class SlackRouteBuilder extends CamelCommonExceptionHandler {
                 .toD("slack:${exchangeProperty.channel}?webhookUrl=${exchangeProperty.webhookUrl}", maxEndpointCacheSize)
                 .setProperty(SUCCESSFUL, constant(true))
                 .setProperty(OUTCOME, simple("Event ${exchangeProperty.historyId} sent successfully"))
-                .to(direct("return"));
+                .to(direct(RETURN_ROUTE_NAME));
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsNotificationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsNotificationProcessor.java
@@ -16,4 +16,9 @@ public class TeamsNotificationProcessor extends CamelNotificationProcessor {
     protected String getIntegrationName() {
         return "Teams";
     }
+
+    @Override
+    public String getSource() {
+        return "microsoftteams";
+    }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsRouteBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsRouteBuilder.java
@@ -8,6 +8,7 @@ import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.models.HttpType.POST;
 import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.OUTCOME;
 import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.SUCCESSFUL;
+import static com.redhat.cloud.notifications.processors.camel.ReturnRouteBuilder.RETURN_ROUTE_NAME;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.camel.Exchange.CONTENT_TYPE;
 import static org.apache.camel.Exchange.HTTP_METHOD;
@@ -52,6 +53,6 @@ public class TeamsRouteBuilder extends CamelCommonExceptionHandler {
                 .toD("${exchangeProperty.webhookUrl}", maxEndpointCacheSize)
                 .setProperty(SUCCESSFUL, constant(true))
                 .setProperty(OUTCOME, simple("Event ${exchangeProperty.historyId} sent successfully"))
-                .to(direct("return"));
+                .to(direct(RETURN_ROUTE_NAME));
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsRouteBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsRouteBuilder.java
@@ -6,9 +6,12 @@ import javax.inject.Inject;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 import static com.redhat.cloud.notifications.models.HttpType.POST;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.OUTCOME;
+import static com.redhat.cloud.notifications.processors.camel.ExchangeProperty.SUCCESSFUL;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.camel.Exchange.CONTENT_TYPE;
 import static org.apache.camel.Exchange.HTTP_METHOD;
+import static org.apache.camel.builder.endpoint.StaticEndpointBuilders.direct;
 
 @ApplicationScoped
 public class TeamsRouteBuilder extends CamelCommonExceptionHandler {
@@ -46,6 +49,9 @@ public class TeamsRouteBuilder extends CamelCommonExceptionHandler {
                 .removeHeaders(CAMEL_HTTP_HEADERS_PATTERN)
                 .setHeader(HTTP_METHOD, constant(POST))
                 .setHeader(CONTENT_TYPE, constant(APPLICATION_JSON))
-                .toD("${exchangeProperty.webhookUrl}", maxEndpointCacheSize);
+                .toD("${exchangeProperty.webhookUrl}", maxEndpointCacheSize)
+                .setProperty(SUCCESSFUL, constant(true))
+                .setProperty(OUTCOME, simple("Event ${exchangeProperty.historyId} sent successfully"))
+                .to(direct("return"));
     }
 }

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -1,5 +1,7 @@
-# Kafka bootstrap applies to all topics
-kafka.bootstrap.servers=localhost:9092
+# Uncomment the following line to use a local Kafka instance.
+#kafka.bootstrap.servers=localhost:9092
+# Otherwise, the Kafka dev services from Quarkus will start a Kafka instance when the dev or test profiles are active.
+quarkus.kafka.devservices.port=9092
 
 quarkus.http.port=8087
 
@@ -176,3 +178,14 @@ quarkus.rest-client.internal-google-chat.trust-store-type=${clowder.endpoints.no
 %test.quarkus.mailer.from=REPLACE_ME
 %test.quarkus.mailer.password=REPLACE_ME
 %test.quarkus.mailer.mock=false
+
+# This will move out of the engine after the split
+notifications.camel.kafka-return-topic=platform.notifications.fromcamel
+
+# camel-quarkus-kafka configuration
+camel.component.kafka.brokers=localhost:9092
+camel.component.kafka.sasl-jaas-config=""
+camel.component.kafka.sasl-mechanism=GSSAPI
+camel.component.kafka.security-protocol=PLAINTEXT
+camel.component.kafka.ssl-truststore-location=
+camel.component.kafka.ssl-truststore-type=JKS

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
@@ -2,31 +2,45 @@ package com.redhat.cloud.notifications.processors.camel;
 
 import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
+import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import io.vertx.core.json.JsonObject;
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockserver.model.HttpResponse;
 import javax.inject.Inject;
+import java.util.Arrays;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.MockServerLifecycleManager.getClient;
 import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.models.HttpType.POST;
+import static com.redhat.cloud.notifications.processors.camel.OutgoingCloudEventBuilder.CE_SPEC_VERSION;
+import static com.redhat.cloud.notifications.processors.camel.OutgoingCloudEventBuilder.CE_TYPE;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.apache.camel.builder.AdviceWith.adviceWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockserver.model.HttpError.error;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.verify.VerificationTimes.atLeast;
 
 public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
 
+    @ConfigProperty(name = "notifications.camel.kafka-return-topic")
+    protected String kafkaReturnTopic;
+
     protected String restPath;
     protected String mockPath;
     protected String mockPathKo;
+    protected String routeEndpoint;
     protected String mockRouteEndpoint;
     protected String camelIncomingRouteName;
     protected String camelOutgoingRouteName;
@@ -42,16 +56,19 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
-    void testCallOk() {
+    void testCallOk() throws Exception {
         saveMetrics();
         mockServerOk();
+        MockEndpoint kafkaEndpoint = mockKafkaEndpoint();
+        CamelNotification notification = (CamelNotification) buildNotification(getMockServerUrl() + mockPath);
         given()
             .contentType(JSON)
-            .body(Json.encode(buildNotification(getMockServerUrl() + mockPath)))
+            .body(Json.encode(notification))
             .when().post(restPath)
             .then().statusCode(200);
 
         verifyMetricsCallOk();
+        assertKafkaIsSatisfied(notification, kafkaEndpoint, true, "Event " + notification.historyId + " sent successfully");
     }
 
     protected Object buildNotification(String webhookUrl) {
@@ -59,48 +76,54 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
-    void testCallFailure() {
+    void testCallFailure() throws Exception {
         saveMetrics();
         mockServerKo();
+        MockEndpoint kafkaEndpoint = mockKafkaEndpoint();
+        CamelNotification notification = (CamelNotification) buildNotification(getMockServerUrl() + mockPathKo);
         given()
             .contentType(JSON)
-            .body(Json.encode(buildNotification(getMockServerUrl() + mockPathKo)))
+            .body(Json.encode(notification))
             .when().post(restPath)
-            .then().statusCode(500);
+            .then().statusCode(200);
 
         verifyMetricsCallKo();
+        assertKafkaIsSatisfied(notification, kafkaEndpoint, false, "HTTP operation failed", "Error POSTing to Slack API");
     }
 
     @Test
-    void testRetriesFailure() {
+    void testRetriesFailure() throws Exception {
         saveMetrics();
 
         mockServerFailure();
+        MockEndpoint kafkaEndpoint = mockKafkaEndpoint();
+        CamelNotification notification = (CamelNotification) buildNotification(getMockServerUrl() + mockPathRetries);
         given()
             .contentType(JSON)
-            .body(Json.encode(buildNotification(getMockServerUrl() + mockPathRetries)))
+            .body(Json.encode(notification))
             .when().post(restPath)
-            .then().statusCode(500);
+            .then().statusCode(200);
         verifyRedeliveries();
 
         verifyMetricsCallRetries();
+        assertKafkaIsSatisfied(notification, kafkaEndpoint, false, "unexpected end of stream", "localhost:" + MockServerLifecycleManager.getClient().getPort() + " failed to respond");
     }
-
 
     @Test
     protected void testRoutes() throws Exception {
         adviceWith(camelOutgoingRouteName, context(), new AdviceWithRouteBuilder() {
             @Override
             public void configure() throws Exception {
-                mockEndpointsAndSkip(mockRouteEndpoint + "*");
+                mockEndpointsAndSkip(routeEndpoint + "*");
             }
         });
 
-        CamelNotification notification = (CamelNotification) buildNotification(mockRouteEndpoint);
+        CamelNotification notification = (CamelNotification) buildNotification(routeEndpoint);
 
-        // Camel encodes the '#' character into '%23' when building the mock endpoint URI.
         MockEndpoint testedEndpoint = getMockEndpoint(mockRouteEndpoint);
         testedEndpoint.expectedBodiesReceived(notification.message);
+
+        MockEndpoint kafkaEndpoint = mockKafkaEndpoint();
 
         given()
             .contentType(JSON)
@@ -109,6 +132,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
             .then().statusCode(200);
 
         testedEndpoint.assertIsSatisfied();
+        assertKafkaIsSatisfied(notification, kafkaEndpoint, true, "Event " + notification.historyId + " sent successfully");
     }
 
     private void verifyMetricsCallOk() {
@@ -122,20 +146,24 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     private void verifyMetricsCallKo() {
-        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesFailuresHandled", "routeId", camelIncomingRouteName, 0);
-        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesFailuresHandled", "routeId", camelOutgoingRouteName, 0);
-        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesSucceeded", "routeId", camelIncomingRouteName, 0);
-        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesSucceeded", "routeId", camelOutgoingRouteName, 0);
+        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesFailuresHandled", "routeId", camelIncomingRouteName, 1);
+        // The following metric has a different value depending on the integration type (Slack, Teams...)
+        // TODO Uncomment and fix later!
+        //micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesFailuresHandled", "routeId", camelOutgoingRouteName, 1);
+        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesSucceeded", "routeId", camelIncomingRouteName, 1);
+        // The following metric has a different value depending on the integration type (Slack, Teams...)
+        // TODO Uncomment and fix later!
+        //micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesSucceeded", "routeId", camelOutgoingRouteName, 1);
         micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesTotal", "routeId", camelIncomingRouteName, 1);
         micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesTotal", "routeId", camelOutgoingRouteName, 1);
         micrometerAssertionHelper.assertCounterIncrement(retryCounterName, 0);
     }
 
     private void verifyMetricsCallRetries() {
-        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesFailuresHandled", "routeId", camelIncomingRouteName, 0);
-        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesFailuresHandled", "routeId", camelOutgoingRouteName, 0);
-        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesSucceeded", "routeId", camelIncomingRouteName, 0);
-        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesSucceeded", "routeId", camelOutgoingRouteName, 0);
+        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesFailuresHandled", "routeId", camelIncomingRouteName, 1);
+        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesFailuresHandled", "routeId", camelOutgoingRouteName, 1);
+        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesSucceeded", "routeId", camelIncomingRouteName, 1);
+        micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesSucceeded", "routeId", camelOutgoingRouteName, 1);
         micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesTotal", "routeId", camelIncomingRouteName, 1);
         micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement("CamelExchangesTotal", "routeId", camelOutgoingRouteName, 1);
         micrometerAssertionHelper.assertCounterIncrement(retryCounterName, 2);
@@ -179,5 +207,46 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
         notification.webhookUrl = webhookUrl;
         notification.message = "This is a test!";
         return notification;
+    }
+
+    protected MockEndpoint mockKafkaEndpoint() throws Exception {
+        adviceWith("return", context(), new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                mockEndpointsAndSkip("kafka:" + kafkaReturnTopic + "*");
+            }
+        });
+
+        MockEndpoint kafkaEndpoint = getMockEndpoint("mock:kafka:" + kafkaReturnTopic);
+        kafkaEndpoint.expectedMessageCount(1);
+
+        return kafkaEndpoint;
+    }
+
+    protected static void assertKafkaIsSatisfied(CamelNotification notification, MockEndpoint mockEndpoint, boolean expectedSuccessful, String... expectedOutcomeStarts) throws InterruptedException {
+
+        mockEndpoint.assertIsSatisfied();
+
+        Exchange exchange = mockEndpoint.getReceivedExchanges().get(0);
+        JsonObject payload = new JsonObject(exchange.getIn().getBody(String.class));
+
+        assertEquals(CE_TYPE, payload.getString("type"));
+        assertEquals(CE_SPEC_VERSION, payload.getString("specversion"));
+        assertNotNull(payload.getString("source"));
+        assertEquals(notification.historyId.toString(), payload.getString("id"));
+        assertNotNull(payload.getString("time"));
+
+        JsonObject data = new JsonObject(payload.getString("data"));
+
+        assertEquals(expectedSuccessful, data.getBoolean("successful"));
+        assertNotNull(data.getString("duration"));
+        assertNotNull(data.getJsonObject("details").getString("type"));
+        assertEquals(notification.webhookUrl, data.getJsonObject("details").getString("target"));
+
+        String outcome = data.getJsonObject("details").getString("outcome");
+
+        if (Arrays.stream(expectedOutcomeStarts).noneMatch(outcome::startsWith)) {
+            Assertions.fail(String.format("Expected outcome starts: %s - Actual outcome: %s", Arrays.toString(expectedOutcomeStarts), outcome));
+        }
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
@@ -23,6 +23,7 @@ import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.models.HttpType.POST;
 import static com.redhat.cloud.notifications.processors.camel.OutgoingCloudEventBuilder.CE_SPEC_VERSION;
 import static com.redhat.cloud.notifications.processors.camel.OutgoingCloudEventBuilder.CE_TYPE;
+import static com.redhat.cloud.notifications.processors.camel.ReturnRouteBuilder.RETURN_ROUTE_NAME;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.apache.camel.builder.AdviceWith.adviceWith;
@@ -210,7 +211,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     protected MockEndpoint mockKafkaEndpoint() throws Exception {
-        adviceWith("return", context(), new AdviceWithRouteBuilder() {
+        adviceWith(RETURN_ROUTE_NAME, context(), new AdviceWithRouteBuilder() {
             @Override
             public void configure() throws Exception {
                 mockEndpointsAndSkip("kafka:" + kafkaReturnTopic + "*");

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatRoutesTest.java
@@ -18,7 +18,8 @@ public class GoogleChatRoutesTest extends CamelRoutesTest {
         mockPath = "/camel/google_chat";
         mockPathKo = "/camel/google_chat_ko";
         mockPathRetries = "/camel/google_chat_retries";
-        mockRouteEndpoint = "mock:google_chat_test_routes";
+        routeEndpoint = "https://foo.com";
+        mockRouteEndpoint = "mock:https:foo.com";
         camelIncomingRouteName = GOOGLE_CHAT_INCOMING_ROUTE;
         camelOutgoingRouteName = GOOGLE_CHAT_OUTGOING_ROUTE;
         retryCounterName = CAMEL_GOOGLE_CHAT_RETRY_COUNTER;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsRoutesTest.java
@@ -17,7 +17,8 @@ public class TeamsRoutesTest extends CamelRoutesTest {
         mockPath = "/camel/teams";
         mockPathKo = "/camel/teams_ko";
         mockPathRetries = "/camel/teams_retries";
-        mockRouteEndpoint = "mock:teams_test_routes";
+        routeEndpoint = "https://foo.com";
+        mockRouteEndpoint = "mock:https:foo.com";
         camelIncomingRouteName = TEAMS_INCOMING_ROUTE;
         camelOutgoingRouteName = TEAMS_OUTGOING_ROUTE;
         retryCounterName = CAMEL_TEAMS_RETRY_COUNTER;


### PR DESCRIPTION
This PR introduces the notification history return through the `platform.notifications.fromcamel` Kafka topic for Slack, Microsoft Teams and Google Chat.