### PR TITLE
[RHCLOUD-27283] Fix Sonar Jacoco config for test coverage report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,9 @@
         <redhat.event-schemas.version>1.4.9</redhat.event-schemas.version>
 
         <sonar.maven.plugin.version>3.9.1.2184</sonar.maven.plugin.version>
+        <jacoco.output.directory>${project.build.directory}/jacoco-report</jacoco.output.directory>
+        <!-- Point the Sonar Qube Plugin always to the same JaCoCo report to aggregate sub-modules reports-->
+        <sonar.coverage.jacoco.xmlReportPaths>${jacoco.output.directory}/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
     </properties>
 
@@ -235,7 +238,7 @@
                         </goals>
                         <configuration>
                             <dataFile>${project.build.directory}/jacoco-quarkus.exec</dataFile>
-                            <outputDirectory>${project.build.directory}/jacoco-report</outputDirectory>
+                            <outputDirectory>${jacoco.output.directory}</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Using sonar.coverage.jacoco.xmlReportPaths property will allow all sub modules to append the same report test file