### PR TITLE
Better deal with 4xx errors in Google Chat connector

### DIFF
--- a/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackExceptionProcessor.java
+++ b/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackExceptionProcessor.java
@@ -4,7 +4,6 @@ import com.redhat.cloud.notifications.connector.ExceptionProcessor;
 import io.quarkus.logging.Log;
 import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -12,6 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.redhat.cloud.notifications.connector.slack.ExchangeProperty.CHANNEL;
+import static org.jboss.logging.Logger.Level;
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.ERROR;
 
@@ -36,7 +36,7 @@ public class SlackExceptionProcessor extends ExceptionProcessor {
         }
     }
 
-    private void log(Logger.Level level, Throwable t, Exchange exchange) {
+    private void log(Level level, Throwable t, Exchange exchange) {
         Log.logf(
                 level,
                 t,


### PR DESCRIPTION
⚠️ ~This PR is based on #1906 which needs to be reviewed and merged first.~

This PR changes the log level from `ERROR` to `DEBUG` when a 4xx error is returned in the Google Chat connector. Because of that change, we will no longer receive alerts in Sentry.

It does not change the notification status returned to the `engine` through Kafka. That notification is still marked as failed.