### PR TITLE
 RHCLOUD-28244 | feature: change the email connector's name

### DIFF
--- a/connector-email/src/main/resources/application.properties
+++ b/connector-email/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 notifications.connector.kafka.incoming.group-id=notifications-connector-email
 notifications.connector.kafka.incoming.topic=${mp.messaging.tocamel.topic}
 notifications.connector.kafka.outgoing.topic=${mp.messaging.fromcamel.topic}
-notifications.connector.name=email_subscription
+notifications.connector.name=email
 notifications.connector.redelivery.counter-name=camel.email.retry.counter
 
 quarkus.http.port=9003

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
@@ -83,6 +83,11 @@ public class EmailProcessor extends SystemEndpointTypeProcessor {
         final JsonObject payload = JsonObject.mapFrom(emailNotification);
 
         final Endpoint endpoint = this.endpointRepository.getOrCreateDefaultSystemSubscription(event.getAccountId(), event.getOrgId(), EndpointType.EMAIL_SUBSCRIPTION);
+
+        // The email connector is named "email", and that is what it expects
+        // in the Kafka header which specifies the target connector that should
+        // process the message. By setting the subtype to "email", we make sure
+        // that the connector sender actually sets that exact text.
         endpoint.setSubType("email");
         this.connectorSender.send(event, endpoint, payload);
     }


### PR DESCRIPTION
The connector is named "notifications-connector-email" everywhere, so I think it makes sense to rename it to the simplest name possible. Also, I suspect the mismatch in the name and the sent Kafka header are making the connector's filter to ignore the Kafka messages.

## Links
[[RHCLOUD-28244]](https://issues.redhat.com/browse/RHCLOUD-28244)