### PR TITLE
RHCLOUD-26500 | feature: activate the request context in the event listener

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/exports/ExportEventListener.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/exports/ExportEventListener.java
@@ -20,6 +20,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.control.ActivateRequestContext;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -71,6 +72,7 @@ public class ExportEventListener {
      * service.
      * @param payload the incoming payload from the channel.
      */
+    @ActivateRequestContext
     @Blocking
     @Incoming(EXPORT_CHANNEL)
     public void eventListener(final String payload) {


### PR DESCRIPTION
From now on, since we have moved away from stateless database sessions, the request context needs to be activated if the function that listens to a Kafka topic accesses the database.

## Links

[[RHCLOUD-26500]](https://issues.redhat.com/browse/RHCLOUD-26500)