### PR TITLE
RHCLOUD-26020 Enable Kafka topic name translation using Clowder config

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/ReturnRouteBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/ReturnRouteBuilder.java
@@ -11,7 +11,7 @@ public class ReturnRouteBuilder extends EndpointRouteBuilder {
 
     public static final String RETURN_ROUTE_NAME = "return";
 
-    @ConfigProperty(name = "notifications.camel.kafka-return-topic")
+    @ConfigProperty(name = "mp.messaging.fromcamel.topic")
     String kafkaReturnTopic;
 
     @Inject

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -180,7 +180,7 @@ quarkus.rest-client.internal-google-chat.trust-store-type=${clowder.endpoints.no
 %test.quarkus.mailer.mock=false
 
 # This will move out of the engine after the split
-notifications.camel.kafka-return-topic=platform.notifications.fromcamel
+mp.messaging.fromcamel.topic=platform.notifications.fromcamel
 
 # camel-quarkus-kafka configuration
 camel.component.kafka.brokers=localhost:9092

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
@@ -35,7 +35,7 @@ import static org.mockserver.verify.VerificationTimes.atLeast;
 
 public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
 
-    @ConfigProperty(name = "notifications.camel.kafka-return-topic")
+    @ConfigProperty(name = "mp.messaging.fromcamel.topic")
     protected String kafkaReturnTopic;
 
     protected String restPath;


### PR DESCRIPTION
The topic name from `application.properties` is not directly used in stage or prod. It is used as a key to retrieve the actual topic name from the Clowder configuration. This only works if the config key starts with `mp.messaging` and ends with `topic`.

See [this](https://github.com/RedHatInsights/clowder-quarkus-config-source/blob/56502b08308acec1248d4feef4b5bbc5ae335625/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java#L176-L189) for more details.