### PR TITLE
Disable Camel routes in the engine

### DIFF
--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -220,4 +220,4 @@ quarkus.cache.caffeine.drawer-template.expire-after-write=PT5M
 
 # Temp - For testing purposes - Revert ASAP
 # When set to 'false', the Camel routes discovery will be disabled in the engine, preventing any Google Chat, Teams or Slack notification from being sent
-quarkus.camel.routes-discovery.enabled=true
+quarkus.camel.routes-discovery.enabled=false

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelRoutesTest.java
@@ -10,6 +10,7 @@ import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockserver.model.HttpResponse;
 
@@ -85,6 +86,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    @Disabled
     void testCallOk() throws Exception {
 
         mockServerOk();
@@ -103,6 +105,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    @Disabled
     void testCallFailure() throws Exception {
 
         mockServerKo();
@@ -117,6 +120,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    @Disabled
     void testRetriesFailure() throws Exception {
 
         mockServerFailure();
@@ -132,6 +136,7 @@ public abstract class CamelRoutesTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    @Disabled
     protected void testRoutes() throws Exception {
         adviceWith(getIncomingRoute(), context(), new AdviceWithRouteBuilder() {
             @Override

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRoutesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackRoutesTest.java
@@ -5,6 +5,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import java.net.URLEncoder;
 
@@ -49,6 +50,7 @@ public class SlackRoutesTest extends CamelRoutesTest {
     }
 
     @Test
+    @Disabled
     @Override
     protected void testRoutes() throws Exception {
         String testRoutesChannel = "#test_routes_channel";


### PR DESCRIPTION
The Camel routes from `engine` need to be disabled again because we're ready to rely completely on the connectors.