### PR TITLE
 RHCLOUD-25597 | fix: export service's endpoint name

### DIFF
--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -212,7 +212,7 @@ camel.component.kafka.ssl-truststore-type=JKS
 # are using a real Export Service application to test the integration, you will
 # need to set this PSK in the PSKS environment variable on that end.
 export-service.psk=development-value-123
-quarkus.rest-client.export-service.url=${clowder.endpoints.export-service.url:http://localhost:10010}
-quarkus.rest-client.export-service.trust-store=${clowder.endpoints.export-service.trust-store-path}
-quarkus.rest-client.export-service.trust-store-password=${clowder.endpoints.export-service.trust-store-password}
-quarkus.rest-client.export-service.trust-store-type=${clowder.endpoints.export-service.trust-store-type}
+quarkus.rest-client.export-service.url=${clowder.endpoints.export-service-service.url:http://localhost:10010}
+quarkus.rest-client.export-service.trust-store=${clowder.endpoints.export-service-service.trust-store-path}
+quarkus.rest-client.export-service.trust-store-password=${clowder.endpoints.export-service-service.trust-store-password}
+quarkus.rest-client.export-service.trust-store-type=${clowder.endpoints.export-service-service.trust-store-type}


### PR DESCRIPTION
The application was complaining that the "export-service" was not being found in Clowder's endpoints section, and the reason was that the naming was wrong.

## Links
[[RHCLOUD-25597]](https://issues.redhat.com/browse/RHCLOUD-25597)