### PR TITLE
RHCLOUD-25863 | feature: migrate to the Floorist operator

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -23,56 +23,6 @@ objects:
     testing:
       iqePlugin: notifications
     jobs:
-    - name: floorist
-      schedule: ${FLOORIST_SCHEDULE}
-      suspend: ${{FLOORIST_SUSPEND}}
-      concurrencyPolicy: Forbid
-      podSpec:
-        image: ${FLOORIST_IMAGE}:${FLOORIST_IMAGE_TAG}
-        env:
-          - name: AWS_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: ${FLOORIST_BUCKET_SECRET_NAME}
-                key: bucket
-          - name: AWS_REGION
-            valueFrom:
-              secretKeyRef:
-                name: ${FLOORIST_BUCKET_SECRET_NAME}
-                key: aws_region
-          - name: AWS_ENDPOINT
-            valueFrom:
-              secretKeyRef:
-                name: ${FLOORIST_BUCKET_SECRET_NAME}
-                key: endpoint
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: ${FLOORIST_BUCKET_SECRET_NAME}
-                key: aws_access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: ${FLOORIST_BUCKET_SECRET_NAME}
-                key: aws_secret_access_key
-          - name: FLOORPLAN_FILE
-            value: "/tmp/floorplan/floorplan.yaml"
-          - name: LOGLEVEL
-            value: ${FLOORIST_LOGLEVEL}
-        volumeMounts:
-          - name: floorplan-volume
-            mountPath: "/tmp/floorplan"
-        volumes:
-          - name: floorplan-volume
-            configMap:
-              name: floorplan
-      resources:
-        limits:
-          cpu: "${CPU_LIMIT_FLOO}"
-          memory: "${MEMORY_LIMIT_FLOO}"
-        requests:
-          cpu: "${CPU_REQUEST_FLOO}"
-          memory: "${MEMORY_REQUEST_FLOO}"
     - name: db-cleaner-cronjob
       schedule: ${DB_CLEANER_SCHEDULE}
       suspend: ${{DISABLE_DB_CLEANER}}
@@ -222,31 +172,36 @@ objects:
       VACUUM ANALYZE notification_history;
       CALL cleanKafkaMessagesIds();
       VACUUM ANALYZE kafka_message;
-- apiVersion: v1
-  kind: ConfigMap
+- apiVersion: metrics.console.redhat.com/v1alpha1
+  kind: FloorPlan
   metadata:
-    name: floorplan
-  data:
-    floorplan.yaml: |
-      - prefix: insights/notifications/splunk
-        query: >-
-          SELECT 
-            DISTINCT "account_id" 
-            FROM "endpoints"
-            WHERE "endpoint_type_v2"='CAMEL' AND "endpoint_sub_type"='splunk';
-      - prefix: insights/notifications/accounts
-        query: >-
-          SELECT
-          "applications"."id", "applications"."name", COUNT("applications"."id") AS "applications_count" 
-          FROM "applications" 
-          INNER JOIN "endpoint_email_subscriptions" ON "applications"."id"="endpoint_email_subscriptions"."application_id" 
-          GROUP BY "applications"."id" HAVING COUNT("applications"."id") > 1;
-      - prefix: insights/notifications/accounts
-        query: >-
-          SELECT
-          COUNT(distinct account_id) 
-          FROM endpoints
-          WHERE endpoint_type_v2 = 'CAMEL' AND endpoint_sub_type = 'splunk' AND enabled IS FALSE;
+    name: notifications
+  spec:
+    database:
+      secretName: ${FLOORIST_DB_SECRET_NAME}
+    objectStore:
+      secretName: ${FLOORIST_BUCKET_SECRET_NAME}
+    suspend: ${{FLOORIST_SUSPEND}}
+    queries:
+    - prefix: insights/notifications/splunk
+      query: >-
+        SELECT
+          DISTINCT "account_id"
+          FROM "endpoints"
+          WHERE "endpoint_type_v2"='CAMEL' AND "endpoint_sub_type"='splunk';
+    - prefix: insights/notifications/accounts
+      query: >-
+        SELECT
+        "applications"."id", "applications"."name", COUNT("applications"."id") AS "applications_count"
+        FROM "applications"
+        INNER JOIN "endpoint_email_subscriptions" ON "applications"."id"="endpoint_email_subscriptions"."application_id"
+        GROUP BY "applications"."id" HAVING COUNT("applications"."id") > 1;
+    - prefix: insights/notifications/accounts
+      query: >-
+        SELECT
+        COUNT(distinct account_id)
+        FROM endpoints
+        WHERE endpoint_type_v2 = 'CAMEL' AND endpoint_sub_type = 'splunk' AND enabled IS FALSE;
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
@@ -320,27 +275,20 @@ parameters:
   value: "false"
 - name: QUARKUS_OPENTELEMETRY_ENDPOINT
   value: "http://localhost:4317"
-- name: FLOORIST_SCHEDULE
-  description: Cronjob schedule definition
-  required: true
-- name: FLOORIST_SUSPEND
-  description: Disable Floorist cronjob execution
-  required: true
-  value: 'true'
-- description: Floorist image name
-  name: FLOORIST_IMAGE
-  value: quay.io/cloudservices/floorist
-- description: Floorist Image tag
-  name: FLOORIST_IMAGE_TAG
-  required: true
-  value: latest
 - description: bucket secret name
   name: FLOORIST_BUCKET_SECRET_NAME
   required: true
   value: dummy-secret
+- name: FLOORIST_DB_SECRET_NAME
+  description: The database's secret name specification for the Floorist operator.
+  value: notifications-backend-db
 - name: FLOORIST_LOGLEVEL
   description: Floorist loglevel config
   value: 'INFO'
+- name: FLOORIST_SUSPEND
+  description: Disable Floorist cronjob execution
+  required: true
+  value: 'true'
 - name: SOURCES_ENABLED
   description: Is the Sources integration enabled? This makes the backend store the endpoint properties' secrets there.
   value: "false"


### PR DESCRIPTION
Implements the steps described in the Floorist's documentation[1] to use the Floorist operator instead of the old, more manual way.

## Links
*  \[1\]: https://docs.engineering.redhat.com/display/COMPL/Floorist+onboarding
* RHCLOUD-25863