### PR TITLE
RHCLOUD-28340 Fix calls to the IT Users Service

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
+            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
+            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Our request body is seralized with `Object#toString` instead of Jackson, resulting in an invalid body being sent to the IT Users Service.

See https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#rest-client.