### PR TITLE
RHCLOUD-26500 Log exception when an upload to the export service fails

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/exports/ExportEventListener.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/exports/ExportEventListener.java
@@ -194,8 +194,6 @@ public class ExportEventListener {
                 if (responseFamily == Response.Status.Family.SERVER_ERROR) {
                     this.failuresCounter.increment();
                 }
-
-                return;
             }
 
             Log.errorf(e, "something went wrong when handling a resource request from the export service. Received payload: %s", payload);


### PR DESCRIPTION
Uploads are currently failing in stage, but we're not logging anything.