### PR TITLE
RHCLOUD-26219 Disable Camel routes discovery in the engine

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -278,8 +278,6 @@ objects:
               optional: true
         - name: QUARKUS_LOG_CATEGORY__COM_REDHAT_CLOUD_NOTIFICATIONS_EXPORTS_EXPORTEVENTLISTENER__LEVEL
           value: ${EXPORT_EVENT_LISTENER_LOG_LEVEL}
-        - name: QUARKUS_CAMEL_ROUTES_DISCOVERY_ENABLED
-          value: ${QUARKUS_CAMEL_ROUTES_DISCOVERY_ENABLED}
         - name: QUARKUS_REST_CLIENT_LOGGING_SCOPE
           value: ${QUARKUS_REST_CLIENT_LOGGING_SCOPE}
         - name: QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL
@@ -486,9 +484,6 @@ parameters:
 - name: EXPORT_EVENT_LISTENER_LOG_LEVEL
   description: The log level for the export service's event listener.
   value: "INFO"
-- name: QUARKUS_CAMEL_ROUTES_DISCOVERY_ENABLED
-  description: When set to 'false', the Camel routes discovery will be disabled in the engine, preventing any Google Chat, Teams or Slack notification from being sent
-  value: "true"
 - name: QUARKUS_REST_CLIENT_LOGGING_SCOPE
   description: When set to 'request-response', rest-client will log the request and response contents
   value: ""

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -215,5 +215,9 @@ quarkus.rest-client.export-service.trust-store-type=${clowder.endpoints.export-s
 
 mp.messaging.tocamel.topic=platform.notifications.tocamel
 
-# Qaurkus caches
+# Quarkus caches
 quarkus.cache.caffeine.drawer-template.expire-after-write=PT5M
+
+# Temp - For testing purposes - Revert ASAP
+# When set to 'false', the Camel routes discovery will be disabled in the engine, preventing any Google Chat, Teams or Slack notification from being sent
+quarkus.camel.routes-discovery.enabled=false

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
@@ -10,6 +10,7 @@ import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockserver.model.HttpResponse;
 
@@ -85,6 +86,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    @Disabled
     void testCallOk() throws Exception {
 
         mockServerOk();
@@ -103,6 +105,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    @Disabled
     void testCallFailure() throws Exception {
 
         mockServerKo();
@@ -117,6 +120,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    @Disabled
     void testRetriesFailure() throws Exception {
 
         mockServerFailure();
@@ -132,6 +136,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    @Disabled
     protected void testRoutes() throws Exception {
         adviceWith(getIncomingRoute(), context(), new AdviceWithRouteBuilder() {
             @Override

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRoutesTest.java
@@ -5,6 +5,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import java.net.URLEncoder;
 
@@ -49,6 +50,7 @@ public class SlackRoutesTest extends CamelRoutesTest {
     }
 
     @Test
+    @Disabled
     @Override
     protected void testRoutes() throws Exception {
         String testRoutesChannel = "#test_routes_channel";


### PR DESCRIPTION
Setting `QUARKUS_CAMEL_ROUTES_DISCOVERY_ENABLED` from a deployment param didn't work. In the Camel version we depend on, that config value is fixed at build time.