### PR TITLE
RHCLOUD-26500 | refactor: remove the export service's endpoint URL

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -282,8 +282,6 @@ objects:
           value: ${QUARKUS_REST_CLIENT_LOGGING_SCOPE}
         - name: QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL
           value: ${QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL}
-        - name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_URL
-          value: ${QUARKUS_REST_CLIENT_EXPORT_SERVICE_URL}
         - name: NOTIFICATIONS_DRAWER_ENABLED
           value: ${NOTIFICATIONS_DRAWER_ENABLED}
 parameters:
@@ -494,6 +492,3 @@ parameters:
   value: INFO
 - name: NOTIFICATIONS_DRAWER_ENABLED
   value: "false"
-- name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_URL
-  description: The URL of the Export service.
-  value: "replaceme"


### PR DESCRIPTION
In order to discard that there is an issue with grabbing the export service's URL from the Clowder's configuration file, it is required to let the engine read it from there, instead of overriding the URL. Removing the URL in AppInterface doesn't do it because there is a default value set in here.

## Links

[[RHCLOUD-26500]](https://issues.redhat.com/browse/RHCLOUD-26500)