### PR TITLE
 [RHCLOUD-26436] Changing markers to split repos

### DIFF
--- a/.rhcicd/stage-backend-post-deployment-tests.yaml
+++ b/.rhcicd/stage-backend-post-deployment-tests.yaml
@@ -15,7 +15,7 @@ objects:
         debug: false
         dynaconfEnvName: stage_post_deploy
         filter: ''
-        marker: 'notification_smoke and api'
+        marker: 'notif_backend and api'
 parameters:
 - name: IMAGE_TAG
   value: ''

--- a/.rhcicd/stage-engine-post-deployment-tests.yaml
+++ b/.rhcicd/stage-engine-post-deployment-tests.yaml
@@ -15,7 +15,7 @@ objects:
         debug: false
         dynaconfEnvName: stage_post_deploy
         filter: ''
-        marker: 'notification_smoke and api'
+        marker: 'notif_engine and api'
 parameters:
 - name: IMAGE_TAG
   value: ''


### PR DESCRIPTION
This will change the markers so that the tests will be split for the backend and engine repos