### PR TITLE
Lower default CPU request/limit for all connectors

### DIFF
--- a/.rhcicd/clowdapp-connector-google-chat.yaml
+++ b/.rhcicd/clowdapp-connector-google-chat.yaml
@@ -95,10 +95,10 @@ parameters:
   value: "500"
 - name: CPU_LIMIT
   description: CPU limit
-  value: 500m
+  value: 200m
 - name: CPU_REQUEST
   description: CPU request
-  value: 250m
+  value: 100m
 - name: ENV_NAME
   description: ClowdEnvironment name (ephemeral, stage, prod)
   required: true

--- a/.rhcicd/clowdapp-connector-microsoft-teams.yaml
+++ b/.rhcicd/clowdapp-connector-microsoft-teams.yaml
@@ -95,10 +95,10 @@ parameters:
   value: "500"
 - name: CPU_LIMIT
   description: CPU limit
-  value: 500m
+  value: 200m
 - name: CPU_REQUEST
   description: CPU request
-  value: 250m
+  value: 100m
 - name: ENV_NAME
   description: ClowdEnvironment name (ephemeral, stage, prod)
   required: true

--- a/.rhcicd/clowdapp-connector-slack.yaml
+++ b/.rhcicd/clowdapp-connector-slack.yaml
@@ -95,10 +95,10 @@ parameters:
   value: "500"
 - name: CPU_LIMIT
   description: CPU limit
-  value: 500m
+  value: 200m
 - name: CPU_REQUEST
   description: CPU request
-  value: 250m
+  value: 100m
 - name: ENV_NAME
   description: ClowdEnvironment name (ephemeral, stage, prod)
   required: true

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -95,10 +95,10 @@ parameters:
   value: "500"
 - name: CPU_LIMIT
   description: CPU limit
-  value: 500m
+  value: 200m
 - name: CPU_REQUEST
   description: CPU request
-  value: 250m
+  value: 100m
 - name: ENV_NAME
   description: ClowdEnvironment name (ephemeral, stage, prod)
   required: true


### PR DESCRIPTION
The new default values are the ones currently used in all environments where the connectors are deployed.