### PR TITLE
Remove compatibility mode in IncomingCloudEventProcessor

### DIFF
--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
@@ -43,13 +43,7 @@ public class IncomingCloudEventProcessor implements Processor {
         // Source of the Cloud Event returned to the Notifications engine.
         exchange.setProperty(RETURN_SOURCE, connectorConfig.getConnectorName());
 
-        JsonObject data;
-        try {
-            data = cloudEvent.getJsonObject(CLOUD_EVENT_DATA);
-        } catch (ClassCastException e) {
-            // TODO Remove this temporary compatibility mode after its deployment in production.
-            data = new JsonObject(cloudEvent.getString(CLOUD_EVENT_DATA));
-        }
+        JsonObject data = cloudEvent.getJsonObject(CLOUD_EVENT_DATA);
         exchange.setProperty(ORG_ID, data.getString("orgId"));
 
         cloudEventDataExtractor.extract(exchange, data);


### PR DESCRIPTION
The engine only sends the `data` field as JSON in all environments now.

Let's wait until #2035 has been merged before merging this PR though.