### PR TITLE
Fix futures check in aggregator job

### DIFF
--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -87,7 +87,8 @@ public class DailyEmailAggregationJob {
                 } catch (JsonProcessingException e) {
                     Log.warn("Could not transform AggregationCommand to JSON object.", e);
                 }
-
+            }
+            if (!futures.isEmpty()) {
                 // resolve completable futures so the Quarkus main thread doesn't stop before everything has been sent
                 try {
                     CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();


### PR DESCRIPTION
There is no point checking if `futures` are completed on each iteration of the `for` loop. Doing it once at the end of the loop is more than enough.