### PR TITLE
RHCLOUD-27100 | fix: inaccuracies with OpenAPI descriptions

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/OrgConfigResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/OrgConfigResourceTest.java
@@ -62,10 +62,10 @@ class OrgConfigResourceTest extends DbIsolatedTest {
 
         Header testMinIdentityHeader = TestHelpers.createRHIdentityHeader(testMinIdentityHeaderValue);
 
-        recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 00), Response.Status.OK.getStatusCode());
-        recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 15), Response.Status.OK.getStatusCode());
-        recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 30), Response.Status.OK.getStatusCode());
-        recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 45), Response.Status.OK.getStatusCode());
+        recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 00), Response.Status.NO_CONTENT.getStatusCode());
+        recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 15), Response.Status.NO_CONTENT.getStatusCode());
+        recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 30), Response.Status.NO_CONTENT.getStatusCode());
+        recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 45), Response.Status.NO_CONTENT.getStatusCode());
         assertEquals(ERROR_MESSAGE_WRONG_MINUTE_VALUE, recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 10), Response.Status.BAD_REQUEST.getStatusCode()));
         assertEquals(ERROR_MESSAGE_WRONG_MINUTE_VALUE, recordDailyDigestTimePreference(testMinIdentityHeader, LocalTime.of(5, 55), Response.Status.BAD_REQUEST.getStatusCode()));
     }
@@ -97,7 +97,7 @@ class OrgConfigResourceTest extends DbIsolatedTest {
     }
 
     private void recordDefaultDailyDigestTimePreference() {
-        recordDailyDigestTimePreference(identityHeader, TIME, Response.Status.OK.getStatusCode());
+        recordDailyDigestTimePreference(identityHeader, TIME, Response.Status.NO_CONTENT.getStatusCode());
     }
 
     private String recordDailyDigestTimePreference(Header header, LocalTime time, int expectedReturnCode) {


### PR DESCRIPTION
The OpenAPI descriptions were describing a bit of a different endpoints than the ones that we had annotated. This was causing the automatically generated clients to not fully comply with the endpoints implemented in the backend, thus causing requests processing to fail.

## Links

[[RHCLOUD-27100]](https://issues.redhat.com/browse/RHCLOUD-27100)