### PR TITLE
RHCLOUD-28170 | fix: revert default value and add one for the engine

### DIFF
--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -90,7 +90,7 @@ objects:
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_ENV
           value: ${NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_ENV}
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_IT_KEY_STORE_LOCATION
-          value: ${IT_SERVICE_TO_SERVICE_KEY_STORE}
+          value: ${NOTIFICATIONS_CONNECTOR_USER_PROVIDER_IT_KEY_STORE_LOCATION}
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_IT_KEY_STORE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -146,8 +146,6 @@ parameters:
   value: quay.io/cloudservices/notifications-connector-email
 - name: IMAGE_TAG
   value: latest
-- name: IT_SERVICE_TO_SERVICE_KEY_STORE
-  description: "Key store for opening a secure connection when communicating with IT. It should be set to 'file:/mnt/secrets/clientkeystore.jks'"
 
 - name: KAFKA_CLIENT_LOG_LEVEL
   description: Log level of the Kafka client library
@@ -195,6 +193,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_ENV
   description: The back office proxy's environment.
   value: "qa"
+- name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_IT_KEY_STORE_LOCATION
+  description: "Key store for opening a secure connection when communicating with IT. It should be set to 'file:/mnt/secrets/clientkeystore.jks'"
+  value: ""
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -422,3 +422,4 @@ parameters:
   value: "false"
 - name: NOTIFICATIONS_EMAIL_CONNECTOR_ENABLED
   description: Is the email connector enabled to process emails there instead of in the engine?
+  value: "false"

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
@@ -44,7 +44,7 @@ public class EmailConnectorConfig extends ConnectorConfig {
     @ConfigProperty(name = IT_ELEMENTS_PAGE, defaultValue = "1000")
     Integer itElementsPerPage;
 
-    @ConfigProperty(name = IT_KEYSTORE_LOCATION, defaultValue = "/mnt/secrets/clientkeystore.jks")
+    @ConfigProperty(name = IT_KEYSTORE_LOCATION)
     String itKeyStoreLocation;
 
     @ConfigProperty(name = IT_KEYSTORE_PASSWORD)

--- a/connector-email/src/main/resources/application.properties
+++ b/connector-email/src/main/resources/application.properties
@@ -38,6 +38,7 @@ notifications.connector.user-provider.bop.client_id=changeme
 notifications.connector.user-provider.bop.env=changeme
 notifications.connector.user-provider.bop.url=https://backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
 
+notifications.connector.user-provider.it.key-store-location=changeme
 notifications.connector.user-provider.it.key-store-password=changeme
 notifications.connector.user-provider.it.url=https://ci.cloud.redhat.com
 


### PR DESCRIPTION
The default value seems to be overridden by Clowder even though we have the default configuration value in the code. I am reverting the previous change and adding the environment variable in AppInterface.

Also, the engine is suffering from the same error because no default value is provided for the connector feature flag. I am providing one just in case.

## Links
[[RHCLOUD-28170]](https://issues.redhat.com/browse/RHCLOUD-28170)