### PR TITLE
RHCLOUD-28170 | fix: the key store location as a default value

### DIFF
--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
@@ -44,7 +44,7 @@ public class EmailConnectorConfig extends ConnectorConfig {
     @ConfigProperty(name = IT_ELEMENTS_PAGE, defaultValue = "1000")
     Integer itElementsPerPage;
 
-    @ConfigProperty(name = IT_KEYSTORE_LOCATION)
+    @ConfigProperty(name = IT_KEYSTORE_LOCATION, defaultValue = "/mnt/secrets/clientkeystore.jks")
     String itKeyStoreLocation;
 
     @ConfigProperty(name = IT_KEYSTORE_PASSWORD)

--- a/connector-email/src/main/resources/application.properties
+++ b/connector-email/src/main/resources/application.properties
@@ -38,7 +38,6 @@ notifications.connector.user-provider.bop.client_id=changeme
 notifications.connector.user-provider.bop.env=changeme
 notifications.connector.user-provider.bop.url=https://backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
 
-notifications.connector.user-provider.it.key-store-location=/mnt/secrets/clientkeystore.jks
 notifications.connector.user-provider.it.key-store-password=changeme
 notifications.connector.user-provider.it.url=https://ci.cloud.redhat.com
 


### PR DESCRIPTION
The ephemeral environment is complaining about not having the environment variable set, and therefore not having a proper value to boot Quarkus with it. Since we already provide a value in the properties file, it might as well be worth specifying it as a default value in the configuration file.

## Links
[[RHCLOUD-28170]](https://issues.redhat.com/browse/RHCLOUD-28170)