### PR TITLE
RHCLOUD-26040 Fix cloud events filtering

### DIFF
--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
@@ -15,6 +15,7 @@ import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.Template;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
+import io.smallrye.reactive.messaging.kafka.api.KafkaMessageMetadata;
 import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
 import io.smallrye.reactive.messaging.providers.connectors.InMemorySink;
 import io.vertx.core.json.JsonObject;
@@ -34,6 +35,8 @@ import java.util.UUID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.processors.ConnectorSender.TOCAMEL_CHANNEL;
+import static com.redhat.cloud.notifications.processors.camel.CamelNotificationProcessor.CLOUD_EVENT_TYPE_HEADER;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.ZoneOffset.UTC;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -95,8 +98,11 @@ public abstract class CamelProcessorTest {
         await().until(() -> inMemorySink.received().size() == 1);
         Message<String> message = inMemorySink.received().get(0);
 
+        assertCloudEventTypeHeader(message);
+
         CloudEventMetadata cloudEventMetadata = message.getMetadata(CloudEventMetadata.class).get();
         assertNotNull(cloudEventMetadata.getId());
+        assertEquals(getExpectedCloudEventType(), cloudEventMetadata.getType());
 
         JsonObject payload = new JsonObject(message.getPayload());
         CamelNotification notification = payload.mapTo(CamelNotification.class);
@@ -104,6 +110,14 @@ public abstract class CamelProcessorTest {
         assertEquals(DEFAULT_ORG_ID, notification.orgId);
         assertEquals(WEBHOOK_URL, notification.webhookUrl);
         assertEquals(getExpectedMessage(), notification.message);
+    }
+
+    protected void assertCloudEventTypeHeader(Message<String> message) {
+        byte[] actualCloudEventType = message.getMetadata(KafkaMessageMetadata.class)
+                .get()
+                .getHeaders().headers(CLOUD_EVENT_TYPE_HEADER)
+                .iterator().next().value();
+        assertEquals(getExpectedCloudEventType(), new String(actualCloudEventType, UTF_8));
     }
 
     protected void mockTemplate() {
@@ -163,4 +177,6 @@ public abstract class CamelProcessorTest {
 
     protected void addExtraEndpointProperties(CamelProperties properties) {
     }
+
+    protected abstract String getExpectedCloudEventType();
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatProcessorTest.java
@@ -7,6 +7,9 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import javax.inject.Inject;
 
+import static com.redhat.cloud.notifications.events.EndpointProcessor.GOOGLE_CHAT_ENDPOINT_SUBTYPE;
+import static com.redhat.cloud.notifications.processors.ConnectorSender.CLOUD_EVENT_TYPE_PREFIX;
+
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
 public class GoogleChatProcessorTest extends CamelProcessorTest {
@@ -36,11 +39,16 @@ public class GoogleChatProcessorTest extends CamelProcessorTest {
 
     @Override
     protected String getSubType() {
-        return "google-chat";
+        return GOOGLE_CHAT_ENDPOINT_SUBTYPE;
     }
 
     @Override
     protected CamelProcessor getCamelProcessor() {
         return googleSpacesProcessor;
+    }
+
+    @Override
+    protected String getExpectedCloudEventType() {
+        return CLOUD_EVENT_TYPE_PREFIX + GOOGLE_CHAT_ENDPOINT_SUBTYPE;
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsProcessorTest.java
@@ -7,6 +7,9 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import javax.inject.Inject;
 
+import static com.redhat.cloud.notifications.events.EndpointProcessor.TEAMS_ENDPOINT_SUBTYPE;
+import static com.redhat.cloud.notifications.processors.ConnectorSender.CLOUD_EVENT_TYPE_PREFIX;
+
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
 public class TeamsProcessorTest extends CamelProcessorTest {
@@ -36,11 +39,16 @@ public class TeamsProcessorTest extends CamelProcessorTest {
 
     @Override
     protected String getSubType() {
-        return "teams";
+        return TEAMS_ENDPOINT_SUBTYPE;
     }
 
     @Override
     protected CamelProcessor getCamelProcessor() {
         return teamsProcessor;
+    }
+
+    @Override
+    protected String getExpectedCloudEventType() {
+        return CLOUD_EVENT_TYPE_PREFIX + TEAMS_ENDPOINT_SUBTYPE;
     }
 }


### PR DESCRIPTION
`IncomingCloudEventFilter` tried to extract the `ce-type` field from the Kafka message headers while it was included as a cloud event payload field. Now, `ce-type` should be available in the headers.