### PR TITLE
Hide user-preferences API

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
@@ -90,6 +90,7 @@ public class UserConfigResource {
     @Path("/notification-preference")
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
+    @Tag(name = OApiFilter.PRIVATE)
     @Transactional
     public Response saveSettings(@Context SecurityContext sec, @NotNull @Valid SettingsValues values) {
 
@@ -157,6 +158,7 @@ public class UserConfigResource {
     @GET
     @Path("/notification-preference/{bundleName}/{applicationName}")
     @Produces(APPLICATION_JSON)
+    @Tag(name = OApiFilter.PRIVATE)
     public UserConfigPreferences getPreferences(
             @Context SecurityContext sec,
             @PathParam("bundleName") String bundleName,
@@ -181,6 +183,7 @@ public class UserConfigResource {
     @GET
     @Path("/notification-preference")
     @Produces(APPLICATION_JSON)
+    @Tag(name = OApiFilter.PRIVATE)
     public Response getSettingsSchema(@Context SecurityContext sec, @QueryParam("bundleName") String bundleName) {
 
         final RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();


### PR DESCRIPTION
 - These APIs are used internally, they are not really user friendly in any way. We should probably create other APIs if customers want to use these.