### PR TITLE
RHCLOUD-26703 | fix: the engine doesn't grab the correct endpoint for the integration

### DIFF
--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -208,10 +208,10 @@ camel.component.kafka.ssl-truststore-type=JKS
 # are using a real Export Service application to test the integration, you will
 # need to set this PSK in the PSKS environment variable on that end.
 export-service.psk=development-value-123
-quarkus.rest-client.export-service.url=${clowder.endpoints.export-service-service.url:http://localhost:10010}
-quarkus.rest-client.export-service.trust-store=${clowder.endpoints.export-service-service.trust-store-path}
-quarkus.rest-client.export-service.trust-store-password=${clowder.endpoints.export-service-service.trust-store-password}
-quarkus.rest-client.export-service.trust-store-type=${clowder.endpoints.export-service-service.trust-store-type}
+quarkus.rest-client.export-service.url=${clowder.private-endpoints.export-service-service.url:http://localhost:10010}
+quarkus.rest-client.export-service.trust-store=${clowder.private-endpoints.export-service-service.trust-store-path}
+quarkus.rest-client.export-service.trust-store-password=${clowder.private-endpoints.export-service-service.trust-store-password}
+quarkus.rest-client.export-service.trust-store-type=${clowder.private-endpoints.export-service-service.trust-store-type}
 
 mp.messaging.tocamel.topic=platform.notifications.tocamel
 


### PR DESCRIPTION
We were attempting to grab the export service's endpoint from the regular endpoints section, while the URL for the private API needed to be generated by reading the configuration from the private endpoints section. After updating our configuration reader, we are ready to change our configuration keys.

## Dependencies

* https://github.com/RedHatInsights/clowder-quarkus-config-source/pull/150

## Links

[[RHCLOUD-26703]](https://issues.redhat.com/browse/RHCLOUD-26703)