### PR TITLE
feat(HMS-1551): Add images email templates

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ImageBuilderAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ImageBuilderAggregator.java
@@ -1,0 +1,81 @@
+package com.redhat.cloud.notifications.processors.email.aggregators;
+
+import com.redhat.cloud.notifications.models.EmailAggregation;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ImageBuilderAggregator extends AbstractEmailPayloadAggregator {
+
+    private static final String EVENT_TYPE = "event_type";
+    private static final String LAUNCH_SUCCESS = "launch-success";
+    private static final String LAUNCH_FAILURE = "launch-failed";
+    private static final String AWS = "aws";
+    private static final String GCP = "gcp";
+    private static final String AZURE = "azure";
+
+    private static final List<String> EVENT_TYPES = Arrays.asList(LAUNCH_SUCCESS, LAUNCH_FAILURE);
+
+    private static final String IMAGE_LAUNCH_KEY = "images";
+    private static final String EVENTS_KEY = "events";
+    private static final String CONTEXT_KEY = "context";
+    private static final String PAYLOAD_KEY = "payload";
+    private static final String PROVIDER = "provider";
+    private static final String INSTANCES_KEY = "instances";
+    private static final String FAILURE_KEY = "failure";
+    private static final String LAUNCH_SUCCESS_KEY = "launch_success";
+    private static final String ERRORS = "errors";
+    private static final String PROVIDER_INIT_JSON = "{\"instances\": 0, \"launch_success\": 0, \"failure\": 0}";
+
+    public ImageBuilderAggregator() {
+        JsonObject imageLaunch = new JsonObject();
+        imageLaunch.put(AWS, new JsonObject(PROVIDER_INIT_JSON));
+        imageLaunch.put(GCP, new JsonObject(PROVIDER_INIT_JSON));
+        imageLaunch.put(AZURE, new JsonObject(PROVIDER_INIT_JSON));
+        imageLaunch.put(ERRORS, new JsonArray());
+        imageLaunch.put(LAUNCH_SUCCESS_KEY, 0);
+
+        context.put(IMAGE_LAUNCH_KEY, imageLaunch);
+    }
+
+    @Override
+    void processEmailAggregation(EmailAggregation notification) {
+        JsonObject imageLaunch = context.getJsonObject(IMAGE_LAUNCH_KEY);
+        JsonObject notificationJson = notification.getPayload();
+        String eventType = notificationJson.getString(EVENT_TYPE);
+
+        if (!EVENT_TYPES.contains(eventType)) {
+            return;
+        }
+
+        JsonObject context = notificationJson.getJsonObject(CONTEXT_KEY);
+        String provider = context.getString(PROVIDER);
+        Integer numberOfInstances = notificationJson.getJsonArray(EVENTS_KEY).size();
+        Integer prevNumberOfInstances;
+        Integer prevNumberOfFailures;
+
+        switch (eventType) {
+            case LAUNCH_SUCCESS:
+                prevNumberOfInstances = imageLaunch.getJsonObject(provider).getInteger(INSTANCES_KEY);
+                imageLaunch.getJsonObject(provider).put(INSTANCES_KEY, prevNumberOfInstances + numberOfInstances);
+                imageLaunch.put(LAUNCH_SUCCESS_KEY, imageLaunch.getInteger(LAUNCH_SUCCESS_KEY) + 1);
+                imageLaunch.getJsonObject(provider).put(LAUNCH_SUCCESS_KEY, imageLaunch.getJsonObject(provider).getInteger(LAUNCH_SUCCESS_KEY) + 1);
+                break;
+            case LAUNCH_FAILURE:
+                prevNumberOfFailures = imageLaunch.getJsonObject(provider).getInteger(FAILURE_KEY);
+                imageLaunch.getJsonObject(provider).put(FAILURE_KEY, prevNumberOfFailures + 1);
+                notificationJson.getJsonArray(EVENTS_KEY).stream().forEach(eventObject -> {
+                    JsonObject event = (JsonObject) eventObject;
+                    JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
+
+                    JsonArray collection = imageLaunch.getJsonArray(ERRORS);
+                    collection.add(payload.getString(ERRORS));
+                });
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -420,6 +420,26 @@ public class EmailTemplateMigrationService {
                 "Vulnerability/dailyEmailBody", "html", "Vulnerability daily email body"
             );
 
+            /*
+             * Former src/main/resources/templates/ImageBuilder folder.
+             */
+
+            createInstantEmailTemplate(
+                warnings, "rhel", "image-builder", List.of("launch-success"),
+                "ImageBuilder/launchSuccessInstantEmailTitle", "txt", "Image Builder launch success title",
+                "ImageBuilder/launchSuccessInstantEmailBody", "html", "Image Builder launch success body"
+            );
+            createInstantEmailTemplate(
+                warnings, "rhel", "image-builder", List.of("launch-failed"),
+                "ImageBuilder/launchFailedInstantEmailTitle", "txt", "Image Builder launch failed title",
+                "ImageBuilder/launchFailedEmailBody", "html", "Image Builder launch failed body"
+            );
+            createDailyEmailTemplate(
+                warnings, "rhel", "image-builder",
+                "ImageBuilder/dailyEmailTitle", "txt", "Image Builder daily digest title",
+                "ImageBuilder/dailyEmailBody", "html", "Image Builder daily digest body"
+            );
+
             getOrCreateTemplate("Common/insightsEmailBody", "html", "Common Insights email body");
         }
         Log.debug("Migration ended");

--- a/engine/src/main/resources/templates/ImageBuilder/dailyEmailBodyV2.html
+++ b/engine/src/main/resources/templates/ImageBuilder/dailyEmailBodyV2.html
@@ -1,0 +1,74 @@
+{@boolean renderSection1AsIncident=action.context.images.errors.size}
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{@boolean renderSection3=true}
+{@boolean renderButtonSection3=true}
+
+{#include Common/insightsEmailBody}
+{#content-title}
+    Daily digest - Image builder - Red Hat Enterprise Linux
+{/content-title}
+{#content-title-section1}
+    Launch failures
+{/content-title-section1}
+{#content-subtitle-section1}
+   {action.context.images.errors.size} launch attempts failed
+{/content-subtitle-section1}
+{#content-title-right-part-section1}
+   {action.context.images.errors.size}
+{/content-title-right-part-section1}
+{#content-body-section1}
+    <table class="rh-data-table-bordered">
+        <thead>
+        <tr>
+            <th>AWS</th>
+            <th>Azure</th>
+            <th>Google cloud</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>{action.context.images.aws.failure}</td>
+            <td>{action.context.images.azure.failure}</td>
+            <td>{action.context.images.gcp.failure}</td>
+        </tr>
+        </tbody>
+    </table>
+{/content-body-section1}
+{#content-title-section2}
+    Successful launch
+{/content-title-section2}
+{#content-subtitle-section2}
+    {action.context.images.launch_success} launch attempts deployed
+     {action.context.images.aws.instances + action.context.images.gcp.instances + action.context.images.azure.instances} instances
+{/content-subtitle-section2}
+{#content-title-right-part-section2}
+   {action.context.images.launch_success}
+{/content-title-right-part-section2}
+{#content-body-section2}
+    <table class="rh-data-table-bordered">
+        <thead>
+        <tr>
+            <th>AWS</th>
+            <th>Azure</th>
+            <th>Google cloud</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td><a target="_blank" href="https://aws.amazon.com/console/">{action.context.images.aws.launch_success} ({action.context.images.aws.instances} instances)</a></td>
+            <td><a target="_blank" href="https://azure.microsoft.com">{action.context.images.azure.launch_success} ({action.context.images.azure.instances} instances)</a></td>
+            <td><a target="_blank" href="https://console.cloud.google.com">{action.context.images.gcp.launch_success} ({action.context.images.gcp.instances} instances)</a></td>
+        </tr>
+        </tbody>
+    </table>
+{/content-body-section2}
+{#content-body-section3}
+    <p>
+    For more details, go to Insights Inventory - Red Hat Enterprise Linux.
+    </p>
+{/content-body-section3}
+{#content-button-section3}
+    <a target="_blank" href="{environment.url}/insights/inventroy">Open Insights Inventory</a>
+{/content-button-section3}
+{/include}

--- a/engine/src/main/resources/templates/ImageBuilder/dailyEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/ImageBuilder/dailyEmailTitleV2.txt
@@ -1,0 +1,1 @@
+Daily digest - Image builder - Red Hat Enterprise Linux

--- a/engine/src/main/resources/templates/ImageBuilder/launchFailedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/ImageBuilder/launchFailedEmailBodyV2.html
@@ -1,0 +1,29 @@
+{@boolean renderSection1=true}
+{@boolean renderSection1AsIncident=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Image builder - Red Hat Enterprise Linux
+{/content-title}
+{#content-title-section1}
+    An image failed to launch on
+{#switch action.context.provider}
+{#case "aws"}
+Amazon Web Services
+{#case "azure"}
+Microsoft Azure
+{#case "gcp"}
+Google Cloud Platform
+{/switch}
+{/content-title-section1}
+{#content-subtitle-section1}
+{action.timestamp.toStringFormat()} | launch id #{action.context.launch_id}
+{/content-subtitle-section1}
+{#content-body-section1}
+    <p>
+        <i>{action.events[0].payload.error}</i>
+    </p>
+    <p>
+        If this issue persists please contact <a class="rh-url" href="https://access.redhat.com/support">Red Hat support</a>.
+    </p>
+{/content-body-section1}
+{/include}

--- a/engine/src/main/resources/templates/ImageBuilder/launchFailedInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/ImageBuilder/launchFailedInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+Instant notification - image launch failed - Image builder - Red Hat Enterprise Linux

--- a/engine/src/main/resources/templates/ImageBuilder/launchSuccessInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/ImageBuilder/launchSuccessInstantEmailBodyV2.html
@@ -1,0 +1,82 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{@boolean renderButtonSection2=true}
+{@boolean hideSubtitleSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+Images builder - Red Hat Enterprise Linux
+{/content-title}
+{#content-title-section1}
+Instances launched successfully
+{/content-title-section1}
+{#content-title-right-part-section1}
+{action.events.size}
+{/content-title-right-part-section1}
+{#content-subtitle-section1}
+via {#switch action.context.provider}
+{#case "aws"}
+Amazon web services
+{#case "azure"}
+Microsoft Azure
+{#case "gcp"}
+Google cloud
+{/switch}, on {action.timestamp.toUtcFormat()}
+{/content-subtitle-section1}
+{#content-body-section1}
+<table class="rh-data-table-bordered">
+    <thead>
+        <tr>
+            <th style="width: 30%">ID</th>
+            <th style="width: 35%">Public IPv4</th>
+            <th style="width: 35%">Public DNS</th>
+        </tr>
+    </thead>
+    <tbody>
+        {#each action.events}
+        <tr>
+            <td>
+                {it.payload.instance_id}
+            </td>
+            <td>
+                {it.payload.detail.public_ipv4}
+            </td>
+            <td>{it.payload.detail.public_dns}</td>
+        </tr>
+        {/each}
+    </tbody>
+</table>
+{/content-body-section1}
+
+{#content-body-section2}
+To see more details about the instances, go to
+{#switch action.context.provider}
+{#case "aws"}
+Amazon Web Services
+{#case "azure"}
+Microsoft Azure
+{#case "gcp"}
+Google Cloud Platform
+{/switch}
+{/content-body-section2}
+{#content-button-section2}
+<a target="_blank" href="{#switch action.context.provider}
+                        {#case "aws"}
+                        https://aws.amazon.com/console/
+                        {#case "azure"}
+                        https://azure.microsoft.com
+                        {#case "gcp"}
+                        https://console.cloud.google.com
+                       {/switch}">
+    <span>
+        {#switch action.context.provider}
+        {#case "aws"}
+        Open AWS
+        {#case "azure"}
+        Open Azure Portal
+        {#case "gcp"}
+        Open GCP console
+        {/switch}
+    </span>
+</a>
+{/content-button-section2}
+{/include}

--- a/engine/src/main/resources/templates/ImageBuilder/launchSuccessInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/ImageBuilder/launchSuccessInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+Instant notification - successful image launch - Image builder - Red Hat Enterprise Linux

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -552,6 +552,67 @@ public class TestHelpers {
         return emailActionMessage;
     }
 
+    public static EmailAggregation createImageBuilderAggregation(String eventType) {
+        EmailAggregation aggregation = new EmailAggregation();
+        aggregation.setBundleName("rhel");
+        aggregation.setApplicationName("image-builder");
+        aggregation.setOrgId(DEFAULT_ORG_ID);
+        Action action = createImageBuilderAction(eventType);
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(action));
+        return aggregation;
+    }
+
+    public static Action createImageBuilderAction(String eventType) {
+        Action emailActionMessage = new Action();
+        emailActionMessage.setBundle("rhel");
+        emailActionMessage.setApplication("image-builder");
+        emailActionMessage.setTimestamp(LocalDateTime.now());
+        emailActionMessage.setEventType(eventType);
+        emailActionMessage.setAccountId(StringUtils.EMPTY);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+        emailActionMessage.setRecipients(List.of());
+
+        emailActionMessage.setContext(
+            new Context.ContextBuilder()
+            .withAdditionalProperty("provider", "aws")
+            .withAdditionalProperty("launch_id", 3011)
+            .build());
+        if (eventType.equals("launch-success")) {
+            emailActionMessage.setEvents(List.of(
+                new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                    .withAdditionalProperty("instance_id", "i-0cbaed564af9faf")
+                    .withAdditionalProperty("detail",
+                        Map.of("public_ipv4", "92.123.32.3", "public_dns",
+                            "ec2-92-123-32-3.compute-1.amazonaws.com"))
+                    .build())
+                .build(),
+                new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                    .withAdditionalProperty("instance_id", "i-0aba12564af9faf")
+                    .withAdditionalProperty("detail",
+                        Map.of("public_ipv4", "91.123.32.4", "public_dns",
+                            "ec91.123.32.4.compute-1.amazonaws.com"))
+                    .build())
+                .build()));
+        } else {
+            emailActionMessage.setEvents(List.of(
+                new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                    .withAdditionalProperty("error", "Some launch error")
+                    .build())
+                .build()));
+
+        }
+        return emailActionMessage;
+    }
+
     public static Action createResourceOptimizationAction() {
         Map<String, Object> aggregatedData = new HashMap<>();
         aggregatedData.put(ResourceOptimizationPayloadAggregator.SYSTEMS_WITH_SUGGESTIONS, 134);

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestImageBuilderTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestImageBuilderTemplate.java
@@ -1,0 +1,79 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.EmailTemplatesInDbHelper;
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.processors.email.aggregators.ImageBuilderAggregator;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestImageBuilderTemplate extends EmailTemplatesInDbHelper {
+
+    static final String LAUNCH_SUCCESS = "launch-success";
+    static final String LAUNCH_FAILURE = "launch-failed";
+
+    private static final Action SUCCESS_ACTION = TestHelpers.createImageBuilderAction(LAUNCH_SUCCESS);
+    private static final Action FAILURE_ACTION = TestHelpers.createImageBuilderAction(LAUNCH_FAILURE);
+
+    @Override
+    protected String getBundle() {
+        return "rhel";
+    }
+
+    @Override
+    protected String getApp() {
+        return "image-builder";
+    }
+
+    @Override
+    protected List<String> getUsedEventTypeNames() {
+        return List.of(LAUNCH_SUCCESS, LAUNCH_FAILURE);
+    }
+
+    @Test
+    public void testSuccessLaunchEmailTitle() {
+        String result = generateEmailSubject(LAUNCH_SUCCESS, SUCCESS_ACTION);
+        assertEquals("Instant notification - successful image launch - Image builder - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testSuccessLaunchEmailBody() {
+        String result = generateEmailBody(LAUNCH_SUCCESS, SUCCESS_ACTION);
+        assertTrue(result.contains("Instances launched successfully"));
+        assertTrue(result.contains("91.123.32.4"));
+    }
+
+    @Test
+    public void testFailedLaunchEmailTitle() {
+        String result = generateEmailSubject(LAUNCH_FAILURE, FAILURE_ACTION);
+        assertEquals("Instant notification - image launch failed - Image builder - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testFailedLaunchEmailBody() {
+        String result = generateEmailBody(LAUNCH_FAILURE, FAILURE_ACTION);
+        assertTrue(result.contains("An image failed to launch"));
+        assertTrue(result.contains("Some launch error"));
+    }
+
+    @Test
+        void testDailyTemplate() {
+        ImageBuilderAggregator aggregator = new ImageBuilderAggregator();
+        aggregator.aggregate(TestHelpers.createImageBuilderAggregation(LAUNCH_SUCCESS));
+        aggregator.aggregate(TestHelpers.createImageBuilderAggregation(LAUNCH_SUCCESS));
+        aggregator.aggregate(TestHelpers.createImageBuilderAggregation(LAUNCH_FAILURE));
+
+        String resultSubject = generateAggregatedEmailSubject(aggregator.getContext());
+        assertEquals("Daily digest - Image builder - Red Hat Enterprise Linux", resultSubject);
+
+        String resultBody = generateAggregatedEmailBody(aggregator.getContext());
+        assertTrue(resultBody.contains("2 launch attempts deployed"));
+        assertTrue(resultBody.contains("1 launch attempts failed"));
+        assertTrue(resultBody.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}


### PR DESCRIPTION
This PR adds instant and daily email templates for images launch, part of the [HMS-1551](https://issues.redhat.com/browse/HMS-1551) and [HMS-738](https://issues.redhat.com/browse/HMS-738) epic

### templates screenshots

successful launch:
![Screen Shot 2023-07-17 at 15 31 18](https://github.com/RedHatInsights/notifications-backend/assets/11807069/e9c9cdfb-3137-47ea-906f-0a188cff24e9)


failed launch:
![Screen Shot 2023-07-17 at 15 32 07](https://github.com/RedHatInsights/notifications-backend/assets/11807069/7e409f7b-2835-4b69-aee4-b60746f5bd78)


daily email:
![Screen Shot 2023-07-17 at 15 24 34](https://github.com/RedHatInsights/notifications-backend/assets/11807069/ea29890c-dbcd-48c7-9e66-716d68011739)
