### PR TITLE
 RHCLOUD-22207 | fix: SonarQube analysis in master branch

### DIFF
--- a/.rhcicd/sonarqube/scanner/scan_code.bash
+++ b/.rhcicd/sonarqube/scanner/scan_code.bash
@@ -12,7 +12,7 @@ set -euxo pipefail
 #
 # On the master branch there is no need to give the pull request details.
 #
-if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "master" ]; then
+if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "origin/master" ]; then
   ./mvnw clean compile sonar:sonar \
     -Dsonar.host.url="${SONARQUBE_HOST_URL}" \
     -Dsonar.exclusions="**/*.sql" \

--- a/.rhcicd/sonarqube/sonarqube.bash
+++ b/.rhcicd/sonarqube/sonarqube.bash
@@ -28,7 +28,7 @@ docker build \
 # Should we be running on master, then skip passing the information regarding
 # the pull request.
 #
-if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "master" ]; then
+if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "origin/master" ]; then
   docker run \
     --env COMMIT_SHORT="${COMMIT_SHORT}" \
     --env GIT_BRANCH="${GIT_BRANCH}" \


### PR DESCRIPTION
The pipeline sets the "GIT_BRANCH" to "origin/master", which is why the "master analysis" SonarQube pipeline was attempting to go the PR route, and failing.

# Links

[RHCLOUD-22207](https://issues.redhat.com/browse/RHCLOUD-22207)