### PR TITLE
RHCLOUD-27503 | feature: increase resources for specific dependencies

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -46,7 +46,7 @@ export APP_NAME="notifications"
 export COMPONENT_NAME="notifications-backend"
 export IMAGE="quay.io/cloudservices/notifications-backend"
 export DEPLOY_TIMEOUT="900"
-export EXTRA_DEPLOY_ARGS="--set-parameter notifications-engine/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-google-chat/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-microsoft-teams/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-servicenow/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-slack/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-splunk/IMAGE_TAG=${IMAGE_TAG}"
+export EXTRA_DEPLOY_ARGS="--set-parameter notifications-engine/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-google-chat/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-microsoft-teams/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-servicenow/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-slack/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-splunk/IMAGE_TAG=${IMAGE_TAG} --no-remove-resources historical-system-profiles --no-remove-resources system-baseline"
 source $CICD_ROOT/deploy_ephemeral_env.sh
 
 # Run IQE tests


### PR DESCRIPTION
The PR checks and ephemeral deployments started to fail because Clowder could not see the "historical-system-profiles" and "system-baseline" services come up, due to an out of memory error.

The specified flags in the PR checks should help solve this issue.

## Links

[[RHCLOUD-27503]](https://issues.redhat.com/browse/RHCLOUD-27503)