### PR TITLE
RHCLOUD-27092 Prevent duplicate Kafka processing for Splunk

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -244,6 +244,8 @@ objects:
           value: ${QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL}
         - name: NOTIFICATIONS_DRAWER_ENABLED
           value: ${NOTIFICATIONS_DRAWER_ENABLED}
+        - name: NOTIFICATIONS_SPLUNK_CONNECTOR_KAFKA_PROCESSING_ENABLED
+          value: ${NOTIFICATIONS_SPLUNK_CONNECTOR_KAFKA_PROCESSING_ENABLED}
 parameters:
 - name: BACKOFFICE_CLIENT_ENV
   description: Back-office client environment
@@ -409,4 +411,6 @@ parameters:
   description: When QUARKUS_REST_CLIENT_LOGGING_SCOPE is set to 'request-response', this logger level needs to be set to DEBUG
   value: INFO
 - name: NOTIFICATIONS_DRAWER_ENABLED
+  value: "false"
+- name: NOTIFICATIONS_SPLUNK_CONNECTOR_KAFKA_PROCESSING_ENABLED
   value: "false"

--- a/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/config/FeatureFlipper.java
@@ -87,6 +87,9 @@ public class FeatureFlipper {
     @ConfigProperty(name = "notifications.add.default.recipient.on.single.email.enabled", defaultValue = "true")
     boolean addDefaultRecipientOnSingleEmail;
 
+    @ConfigProperty(name = "notifications.splunk-connector.kafka-processing.enabled", defaultValue = "false")
+    boolean splunkConnectorKafkaProcessingEnabled;
+
     void logFeaturesStatusAtStartup(@Observes StartupEvent event) {
         Log.infof("=== %s startup status ===", FeatureFlipper.class.getSimpleName());
         Log.infof("The behavior groups unique name constraint is %s", enforceBehaviorGroupNameUnicity ? "enabled" : "disabled");
@@ -105,6 +108,7 @@ public class FeatureFlipper {
         Log.infof("The integration with the export service is %s", exportServiceIntegrationEnabled ? "enabled" : "disabled");
         Log.infof("Drawer feature is %s", drawerEnabled ? "enabled" : "disabled");
         Log.infof("The add of default recipient on single email is %s", addDefaultRecipientOnSingleEmail ? "enabled" : "disabled");
+        Log.infof("The Kafka processing in the Splunk connector is %s", splunkConnectorKafkaProcessingEnabled ? "enabled" : "disabled");
     }
 
     public boolean isEnforceBehaviorGroupNameUnicity() {
@@ -245,6 +249,10 @@ public class FeatureFlipper {
     public void setAddDefaultRecipientOnSingleEmail(boolean addDefaultRecipientOnSingleEmail) {
         checkTestLaunchMode();
         this.addDefaultRecipientOnSingleEmail = addDefaultRecipientOnSingleEmail;
+    }
+
+    public boolean isSplunkConnectorKafkaProcessingEnabled() {
+        return splunkConnectorKafkaProcessingEnabled;
     }
 
     /**

--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/ExchangeProperty.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/ExchangeProperty.java
@@ -6,4 +6,6 @@ public class ExchangeProperty {
     public static final String AUTHENTICATION_TOKEN = "authenticationToken";
     public static final String TARGET_URL_NO_SCHEME = "targetUrlNoScheme";
     public static final String TRUST_ALL = "trustAll";
+    // TODO For migration purposes - Remove ASAP!
+    public static final String KAFKA_PROCESSOR = "kafkaProcessor";
 }

--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/MigrationFilter.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/MigrationFilter.java
@@ -1,0 +1,24 @@
+package com.redhat.cloud.notifications.connector.splunk;
+
+import io.quarkus.logging.Log;
+import org.apache.camel.Exchange;
+import org.apache.camel.Predicate;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.KAFKA_PROCESSOR;
+
+@ApplicationScoped
+public class MigrationFilter implements Predicate {
+
+    @Override
+    public boolean matches(Exchange exchange) {
+        String kafkaProcessor = exchange.getProperty(KAFKA_PROCESSOR, String.class);
+        if ("connector".equals(kafkaProcessor)) {
+            return true;
+        } else {
+            Log.info("Kafka message ignored because it is marked to be processed by the Eventing app");
+            return false;
+        }
+    }
+}

--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractor.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractor.java
@@ -12,6 +12,7 @@ import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.TARGET_URL;
 import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.ACCOUNT_ID;
 import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.AUTHENTICATION_TOKEN;
+import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.KAFKA_PROCESSOR;
 import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.TARGET_URL_NO_SCHEME;
 import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.TRUST_ALL;
 import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URLS;
@@ -40,6 +41,7 @@ public class SplunkCloudEventDataExtractor extends CloudEventDataExtractor {
         exchange.setProperty(TARGET_URL, metadata.getString("url"));
         exchange.setProperty(AUTHENTICATION_TOKEN, metadata.getString("X-Insight-Token"));
         exchange.setProperty(TRUST_ALL, Boolean.valueOf(metadata.getString("trustAll")));
+        exchange.setProperty(KAFKA_PROCESSOR, metadata.getString("kafkaProcessor"));
         cloudEventData.remove(NOTIF_METADATA);
 
         validateTargetUrl(exchange);

--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkRouteBuilder.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkRouteBuilder.java
@@ -26,12 +26,17 @@ public class SplunkRouteBuilder extends EngineToConnectorRouteBuilder {
     ConnectorConfig connectorConfig;
 
     @Inject
+    MigrationFilter migrationFilter;
+
+    @Inject
     EventsSplitter eventsSplitter;
 
     @Override
     public void configureRoute() {
         from(direct(ENGINE_TO_CONNECTOR))
                 .routeId(connectorConfig.getConnectorName())
+                // TODO For migration purposes - Remove ASAP!
+                .filter(migrationFilter)
                 // Events are split to be sent in batch to Splunk HEC.
                 .process(eventsSplitter)
                 .setHeader("Authorization", simple("Splunk ${exchangeProperty." + AUTHENTICATION_TOKEN + "}"))

--- a/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkConnectorRoutesTest.java
+++ b/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkConnectorRoutesTest.java
@@ -43,6 +43,7 @@ public class SplunkConnectorRoutesTest extends ConnectorRoutesTest {
         metadata.put("url", targetUrl);
         metadata.put("X-Insight-Token", "super-secret-token");
         metadata.put("trustAll", "true");
+        metadata.put("kafkaProcessor", "connector");
 
         JsonObject payload = new JsonObject();
         payload.put(NOTIF_METADATA, metadata);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
@@ -87,6 +87,11 @@ public class EventingProcessor extends EndpointTypeProcessor {
 
         JsonObject payload = buildPayload(event, endpoint, originalEventId);
 
+        // TODO For migration purposes - Remove ASAP!
+        if (featureFlipper.isSplunkConnectorKafkaProcessingEnabled() && "splunk".equals(endpoint.getSubType())) {
+            payload.getJsonObject(NOTIF_METADATA_KEY).put("kafkaProcessor", "connector");
+        }
+
         try {
             connectorSender.send(payload, historyId, endpoint.getSubType());
         } catch (Exception e) {


### PR DESCRIPTION
Related to https://github.com/RedHatInsights/eventing-integrations/pull/210

When `notifications-connector-splunk` will be deployed in production, it will belong to a different Kafka group (`notifications-connector-splunk`) compared to the old eventing app (`eventing-splunk`). Because of that change, the connector will automatically consume the Kafka topic from the smallest Kafka offset available rather than from the offset of the latest message consumed by the `eventing-splunk` Kafka group.

This PR introduces the `NOTIFICATIONS_SPLUNK_CONNECTOR_KAFKA_PROCESSING_ENABLED` feature flag in `engine` which will be used to prevent duplicate processing during the switch from eventing to the connector. When that flag is `true` and a message is produced, the connector will consume that message and eventing will ignore it. When the flag is `false` or missing, eventing will consume the message and the connector will ignore it.