### PR TITLE
RHCLOUD-26443 Fix the post deployment tests run

### DIFF
--- a/.rhcicd/stage-backend-post-deployment-tests.yaml
+++ b/.rhcicd/stage-backend-post-deployment-tests.yaml
@@ -7,7 +7,7 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: notifications-backend-post-deployment-tests-${IMAGE_TAG}-${UID}
+    name: notifications-backend-iqe-tests-${IMAGE_TAG}-${UID}
   spec:
     appName: notifications-backend
     testing:

--- a/.rhcicd/stage-engine-post-deployment-tests.yaml
+++ b/.rhcicd/stage-engine-post-deployment-tests.yaml
@@ -7,7 +7,7 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: notifications-engine-post-deployment-tests-${IMAGE_TAG}-${UID}
+    name: notifications-engine-iqe-tests-${IMAGE_TAG}-${UID}
   spec:
     appName: notifications-backend
     testing:


### PR DESCRIPTION
The name of the post deployment tests pods cannot exceed 63 characters.