### PR TITLE
RHCLOUD-28170 | fix: missing volume mount for the IT certificate

### DIFF
--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -34,6 +34,19 @@ objects:
           limits:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
+        volumes:
+          - name: keystore
+            secret:
+              secretName: it-services
+              items:
+                - key: keystore.jks
+                  path: clientkeystore.jks
+              defaultMode: 420
+              optional: true
+        volumeMounts:
+          - name: keystore
+            readOnly: true
+            mountPath: /mnt/secrets
         readinessProbe:
           httpGet:
             path: /q/health/ready


### PR DESCRIPTION
The volume which should contain the IT certificate is missing, which makes the deployment fail.

## Links
[[RHCLOUD-28170]](https://issues.redhat.com/browse/RHCLOUD-28170)