### PR TITLE
RHCLOUD-23645 | feature: fetch users from MBOP instead of the IT service

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -246,6 +246,8 @@ objects:
           value: ${NOTIFICATIONS_DRAWER_ENABLED}
         - name: NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS
           value: ${NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS}
+        - name: QUARKUS_REST_CLIENT_MBOP_URL
+          value: ${QUARKUS_REST_CLIENT_MBOP_URL}
 parameters:
 - name: BACKOFFICE_CLIENT_ENV
   description: Back-office client environment
@@ -414,3 +416,5 @@ parameters:
   value: "false"
 - name: NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS
   value: "false"
+- name: QUARKUS_REST_CLIENT_MBOP_URL
+  required: true

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -244,6 +244,8 @@ objects:
           value: ${QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL}
         - name: NOTIFICATIONS_DRAWER_ENABLED
           value: ${NOTIFICATIONS_DRAWER_ENABLED}
+        - name: NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS
+          value: ${NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS}
 parameters:
 - name: BACKOFFICE_CLIENT_ENV
   description: Back-office client environment
@@ -409,4 +411,6 @@ parameters:
   description: When QUARKUS_REST_CLIENT_LOGGING_SCOPE is set to 'request-response', this logger level needs to be set to DEBUG
   value: INFO
 - name: NOTIFICATIONS_DRAWER_ENABLED
+  value: "false"
+- name: NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS
   value: "false"

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -246,8 +246,6 @@ objects:
           value: ${NOTIFICATIONS_DRAWER_ENABLED}
         - name: NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS
           value: ${NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS}
-        - name: QUARKUS_REST_CLIENT_MBOP_URL
-          value: ${QUARKUS_REST_CLIENT_MBOP_URL}
 parameters:
 - name: BACKOFFICE_CLIENT_ENV
   description: Back-office client environment
@@ -416,5 +414,3 @@ parameters:
   value: "false"
 - name: NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS
   value: "false"
-- name: QUARKUS_REST_CLIENT_MBOP_URL
-  required: true

--- a/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
@@ -87,6 +87,9 @@ public class FeatureFlipper {
     @ConfigProperty(name = "notifications.add.default.recipient.on.single.email.enabled", defaultValue = "true")
     boolean addDefaultRecipientOnSingleEmail;
 
+    @ConfigProperty(name = "notifications.use-mbop-for-fetching-users", defaultValue = "false")
+    boolean useMBOPForFetchingUsers;
+
     void logFeaturesStatusAtStartup(@Observes StartupEvent event) {
         Log.infof("=== %s startup status ===", FeatureFlipper.class.getSimpleName());
         Log.infof("The behavior groups unique name constraint is %s", enforceBehaviorGroupNameUnicity ? "enabled" : "disabled");
@@ -105,6 +108,7 @@ public class FeatureFlipper {
         Log.infof("The integration with the export service is %s", exportServiceIntegrationEnabled ? "enabled" : "disabled");
         Log.infof("Drawer feature is %s", drawerEnabled ? "enabled" : "disabled");
         Log.infof("The add of default recipient on single email is %s", addDefaultRecipientOnSingleEmail ? "enabled" : "disabled");
+        Log.infof("The use of BOP/MBOP for fetching users is %s", useMBOPForFetchingUsers ? "enabled" : "disabled");
     }
 
     public boolean isEnforceBehaviorGroupNameUnicity() {
@@ -245,6 +249,15 @@ public class FeatureFlipper {
     public void setAddDefaultRecipientOnSingleEmail(boolean addDefaultRecipientOnSingleEmail) {
         checkTestLaunchMode();
         this.addDefaultRecipientOnSingleEmail = addDefaultRecipientOnSingleEmail;
+    }
+
+    public boolean isUseMBOPForFetchingUsers() {
+        return this.useMBOPForFetchingUsers;
+    }
+
+    public void setUseMBOPForFetchingUsers(final boolean useMBOPForFetchingUsers) {
+        checkTestLaunchMode();
+        this.useMBOPForFetchingUsers = useMBOPForFetchingUsers;
     }
 
     /**

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSender.java
@@ -11,6 +11,7 @@ import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.processors.webclient.BopWebClient;
 import com.redhat.cloud.notifications.processors.webhooks.WebhookTypeProcessor;
 import com.redhat.cloud.notifications.recipients.User;
+import com.redhat.cloud.notifications.recipients.mbop.Constants;
 import com.redhat.cloud.notifications.templates.TemplateService;
 import com.redhat.cloud.notifications.utils.LineBreakCleaner;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -35,9 +36,6 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class EmailSender {
 
-    static final String BOP_APITOKEN_HEADER = "x-rh-apitoken";
-    static final String BOP_CLIENT_ID_HEADER = "x-rh-clientid";
-    static final String BOP_ENV_HEADER = "x-rh-insights-env";
     static final String BODY_TYPE_HTML = "html";
     static final ZoneOffset UTC = ZoneOffset.UTC;
 
@@ -225,9 +223,9 @@ public class EmailSender {
     protected HttpRequest<Buffer> buildBOPHttpRequest() {
         return bopWebClient
                 .postAbs(bopUrl)
-                .putHeader(BOP_APITOKEN_HEADER, bopApiToken)
-                .putHeader(BOP_CLIENT_ID_HEADER, bopClientId)
-                .putHeader(BOP_ENV_HEADER, bopEnv);
+                .putHeader(Constants.MBOP_APITOKEN_HEADER, bopApiToken)
+                .putHeader(Constants.MBOP_CLIENT_ID_HEADER, bopClientId)
+                .putHeader(Constants.MBOP_ENV_HEADER, bopEnv);
     }
 
     @Deprecated(forRemoval = true)

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/Constants.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/Constants.java
@@ -1,0 +1,7 @@
+package com.redhat.cloud.notifications.recipients.mbop;
+
+public class Constants {
+    public static final String MBOP_APITOKEN_HEADER = "x-rh-apitoken";
+    public static final String MBOP_CLIENT_ID_HEADER = "x-rh-clientid";
+    public static final String MBOP_ENV_HEADER = "x-rh-insights-env";
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/MBOPService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/MBOPService.java
@@ -5,6 +5,7 @@ import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -18,6 +19,11 @@ import java.util.List;
 public interface MBOPService {
     /**
      * Gets the users of a given tenant by its organization ID.
+     * @param apiToken the API token which MBOP will use to communicate with
+     *                 authentication services.
+     * @param clientId the Client ID which MBOP will use to communicate with
+     *                 authentication services.
+     * @param environment the environment in which the application is running.
      * @param orgId the organization to look the users from.
      * @param adminOnly do we want to fetch just organization administrators?
      * @param sortOrder sort order, either {@code asc} or {@code des}.
@@ -30,10 +36,13 @@ public interface MBOPService {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     List<MBOPUser> getUsersByOrgId(
-        @RestPath                   String orgId,
-        @RestQuery("admin_only")    boolean adminOnly,
-        @RestQuery("sortOrder")     String sortOrder,
-        @RestQuery("limit")         int limit,
-        @RestQuery("offset")        int offset
+        @HeaderParam(Constants.MBOP_APITOKEN_HEADER)    String apiToken,
+        @HeaderParam(Constants.MBOP_CLIENT_ID_HEADER)   String clientId,
+        @HeaderParam(Constants.MBOP_ENV_HEADER)         String environment,
+        @RestPath                                       String orgId,
+        @RestQuery("admin_only")                        boolean adminOnly,
+        @RestQuery("sortOrder")                         String sortOrder,
+        @RestQuery("limit")                             int limit,
+        @RestQuery("offset")                            int offset
     );
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/MBOPService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/MBOPService.java
@@ -1,0 +1,39 @@
+package com.redhat.cloud.notifications.recipients.mbop;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.resteasy.reactive.RestQuery;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+/**
+ * REST client for both BOP and MBOP services, which in turn, talk to the IT
+ * service.
+ */
+@RegisterRestClient(configKey = "mbop")
+public interface MBOPService {
+    /**
+     * Gets the users of a given tenant by its organization ID.
+     * @param orgId the organization to look the users from.
+     * @param adminOnly do we want to fetch just organization administrators?
+     * @param sortOrder sort order, either {@code asc} or {@code des}.
+     * @param limit number of records to return per page. Defaults to 100.
+     * @param offset the offset to apply to the requested records. Defaults
+     *               to 0.
+     * @return the list of requested users.
+     */
+    @Path("/v3/accounts/{orgId}/users")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<MBOPUser> getUsersByOrgId(
+        @RestPath                   String orgId,
+        @RestQuery("admin_only")    boolean adminOnly,
+        @RestQuery("sortOrder")     String sortOrder,
+        @RestQuery("limit")         int limit,
+        @RestQuery("offset")        int offset
+    );
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/MBOPUser.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/MBOPUser.java
@@ -1,0 +1,25 @@
+package com.redhat.cloud.notifications.recipients.mbop;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * Represents the response to the {@link MBOPService#getUsersByOrgId(String, boolean, String, int, int)}
+ * REST API call. The {@link JsonProperty} annotations are required because
+ * otherwise Jackson struggles to deserialize the incoming payload into a
+ * record structure.
+ */
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record MBOPUser(
+    @JsonProperty("id")             String id,
+    @JsonProperty("username")       String username,
+    @JsonProperty("email")          String email,
+    @JsonProperty("first_name")     String firstName,
+    @JsonProperty("last_name")      String lastName,
+    @JsonProperty("is_active")      Boolean isActive,
+    @JsonProperty("is_org_admin")   Boolean isOrgAdmin,
+    @JsonProperty("is_internal")    Boolean isInternal,
+    @JsonProperty("locale")         String locale
+) {
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/MBOPUser.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/mbop/MBOPUser.java
@@ -1,16 +1,13 @@
 package com.redhat.cloud.notifications.recipients.mbop;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 /**
- * Represents the response to the {@link MBOPService#getUsersByOrgId(String, boolean, String, int, int)}
+ * Represents the response to the {@link MBOPService#getUsersByOrgId(String, String, String, String, boolean, String, int, int)}
  * REST API call. The {@link JsonProperty} annotations are required because
  * otherwise Jackson struggles to deserialize the incoming payload into a
  * record structure.
  */
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record MBOPUser(
     @JsonProperty("id")             String id,
     @JsonProperty("username")       String username,

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProvider.java
@@ -94,6 +94,15 @@ public class RbacRecipientUsersProvider {
     @ConfigProperty(name = "mbop.retry.back-off.max-value", defaultValue = "1S")
     Duration MBOPMaxBackOff;
 
+    @ConfigProperty(name = "processor.email.bop_apitoken")
+    String bopApiToken;
+
+    @ConfigProperty(name = "processor.email.bop_client_id")
+    String bopClientId;
+
+    @ConfigProperty(name = "processor.email.bop_env")
+    String bopEnv;
+
     @Inject
     MeterRegistry meterRegistry;
 
@@ -178,7 +187,16 @@ public class RbacRecipientUsersProvider {
                 // the captured variables.
                 int finalOffset = offset;
                 final List<MBOPUser> receivedUsers = this.retryOnMBOPError(() ->
-                    this.mbopService.getUsersByOrgId(orgId, adminsOnly, MBOP_SORT_ORDER, this.MBOPMaxResultsPerPage, finalOffset)
+                    this.mbopService.getUsersByOrgId(
+                        this.bopApiToken,
+                        this.bopClientId,
+                        this.bopEnv,
+                        orgId,
+                        adminsOnly,
+                        MBOP_SORT_ORDER,
+                        this.MBOPMaxResultsPerPage,
+                        finalOffset
+                    )
                 );
 
                 mbopUsers.addAll(receivedUsers);

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -203,8 +203,7 @@ quarkus.rest-client.export-service.trust-store-type=${clowder.private-endpoints.
 # Quarkus caches
 quarkus.cache.caffeine.drawer-template.expire-after-write=PT5M
 
-# REST client settings for the back office proxy, BOP or MBOP.
+# REST client settings for the back office proxy, BOP or MBOP. The proxy isn't
+# a Clowder application, so the parameter must be overriden in stage and
+# production.
 quarkus.rest-client.mbop.url=http://localhost:8090
-quarkus.rest-client.mbop.trust-store=${clowder.private-endpoints.export-service-service.trust-store-path}
-quarkus.rest-client.mbop.trust-store-password=${clowder.private-endpoints.export-service-service.trust-store-password}
-quarkus.rest-client.mbop.trust-store-type=${clowder.private-endpoints.export-service-service.trust-store-type}

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -130,6 +130,7 @@ quarkus.log.sentry.in-app-packages=*
 quarkus.log.sentry.dsn=FILL_ME
 
 # BOP properties
+quarkus.rest-client.mbop.url=https://backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
 processor.email.bop_url=https://backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
 processor.email.bop_apitoken=addme
 processor.email.bop_client_id=policies
@@ -202,8 +203,3 @@ quarkus.rest-client.export-service.trust-store-type=${clowder.private-endpoints.
 
 # Quarkus caches
 quarkus.cache.caffeine.drawer-template.expire-after-write=PT5M
-
-# REST client settings for the back office proxy, BOP or MBOP. The proxy isn't
-# a Clowder application, so the parameter must be overriden in stage and
-# production.
-quarkus.rest-client.mbop.url=http://localhost:8090

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -202,3 +202,9 @@ quarkus.rest-client.export-service.trust-store-type=${clowder.private-endpoints.
 
 # Quarkus caches
 quarkus.cache.caffeine.drawer-template.expire-after-write=PT5M
+
+# REST client settings for the back office proxy, BOP or MBOP.
+quarkus.rest-client.mbop.url=http://localhost:8090
+quarkus.rest-client.mbop.trust-store=${clowder.private-endpoints.export-service-service.trust-store-path}
+quarkus.rest-client.mbop.trust-store-password=${clowder.private-endpoints.export-service-service.trust-store-password}
+quarkus.rest-client.mbop.trust-store-type=${clowder.private-endpoints.export-service-service.trust-store-type}

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -130,7 +130,7 @@ quarkus.log.sentry.in-app-packages=*
 quarkus.log.sentry.dsn=FILL_ME
 
 # BOP properties
-quarkus.rest-client.mbop.url=https://backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
+quarkus.rest-client.mbop.url=${processor.email.bop_url}
 processor.email.bop_url=https://backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
 processor.email.bop_apitoken=addme
 processor.email.bop_client_id=policies

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailTest.java
@@ -20,6 +20,7 @@ import com.redhat.cloud.notifications.recipients.itservice.pojo.response.Account
 import com.redhat.cloud.notifications.recipients.itservice.pojo.response.Authentication;
 import com.redhat.cloud.notifications.recipients.itservice.pojo.response.ITUserResponse;
 import com.redhat.cloud.notifications.recipients.itservice.pojo.response.PersonalInformation;
+import com.redhat.cloud.notifications.recipients.mbop.Constants;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.vertx.core.json.JsonArray;
@@ -116,9 +117,9 @@ public class EmailTest {
         final List<String> bodyRequests = new ArrayList<>();
 
         ExpectationResponseCallback verifyEmptyRequest = req -> {
-            assertEquals(BOP_TOKEN, req.getHeader(EmailSender.BOP_APITOKEN_HEADER).get(0));
-            assertEquals(BOP_CLIENT_ID, req.getHeader(EmailSender.BOP_CLIENT_ID_HEADER).get(0));
-            assertEquals(BOP_ENV, req.getHeader(EmailSender.BOP_ENV_HEADER).get(0));
+            assertEquals(BOP_TOKEN, req.getHeader(Constants.MBOP_APITOKEN_HEADER).get(0));
+            assertEquals(BOP_CLIENT_ID, req.getHeader(Constants.MBOP_CLIENT_ID_HEADER).get(0));
+            assertEquals(BOP_ENV, req.getHeader(Constants.MBOP_ENV_HEADER).get(0));
             bodyRequests.add(req.getBodyAsString());
             return response().withStatusCode(200);
         };
@@ -205,9 +206,9 @@ public class EmailTest {
         final List<String> bodyRequests = new ArrayList<>();
 
         ExpectationResponseCallback verifyEmptyRequest = req -> {
-            assertEquals(BOP_TOKEN, req.getHeader(EmailSender.BOP_APITOKEN_HEADER).get(0));
-            assertEquals(BOP_CLIENT_ID, req.getHeader(EmailSender.BOP_CLIENT_ID_HEADER).get(0));
-            assertEquals(BOP_ENV, req.getHeader(EmailSender.BOP_ENV_HEADER).get(0));
+            assertEquals(BOP_TOKEN, req.getHeader(Constants.MBOP_APITOKEN_HEADER).get(0));
+            assertEquals(BOP_CLIENT_ID, req.getHeader(Constants.MBOP_CLIENT_ID_HEADER).get(0));
+            assertEquals(BOP_ENV, req.getHeader(Constants.MBOP_ENV_HEADER).get(0));
             bodyRequests.add(req.getBodyAsString());
             return response().withStatusCode(200);
         };

--- a/engine/src/test/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProviderTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/recipients/rbac/RbacRecipientUsersProviderTest.java
@@ -52,6 +52,15 @@ public class RbacRecipientUsersProviderTest {
     @ConfigProperty(name = "recipient-provider.mbop.max-results-per-page", defaultValue = "1000")
     int MBOPMaxResultsPerPage;
 
+    @ConfigProperty(name = "processor.email.bop_apitoken")
+    String bopApiToken;
+
+    @ConfigProperty(name = "processor.email.bop_client_id")
+    String bopClientId;
+
+    @ConfigProperty(name = "processor.email.bop_env")
+    String bopEnv;
+
     @InjectMock
     @RestClient
     RbacServiceToService rbacServiceToService;
@@ -306,7 +315,7 @@ public class RbacRecipientUsersProviderTest {
             // the configured maximum limit, so that we can test that the loop
             // is working as expected.
             Mockito
-                .when(this.mbopService.getUsersByOrgId(Mockito.eq(TestConstants.DEFAULT_ORG_ID), Mockito.eq(adminsOnly), Mockito.eq(RbacRecipientUsersProvider.MBOP_SORT_ORDER), Mockito.eq(this.MBOPMaxResultsPerPage), Mockito.anyInt()))
+                .when(this.mbopService.getUsersByOrgId(Mockito.eq(this.bopApiToken), Mockito.eq(this.bopClientId), Mockito.eq(this.bopEnv), Mockito.eq(TestConstants.DEFAULT_ORG_ID), Mockito.eq(adminsOnly), Mockito.eq(RbacRecipientUsersProvider.MBOP_SORT_ORDER), Mockito.eq(this.MBOPMaxResultsPerPage), Mockito.anyInt()))
                 .thenReturn(firstPageMBOPUsers, secondPageMBOPUsers, thirdPageMBOPUsers);
 
             // Call the function under test.
@@ -315,7 +324,7 @@ public class RbacRecipientUsersProviderTest {
             // Verify that the offset argument, which is the one that changes
             // on each iteration, has been correctly incremented.
             final ArgumentCaptor<Integer> capturedOffset = ArgumentCaptor.forClass(Integer.class);
-            Mockito.verify(this.mbopService, Mockito.times(3)).getUsersByOrgId(Mockito.eq(TestConstants.DEFAULT_ORG_ID), Mockito.eq(adminsOnly), Mockito.eq(RbacRecipientUsersProvider.MBOP_SORT_ORDER), Mockito.eq(this.MBOPMaxResultsPerPage), capturedOffset.capture());
+            Mockito.verify(this.mbopService, Mockito.times(3)).getUsersByOrgId(Mockito.eq(this.bopApiToken), Mockito.eq(this.bopClientId), Mockito.eq(this.bopEnv), Mockito.eq(TestConstants.DEFAULT_ORG_ID), Mockito.eq(adminsOnly), Mockito.eq(RbacRecipientUsersProvider.MBOP_SORT_ORDER), Mockito.eq(this.MBOPMaxResultsPerPage), capturedOffset.capture());
 
             final List<Integer> capturedValues = capturedOffset.getAllValues();
             assertIterableEquals(


### PR DESCRIPTION
Notifications shouldn't be directly calling the IT service for users, since MBOP has been designed and developed to act as the middleman, thus saving us from having to deal with things like certificates in our application. Therefore, this is the first step to replace that integration.

## Links

[[RHCLOUD-23645]](https://issues.redhat.com/browse/RHCLOUD-23645)