### PR TITLE
RHCLOUD-25597 | feature: specify the Kafka topic for the export service

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -34,6 +34,9 @@ objects:
     - topicName: platform.notifications.aggregation
       partitions: 2
       replicas: 3
+    - topicName: platform.export.requests
+      partitions: 3
+      replicas: 3
     deployments:
     - name: service
       minReplicas: ${{MIN_REPLICAS}}


### PR DESCRIPTION
I forgot to specify the aforementioned Kafka topic which causes the engine to fail at connecting.

## Links
[[RHCLOUD-25597]](https://issues.redhat.com/browse/RHCLOUD-22207)