### PR TITLE
Prevent eventing history update failure

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ConnectorReceiver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ConnectorReceiver.java
@@ -78,7 +78,7 @@ public class ConnectorReceiver {
             reinjectIfNeeded(decodedPayload);
             boolean updated = camelHistoryFillerHelper.updateHistoryItem(decodedPayload);
             if (!updated) {
-                Log.infof("Camel notification history update failed because no record was found with [id=%s]", decodedPayload.get("historyId"));
+                Log.warnf("Camel notification history update failed because no record was found with [id=%s]", decodedPayload.get("historyId"));
             }
         } catch (Exception e) {
             messagesErrorCounter.increment();


### PR DESCRIPTION
On rare occasions, the following issue can happen in any environment:
```
2023-06-20 17:12:04,813 INFO  [com.red.clo.not.eve.ConnectorReceiver] (executor-thread-0) Camel notification history update failed because no record was found with [id=4ef1a736-ec9e-4b96-bf49-a385e40ebf94]
```
This PR prevents that by persisting the history in the DB before the engine receives the return Kafka message from the eventing apps.