### PR TITLE
RHCLOUD-28170 | fix: add RBAC as a dependency

### DIFF
--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -9,6 +9,8 @@ objects:
   metadata:
     name: notifications-connector-email
   spec:
+    dependencies:
+    - rbac
     envName: ${ENV_NAME}
     kafkaTopics:
     - topicName: platform.notifications.tocamel


### PR DESCRIPTION
RBAC is not listed as a dependency, and that makes the "cdappconfig.json" file not to have the required endpoint for the email connector to work.

## Links 
[[RHCLOUD-28170]](https://issues.redhat.com/browse/RHCLOUD-28170)