### PR TITLE
RHCLOUD-26500 | fix: incorrect error payload sent to the export service

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/exports/ExportError.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/exports/ExportError.java
@@ -2,29 +2,7 @@ package com.redhat.cloud.notifications.exports;
 
 /**
  * Represents the expected payload for an error request in the "export service".
+ * @param error   the HTTP code of the error.
+ * @param message the error message describing what went wrong.
  */
-public class ExportError {
-    /**
-     * The code is represented as a string since that is what the export
-     * service expects.
-     */
-    private final String code;
-    private final String message;
-
-    /**
-     * @param httpStatus the HTTP code of the error.
-     * @param message the error message describing what went wrong.
-     */
-    public ExportError(final int httpStatus, final String message) {
-        this.code = String.valueOf(httpStatus);
-        this.message = message;
-    }
-
-    public String getCode() {
-        return this.code;
-    }
-
-    public String getMessage() {
-        return this.message;
-    }
-}
+public record ExportError(int error, String message) { }

--- a/engine/src/test/java/com/redhat/cloud/notifications/exports/ExportEventListenerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/exports/ExportEventListenerTest.java
@@ -16,6 +16,7 @@ import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
 import io.smallrye.reactive.messaging.providers.connectors.InMemorySource;
 import io.vertx.core.json.JsonArray;
+import org.apache.http.HttpStatus;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.AfterEach;
@@ -127,7 +128,7 @@ public class ExportEventListenerTest {
         exportIn.send(consoleCloudEventParser.toJson(cee));
 
         // Assert that the export service was called as expected.
-        this.assertErrorNotificationIsCorrect("400", "the specified resource type is unsupported by this application");
+        this.assertErrorNotificationIsCorrect(HttpStatus.SC_BAD_REQUEST, "the specified resource type is unsupported by this application");
 
         // Assert that the errors counter was incremented, and that the
         // successes counter did not increment.
@@ -168,7 +169,7 @@ public class ExportEventListenerTest {
         exportIn.send(consoleCloudEventParser.toJson(cee));
 
         // Assert that the export service was called as expected.
-        this.assertErrorNotificationIsCorrect("400", "unable to parse the 'from' date filter with the 'yyyy-mm-dd' format");
+        this.assertErrorNotificationIsCorrect(HttpStatus.SC_BAD_REQUEST, "unable to parse the 'from' date filter with the 'yyyy-mm-dd' format");
 
         // Assert that the errors counter was incremented, and that the
         // successes counter did not increment.
@@ -209,7 +210,7 @@ public class ExportEventListenerTest {
         exportIn.send(consoleCloudEventParser.toJson(cee));
 
         // Assert that the export service was called as expected.
-        this.assertErrorNotificationIsCorrect("400", "unable to parse the 'to' date filter with the 'yyyy-mm-dd' format");
+        this.assertErrorNotificationIsCorrect(HttpStatus.SC_BAD_REQUEST, "unable to parse the 'to' date filter with the 'yyyy-mm-dd' format");
 
         // Assert that the errors counter was incremented, and that the
         // successes counter did not increment.
@@ -313,7 +314,7 @@ public class ExportEventListenerTest {
             exportIn.send(consoleCloudEventParser.toJson(cee));
 
             // Assert that the export service was called as expected.
-            this.assertErrorNotificationIsCorrect("400", testCase.expectedErrorMessage());
+            this.assertErrorNotificationIsCorrect(HttpStatus.SC_BAD_REQUEST, testCase.expectedErrorMessage());
 
             // Clear the invocations to the mock.
             Mockito.clearInvocations(this.exportService);
@@ -475,7 +476,7 @@ public class ExportEventListenerTest {
      * @param expectedStatusCode the expected status code to check.
      * @param expectedErrorMessage the expected error message to check.
      */
-    void assertErrorNotificationIsCorrect(final String expectedStatusCode, final String expectedErrorMessage) {
+    void assertErrorNotificationIsCorrect(final int expectedStatusCode, final String expectedErrorMessage) {
         // Assert that the export service was called as expected.
         final ArgumentCaptor<String> capturedPsk = ArgumentCaptor.forClass(String.class);
         final ArgumentCaptor<UUID> capturedExportUuid = ArgumentCaptor.forClass(UUID.class);
@@ -501,7 +502,7 @@ public class ExportEventListenerTest {
         // Assert that the sent error has the expected payload.
         final ExportError capturedPayload = capturedError.getValue();
 
-        Assertions.assertEquals(expectedStatusCode, capturedPayload.getCode(), "unexpected status code sent to the export service");
-        Assertions.assertEquals(expectedErrorMessage, capturedPayload.getMessage(), "unexpected error message sent to the export service");
+        Assertions.assertEquals(expectedStatusCode, capturedPayload.error(), "unexpected status code sent to the export service");
+        Assertions.assertEquals(expectedErrorMessage, capturedPayload.message(), "unexpected error message sent to the export service");
     }
 }


### PR DESCRIPTION
The payload that was being sent to the export service didn't have the correct body, which caused the latter service to respond with an invalid status code to our request.

## Links

[RHCLOUD-26500](https://issues.redhat.com/browse/RHCLOUD-26500)