### PR TITLE
RHCLOUD-26894 | feature: remove the export service's parameters from Clowder

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -244,14 +244,6 @@ objects:
           value: ${QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL}
         - name: NOTIFICATIONS_DRAWER_ENABLED
           value: ${NOTIFICATIONS_DRAWER_ENABLED}
-        - name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_URL
-          value: ${QUARKUS_REST_CLIENT_EXPORT_SERVICE_URL}
-        - name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_TRUST_STORE
-          value: ${QUARKUS_REST_CLIENT_EXPORT_SERVICE_TRUST_STORE}
-        - name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_TRUST_STORE_PASSWORD
-          value: ${QUARKUS_REST_CLIENT_EXPORT_SERVICE_TRUST_STORE_PASSWORD}
-        - name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_TRUST_STORE_TYPE
-          value: ${QUARKUS_REST_CLIENT_EXPORT_SERVICE_TRUST_STORE_TYPE}
 parameters:
 - name: BACKOFFICE_CLIENT_ENV
   description: Back-office client environment
@@ -418,15 +410,3 @@ parameters:
   value: INFO
 - name: NOTIFICATIONS_DRAWER_ENABLED
   value: "false"
-- name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_URL
-  description: Temporary workaround - Remove when the export service configuration is available in Clowder in production
-  value: "${clowder.private-endpoints.export-service-service.url:http://localhost:10010}"
-- name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_TRUST_STORE
-  description: Temporary workaround - Remove when the export service configuration is available in Clowder in production
-  value: "${clowder.private-endpoints.export-service-service.trust-store-path}"
-- name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_TRUST_STORE_PASSWORD
-  description: Temporary workaround - Remove when the export service configuration is available in Clowder in production
-  value: "${clowder.private-endpoints.export-service-service.trust-store-password}"
-- name: QUARKUS_REST_CLIENT_EXPORT_SERVICE_TRUST_STORE_TYPE
-  description: Temporary workaround - Remove when the export service configuration is available in Clowder in production
-  value: "${clowder.private-endpoints.export-service-service.trust-store-type}"


### PR DESCRIPTION
The export service got released in production, and the DevProd team confirmed that we do have their connection details in the "private endpoints" section in our configuration file.

## Links

[[RHCLOUD-26894]](https://issues.redhat.com/browse/RHCLOUD-26894)