### PR TITLE
RHCLOUD-28244 | refactor: rename the email connector

### DIFF
--- a/connector-email/src/main/resources/application.properties
+++ b/connector-email/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 notifications.connector.kafka.incoming.group-id=notifications-connector-email
 notifications.connector.kafka.incoming.topic=${mp.messaging.tocamel.topic}
 notifications.connector.kafka.outgoing.topic=${mp.messaging.fromcamel.topic}
-notifications.connector.name=email
+notifications.connector.name=email_subscription
 notifications.connector.redelivery.counter-name=camel.email.retry.counter
 
 quarkus.http.port=9003

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
@@ -84,11 +84,6 @@ public class EmailProcessor extends SystemEndpointTypeProcessor {
 
         final Endpoint endpoint = this.endpointRepository.getOrCreateDefaultSystemSubscription(event.getAccountId(), event.getOrgId(), EndpointType.EMAIL_SUBSCRIPTION);
 
-        // The email connector is named "email", and that is what it expects
-        // in the Kafka header which specifies the target connector that should
-        // process the message. By setting the subtype to "email", we make sure
-        // that the connector sender actually sets that exact text.
-        endpoint.setSubType("email");
         this.connectorSender.send(event, endpoint, payload);
     }
 }


### PR DESCRIPTION
Setting the "subtype" in the result endpoint causes the history stub to be stored with an "email_subscription" endpoint type and an "email" subtype, which causes the user interface in the event log page to break, since they do not rightfully expect a subtype when fetching a history element that is associated to an email endpoint.

## Links
[[RHCLOUD-28244]](https://issues.redhat.com/browse/RHCLOUD-28244)