### PR TITLE
RHCLOUD-27205 Make Kafka polling strategy easier to configure

### DIFF
--- a/.rhcicd/clowdapp-connector-google-chat.yaml
+++ b/.rhcicd/clowdapp-connector-google-chat.yaml
@@ -53,12 +53,14 @@ objects:
           successThreshold: 1
           failureThreshold: 5
         env:
-        - name: CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS
-          value: ${CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS}
         - name: ENV_NAME
           value: ${ENV_NAME}
         - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
           value: ${NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_INTERVAL_MS
+          value: ${KAFKA_MAX_POLL_INTERVAL_MS}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_RECORDS
+          value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -90,9 +92,6 @@ objects:
         - name: QUARKUS_LOG_SENTRY_ENVIRONMENT
           value: ${ENV_NAME}
 parameters:
-- name: CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS
-  description: Maximum number of records returned in a single call to poll(). Defaults to 500.
-  value: "500"
 - name: CPU_LIMIT
   description: CPU limit
   value: 200m
@@ -110,6 +109,12 @@ parameters:
 - name: KAFKA_CLIENT_LOG_LEVEL
   description: Log level of the Kafka client library
   value: WARN
+- name: KAFKA_MAX_POLL_INTERVAL_MS
+  description: Maximum delay in milliseconds between two calls of poll(). Defaults to 300000 (5 minutes).
+  value: "300000"
+- name: KAFKA_MAX_POLL_RECORDS
+  description: Maximum number of records returned in a single call of poll(). Defaults to 500.
+  value: "500"
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 500Mi

--- a/.rhcicd/clowdapp-connector-microsoft-teams.yaml
+++ b/.rhcicd/clowdapp-connector-microsoft-teams.yaml
@@ -53,12 +53,14 @@ objects:
           successThreshold: 1
           failureThreshold: 5
         env:
-        - name: CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS
-          value: ${CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS}
         - name: ENV_NAME
           value: ${ENV_NAME}
         - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
           value: ${NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_INTERVAL_MS
+          value: ${KAFKA_MAX_POLL_INTERVAL_MS}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_RECORDS
+          value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -90,9 +92,6 @@ objects:
         - name: QUARKUS_LOG_SENTRY_ENVIRONMENT
           value: ${ENV_NAME}
 parameters:
-- name: CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS
-  description: Maximum number of records returned in a single call to poll(). Defaults to 500.
-  value: "500"
 - name: CPU_LIMIT
   description: CPU limit
   value: 200m
@@ -110,6 +109,12 @@ parameters:
 - name: KAFKA_CLIENT_LOG_LEVEL
   description: Log level of the Kafka client library
   value: WARN
+- name: KAFKA_MAX_POLL_INTERVAL_MS
+  description: Maximum delay in milliseconds between two calls of poll(). Defaults to 300000 (5 minutes).
+  value: "300000"
+- name: KAFKA_MAX_POLL_RECORDS
+  description: Maximum number of records returned in a single call of poll(). Defaults to 500.
+  value: "500"
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 500Mi

--- a/.rhcicd/clowdapp-connector-slack.yaml
+++ b/.rhcicd/clowdapp-connector-slack.yaml
@@ -53,12 +53,14 @@ objects:
           successThreshold: 1
           failureThreshold: 5
         env:
-        - name: CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS
-          value: ${CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS}
         - name: ENV_NAME
           value: ${ENV_NAME}
         - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
           value: ${NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_INTERVAL_MS
+          value: ${KAFKA_MAX_POLL_INTERVAL_MS}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_RECORDS
+          value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -90,9 +92,6 @@ objects:
         - name: QUARKUS_LOG_SENTRY_ENVIRONMENT
           value: ${ENV_NAME}
 parameters:
-- name: CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS
-  description: Maximum number of records returned in a single call to poll(). Defaults to 500.
-  value: "500"
 - name: CPU_LIMIT
   description: CPU limit
   value: 200m
@@ -110,6 +109,12 @@ parameters:
 - name: KAFKA_CLIENT_LOG_LEVEL
   description: Log level of the Kafka client library
   value: WARN
+- name: KAFKA_MAX_POLL_INTERVAL_MS
+  description: Maximum delay in milliseconds between two calls of poll(). Defaults to 300000 (5 minutes).
+  value: "300000"
+- name: KAFKA_MAX_POLL_RECORDS
+  description: Maximum number of records returned in a single call of poll(). Defaults to 500.
+  value: "500"
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 500Mi

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -53,12 +53,14 @@ objects:
           successThreshold: 1
           failureThreshold: 5
         env:
-        - name: CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS
-          value: ${CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS}
         - name: ENV_NAME
           value: ${ENV_NAME}
         - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
           value: ${NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_INTERVAL_MS
+          value: ${KAFKA_MAX_POLL_INTERVAL_MS}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_RECORDS
+          value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -90,9 +92,6 @@ objects:
         - name: QUARKUS_LOG_SENTRY_ENVIRONMENT
           value: ${ENV_NAME}
 parameters:
-- name: CAMEL_COMPONENT_KAFKA_MAXPOLLRECORDS
-  description: Maximum number of records returned in a single call to poll(). Defaults to 500.
-  value: "500"
 - name: CPU_LIMIT
   description: CPU limit
   value: 200m
@@ -110,6 +109,12 @@ parameters:
 - name: KAFKA_CLIENT_LOG_LEVEL
   description: Log level of the Kafka client library
   value: WARN
+- name: KAFKA_MAX_POLL_INTERVAL_MS
+  description: Maximum delay in milliseconds between two calls of poll(). Defaults to 300000 (5 minutes).
+  value: "300000"
+- name: KAFKA_MAX_POLL_RECORDS
+  description: Maximum number of records returned in a single call of poll(). Defaults to 500.
+  value: "500"
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 500Mi

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
@@ -16,6 +16,14 @@ public class ConnectorConfig {
     @ConfigProperty(name = "notifications.connector.kafka.incoming.group-id")
     String incomingKafkaGroupId;
 
+    // https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#max-poll-interval-ms
+    @ConfigProperty(name = "notifications.connector.kafka.incoming.max-poll-interval-ms", defaultValue = "300000")
+    long incomingKafkaMaxPollIntervalMs;
+
+    // https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#max-poll-records
+    @ConfigProperty(name = "notifications.connector.kafka.incoming.max-poll-records", defaultValue = "500")
+    int incomingKafkaMaxPollRecords;
+
     @ConfigProperty(name = "notifications.connector.kafka.incoming.topic")
     String incomingKafkaTopic;
 
@@ -50,6 +58,24 @@ public class ConnectorConfig {
     public void setIncomingKafkaGroupId(String incomingKafkaGroupId) {
         checkTestLaunchMode();
         this.incomingKafkaGroupId = incomingKafkaGroupId;
+    }
+
+    public long getIncomingKafkaMaxPollIntervalMs() {
+        return incomingKafkaMaxPollIntervalMs;
+    }
+
+    public void setIncomingKafkaMaxPollIntervalMs(long incomingKafkaMaxPollIntervalMs) {
+        checkTestLaunchMode();
+        this.incomingKafkaMaxPollIntervalMs = incomingKafkaMaxPollIntervalMs;
+    }
+
+    public int getIncomingKafkaMaxPollRecords() {
+        return incomingKafkaMaxPollRecords;
+    }
+
+    public void setIncomingKafkaMaxPollRecords(int incomingKafkaMaxPollRecords) {
+        checkTestLaunchMode();
+        this.incomingKafkaMaxPollRecords = incomingKafkaMaxPollRecords;
     }
 
     public String getIncomingKafkaTopic() {

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/EngineToConnectorRouteBuilder.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/EngineToConnectorRouteBuilder.java
@@ -5,6 +5,7 @@ import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
 import javax.inject.Inject;
 
 import static org.apache.camel.LoggingLevel.DEBUG;
+import static org.apache.camel.builder.endpoint.dsl.KafkaEndpointBuilderFactory.KafkaEndpointConsumerBuilder;
 
 public abstract class EngineToConnectorRouteBuilder extends EndpointRouteBuilder {
 
@@ -45,7 +46,7 @@ public abstract class EngineToConnectorRouteBuilder extends EndpointRouteBuilder
                 .handled(true)
                 .process(exceptionProcessor);
 
-        from(kafka(connectorConfig.getIncomingKafkaTopic()).groupId(connectorConfig.getIncomingKafkaGroupId()))
+        from(buildKafkaEndpoint())
                 .routeId(ENGINE_TO_CONNECTOR)
                 .to(log(getClass().getName()).level("DEBUG").showHeaders(true).showBody(true))
                 .filter(incomingCloudEventFilter)
@@ -59,4 +60,11 @@ public abstract class EngineToConnectorRouteBuilder extends EndpointRouteBuilder
     }
 
     public abstract void configureRoute();
+
+    private KafkaEndpointConsumerBuilder buildKafkaEndpoint() {
+        return kafka(connectorConfig.getIncomingKafkaTopic())
+                .groupId(connectorConfig.getIncomingKafkaGroupId())
+                .maxPollRecords(connectorConfig.getIncomingKafkaMaxPollRecords())
+                .maxPollIntervalMs(connectorConfig.getIncomingKafkaMaxPollIntervalMs());
+    }
 }


### PR DESCRIPTION
This PR makes changes to the Kafka polling strategy easier for connectors.

Changing the max poll records or delay is often needed when long running requests (such as calls to failing external hosts) are performed during the processing of a Kafka message.