### PR TITLE
Revert changes introduced to investigate the Kafka outage

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EndpointProcessor.java
@@ -14,7 +14,6 @@ import com.redhat.cloud.notifications.processors.eventing.EventingProcessor;
 import com.redhat.cloud.notifications.processors.webhooks.WebhookTypeProcessor;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.quarkus.logging.Log;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -93,16 +92,12 @@ public class EndpointProcessor {
                             for (Map.Entry<String, List<Endpoint>> endpointsBySubTypeEntry : endpointsBySubType.entrySet()) {
                                 try {
                                     if ("slack".equals(endpointsBySubTypeEntry.getKey())) {
-                                        Log.debugf("Preparing to call Slack processor for eventId=%s", event.getId());
                                         slackProcessor.process(event, endpointsBySubTypeEntry.getValue());
                                     } else if ("teams".equals(endpointsBySubTypeEntry.getKey())) {
-                                        Log.debugf("Preparing to call Teams processor for eventId=%s", event.getId());
                                         teamsProcessor.process(event, endpointsBySubTypeEntry.getValue());
                                     } else if ("google_chat".equals(endpointsBySubTypeEntry.getKey())) {
-                                        Log.debugf("Preparing to call Google Chat processor for eventId=%s", event.getId());
                                         googleChatProcessor.process(event, endpointsBySubTypeEntry.getValue());
                                     } else {
-                                        Log.debugf("Preparing to call Eventing processor for eventId=%s", event.getId());
                                         camelProcessor.process(event, endpointsBySubTypeEntry.getValue());
                                     }
                                 } catch (Exception e) {
@@ -111,12 +106,10 @@ public class EndpointProcessor {
                             }
                             break;
                         case EMAIL_SUBSCRIPTION:
-                            Log.debugf("Preparing to call Email processor for eventId=%s", event.getId());
                             emailProcessor.process(event, endpointsByTypeEntry.getValue());
                             break;
                         case WEBHOOK:
                         case ANSIBLE:
-                            Log.debugf("Preparing to call Webhook processor for eventId=%s", event.getId());
                             webhookProcessor.process(event, endpointsByTypeEntry.getValue());
                             break;
                         default:

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
@@ -87,9 +87,6 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
             history.setDetails(Map.of("failure", e.getMessage()));
             notificationHistoryRepository.updateHistoryItem(history);
             Log.infof(e, "Sending %s notification through Camel failed [eventId=%s, historyId=%s]", getIntegrationName(), event.getId(), historyId);
-        } finally {
-            Log.debugf("Done sending %s notification through Camel [orgId=%s, eventId=%s, historyId=%s]",
-                    getIntegrationName(), endpoint.getOrgId(), event.getId(), historyId);
         }
     }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -200,9 +200,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
                 }
 
                 // TODO NOTIF-488 We may want to move to a non-reactive HTTP client in the future.
-                Log.debugf("Starting webhook call for eventId=%s to url=%s", event.getId(), url);
                 HttpResponse<Buffer> resp = req.sendJsonObject(payload).await().atMost(awaitTimeout);
-                Log.debugf("Ended webhook call for eventId=%s to url=%s", event.getId(), url);
 
                 boolean serverError = false;
                 boolean shouldResetEndpointServerErrors = false;

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -4,6 +4,7 @@
 quarkus.kafka.devservices.port=9092
 
 quarkus.http.port=8087
+
 # Change port for tests to avoid messing with local Kafka instance
 %test.quarkus.http.port=9087
 %test.quarkus.http.test-port=9087
@@ -14,6 +15,7 @@ mp.messaging.incoming.aggregation.topic=platform.notifications.aggregation
 mp.messaging.incoming.aggregation.group.id=integrations
 mp.messaging.incoming.aggregation.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.aggregation.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+mp.messaging.incoming.aggregation.cloud-events=false
 
 # Output aggregation queue
 mp.messaging.outgoing.toaggregation.connector=smallrye-kafka
@@ -54,6 +56,7 @@ mp.messaging.incoming.fromcamel.topic=platform.notifications.fromcamel
 mp.messaging.incoming.fromcamel.group.id=integrations
 mp.messaging.incoming.fromcamel.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.fromcamel.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+mp.messaging.incoming.fromcamel.cloud-events=false
 
 # Input queue for the "export requests" coming from the export service.
 mp.messaging.incoming.exportrequests.connector=smallrye-kafka
@@ -62,6 +65,7 @@ mp.messaging.incoming.exportrequests.topic=platform.export.requests
 mp.messaging.incoming.exportrequests.group.id=integrations
 mp.messaging.incoming.exportrequests.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.exportrequests.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+mp.messaging.incoming.exportrequests.cloud-events=false
 
 # Enable the export request ingress in tests as otherwise they fail.
 %test.mp.messaging.incoming.exportrequests.enabled=true
@@ -200,8 +204,6 @@ camel.component.kafka.sasl-mechanism=GSSAPI
 camel.component.kafka.security-protocol=PLAINTEXT
 camel.component.kafka.ssl-truststore-location=
 camel.component.kafka.ssl-truststore-type=JKS
-
-quarkus.log.category."org.apache.kafka.clients.consumer.internals.Fetcher".level=INFO
 
 # Rest client settings for the export service. When used locally, it should
 # point to the private internal server.

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -116,7 +115,6 @@ public class EventConsumerTest {
     }
 
     @Test
-    @Disabled
     void testValidPayloadWithMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction(true);
@@ -145,7 +143,6 @@ public class EventConsumerTest {
     }
 
     @Test
-    @Disabled
     void testValidPayloadWithoutMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction(false);
@@ -172,7 +169,6 @@ public class EventConsumerTest {
     }
 
     @Test
-    @Disabled
     void testInvalidPayloadWithMessageId() {
         Message<String> message = buildMessageWithId(UUID.randomUUID().toString().getBytes(UTF_8), "I am not a valid payload!");
         inMemoryConnector.source(INGRESS_CHANNEL).send(message);
@@ -197,7 +193,6 @@ public class EventConsumerTest {
     }
 
     @Test
-    @Disabled
     void testUnknownEventTypeWithoutMessageId() {
         mockGetUnknownEventType();
         Action action = buildValidAction(false);
@@ -224,7 +219,6 @@ public class EventConsumerTest {
     }
 
     @Test
-    @Disabled
     void testProcessingErrorWithoutMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         mockProcessingFailure();
@@ -251,7 +245,6 @@ public class EventConsumerTest {
     }
 
     @Test
-    @Disabled
     void testDuplicatePayload() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction(false);
@@ -281,7 +274,6 @@ public class EventConsumerTest {
     }
 
     @Test
-    @Disabled
     void testNullMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction(false);
@@ -309,7 +301,6 @@ public class EventConsumerTest {
     }
 
     @Test
-    @Disabled
     void testInvalidMessageId() {
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction(false);


### PR DESCRIPTION
https://github.com/RedHatInsights/notifications-backend/compare/132e9fb8bdd5dfe717c79f1e32fc90dfac326992...dc3eb724b4e37e485c1346fad991b8ce610f5254

This PR does NOT revert:
- the new ClowdApp params used to change the log level of Hibernate, Kafka client and SmallRye Reactive Messaging
- the removal of `@Acknowledgment(PRE_PROCESSING)` in `EventConsumer`
- the addition of `cloud-events=false` in the Reactive Messaging channels configuration