### PR TITLE
fix(HMS-2321): fix image builder instant email templates

### DIFF
--- a/engine/src/main/resources/templates/ImageBuilder/launchFailedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/ImageBuilder/launchFailedEmailBodyV2.html
@@ -16,7 +16,7 @@ Google Cloud Platform
 {/switch}
 {/content-title-section1}
 {#content-subtitle-section1}
-{action.timestamp.toStringFormat()} | launch id #{action.context.launch_id}
+Launch id #{action.context.launch_id}
 {/content-subtitle-section1}
 {#content-body-section1}
     <p>

--- a/engine/src/main/resources/templates/ImageBuilder/launchSuccessInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/ImageBuilder/launchSuccessInstantEmailBodyV2.html
@@ -20,7 +20,7 @@ Amazon web services
 Microsoft Azure
 {#case "gcp"}
 Google cloud
-{/switch}, on {action.timestamp.toUtcFormat()}
+{/switch}
 {/content-subtitle-section1}
 {#content-body-section1}
 <table class="rh-data-table-bordered">
@@ -40,7 +40,13 @@ Google cloud
             <td>
                 {it.payload.detail.public_ipv4}
             </td>
-            <td>{it.payload.detail.public_dns}</td>
+            <td>
+            {#if it.payload.detail.public_dns}
+                {it.payload.detail.public_dns}
+            {#else}
+                n/a
+            {/if}
+            </td>
         </tr>
         {/each}
     </tbody>

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -596,7 +596,7 @@ public class TestHelpers {
                     .withAdditionalProperty("instance_id", "i-0aba12564af9faf")
                     .withAdditionalProperty("detail",
                         Map.of("public_ipv4", "91.123.32.4", "public_dns",
-                            "ec91.123.32.4.compute-1.amazonaws.com"))
+                            ""))
                     .build())
                 .build()));
         } else {

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestImageBuilderTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestImageBuilderTemplate.java
@@ -46,6 +46,8 @@ public class TestImageBuilderTemplate extends EmailTemplatesInDbHelper {
         String result = generateEmailBody(LAUNCH_SUCCESS, SUCCESS_ACTION);
         assertTrue(result.contains("Instances launched successfully"));
         assertTrue(result.contains("91.123.32.4"));
+        // testing empty dns value
+        assertTrue(result.contains("n/a"));
     }
 
     @Test


### PR DESCRIPTION
This PR removes timestamps from instant emails and adds a `n/a` value to the DNS column when the value is empty (can be empty in some cloud providers).

![Screen Shot 2023-08-10 at 19 35 17](https://github.com/RedHatInsights/notifications-backend/assets/11807069/4a850f8b-ee72-40dc-bda7-26a5417795d7)
