### PR TITLE
RHCLOUD-25256 Replace Splunk /raw endpoint with /event endpoint

### DIFF
--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractor.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractor.java
@@ -23,6 +23,8 @@ public class SplunkCloudEventDataExtractor extends CloudEventDataExtractor {
     public static final String SERVICES_COLLECTOR = "/services/collector";
     public static final String EVENT = "/event";
     public static final String SERVICES_COLLECTOR_EVENT = SERVICES_COLLECTOR + EVENT;
+    public static final String RAW = "/raw";
+    public static final String SERVICES_COLLECTOR_RAW = SERVICES_COLLECTOR + RAW;
 
     private static final UrlValidator HTTP_URL_VALIDATOR = new UrlValidator(new String[] {"http"}, ALLOW_LOCAL_URLS);
     private static final UrlValidator HTTPS_URL_VALIDATOR = new UrlValidator(new String[] {"https"}, ALLOW_LOCAL_URLS);
@@ -62,7 +64,9 @@ public class SplunkCloudEventDataExtractor extends CloudEventDataExtractor {
             targetUrl = targetUrl.substring(0, targetUrl.length() - 1);
         }
         if (!targetUrl.endsWith(SERVICES_COLLECTOR_EVENT)) {
-            if (targetUrl.endsWith(SERVICES_COLLECTOR)) {
+            if (targetUrl.endsWith(SERVICES_COLLECTOR_RAW)) {
+                targetUrl = targetUrl.substring(0, targetUrl.length() - RAW.length()) + EVENT;
+            } else if (targetUrl.endsWith(SERVICES_COLLECTOR)) {
                 targetUrl += EVENT;
             } else {
                 targetUrl += SERVICES_COLLECTOR_EVENT;

--- a/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractorTest.java
+++ b/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractorTest.java
@@ -114,6 +114,11 @@ public class SplunkCloudEventDataExtractorTest extends CamelQuarkusTestSupport {
         testExtract("https://foo.bar/services/collector/event", false);
     }
 
+    @Test
+    void testExtractWithRawTargetUrlPath() throws Exception {
+        testExtract("https://foo.bar/services/collector/raw", false);
+    }
+
     private void assertValidTargetUrl(String url) {
         Exchange exchange = createExchangeWithBody("I am not used!");
         JsonObject cloudEventData = createCloudEventData(url, false);
@@ -138,7 +143,6 @@ public class SplunkCloudEventDataExtractorTest extends CamelQuarkusTestSupport {
 
         assertEquals(exchange.getProperty(ORG_ID, String.class), cloudEventData.getString("org_id"));
         assertEquals(exchange.getProperty(ACCOUNT_ID, String.class), cloudEventData.getString("account_id"));
-        assertTrue(exchange.getProperty(TARGET_URL, String.class).contains(cloudEventDataCopy.getJsonObject(NOTIF_METADATA).getString("url")));
         assertTrue(exchange.getProperty(TARGET_URL, String.class).endsWith(SERVICES_COLLECTOR_EVENT));
         // Trailing slashes should be removed before we modify the target URL path.
         assertFalse(exchange.getProperty(TARGET_URL, String.class).endsWith("/" + SERVICES_COLLECTOR_EVENT));


### PR DESCRIPTION
https://docs.splunk.com/Documentation/Splunk/9.0.5/Data/HECRESTendpoints

While this is not requested, org admins may add the `/services/collector/raw` path at the end of their Splunk URL, in the integrations settings. When that happens, we want to send to events to `/services/collector/event` instead.