### PR TITLE
Revert Camel config in engine

### DIFF
--- a/.rhcicd/clowdapp-connector-google-chat.yaml
+++ b/.rhcicd/clowdapp-connector-google-chat.yaml
@@ -109,7 +109,7 @@ parameters:
   value: latest
 - name: KAFKA_CLIENT_LOG_LEVEL
   description: Log level of the Kafka client library
-  value: INFO
+  value: WARN
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 500Mi

--- a/.rhcicd/clowdapp-connector-microsoft-teams.yaml
+++ b/.rhcicd/clowdapp-connector-microsoft-teams.yaml
@@ -109,7 +109,7 @@ parameters:
   value: latest
 - name: KAFKA_CLIENT_LOG_LEVEL
   description: Log level of the Kafka client library
-  value: INFO
+  value: WARN
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 500Mi

--- a/.rhcicd/clowdapp-connector-slack.yaml
+++ b/.rhcicd/clowdapp-connector-slack.yaml
@@ -109,7 +109,7 @@ parameters:
   value: latest
 - name: KAFKA_CLIENT_LOG_LEVEL
   description: Log level of the Kafka client library
-  value: INFO
+  value: WARN
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 500Mi

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -473,7 +473,7 @@ parameters:
 - name: IO_SMALLRYE_REACTIVE_MESSAGING_LOG_LEVEL
   value: INFO
 - name: KAFKA_CLIENT_LOG_LEVEL
-  value: INFO
+  value: WARN
 - name: NOTIFICATIONS_EXPORT_SERVICE_ENABLED
   description: Enables the integration with the export service.
   value: "false"

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -220,4 +220,4 @@ quarkus.cache.caffeine.drawer-template.expire-after-write=PT5M
 
 # Temp - For testing purposes - Revert ASAP
 # When set to 'false', the Camel routes discovery will be disabled in the engine, preventing any Google Chat, Teams or Slack notification from being sent
-quarkus.camel.routes-discovery.enabled=false
+quarkus.camel.routes-discovery.enabled=true

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
@@ -10,7 +10,6 @@ import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockserver.model.HttpResponse;
 
@@ -86,7 +85,6 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
-    @Disabled
     void testCallOk() throws Exception {
 
         mockServerOk();
@@ -105,7 +103,6 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
-    @Disabled
     void testCallFailure() throws Exception {
 
         mockServerKo();
@@ -120,7 +117,6 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
-    @Disabled
     void testRetriesFailure() throws Exception {
 
         mockServerFailure();
@@ -136,7 +132,6 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
-    @Disabled
     protected void testRoutes() throws Exception {
         adviceWith(getIncomingRoute(), context(), new AdviceWithRouteBuilder() {
             @Override

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRoutesTest.java
@@ -5,7 +5,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import java.net.URLEncoder;
 
@@ -50,7 +49,6 @@ public class SlackRoutesTest extends CamelRoutesTest {
     }
 
     @Test
-    @Disabled
     @Override
     protected void testRoutes() throws Exception {
         String testRoutesChannel = "#test_routes_channel";


### PR DESCRIPTION
The Camel routes in `engine` were disabled for testing purposes. This PR reverts that.