### PR TITLE
Configure Splunk HTTPS timeouts programmatically

### DIFF
--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -63,6 +63,10 @@ objects:
           value: ${ENV_NAME}
         - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
           value: ${NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE}
+        - name: NOTIFICATIONS_CONNECTOR_HTTPS_CONNECT_TIMEOUT_MS
+          value: ${NOTIFICATIONS_CONNECTOR_HTTPS_CONNECT_TIMEOUT_MS}
+        - name: NOTIFICATIONS_CONNECTOR_HTTPS_SOCKET_TIMEOUT_MS
+          value: ${NOTIFICATIONS_CONNECTOR_HTTPS_SOCKET_TIMEOUT_MS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_INTERVAL_MS
           value: ${KAFKA_MAX_POLL_INTERVAL_MS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_RECORDS
@@ -137,6 +141,12 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
   description: Maximum size of the Camel endpoints cache
   value: "100"
+- name: NOTIFICATIONS_CONNECTOR_HTTPS_CONNECT_TIMEOUT_MS
+  description: Maximum time in milliseconds allowed to establish an HTTPS connection
+  value: "2500"
+- name: NOTIFICATIONS_CONNECTOR_HTTPS_SOCKET_TIMEOUT_MS
+  description: Maximum time in milliseconds allowed to wait for HTTPS data
+  value: "2500"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
@@ -1,14 +1,13 @@
 package com.redhat.cloud.notifications.connector;
 
+import io.quarkus.arc.DefaultBean;
 import io.quarkus.logging.Log;
-import io.quarkus.runtime.configuration.ProfileManager;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import static io.quarkus.runtime.LaunchMode.TEST;
-
 @ApplicationScoped
+@DefaultBean
 public class ConnectorConfig {
 
     private static final String ENDPOINT_CACHE_MAX_SIZE = "notifications.connector.endpoint-cache-max-size";
@@ -77,109 +76,43 @@ public class ConnectorConfig {
         return endpointCacheMaxSize;
     }
 
-    public void setEndpointCacheMaxSize(int endpointCacheMaxSize) {
-        checkTestLaunchMode();
-        this.endpointCacheMaxSize = endpointCacheMaxSize;
-    }
-
     public String getIncomingKafkaGroupId() {
         return incomingKafkaGroupId;
-    }
-
-    public void setIncomingKafkaGroupId(String incomingKafkaGroupId) {
-        checkTestLaunchMode();
-        this.incomingKafkaGroupId = incomingKafkaGroupId;
     }
 
     public long getIncomingKafkaMaxPollIntervalMs() {
         return incomingKafkaMaxPollIntervalMs;
     }
 
-    public void setIncomingKafkaMaxPollIntervalMs(long incomingKafkaMaxPollIntervalMs) {
-        checkTestLaunchMode();
-        this.incomingKafkaMaxPollIntervalMs = incomingKafkaMaxPollIntervalMs;
-    }
-
     public int getIncomingKafkaMaxPollRecords() {
         return incomingKafkaMaxPollRecords;
-    }
-
-    public void setIncomingKafkaMaxPollRecords(int incomingKafkaMaxPollRecords) {
-        checkTestLaunchMode();
-        this.incomingKafkaMaxPollRecords = incomingKafkaMaxPollRecords;
     }
 
     public String getIncomingKafkaPollOnError() {
         return incomingKafkaPollOnError;
     }
 
-    public void setIncomingKafkaPollOnError(String incomingKafkaPollOnError) {
-        checkTestLaunchMode();
-        this.incomingKafkaPollOnError = incomingKafkaPollOnError;
-    }
-
     public String getIncomingKafkaTopic() {
         return incomingKafkaTopic;
-    }
-
-    public void setIncomingKafkaTopic(String incomingKafkaTopic) {
-        checkTestLaunchMode();
-        this.incomingKafkaTopic = incomingKafkaTopic;
     }
 
     public String getOutgoingKafkaTopic() {
         return outgoingKafkaTopic;
     }
 
-    public void setOutgoingKafkaTopic(String outgoingKafkaTopic) {
-        checkTestLaunchMode();
-        this.outgoingKafkaTopic = outgoingKafkaTopic;
-    }
-
     public String getConnectorName() {
         return connectorName;
-    }
-
-    public void setConnectorName(String connectorName) {
-        checkTestLaunchMode();
-        this.connectorName = connectorName;
     }
 
     public String getRedeliveryCounterName() {
         return redeliveryCounterName;
     }
 
-    public void setRedeliveryCounterName(String redeliveryCounterName) {
-        checkTestLaunchMode();
-        this.redeliveryCounterName = redeliveryCounterName;
-    }
-
     public long getRedeliveryDelay() {
         return redeliveryDelay;
     }
 
-    public void setRedeliveryDelay(long redeliveryDelay) {
-        checkTestLaunchMode();
-        this.redeliveryDelay = redeliveryDelay;
-    }
-
     public int getRedeliveryMaxAttempts() {
         return redeliveryMaxAttempts;
-    }
-
-    public void setRedeliveryMaxAttempts(int redeliveryMaxAttempts) {
-        checkTestLaunchMode();
-        this.redeliveryMaxAttempts = redeliveryMaxAttempts;
-    }
-
-    /**
-     * This method throws an {@link IllegalStateException} if it is invoked with a launch mode different from
-     * {@link io.quarkus.runtime.LaunchMode#TEST TEST}. It should be added to methods that allow overriding a
-     * config value from tests only, preventing doing so from runtime code.
-     */
-    private static void checkTestLaunchMode() {
-        if (ProfileManager.getLaunchMode() != TEST) {
-            throw new IllegalStateException("Illegal config value override detected");
-        }
     }
 }

--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkConnectorConfig.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkConnectorConfig.java
@@ -1,0 +1,34 @@
+package com.redhat.cloud.notifications.connector.splunk;
+
+import com.redhat.cloud.notifications.connector.ConnectorConfig;
+import io.quarkus.logging.Log;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SplunkConnectorConfig extends ConnectorConfig {
+
+    private static final String HTTPS_CONNECT_TIMEOUT_MS = "notifications.connector.https.connect-timeout-ms";
+    private static final String HTTPS_SOCKET_TIMEOUT_MS = "notifications.connector.https.socket-timeout-ms";
+
+    @ConfigProperty(name = HTTPS_CONNECT_TIMEOUT_MS, defaultValue = "2500")
+    int httpsConnectTimeout;
+
+    @ConfigProperty(name = HTTPS_SOCKET_TIMEOUT_MS, defaultValue = "2500")
+    int httpsSocketTimeout;
+
+    public void log() {
+        super.log();
+        Log.infof("%s=%s", HTTPS_CONNECT_TIMEOUT_MS, httpsConnectTimeout);
+        Log.infof("%s=%s", HTTPS_SOCKET_TIMEOUT_MS, httpsSocketTimeout);
+    }
+
+    public int getHttpsConnectTimeout() {
+        return httpsConnectTimeout;
+    }
+
+    public int getHttpsSocketTimeout() {
+        return httpsSocketTimeout;
+    }
+}

--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkRouteBuilder.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkRouteBuilder.java
@@ -1,7 +1,7 @@
 package com.redhat.cloud.notifications.connector.splunk;
 
-import com.redhat.cloud.notifications.connector.ConnectorConfig;
 import com.redhat.cloud.notifications.connector.EngineToConnectorRouteBuilder;
+import org.apache.camel.component.http.HttpComponent;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -23,7 +23,7 @@ import static org.apache.camel.builder.endpoint.dsl.HttpEndpointBuilderFactory.H
 public class SplunkRouteBuilder extends EngineToConnectorRouteBuilder {
 
     @Inject
-    ConnectorConfig connectorConfig;
+    SplunkConnectorConfig connectorConfig;
 
     @Inject
     MigrationFilter migrationFilter;
@@ -33,6 +33,9 @@ public class SplunkRouteBuilder extends EngineToConnectorRouteBuilder {
 
     @Override
     public void configureRoute() {
+
+        configureHttpsComponent();
+
         from(direct(ENGINE_TO_CONNECTOR))
                 .routeId(connectorConfig.getConnectorName())
                 // TODO For migration purposes - Remove ASAP!
@@ -52,6 +55,12 @@ public class SplunkRouteBuilder extends EngineToConnectorRouteBuilder {
                         "(orgId ${exchangeProperty." + ORG_ID + "} account ${exchangeProperty." + ACCOUNT_ID + "}) " +
                         "to ${exchangeProperty." + TARGET_URL + "}")
                 .to(direct(SUCCESS));
+    }
+
+    private void configureHttpsComponent() {
+        HttpComponent httpComponent = getCamelContext().getComponent("https", HttpComponent.class);
+        httpComponent.setConnectTimeout(connectorConfig.getHttpsConnectTimeout());
+        httpComponent.setSocketTimeout(connectorConfig.getHttpsSocketTimeout());
     }
 
     private HttpEndpointBuilder buildSplunkEndpoint(boolean trustAll) {

--- a/connector-splunk/src/main/resources/application.properties
+++ b/connector-splunk/src/main/resources/application.properties
@@ -24,11 +24,6 @@ camel.component.kafka.ssl-truststore-type=JKS
 camel.component.kafka.retries=3
 camel.component.kafka.retry-backoff-ms=200
 
-# Maximum time in milliseconds allowed to establish an HTTP connection
-camel.component.http.connect-timeout=2500
-# Maximum time in milliseconds allowed to wait for HTTP data
-camel.component.http.socket-timeout=2500
-
 camel.context.name=notifications-connector-splunk
 
 mp.messaging.tocamel.topic=platform.notifications.tocamel


### PR DESCRIPTION
I suspect that the HTTP timeout settings we had until now for Splunk were ignored by the Camel `https` component.

This PR changes the configuration of these timeouts from `application.properties` to a programmatic approach with some logging at startup and the possibility to override the config values from the deployment params.