### PR TITLE
Fix PR check

### DIFF
--- a/.rhcicd/clowdapp-connector-servicenow.yaml
+++ b/.rhcicd/clowdapp-connector-servicenow.yaml
@@ -13,7 +13,6 @@ objects:
     testing:
       iqePlugin: eventing
     optionalDependencies:
-    - advisor-backend
     - drift
     - notifications-backend
     - policies-engine

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -13,7 +13,6 @@ objects:
     testing:
       iqePlugin: eventing
     optionalDependencies:
-    - advisor-backend
     - drift
     - notifications-backend
     - policies-engine


### PR DESCRIPTION
`advisor-backend` cannot be used as a ClowdApp dependency because the repository is not public.

This temporary PR fixes the PR check but we may need to add `advisor-backend` back later, with additional changes in app-interface.