### PR TITLE
Make export-service a hard dependency

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -16,8 +16,8 @@ objects:
     - ingress
     - notifications-backend
     - rbac
-    optionalDependencies:
     - export-service
+    optionalDependencies:
     - sources-api # https://issues.redhat.com/browse/RHCLOUD-23993
     database:
       sharedDbAppName: notifications-backend


### PR DESCRIPTION
To make sure we always deploy the export-service along the engine :)