### PR TITLE
RHCLOUD-26443 Split the post deployment tests configuration

### DIFF
--- a/.rhcicd/stage-backend-post-deployment-tests.yaml
+++ b/.rhcicd/stage-backend-post-deployment-tests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: notifications-backend-post-deployment-tests
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: notifications-backend-post-deployment-tests-${IMAGE_TAG}-${UID}
+  spec:
+    appName: notifications-backend
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        marker: 'notification_smoke and api'
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"

--- a/.rhcicd/stage-engine-post-deployment-tests.yaml
+++ b/.rhcicd/stage-engine-post-deployment-tests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: notifications-engine-post-deployment-tests
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: notifications-engine-post-deployment-tests-${IMAGE_TAG}-${UID}
+  spec:
+    appName: notifications-backend
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        marker: 'notification_smoke and api'
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"


### PR DESCRIPTION
The new files will be updated with different tests markers by the QE team soon.

The old file remains in this repo for now to make the transition in app-interface smooth.