### PR TITLE
RHCLOUD-26500 Fix export service root path

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/exports/ExportService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/exports/ExportService.java
@@ -15,7 +15,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.UUID;
 
-@Path("/app/export/v1")
+@Path("/api/export/v1")
 @RegisterRestClient(configKey = "export-service")
 public interface ExportService {
 


### PR DESCRIPTION
Uploads to the export service are failing with a 404 in stage because of the path typo fixed in this PR.