### PR TITLE
RHCLOUD-28235 Unify how org ID is passed to connectors

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
@@ -43,6 +43,7 @@ public class ConnectorSender {
     NotificationHistoryRepository notificationHistoryRepository;
 
     public void send(Event event, Endpoint endpoint, JsonObject payload) {
+        payload.put("orgId", event.getOrgId());
 
         String connector = getConnector(endpoint);
 
@@ -50,7 +51,7 @@ public class ConnectorSender {
         history.setStatus(PROCESSING);
 
         Log.infof("Sending notification to connector [orgId=%s, eventId=%s, connector=%s, historyId=%s]",
-                endpoint.getOrgId(), event.getId(), connector, history.getId());
+                event.getOrgId(), event.getId(), connector, history.getId());
 
         notificationHistoryRepository.createNotificationHistory(history);
 
@@ -62,7 +63,7 @@ public class ConnectorSender {
             history.setDetails(Map.of("failure", e.getMessage()));
             notificationHistoryRepository.updateHistoryItem(history);
             Log.infof(e, "Failed to send notification to connector [orgId=%s, eventId=%s, connector=%s, historyId=%s]",
-                    endpoint.getOrgId(), event.getId(), connector, history.getId());
+                    event.getOrgId(), event.getId(), connector, history.getId());
         }
     }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelNotification.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelNotification.java
@@ -2,14 +2,7 @@ package com.redhat.cloud.notifications.processors.camel;
 
 public class CamelNotification {
 
-    public String orgId;
-
     public String webhookUrl;
 
     public String message;
-
-    @Override
-    public String toString() {
-        return "CamelNotification [orgId=" + orgId + ", webhookUrl=" + webhookUrl + "]";
-    }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
@@ -103,7 +103,6 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
         CamelProperties properties = endpoint.getProperties(CamelProperties.class);
 
         CamelNotification notification = new CamelNotification();
-        notification.orgId = endpoint.getOrgId();
         notification.webhookUrl = properties.getUrl();
         notification.message = message;
         return notification;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackNotification.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackNotification.java
@@ -5,9 +5,4 @@ import com.redhat.cloud.notifications.processors.camel.CamelNotification;
 public class SlackNotification extends CamelNotification {
 
     public String channel;
-
-    @Override
-    public String toString() {
-        return "SlackNotification [orgId=" + orgId + ", webhookUrl=" + webhookUrl + ", channel=" + channel + "]";
-    }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessor.java
@@ -28,7 +28,6 @@ public class SlackProcessor extends CamelProcessor {
         CamelProperties properties = endpoint.getProperties(CamelProperties.class);
 
         SlackNotification notification = new SlackNotification();
-        notification.orgId = endpoint.getOrgId();
         notification.webhookUrl = properties.getUrl();
         notification.channel = properties.getExtras().get("channel");
         notification.message = message;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
@@ -105,11 +105,11 @@ public abstract class CamelProcessorTest {
         assertNotNull(cloudEventMetadata.getId());
         assertEquals(getExpectedCloudEventType(), cloudEventMetadata.getType());
 
-        CamelNotification notification = message.getPayload().mapTo(CamelNotification.class);
+        JsonObject notification = message.getPayload();
 
-        assertEquals(DEFAULT_ORG_ID, notification.orgId);
-        assertEquals(WEBHOOK_URL, notification.webhookUrl);
-        assertEquals(getExpectedMessage(), notification.message);
+        assertEquals(DEFAULT_ORG_ID, notification.getString("orgId"));
+        assertEquals(WEBHOOK_URL, notification.getString("webhookUrl"));
+        assertEquals(getExpectedMessage(), notification.getString("message"));
     }
 
     protected void assertNotificationsConnectorHeader(Message<JsonObject> message) {
@@ -155,6 +155,7 @@ public abstract class CamelProcessorTest {
 
         Event event = new Event();
         event.setId(UUID.randomUUID());
+        event.setOrgId(DEFAULT_ORG_ID);
         event.setEventWrapper(new EventWrapperAction(action));
 
         return event;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessorTest.java
@@ -66,12 +66,12 @@ public class SlackProcessorTest extends CamelProcessorTest {
         assertNotNull(cloudEventMetadata.getId());
         assertEquals(getExpectedCloudEventType(), cloudEventMetadata.getType());
 
-        SlackNotification notification = message.getPayload().mapTo(SlackNotification.class);
+        JsonObject notification = message.getPayload();
 
-        assertEquals(DEFAULT_ORG_ID, notification.orgId);
-        assertEquals(WEBHOOK_URL, notification.webhookUrl);
-        assertEquals(CHANNEL, notification.channel);
-        assertEquals(SLACK_EXPECTED_MSG, notification.message);
+        assertEquals(DEFAULT_ORG_ID, notification.getString("orgId"));
+        assertEquals(WEBHOOK_URL, notification.getString("webhookUrl"));
+        assertEquals(CHANNEL, notification.getString("channel"));
+        assertEquals(SLACK_EXPECTED_MSG, notification.getString("message"));
     }
 
     @Override


### PR DESCRIPTION
This is phase 1 of a two-steps change:
- Phase 1: we're passing the top-level `orgId` field to all connectors from the `engine`
- Phase 2: after the `engine` has been deployed in production, we'll use the top-level `orgId` field from all connectors and stop using other sources of org ID