### PR TITLE
RHCLOUD-2600 | feature: environment variable for the export service's URL

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -284,6 +284,8 @@ objects:
           value: ${QUARKUS_REST_CLIENT_LOGGING_SCOPE}
         - name: QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL
           value: ${QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL}
+        - name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_URL
+          value: ${QUARKUS_REST_CLIENT_EXPORT_SERVICE_URL}
         - name: NOTIFICATIONS_DRAWER_ENABLED
           value: ${NOTIFICATIONS_DRAWER_ENABLED}
 parameters:
@@ -497,3 +499,6 @@ parameters:
   value: INFO
 - name: NOTIFICATIONS_DRAWER_ENABLED
   value: "false"
+- name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_URL
+  description: The URL of the Export service.
+  value: "replaceme"


### PR DESCRIPTION
By allowing to specify the export service URL with an environment variable, we will be able to more flexibly debug what might be going on.

 ## Links

[[RHCLOUD-2600]](https://issues.redhat.com/browse/RHCLOUD-26500)