### PR TITLE
Change base image to ubi9/openjdk-17-runtime

### DIFF
--- a/docker/Dockerfile.notifications-aggregator.jvm
+++ b/docker/Dockerfile.notifications-aggregator.jvm
@@ -3,38 +3,26 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-common-aggregator,:notifications-database,:notifications-aggregator --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 ENV JAVA_OPTIONS="-Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=build --chown=1001 /home/jboss/aggregator/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build --chown=1001 /home/jboss/aggregator/target/quarkus-app/*.jar /deployments/
-COPY --from=build --chown=1001 /home/jboss/aggregator/target/quarkus-app/app/ /deployments/app/
-COPY --from=build --chown=1001 /home/jboss/aggregator/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=build --chown=185 /home/jboss/aggregator/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /home/jboss/aggregator/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /home/jboss/aggregator/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /home/jboss/aggregator/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]

--- a/docker/Dockerfile.notifications-backend.jvm
+++ b/docker/Dockerfile.notifications-backend.jvm
@@ -3,38 +3,26 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-common,:notifications-common-aggregator,:notifications-database,:notifications-backend --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=build --chown=1001 /home/jboss/backend/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build --chown=1001 /home/jboss/backend/target/quarkus-app/*.jar /deployments/
-COPY --from=build --chown=1001 /home/jboss/backend/target/quarkus-app/app/ /deployments/app/
-COPY --from=build --chown=1001 /home/jboss/backend/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=build --chown=185 /home/jboss/backend/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /home/jboss/backend/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /home/jboss/backend/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /home/jboss/backend/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]

--- a/docker/Dockerfile.notifications-connector-google-chat.jvm
+++ b/docker/Dockerfile.notifications-connector-google-chat.jvm
@@ -3,38 +3,26 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-google-chat --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=build --chown=1001 /home/jboss/connector-google-chat/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build --chown=1001 /home/jboss/connector-google-chat/target/quarkus-app/*.jar /deployments/
-COPY --from=build --chown=1001 /home/jboss/connector-google-chat/target/quarkus-app/app/ /deployments/app/
-COPY --from=build --chown=1001 /home/jboss/connector-google-chat/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=build --chown=185 /home/jboss/connector-google-chat/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /home/jboss/connector-google-chat/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /home/jboss/connector-google-chat/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /home/jboss/connector-google-chat/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]

--- a/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
+++ b/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
@@ -3,38 +3,26 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-microsoft-teams --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=build --chown=1001 /home/jboss/connector-microsoft-teams/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build --chown=1001 /home/jboss/connector-microsoft-teams/target/quarkus-app/*.jar /deployments/
-COPY --from=build --chown=1001 /home/jboss/connector-microsoft-teams/target/quarkus-app/app/ /deployments/app/
-COPY --from=build --chown=1001 /home/jboss/connector-microsoft-teams/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=build --chown=185 /home/jboss/connector-microsoft-teams/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /home/jboss/connector-microsoft-teams/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /home/jboss/connector-microsoft-teams/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /home/jboss/connector-microsoft-teams/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]

--- a/docker/Dockerfile.notifications-connector-servicenow.jvm
+++ b/docker/Dockerfile.notifications-connector-servicenow.jvm
@@ -3,38 +3,26 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-servicenow --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=build --chown=1001 /home/jboss/connector-servicenow/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build --chown=1001 /home/jboss/connector-servicenow/target/quarkus-app/*.jar /deployments/
-COPY --from=build --chown=1001 /home/jboss/connector-servicenow/target/quarkus-app/app/ /deployments/app/
-COPY --from=build --chown=1001 /home/jboss/connector-servicenow/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=build --chown=185 /home/jboss/connector-servicenow/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /home/jboss/connector-servicenow/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /home/jboss/connector-servicenow/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /home/jboss/connector-servicenow/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]

--- a/docker/Dockerfile.notifications-connector-slack.jvm
+++ b/docker/Dockerfile.notifications-connector-slack.jvm
@@ -3,38 +3,26 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-slack --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=build --chown=1001 /home/jboss/connector-slack/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build --chown=1001 /home/jboss/connector-slack/target/quarkus-app/*.jar /deployments/
-COPY --from=build --chown=1001 /home/jboss/connector-slack/target/quarkus-app/app/ /deployments/app/
-COPY --from=build --chown=1001 /home/jboss/connector-slack/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=build --chown=185 /home/jboss/connector-slack/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /home/jboss/connector-slack/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /home/jboss/connector-slack/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /home/jboss/connector-slack/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]

--- a/docker/Dockerfile.notifications-connector-splunk.jvm
+++ b/docker/Dockerfile.notifications-connector-splunk.jvm
@@ -3,38 +3,26 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-splunk --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=build --chown=1001 /home/jboss/connector-splunk/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build --chown=1001 /home/jboss/connector-splunk/target/quarkus-app/*.jar /deployments/
-COPY --from=build --chown=1001 /home/jboss/connector-splunk/target/quarkus-app/app/ /deployments/app/
-COPY --from=build --chown=1001 /home/jboss/connector-splunk/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=build --chown=185 /home/jboss/connector-splunk/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /home/jboss/connector-splunk/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /home/jboss/connector-splunk/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /home/jboss/connector-splunk/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]

--- a/docker/Dockerfile.notifications-connector-webhook.jvm
+++ b/docker/Dockerfile.notifications-connector-webhook.jvm
@@ -3,38 +3,26 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-webhook --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=build --chown=1001 /home/jboss/connector-webhook/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build --chown=1001 /home/jboss/connector-webhook/target/quarkus-app/*.jar /deployments/
-COPY --from=build --chown=1001 /home/jboss/connector-webhook/target/quarkus-app/app/ /deployments/app/
-COPY --from=build --chown=1001 /home/jboss/connector-webhook/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=build --chown=185 /home/jboss/connector-webhook/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /home/jboss/connector-webhook/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /home/jboss/connector-webhook/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /home/jboss/connector-webhook/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -3,38 +3,26 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-common,:notifications-common-aggregator,:notifications-database,:notifications-engine --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
-ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
 # Use four distinct layers so if there are application changes the library layers can be re-used
-COPY --from=build --chown=1001 /home/jboss/engine/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build --chown=1001 /home/jboss/engine/target/quarkus-app/*.jar /deployments/
-COPY --from=build --chown=1001 /home/jboss/engine/target/quarkus-app/app/ /deployments/app/
-COPY --from=build --chown=1001 /home/jboss/engine/target/quarkus-app/quarkus/ /deployments/quarkus/
+COPY --from=build --chown=185 /home/jboss/engine/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=185 /home/jboss/engine/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=185 /home/jboss/engine/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=185 /home/jboss/engine/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]


### PR DESCRIPTION
This is a test.

I'm discussing with the team responsible for `ubi9/openjdk-17-runtime` to determine if we can switch to that image.