### PR TITLE
RHCLOUD-27421 | feature: include labels in bundles and applications

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
@@ -357,7 +357,7 @@ public class UserConfigResource {
 
 
     private String settingsValuesToJsonForm(SettingsValuesByEventType settingsValues, String bundleName, String applicationName) {
-        SettingsValueByEventTypeJsonForm.EventTypes settingsValueJsonForm = SettingsValueByEventTypeJsonForm.fromSettingsValueEventTypes(settingsValues, bundleName, applicationName);
+        final SettingsValueByEventTypeJsonForm.Application settingsValueJsonForm = SettingsValueByEventTypeJsonForm.fromSettingsValueEventTypes(settingsValues, bundleName, applicationName);
         try {
             return mapper.writeValueAsString(settingsValueJsonForm);
         } catch (JsonProcessingException jpe) {


### PR DESCRIPTION
The new UI on the users' preferences requires the labels for the bundles and the applications.

```json
{
    "bundles": {
        "console": {
            "applications": {
                "integrations": {
                    "eventTypes": [
                        {
                            "name": "integration-disabled",
                            "label": "Integration disabled",
                            "fields": [
                                {
                                    "name": "bundles[console].applications[integrations].eventTypes[integration-disabled].emailSubscriptionTypes[DAILY]",
                                    "label": "Daily digest",
                                    "description": "Daily summary of triggered application events in 24 hours span.",
                                    "initialValue": false,
                                    "component": "descriptiveCheckbox",
                                    "validate": []
                                }
                            ]
                        },
                        {
                            "name": "integration-test",
                            "label": "Integration Test",
                            "fields": [
                                {
                                    "name": "bundles[console].applications[integrations].eventTypes[integration-test].emailSubscriptionTypes[DAILY]",
                                    "label": "Daily digest",
                                    "description": "Daily summary of triggered application events in 24 hours span.",
                                    "initialValue": true,
                                    "component": "descriptiveCheckbox",
                                    "validate": []
                                }
                            ]
                        },
                        {
                            "name": "integration-failed",
                            "label": "Integration failed",
                            "fields": [
                                {
                                    "name": "bundles[console].applications[integrations].eventTypes[integration-failed].emailSubscriptionTypes[DAILY]",
                                    "label": "Daily digest",
                                    "description": "Daily summary of triggered application events in 24 hours span.",
                                    "initialValue": false,
                                    "component": "descriptiveCheckbox",
                                    "validate": []
                                }
                            ]
                        }
                    ],
                    "label": "Integrations"
                }
            },
            "label": "Console"
        }
    }
}
```

## Links

[[RHCLOUD-27421]](https://issues.redhat.com/browse/RHCLOUD-27421)