### PR TITLE
RHCLOUD-28170 | fix: remove the default value for the "IT keystore location" env var

### DIFF
--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -148,8 +148,6 @@ parameters:
   value: latest
 - name: IT_SERVICE_TO_SERVICE_KEY_STORE
   description: "Key store for opening a secure connection when communicating with IT. It should be set to 'file:/mnt/secrets/clientkeystore.jks'"
-  value: ""
-
 
 - name: KAFKA_CLIENT_LOG_LEVEL
   description: Log level of the Kafka client library


### PR DESCRIPTION
The empty string is causing Clowder to actually apply the environment variable, which in turn causes Quarkus to fail because it cannot load an empty string as a configuration parameter.

## Links
[[RHCLOUD-28170]](https://issues.redhat.com/browse/RHCLOUD-28170)