### PR TITLE
RHCLOUD-26685 Fix default email templates for cloud events

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/extensions/ActionExtension.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/extensions/ActionExtension.java
@@ -2,19 +2,34 @@ package com.redhat.cloud.notifications.templates.extensions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.event.parser.ConsoleCloudEventParser;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Parser;
 import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.models.NotificationsConsoleCloudEvent;
 import io.quarkus.qute.TemplateExtension;
 
 public class ActionExtension {
+
+
+    private static final ConsoleCloudEventParser consoleCloudEventParser = new ConsoleCloudEventParser();
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @TemplateExtension(matchName = TemplateExtension.ANY)
     public static Object getFromContext(Context context, String key) {
         return context.getAdditionalProperties().get(key);
+    }
+
+    @TemplateExtension
+    public static boolean isCloudEvent(Action action) {
+        return false;
+    }
+
+    @TemplateExtension
+    public static boolean isCloudEvent(NotificationsConsoleCloudEvent event) {
+        return true;
     }
 
     @TemplateExtension(matchName = TemplateExtension.ANY)
@@ -27,6 +42,16 @@ public class ActionExtension {
         try {
             // Ensures we are encoding the action as per our configured encoder
             String encodedAction = Parser.encode(action);
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(encodedAction));
+        } catch (JsonProcessingException jpe) {
+            throw new RuntimeException("Error while transforming action to json", jpe);
+        }
+    }
+
+    @TemplateExtension
+    public static String toPrettyJson(NotificationsConsoleCloudEvent event) {
+        try {
+            String encodedAction = consoleCloudEventParser.toJson(event);
             return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(encodedAction));
         } catch (JsonProcessingException jpe) {
             throw new RuntimeException("Error while transforming action to json", jpe);

--- a/engine/src/main/resources/templates/Common/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Common/insightsEmailBody.html
@@ -581,7 +581,7 @@
                             <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td class="rh-footer__text">
-                                        This email was sent by Hybrid Cloud Console | <a href="{environment.url}/user-preferences/notifications/{action.bundle}" target="_blank">Manage email preferences</a>
+                                        This email was sent by Hybrid Cloud Console | <a href="{environment.url}/user-preferences/notifications/{action.bundle.or("")}" target="_blank">Manage email preferences</a>
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/Default/instantEmailBody.html
+++ b/engine/src/main/resources/templates/Default/instantEmailBody.html
@@ -1,13 +1,23 @@
 {@boolean renderSection1=true}
 {#include Common/insightsEmailBody}
 {#content-title}
+{#if action.isCloudEvent()}
+    {action.type}
+{#else}
     {action.application} - {action.bundle}
+{/if}
 {/content-title}
 {#content-title-section1}
     Notification
 {/content-title-section1}
 {#content-body-section1}
-    <p>{action.bundle}/{action.application}/{action.eventType} notification was triggered.</p>
+    <p>
+        {#if action.isCloudEvent()}
+            {action.type} notification was triggered.
+        {#else}
+            {action.bundle}/{action.application}/{action.eventType} notification was triggered.
+        {/if}
+    </p>
     <p>You are receiving this email because the email template associated with this event type is not configured properly.</p>
     <p>Please see the <a class="rh-url" href="https://core-platform-apps.pages.redhat.com/notifications-docs/dev/user-guide/email-templates.html">documentation</a> for information about setting up email templates.</p>
 

--- a/engine/src/main/resources/templates/Default/instantEmailTitle.txt
+++ b/engine/src/main/resources/templates/Default/instantEmailTitle.txt
@@ -1,1 +1,5 @@
+{#if action.isCloudEvent()}
+{action.type} triggered
+{#else}
 {action.bundle}/{action.application}/{action.eventType} triggered
+{/if}

--- a/engine/src/test/java/com/redhat/cloud/notifications/EmailTemplatesInDbHelper.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/EmailTemplatesInDbHelper.java
@@ -9,6 +9,7 @@ import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.InstantEmailTemplate;
+import com.redhat.cloud.notifications.models.NotificationsConsoleCloudEvent;
 import com.redhat.cloud.notifications.recipients.User;
 import com.redhat.cloud.notifications.templates.EmailTemplateMigrationService;
 import com.redhat.cloud.notifications.templates.TemplateService;
@@ -100,15 +101,31 @@ public abstract class EmailTemplatesInDbHelper {
     }
 
     protected String generateEmailSubject(String eventTypeStr, Action action) {
+        return generateEmailSubject(eventTypeStr, (Object) action);
+    }
+
+    protected String generateEmailSubject(String eventTypeStr, NotificationsConsoleCloudEvent event) {
+        return generateEmailSubject(eventTypeStr, (Object) event);
+    }
+
+    private String generateEmailSubject(String eventTypeStr, Object event) {
         InstantEmailTemplate emailTemplate = templateRepository.findInstantEmailTemplate(eventTypes.get(eventTypeStr)).get();
         TemplateInstance subjectTemplate = templateService.compileTemplate(emailTemplate.getSubjectTemplate().getData(), emailTemplate.getSubjectTemplate().getName());
-        return generateEmail(subjectTemplate, action);
+        return generateEmail(subjectTemplate, event);
     }
 
     protected String generateEmailBody(String eventTypeStr, Action action) {
+        return generateEmailBody(eventTypeStr, (Object) action);
+    }
+
+    protected String generateEmailBody(String eventTypeStr, NotificationsConsoleCloudEvent event) {
+        return generateEmailBody(eventTypeStr, (Object) event);
+    }
+
+    private String generateEmailBody(String eventTypeStr, Object event) {
         InstantEmailTemplate emailTemplate = templateRepository.findInstantEmailTemplate(eventTypes.get(eventTypeStr)).get();
         TemplateInstance bodyTemplate = templateService.compileTemplate(emailTemplate.getBodyTemplate().getData(), emailTemplate.getBodyTemplate().getName());
-        return generateEmail(bodyTemplate, action);
+        return generateEmail(bodyTemplate, event);
     }
 
     protected String generateAggregatedEmailSubject(Map<String, Object> context) {

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications;
 
+import com.redhat.cloud.event.parser.ConsoleCloudEventParser;
 import com.redhat.cloud.notifications.events.EventWrapperAction;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
@@ -9,12 +10,15 @@ import com.redhat.cloud.notifications.ingress.Parser;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.ingress.Recipient;
 import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.models.NotificationsConsoleCloudEvent;
 import com.redhat.cloud.notifications.processors.email.aggregators.ResourceOptimizationPayloadAggregator;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -27,6 +31,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TestHelpers {
 
@@ -620,5 +625,13 @@ public class TestHelpers {
         event.setEventWrapper(new EventWrapperAction(action));
 
         return new BaseTransformer().toJsonObject(event);
+    }
+
+    public static NotificationsConsoleCloudEvent createConsoleCloudEvent() throws IOException {
+        InputStream policyCloudEvent = MockServerConfig.class.getClassLoader().getResourceAsStream("cloudevents/cloudevent.json");
+        return new ConsoleCloudEventParser().fromJsonString(
+                IOUtils.toString(policyCloudEvent, UTF_8),
+                NotificationsConsoleCloudEvent.class
+        );
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestDefaultTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestDefaultTemplate.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.EmailTemplatesInDbHelper;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.models.NotificationsConsoleCloudEvent;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import javax.inject.Inject;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
@@ -55,6 +57,23 @@ public class TestDefaultTemplate extends EmailTemplatesInDbHelper {
         Action action = TestHelpers.createPoliciesAction("", "my-bundle", "my-app", "FooMachine");
         String result = generateEmailBody(EVENT_TYPE_NAME, action);
         assertTrue(result.contains("my-bundle/my-app/test-email-subscription-instant notification was triggered"), "Body should contain bundle/app/event-type");
+        assertTrue(result.contains("You are receiving this email because the email template associated with this event type is not configured properly"));
+    }
+
+    @Test
+    public void testInstantEmailTitleCloudEvents() throws Exception {
+        NotificationsConsoleCloudEvent event = TestHelpers.createConsoleCloudEvent();
+        String result = generateEmailSubject(EVENT_TYPE_NAME, event);
+
+        assertEquals("com.redhat.console.insights.policies.policy-triggered triggered", result.trim());
+    }
+
+    @Test
+    public void testInstantEmailBodyCloudEvents() throws Exception {
+        NotificationsConsoleCloudEvent event = TestHelpers.createConsoleCloudEvent();
+        String result = generateEmailBody(EVENT_TYPE_NAME, event);
+
+        assertTrue(result.contains("com.redhat.console.insights.policies.policy-triggered notification was triggered"), "Body should contain bundle/app/event-type");
         assertTrue(result.contains("You are receiving this email because the email template associated with this event type is not configured properly"));
     }
 }


### PR DESCRIPTION
Depends on #2036 

@g-duval I think we will need to do something similar for the default templates when using the drawer.
If the bundle/app/event-type are needed, we could implement something to actually have that information. 
