### PR TITLE
RHCLOUD-28341 Fix email aggregation DB sequence

### DIFF
--- a/common-aggregator/src/main/java/com/redhat/cloud/notifications/models/EmailAggregation.java
+++ b/common-aggregator/src/main/java/com/redhat/cloud/notifications/models/EmailAggregation.java
@@ -7,8 +7,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -16,13 +16,17 @@ import jakarta.validation.constraints.Size;
 import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
+import static jakarta.persistence.GenerationType.SEQUENCE;
 
 @Entity
 @Table(name = "email_aggregation")
 public class EmailAggregation extends CreationTimestamped {
 
+    private static final String SEQUENCE_GENERATOR = "email-aggregation-sequence-generator";
+
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO, generator = "email_aggregation_id_seq")
+    @GeneratedValue(strategy = SEQUENCE, generator = SEQUENCE_GENERATOR)
+    @SequenceGenerator(name = SEQUENCE_GENERATOR, sequenceName = "email_aggregation_id_seq")
     @JsonProperty(access = READ_ONLY)
     private Integer id;
 

--- a/database/src/main/resources/db/migration/V1.81.0__RHCLOUD-28341_email_aggregation_sequence.sql
+++ b/database/src/main/resources/db/migration/V1.81.0__RHCLOUD-28341_email_aggregation_sequence.sql
@@ -1,0 +1,5 @@
+ALTER SEQUENCE email_aggregation_id_seq
+    INCREMENT BY 50;
+
+LOCK TABLE email_aggregation IN EXCLUSIVE MODE;
+SELECT SETVAL('email_aggregation_id_seq', (SELECT MAX(id) + 1 FROM email_aggregation), false);


### PR DESCRIPTION
Hibernate 6 changed the way sequences are incremented in the DB.

Our `email_aggregation_id_seq` sequence is currently lagging behind the actual `max(id)` from `email_aggregation` in stage.

This PR:
- changes the JPA annotations we use to declare the sequence, as per the [Hibernate 6 doc](https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#identifiers-generators-sequence)
- aligns the sequence increment in the DB (50) with the `SequenceGenerator#allocationSize` default value
- resets the sequence value to the current `max(id)` from `email_aggregation`

It should fix the issue in stage and prevent it from happening in production 🤞 