### PR TITLE
feature: pass the event wrapper to the rendering engine

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
@@ -61,8 +61,8 @@ public class EmailProcessor extends SystemEndpointTypeProcessor {
         final TemplateInstance subjectTemplate = this.templateService.compileTemplate(subjectData, "subject");
         final TemplateInstance bodyTemplate = this.templateService.compileTemplate(bodyData, "body");
 
-        final String subject = this.templateService.renderTemplate(event, subjectTemplate);
-        final String body = this.templateService.renderTemplate(event, bodyTemplate);
+        final String subject = this.templateService.renderTemplate(event.getEventWrapper().getEvent(), subjectTemplate);
+        final String body = this.templateService.renderTemplate(event.getEventWrapper().getEvent(), bodyTemplate);
 
         // Get the set of user IDs that should receive an email notification for
         // the given event.


### PR DESCRIPTION
The templates are expecting the event wrapper, and not the event itself. This is causing the email connector's email processor to fail when trying to render the templates.

## Links
[[RHCLOUD-28244]](https://issues.redhat.com/browse/RHCLOUD-28244)