### PR TITLE
RHCLOUD-28244 | refactor: include the org ID in the payload for the email connector

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
@@ -74,10 +74,11 @@ public class EmailProcessor extends SystemEndpointTypeProcessor {
 
         // Prepare all the data to be sent to the connector.
         final EmailNotification emailNotification = new EmailNotification(
-            subscribers,
-            recipientSettings,
             body,
-            subject
+            subject,
+            event.getOrgId(),
+            recipientSettings,
+            subscribers
         );
 
         final JsonObject payload = JsonObject.mapFrom(emailNotification);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/connector/dto/EmailNotification.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/connector/dto/EmailNotification.java
@@ -6,14 +6,20 @@ import java.util.Collection;
 
 /**
  * Represents the data structure that the email connector is expecting.
- * @param subscribers the list of user {@link java.util.UUID}s which were
- *                    subscribed to the event.
- * @param emailBody the rendered body of the email to be sent
- * @param emailSubject the rendered subject of the email to be sent.
+ * @param emailBody         the rendered body of the email to be sent.
+ * @param emailSubject      the rendered subject of the email to be sent.
+ * @param orgId             the organization ID associated with the triggered
+ *                          event.
+ * @param recipientSettings the collection of recipient settings extracted from
+ *                          both the event and the related endpoints to the
+ *                          event.
+ * @param subscribers       the list of user {@link java.util.UUID}s which were
+ *                          subscribed to the event.
  */
 public record EmailNotification(
-        @JsonProperty("subscribers")        Collection<String> subscribers,
-        @JsonProperty("recipient_settings") Collection<RecipientSettings> recipientSettings,
-        @JsonProperty("email_body")         String emailBody,
-        @JsonProperty("email_subject")      String emailSubject
+    @JsonProperty("email_body")         String emailBody,
+    @JsonProperty("email_subject")      String emailSubject,
+    @JsonProperty("orgId")              String orgId,
+    @JsonProperty("recipient_settings") Collection<RecipientSettings> recipientSettings,
+    @JsonProperty("subscribers")        Collection<String> subscribers
 )  { }


### PR DESCRIPTION
The email connector was not being able to extract the organization ID
from the payload because the engine was not sending it. That caused the
email connector not to send the organization ID to the RBAC service,
and that service ended up responding with a 401 instead of the response
we were expecting.

## Depends on
* https://github.com/RedHatInsights/notifications-backend/pull/2163

## Links
[[RHCLOUD-28244]](https://issues.redhat.com/browse/RHCLOUD-28244)