### PR TITLE
RHCLOUD-28244 | feature: authenticate RBAC requests

### DIFF
--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -102,6 +102,13 @@ objects:
               key: client-id
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_ENV
           value: ${NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_ENV}
+        - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_RBAC_APPLICATION_KEY
+          value: ${NOTIFICATIONS_CONNECTOR_USER_PROVIDER_RBAC_APPLICATION_KEY}
+        - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_RBAC_PSKS
+          valueFrom:
+            secretKeyRef:
+              name: rbac-psks
+              key: psks.json
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_IT_KEY_STORE_LOCATION
           value: ${NOTIFICATIONS_CONNECTOR_USER_PROVIDER_IT_KEY_STORE_LOCATION}
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_IT_KEY_STORE_PASSWORD
@@ -206,6 +213,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_ENV
   description: The back office proxy's environment.
   value: "qa"
+- name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_RBAC_APPLICATION_KEY
+  description: The application's key which will be used to authenticate to RBAC.
+  value: "notifications"
 - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_IT_KEY_STORE_LOCATION
   description: "Key store for opening a secure connection when communicating with IT. It should be set to 'file:/mnt/secrets/clientkeystore.jks'"
   value: ""

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
@@ -1,11 +1,17 @@
 package com.redhat.cloud.notifications.connector.email.config;
 
 import com.redhat.cloud.notifications.connector.ConnectorConfig;
+import io.quarkus.logging.Log;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import javax.enterprise.context.ApplicationScoped;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @ApplicationScoped
 public class EmailConnectorConfig extends ConnectorConfig {
@@ -18,10 +24,16 @@ public class EmailConnectorConfig extends ConnectorConfig {
     private static final String IT_KEYSTORE_LOCATION = "notifications.connector.user-provider.it.key-store-location";
     private static final String IT_KEYSTORE_PASSWORD = "notifications.connector.user-provider.it.key-store-password";
     private static final String IT_USER_SERVICE_URL = "notifications.connector.user-provider.it.url";
+    private static final String RBAC_APPLICATION_KEY = "notifications.connector.user-provider.rbac.application-key";
     private static final String RBAC_ELEMENTS_PAGE = "notifications.connector.user-provider.rbac.elements-per-page";
     private static final String RBAC_URL = "notifications.connector.user-provider.rbac.url";
     @Deprecated(forRemoval = true)
     private static final String SINGLE_EMAIL_PER_USER = "notifications.connector.single-email-per-user.enabled";
+
+    // The following two keys are public in order to make it easier for
+    // overriding them in the tests.
+    public static final String RBAC_DEVELOPMENT_AUTHENTICATION_KEY = "notifications.connector.user-provider.rbac.development-authentication-key";
+    public static final String RBAC_PSKS = "notifications.connector.user-provider.rbac.psks";
 
     @ConfigProperty(name = BOP_API_TOKEN)
     String bopApiToken;
@@ -53,8 +65,30 @@ public class EmailConnectorConfig extends ConnectorConfig {
     @ConfigProperty(name = IT_USER_SERVICE_URL)
     String itUserServiceURL;
 
+    @ConfigProperty(name = RBAC_APPLICATION_KEY, defaultValue = "notifications")
+    String rbacApplicationKey;
+
+    @ConfigProperty(name = RBAC_DEVELOPMENT_AUTHENTICATION_KEY)
+    Optional<String> rbacDevelopmentAuthenticationKey;
+
+    /**
+     * Base64 encoded {@link EmailConnectorConfig#rbacDevelopmentAuthenticationKey}
+     * value, used to bypass RBAC's authentication mechanism when developing,
+     * in order to make development faster.
+     */
+    String rbacDevelopmentAuthenticationKeyAuthInfo;
+
     @ConfigProperty(name = RBAC_ELEMENTS_PAGE, defaultValue = "1000")
     Integer rbacElementsPerPage;
+
+    @ConfigProperty(name = RBAC_PSKS, defaultValue = "{}")
+    String rbacPSKs;
+
+    /**
+     * Computed value combining the PSKs' JSON and the specified RBAC
+     * application key.
+     */
+    String rbacPSK;
 
     @ConfigProperty(name = RBAC_URL)
     String rbacURL;
@@ -72,6 +106,7 @@ public class EmailConnectorConfig extends ConnectorConfig {
         additionalEntries.put(IT_KEYSTORE_LOCATION, this.itKeyStoreLocation);
         additionalEntries.put(IT_KEYSTORE_PASSWORD, this.itKeyStorePassword);
         additionalEntries.put(IT_USER_SERVICE_URL, this.itUserServiceURL);
+        additionalEntries.put(RBAC_APPLICATION_KEY, this.rbacApplicationKey);
         additionalEntries.put(RBAC_ELEMENTS_PAGE, this.rbacElementsPerPage);
         additionalEntries.put(RBAC_URL, this.rbacURL);
         additionalEntries.put(SINGLE_EMAIL_PER_USER, this.singleEmailPerUserEnabled);
@@ -115,8 +150,53 @@ public class EmailConnectorConfig extends ConnectorConfig {
         return this.itUserServiceURL;
     }
 
+    public boolean isRbacDevelopmentAuthenticationKeyPresent() {
+        return this.rbacDevelopmentAuthenticationKey.isPresent()
+            && !this.rbacDevelopmentAuthenticationKey.get().isBlank();
+    }
+
+    public String getRbacDevelopmentAuthenticationKeyAuthInfo() {
+        if (this.rbacDevelopmentAuthenticationKeyAuthInfo != null) {
+            return this.rbacDevelopmentAuthenticationKeyAuthInfo;
+        }
+
+        // Base64 encode the authentication key if it is present.
+        if (this.rbacDevelopmentAuthenticationKey.isPresent() && !this.rbacDevelopmentAuthenticationKey.get().isBlank()) {
+            this.rbacDevelopmentAuthenticationKeyAuthInfo = new String(
+                Base64.getEncoder().encode(this.rbacDevelopmentAuthenticationKey.get().getBytes(StandardCharsets.UTF_8)),
+                StandardCharsets.UTF_8
+            );
+        }
+
+        return this.rbacDevelopmentAuthenticationKeyAuthInfo;
+    }
+
     public Integer getRbacElementsPerPage() {
         return this.rbacElementsPerPage;
+    }
+
+    public String getRbacPSK() {
+        if (this.rbacPSK != null) {
+            return this.rbacPSK;
+        }
+
+        final JsonObject rbacPSKs;
+        try {
+            rbacPSKs = new JsonObject(this.rbacPSKs);
+        } catch (final DecodeException | NullPointerException e) {
+            Log.errorf("Unable to load the RBAC PSKs from the environment variable", e);
+            return "";
+        }
+
+        final JsonObject secret = rbacPSKs.getJsonObject(this.rbacApplicationKey);
+        if (secret == null) {
+            Log.errorf("Unable to find the \"notifications\" secret in the RBAC PSKs' JSON file");
+            return "";
+        }
+
+        this.rbacPSK = secret.getString("secret");
+
+        return this.rbacPSK;
     }
 
     public String getRbacURL() {

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
@@ -150,6 +150,10 @@ public class EmailConnectorConfig extends ConnectorConfig {
         return this.itUserServiceURL;
     }
 
+    public String getRbacApplicationKey() {
+        return this.rbacApplicationKey;
+    }
+
     public boolean isRbacDevelopmentAuthenticationKeyPresent() {
         return this.rbacDevelopmentAuthenticationKey.isPresent()
             && !this.rbacDevelopmentAuthenticationKey.get().isBlank();

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACConstants.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACConstants.java
@@ -9,4 +9,9 @@ public class RBACConstants {
      * RBAC's specific ORG ID header which the service is expecting.
      */
     public static final String HEADER_X_RH_RBAC_ORG_ID = "x-rh-rbac-org-id";
+    /**
+     * RBAC's PSK header which the target service requires in order to
+     * authenticate our requests and to be authorized to respond.
+     */
+    public static final String HEADER_X_RH_RBAC_PSK = "x-rh-rbac-psk";
 }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACConstants.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACConstants.java
@@ -6,6 +6,10 @@ public class RBACConstants {
      */
     public static final String RBAC_GROUP_IS_PLATFORM_DEFAULT = "rbac-group-is-platform-default";
     /**
+     * RBAC header which tells which application is making the request.
+     */
+    public static final String HEADER_X_RH_RBAC_CLIENT_ID = "x-rh-rbac-client-id";
+    /**
      * RBAC's specific ORG ID header which the service is expecting.
      */
     public static final String HEADER_X_RH_RBAC_ORG_ID = "x-rh-rbac-org-id";

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACPrincipalsRequestPreparerProcessor.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACPrincipalsRequestPreparerProcessor.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.connector.email.processors.rbac;
 import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
 import com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty;
 import com.redhat.cloud.notifications.connector.email.model.settings.RecipientSettings;
+import com.redhat.cloud.notifications.connector.email.processors.rbac.authentication.RBACAuthenticationUtilities;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 
@@ -16,6 +17,9 @@ public class RBACPrincipalsRequestPreparerProcessor implements Processor {
     @Inject
     EmailConnectorConfig emailConnectorConfig;
 
+    @Inject
+    RBACAuthenticationUtilities rbacAuthenticationUtilities;
+
     @Override
     public void process(final Exchange exchange) {
         final String orgId = exchange.getProperty(ORG_ID, String.class);
@@ -28,8 +32,8 @@ public class RBACPrincipalsRequestPreparerProcessor implements Processor {
         // Set the accept header for the response's payload.
         exchange.getMessage().setHeader("Accept", "application/json");
 
-        // Set the ORG ID required by the other end.
-        exchange.getMessage().setHeader(RBACConstants.HEADER_X_RH_RBAC_ORG_ID, orgId);
+        // Set the authentication headers for RBAC.
+        this.rbacAuthenticationUtilities.setAuthenticationHeaders(exchange, orgId);
 
         // Set the path of the request's call. Beware that RBAC is expecting
         // the trailing slash.

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilities.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilities.java
@@ -27,6 +27,10 @@ public class RBACAuthenticationUtilities {
             // purposes.
             exchange.getMessage().setHeader("Authorization", String.format("Basic %s", this.emailConnectorConfig.getRbacDevelopmentAuthenticationKeyAuthInfo()));
         } else {
+            // Set the client ID which RBAC expects, to discern which
+            // application is making the request.
+            exchange.getMessage().setHeader(RBACConstants.HEADER_X_RH_RBAC_CLIENT_ID, this.emailConnectorConfig.getRbacApplicationKey());
+
             // Set the PSK required for the request to be authenticated in RBAC.
             exchange.getMessage().setHeader(RBACConstants.HEADER_X_RH_RBAC_PSK, this.emailConnectorConfig.getRbacPSK());
 

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilities.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilities.java
@@ -1,0 +1,37 @@
+package com.redhat.cloud.notifications.connector.email.processors.rbac.authentication;
+
+import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
+import com.redhat.cloud.notifications.connector.email.processors.rbac.RBACConstants;
+import org.apache.camel.Exchange;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class RBACAuthenticationUtilities {
+    @Inject
+    EmailConnectorConfig emailConnectorConfig;
+
+    /**
+     * Sets the authentications headers for RBAC. In case we are in development
+     * mode and the development key has been given, a basic authorization
+     * header is set instead of the RBAC's PSK, which usually is taken from
+     * a JSON secret set in Clowder.
+     * @param exchange the exchange to set the authentication headers to.
+     * @param orgId the tenant's organization ID required to set it if the
+     *              authentication is made via a PSK secret.
+     */
+    public void setAuthenticationHeaders(final Exchange exchange, final String orgId) {
+        if (this.emailConnectorConfig.isRbacDevelopmentAuthenticationKeyPresent()) {
+            // Set a basic authentication header which is used for development
+            // purposes.
+            exchange.getMessage().setHeader("Authorization", String.format("Basic %s", this.emailConnectorConfig.getRbacDevelopmentAuthenticationKeyAuthInfo()));
+        } else {
+            // Set the PSK required for the request to be authenticated in RBAC.
+            exchange.getMessage().setHeader(RBACConstants.HEADER_X_RH_RBAC_PSK, this.emailConnectorConfig.getRbacPSK());
+
+            // Set the ORG ID required by the other end.
+            exchange.getMessage().setHeader(RBACConstants.HEADER_X_RH_RBAC_ORG_ID, orgId);
+        }
+    }
+}

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupPrincipalsRequestPreparerProcessor.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupPrincipalsRequestPreparerProcessor.java
@@ -1,25 +1,28 @@
 package com.redhat.cloud.notifications.connector.email.processors.rbac.group;
 
 import com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty;
-import com.redhat.cloud.notifications.connector.email.processors.rbac.RBACConstants;
+import com.redhat.cloud.notifications.connector.email.processors.rbac.authentication.RBACAuthenticationUtilities;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.http.HttpMethods;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 
 @ApplicationScoped
 public class RBACGroupPrincipalsRequestPreparerProcessor implements Processor {
+    @Inject
+    RBACAuthenticationUtilities rbacAuthenticationUtilities;
+
     @Override
     public void process(final Exchange exchange) {
         // Set the "Accept" header for the incoming payload.
         exchange.getMessage().setHeader("Accept", "application/json");
 
-        // Set the required Org ID header expected by RBAC.
-        final String orgId = exchange.getProperty(ORG_ID, String.class);
-        exchange.getMessage().setHeader(RBACConstants.HEADER_X_RH_RBAC_ORG_ID, orgId);
+        // Set the authentication headers for RBAC.
+        this.rbacAuthenticationUtilities.setAuthenticationHeaders(exchange, exchange.getProperty(ORG_ID, String.class));
 
         // Set the path and methods of the request. Beware that RBAC is
         // expecting the trailing slash in the path.

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupRequestPreparerProcessor.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupRequestPreparerProcessor.java
@@ -1,25 +1,28 @@
 package com.redhat.cloud.notifications.connector.email.processors.rbac.group;
 
 import com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty;
-import com.redhat.cloud.notifications.connector.email.processors.rbac.RBACConstants;
+import com.redhat.cloud.notifications.connector.email.processors.rbac.authentication.RBACAuthenticationUtilities;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.component.http.HttpMethods;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 
 @ApplicationScoped
 public class RBACGroupRequestPreparerProcessor implements Processor {
+    @Inject
+    RBACAuthenticationUtilities rbacAuthenticationUtilities;
+
     @Override
     public void process(final Exchange exchange) {
         // Set the "Accept" header for the incoming payload.
         exchange.getMessage().setHeader("Accept", "application/json");
 
-        // Set the required Org ID header expected by RBAC.
-        final String orgId = exchange.getProperty(ORG_ID, String.class);
-        exchange.getMessage().setHeader(RBACConstants.HEADER_X_RH_RBAC_ORG_ID, orgId);
+        // Set the authentication headers for RBAC.
+        this.rbacAuthenticationUtilities.setAuthenticationHeaders(exchange, exchange.getProperty(ORG_ID, String.class));
 
         // Set the path and methods of the request. Beware that RBAC is
         // expecting the trailing slash in the path.

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACPrincipalsRequestPreparerProcessorTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACPrincipalsRequestPreparerProcessorTest.java
@@ -46,6 +46,7 @@ public class RBACPrincipalsRequestPreparerProcessorTest extends CamelQuarkusTest
         // Assert that the headers are correct.
         final Map<String, Object> headers = exchange.getMessage().getHeaders();
         Assertions.assertEquals("application/json", headers.get("Accept"));
+        Assertions.assertEquals(this.emailConnectorConfig.getRbacPSK(), headers.get(RBACConstants.HEADER_X_RH_RBAC_PSK));
         Assertions.assertEquals(orgId, headers.get(RBACConstants.HEADER_X_RH_RBAC_ORG_ID));
         Assertions.assertEquals("/api/rbac/v1/principals/", headers.get(Exchange.HTTP_PATH));
         Assertions.assertEquals(

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACPrincipalsRequestPreparerProcessorTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACPrincipalsRequestPreparerProcessorTest.java
@@ -46,6 +46,7 @@ public class RBACPrincipalsRequestPreparerProcessorTest extends CamelQuarkusTest
         // Assert that the headers are correct.
         final Map<String, Object> headers = exchange.getMessage().getHeaders();
         Assertions.assertEquals("application/json", headers.get("Accept"));
+        Assertions.assertEquals(this.emailConnectorConfig.getRbacApplicationKey(), headers.get(RBACConstants.HEADER_X_RH_RBAC_CLIENT_ID));
         Assertions.assertEquals(this.emailConnectorConfig.getRbacPSK(), headers.get(RBACConstants.HEADER_X_RH_RBAC_PSK));
         Assertions.assertEquals(orgId, headers.get(RBACConstants.HEADER_X_RH_RBAC_ORG_ID));
         Assertions.assertEquals("/api/rbac/v1/principals/", headers.get(Exchange.HTTP_PATH));

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilitiesDevelopmentKeyTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilitiesDevelopmentKeyTest.java
@@ -1,0 +1,51 @@
+package com.redhat.cloud.notifications.connector.email.processors.rbac.authentication;
+
+import com.redhat.cloud.notifications.connector.email.processors.rbac.authentication.testprofiles.DevelopmentKeyTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.camel.Exchange;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.UUID;
+
+@QuarkusTest
+@TestProfile(DevelopmentKeyTestProfile.class)
+public class RBACAuthenticationUtilitiesDevelopmentKeyTest extends CamelQuarkusTestSupport {
+    @Inject
+    RBACAuthenticationUtilities rbacAuthenticationUtilities;
+
+    /**
+     * Tests that the correct basic authentication header is set after calling
+     * the authentication utilities. The development key configuration property
+     * is set via a test profile for this to test to work.
+     */
+    @Test
+    void testDevelopmentKey() {
+        // Prepare the required elements for the test to work.
+        final Exchange exchange = this.createExchangeWithBody("");
+        final String orgId = UUID.randomUUID().toString();
+
+        // Call the function under test.
+        this.rbacAuthenticationUtilities.setAuthenticationHeaders(exchange, orgId);
+
+        // Assert that the basic authentication header was set. Since we are at
+        // it, we will also compute the Base64 contents of the header, to make
+        // sure we are doing it right in the connector's configuration class.
+        final Map<String, Object> headers = exchange.getMessage().getHeaders();
+
+        final String base64EncodedAuthentication = new String(
+            Base64.getEncoder().encode(DevelopmentKeyTestProfile.DEVELOPMENT_AUTHENTICATION_KEY.getBytes(StandardCharsets.UTF_8)),
+            StandardCharsets.UTF_8
+        );
+
+        final String expectedValue = String.format("Basic %s", base64EncodedAuthentication);
+
+        Assertions.assertEquals(expectedValue, headers.get("Authorization"), "incorrect authorization header value found after calling the RBAC authentication utilities");
+    }
+}

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilitiesPSKTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilitiesPSKTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.connector.email.processors.rbac.authentication;
 
+import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
 import com.redhat.cloud.notifications.connector.email.processors.rbac.RBACConstants;
 import com.redhat.cloud.notifications.connector.email.processors.rbac.authentication.testprofiles.PSKsTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -16,6 +17,9 @@ import java.util.UUID;
 @QuarkusTest
 @TestProfile(PSKsTestProfile.class)
 public class RBACAuthenticationUtilitiesPSKTest extends CamelQuarkusTestSupport {
+    @Inject
+    EmailConnectorConfig emailConnectorConfig;
+
     @Inject
     RBACAuthenticationUtilities rbacAuthenticationUtilities;
 
@@ -37,6 +41,7 @@ public class RBACAuthenticationUtilitiesPSKTest extends CamelQuarkusTestSupport 
         final Map<String, Object> headers = exchange.getMessage().getHeaders();
 
         Assertions.assertEquals(PSKsTestProfile.NOTIFICATIONS_PSK_SECRET, headers.get(RBACConstants.HEADER_X_RH_RBAC_PSK), "incorrect PSK header value found after calling the RBAC authentication utilities");
+        Assertions.assertEquals(this.emailConnectorConfig.getRbacApplicationKey(), headers.get(RBACConstants.HEADER_X_RH_RBAC_CLIENT_ID));
         Assertions.assertEquals(orgId, headers.get(RBACConstants.HEADER_X_RH_RBAC_ORG_ID), "incorrect organization ID header value found after calling the RBAC authentication utilities");
     }
 }

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilitiesPSKTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/RBACAuthenticationUtilitiesPSKTest.java
@@ -1,0 +1,42 @@
+package com.redhat.cloud.notifications.connector.email.processors.rbac.authentication;
+
+import com.redhat.cloud.notifications.connector.email.processors.rbac.RBACConstants;
+import com.redhat.cloud.notifications.connector.email.processors.rbac.authentication.testprofiles.PSKsTestProfile;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.camel.Exchange;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+
+@QuarkusTest
+@TestProfile(PSKsTestProfile.class)
+public class RBACAuthenticationUtilitiesPSKTest extends CamelQuarkusTestSupport {
+    @Inject
+    RBACAuthenticationUtilities rbacAuthenticationUtilities;
+
+    /**
+     * Tests that the correct PSK and organization ID headers are set after
+     * calling the authentication utilities. The PSK configuration properties
+     * are set via a test profile for this to test to work.
+     */
+    @Test
+    void testPSKs() {
+        // Prepare the required elements for the test to work.
+        final Exchange exchange = this.createExchangeWithBody("");
+        final String orgId = UUID.randomUUID().toString();
+
+        // Call the function under test.
+        this.rbacAuthenticationUtilities.setAuthenticationHeaders(exchange, orgId);
+
+        // Assert that the PSK and organization ID headers were set.
+        final Map<String, Object> headers = exchange.getMessage().getHeaders();
+
+        Assertions.assertEquals(PSKsTestProfile.NOTIFICATIONS_PSK_SECRET, headers.get(RBACConstants.HEADER_X_RH_RBAC_PSK), "incorrect PSK header value found after calling the RBAC authentication utilities");
+        Assertions.assertEquals(orgId, headers.get(RBACConstants.HEADER_X_RH_RBAC_ORG_ID), "incorrect organization ID header value found after calling the RBAC authentication utilities");
+    }
+}

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/testprofiles/DevelopmentKeyTestProfile.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/testprofiles/DevelopmentKeyTestProfile.java
@@ -1,0 +1,21 @@
+package com.redhat.cloud.notifications.connector.email.processors.rbac.authentication.testprofiles;
+
+import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class DevelopmentKeyTestProfile implements QuarkusTestProfile {
+    public static final String DEVELOPMENT_AUTHENTICATION_KEY = "user:password";
+
+    /**
+     * Sets the {@link EmailConnectorConfig#RBAC_DEVELOPMENT_AUTHENTICATION_KEY}
+     * to contain the {@link DevelopmentKeyTestProfile#DEVELOPMENT_AUTHENTICATION_KEY}
+     * value.
+     * @return a configuration override with the configured development key.
+     */
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(EmailConnectorConfig.RBAC_DEVELOPMENT_AUTHENTICATION_KEY, DEVELOPMENT_AUTHENTICATION_KEY);
+    }
+}

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/testprofiles/PSKsTestProfile.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/authentication/testprofiles/PSKsTestProfile.java
@@ -1,0 +1,29 @@
+package com.redhat.cloud.notifications.connector.email.processors.rbac.authentication.testprofiles;
+
+import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Map;
+
+public class PSKsTestProfile implements QuarkusTestProfile {
+    public static final String NOTIFICATIONS_PSK_SECRET = "psk-secret-for-notifications";
+
+    /**
+     * Sets the {@link EmailConnectorConfig#RBAC_PSKS} to contain the
+     * {@link PSKsTestProfile#NOTIFICATIONS_PSK_SECRET} secret in the
+     * "notifications" key.
+     * @return a configuration override with the configured RBAC PSK for
+     * notifications.
+     */
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        final JsonObject notifications = new JsonObject();
+        notifications.put("secret", NOTIFICATIONS_PSK_SECRET);
+
+        final JsonObject psks = new JsonObject();
+        psks.put("notifications", notifications);
+
+        return Map.of(EmailConnectorConfig.RBAC_PSKS, psks.encode());
+    }
+}

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupPrincipalsRequestPreparerProcessorTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupPrincipalsRequestPreparerProcessorTest.java
@@ -42,6 +42,7 @@ public class RBACGroupPrincipalsRequestPreparerProcessorTest extends CamelQuarku
         // Assert that the correct headers were set in the processor.
         final Map<String, Object> headers = exchange.getMessage().getHeaders();
         Assertions.assertEquals("application/json", headers.get("Accept"), "the \"Accept\" header has an incorrect value");
+        Assertions.assertEquals(this.emailConnectorConfig.getRbacApplicationKey(), headers.get(RBACConstants.HEADER_X_RH_RBAC_CLIENT_ID));
         Assertions.assertEquals(this.emailConnectorConfig.getRbacPSK(), headers.get(RBACConstants.HEADER_X_RH_RBAC_PSK));
         Assertions.assertEquals(orgId, headers.get(RBACConstants.HEADER_X_RH_RBAC_ORG_ID), "the RBAC's ORG ID header has an incorrect value");
         Assertions.assertEquals(String.format("/api/rbac/v1/groups/%s/principals/", groupUUID), headers.get(Exchange.HTTP_PATH), "the wrong path was set in the processor");

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupPrincipalsRequestPreparerProcessorTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupPrincipalsRequestPreparerProcessorTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.connector.email.processors.rbac.group;
 
+import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
 import com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty;
 import com.redhat.cloud.notifications.connector.email.processors.rbac.RBACConstants;
 import io.quarkus.test.junit.QuarkusTest;
@@ -15,6 +16,9 @@ import java.util.UUID;
 
 @QuarkusTest
 public class RBACGroupPrincipalsRequestPreparerProcessorTest extends CamelQuarkusTestSupport {
+    @Inject
+    EmailConnectorConfig emailConnectorConfig;
+
     @Inject
     RBACGroupPrincipalsRequestPreparerProcessor rbacGroupPrincipalsRequestPreparerProcessor;
 
@@ -38,6 +42,7 @@ public class RBACGroupPrincipalsRequestPreparerProcessorTest extends CamelQuarku
         // Assert that the correct headers were set in the processor.
         final Map<String, Object> headers = exchange.getMessage().getHeaders();
         Assertions.assertEquals("application/json", headers.get("Accept"), "the \"Accept\" header has an incorrect value");
+        Assertions.assertEquals(this.emailConnectorConfig.getRbacPSK(), headers.get(RBACConstants.HEADER_X_RH_RBAC_PSK));
         Assertions.assertEquals(orgId, headers.get(RBACConstants.HEADER_X_RH_RBAC_ORG_ID), "the RBAC's ORG ID header has an incorrect value");
         Assertions.assertEquals(String.format("/api/rbac/v1/groups/%s/principals/", groupUUID), headers.get(Exchange.HTTP_PATH), "the wrong path was set in the processor");
         Assertions.assertEquals(HttpMethods.GET, headers.get(Exchange.HTTP_METHOD), "the wrong HTTP method was set in the processor");

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupRequestPreparerProcessorTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupRequestPreparerProcessorTest.java
@@ -42,6 +42,7 @@ public class RBACGroupRequestPreparerProcessorTest extends CamelQuarkusTestSuppo
         // Assert that the correct headers were set in the processor.
         final Map<String, Object> headers = exchange.getMessage().getHeaders();
         Assertions.assertEquals("application/json", headers.get("Accept"), "the \"Accept\" header has an incorrect value");
+        Assertions.assertEquals(this.emailConnectorConfig.getRbacApplicationKey(), headers.get(RBACConstants.HEADER_X_RH_RBAC_CLIENT_ID));
         Assertions.assertEquals(this.emailConnectorConfig.getRbacPSK(), headers.get(RBACConstants.HEADER_X_RH_RBAC_PSK));
         Assertions.assertEquals(orgId, headers.get(RBACConstants.HEADER_X_RH_RBAC_ORG_ID), "the RBAC's ORG ID header has an incorrect value");
         Assertions.assertEquals(String.format("/api/rbac/v1/groups/%s/", groupUUID), headers.get(Exchange.HTTP_PATH), "the wrong path was set in the processor");

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupRequestPreparerProcessorTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/group/RBACGroupRequestPreparerProcessorTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.connector.email.processors.rbac.group;
 
+import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
 import com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty;
 import com.redhat.cloud.notifications.connector.email.processors.rbac.RBACConstants;
 import io.quarkus.test.junit.QuarkusTest;
@@ -15,6 +16,9 @@ import java.util.UUID;
 
 @QuarkusTest
 public class RBACGroupRequestPreparerProcessorTest extends CamelQuarkusTestSupport {
+    @Inject
+    EmailConnectorConfig emailConnectorConfig;
+
     @Inject
     RBACGroupRequestPreparerProcessor rbacGroupRequestPreparerProcessor;
 
@@ -38,6 +42,7 @@ public class RBACGroupRequestPreparerProcessorTest extends CamelQuarkusTestSuppo
         // Assert that the correct headers were set in the processor.
         final Map<String, Object> headers = exchange.getMessage().getHeaders();
         Assertions.assertEquals("application/json", headers.get("Accept"), "the \"Accept\" header has an incorrect value");
+        Assertions.assertEquals(this.emailConnectorConfig.getRbacPSK(), headers.get(RBACConstants.HEADER_X_RH_RBAC_PSK));
         Assertions.assertEquals(orgId, headers.get(RBACConstants.HEADER_X_RH_RBAC_ORG_ID), "the RBAC's ORG ID header has an incorrect value");
         Assertions.assertEquals(String.format("/api/rbac/v1/groups/%s/", groupUUID), headers.get(Exchange.HTTP_PATH), "the wrong path was set in the processor");
         Assertions.assertEquals(HttpMethods.GET, headers.get(Exchange.HTTP_METHOD), "the wrong HTTP method was set in the processor");


### PR DESCRIPTION
The integration with RBAC does not work because the connector is not sending the required PSK authentication header.

## Links
[[RHCLOUD-28244]](https://issues.redhat.com/browse/RHCLOUD-28244)