### PR TITLE
RHCLOUD-22207 | fix sonarqube pipeline

### DIFF
--- a/.rhcicd/sonarqube/scanner/scan_code.bash
+++ b/.rhcicd/sonarqube/scanner/scan_code.bash
@@ -13,7 +13,7 @@ set -euxo pipefail
 # On the master branch there is no need to give the pull request details.
 #
 if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "master" ]; then
-  ./mvnw sonar:sonar \
+  ./mvnw clean compile sonar:sonar \
     -Dsonar.host.url="${SONARQUBE_HOST_URL}" \
     -Dsonar.exclusions="**/*.sql" \
     -Dsonar.projectKey="com.redhat.console.notifications.backend" \
@@ -21,7 +21,7 @@ if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "master" ]; then
     -Dsonar.sourceEncoding="UTF-8" \
     -Dsonar.token="${SONARQUBE_TOKEN}"
 else
-  ./mvnw sonar:sonar \
+  ./mvnw clean compile sonar:sonar \
     -Dsonar.host.url="${SONARQUBE_HOST_URL}" \
     -Dsonar.exclusions="**/*.sql" \
     -Dsonar.projectKey="com.redhat.console.notifications.backend" \

--- a/.rhcicd/sonarqube/scanner/scan_code.bash
+++ b/.rhcicd/sonarqube/scanner/scan_code.bash
@@ -19,7 +19,8 @@ if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "master" ]; then
     -Dsonar.projectKey="com.redhat.console.notifications.backend" \
     -Dsonar.projectVersion="${COMMIT_SHORT}" \
     -Dsonar.sourceEncoding="UTF-8" \
-    -Dsonar.token="${SONARQUBE_TOKEN}"
+    -Dsonar.token="${SONARQUBE_TOKEN}" \
+    --no-transfer-progress
 else
   ./mvnw clean compile sonar:sonar \
     -Dsonar.host.url="${SONARQUBE_HOST_URL}" \
@@ -30,5 +31,6 @@ else
     -Dsonar.pullrequest.branch="${GIT_BRANCH}" \
     -Dsonar.pullrequest.key="${GITHUB_PULL_REQUEST_ID}" \
     -Dsonar.sourceEncoding="UTF-8" \
-    -Dsonar.token="${SONARQUBE_TOKEN}"
+    -Dsonar.token="${SONARQUBE_TOKEN}" \
+    --no-transfer-progress
 fi


### PR DESCRIPTION
The scanner was complaining that the ".java" files were not compiled,
and that should be provided via a property. It was working locally
because I always have the compiled project there, so by copying all the
contents of the project's directory it also copied the compiled classes.
However, in a pipeline, where everything is fresh, that didn't happen,
which I suppose is causing the scanner to complain.

## Links
[[RHCLOUD-22207]](https://issues.redhat.com/browse/RHCLOUD-22207)