### PR TITLE
RHCLOUD-28393 Lower time spent processing RBAC events

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EventTypeRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EventTypeRepository.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.EventTypeKey;
 import com.redhat.cloud.notifications.models.EventTypeKeyBundleAppEventTriplet;
 import com.redhat.cloud.notifications.models.EventTypeKeyFqn;
+import io.quarkus.cache.CacheResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -25,6 +26,7 @@ public class EventTypeRepository {
         throw new IllegalArgumentException("Unsupported EventTypeKey found: " + eventTypeKey.getClass());
     }
 
+    @CacheResult(cacheName = "event-types-from-baet")
     public EventType getEventType(String bundleName, String applicationName, String eventTypeName) {
         String query = "FROM EventType e JOIN FETCH e.application a JOIN FETCH a.bundle b " +
                 "WHERE e.name = :eventTypeName AND a.name = :applicationName AND b.name = :bundleName";
@@ -35,6 +37,7 @@ public class EventTypeRepository {
                 .getSingleResult();
     }
 
+    @CacheResult(cacheName = "event-types-from-fqn")
     public EventType getEventType(String fullyQualifiedName) {
         String query = "FROM EventType e JOIN FETCH e.application a JOIN FETCH a.bundle b " +
                 "WHERE e.fullyQualifiedName = :fullyQualifiedName";

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -39,7 +39,6 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -60,10 +59,6 @@ public class EmailSubscriptionTypeProcessor extends SystemEndpointTypeProcessor 
     public static final String AGGREGATION_CONSUMED_TIMER_NAME = "aggregation.time.consumed";
     protected static final String TAG_KEY_BUNDLE = "bundle";
     protected static final String TAG_KEY_APPLICATION = "application";
-
-    private static final List<EmailSubscriptionType> NON_INSTANT_SUBSCRIPTION_TYPES = Arrays.stream(EmailSubscriptionType.values())
-            .filter(emailSubscriptionType -> emailSubscriptionType != EmailSubscriptionType.INSTANT)
-            .collect(Collectors.toList());
 
     @Inject
     EmailAggregationRepository emailAggregationRepository;
@@ -126,7 +121,7 @@ public class EmailSubscriptionTypeProcessor extends SystemEndpointTypeProcessor 
         final String bundleName = eventType.getApplication().getBundle().getName();
         final String applicationName = eventType.getApplication().getName();
 
-        final boolean shouldSaveAggregation = this.templateRepository.isEmailAggregationSupported(bundleName, applicationName, NON_INSTANT_SUBSCRIPTION_TYPES);
+        final boolean shouldSaveAggregation = this.templateRepository.isEmailAggregationSupported(eventType.getApplicationId());
 
         if (shouldSaveAggregation) {
             final EmailAggregation aggregation = new EmailAggregation();

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
@@ -6,6 +6,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,6 +41,15 @@ public class RecipientResolver {
     }
 
     private Set<User> recipientUsers(String orgId, RecipientSettings request, Set<String> subscribers, boolean isOptIn) {
+        /*
+         If the subscription type is opt-in, the user preferences should NOT be ignored and the subscribers Set is empty,
+         then we don't need to retrieve the users from RBAC/IT/BOP because we'll return an empty Set anyway.
+         */
+        // TODO Report this change in the email connector ASAP.
+        if (isOptIn && !request.isIgnoreUserPreferences() && subscribers.isEmpty()) {
+            return Collections.emptySet();
+        }
+
         List<User> rbacUsers;
         if (request.getGroupId() == null) {
             rbacUsers = rbacRecipientUsersProvider.getUsers(orgId, request.isOnlyAdmins());

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
@@ -47,6 +47,7 @@ public class RecipientResolver {
          */
         // TODO Report this change in the email connector ASAP.
         if (isOptIn && !request.isIgnoreUserPreferences() && subscribers.isEmpty()) {
+            usersCount.set(0);
             return Collections.emptySet();
         }
 

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -155,9 +155,6 @@ quarkus.log.cloudwatch.level=INFO
 quarkus.log.cloudwatch.access-key-id=placeholder
 quarkus.log.cloudwatch.access-key-secret=placeholder
 
-quarkus.cache.caffeine.rbac-recipient-users-provider-get-users.expire-after-write=PT10M
-quarkus.cache.caffeine.rbac-recipient-users-provider-get-group-users.expire-after-write=PT10M
-
 quarkus.log.category."com.redhat.cloud.notifications.health.KafkaConsumedTotalChecker".level=DEBUG
 
 # Should messages about failed injections be delivered as new events (and thus emails to admins)
@@ -207,3 +204,9 @@ quarkus.rest-client.export-service.trust-store-type=${clowder.private-endpoints.
 
 # Quarkus caches
 quarkus.cache.caffeine.drawer-template.expire-after-write=PT5M
+quarkus.cache.caffeine.event-types-from-baet.expire-after-write=PT5M
+quarkus.cache.caffeine.event-types-from-fqn.expire-after-write=PT5M
+quarkus.cache.caffeine.instant-email-templates.expire-after-write=PT5M
+quarkus.cache.caffeine.is-email-aggregation-supported.expire-after-write=PT5M
+quarkus.cache.caffeine.rbac-recipient-users-provider-get-users.expire-after-write=PT10M
+quarkus.cache.caffeine.rbac-recipient-users-provider-get-group-users.expire-after-write=PT10M

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
@@ -8,6 +8,7 @@ import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.InstantEmailTemplate;
 import com.redhat.cloud.notifications.models.Template;
+import io.quarkus.cache.CacheInvalidate;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -60,6 +61,7 @@ public class TemplateRepositoryTest {
 
         // Then we link an aggregation (DAILY) email template with app-1.
         AggregationEmailTemplate createdTemplate = resourceHelpers.createAggregationEmailTemplate(app1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
+        invalidateIsEmailAggregationSupportedCache(app1.getId());
 
         /*
          * Expectations:
@@ -68,6 +70,10 @@ public class TemplateRepositoryTest {
          */
         assertIsEmailAggregationSupported(true, false);
         resourceHelpers.deleteEmailTemplatesById(createdTemplate.getId());
+    }
+
+    @CacheInvalidate(cacheName = "is-email-aggregation-supported")
+    void invalidateIsEmailAggregationSupportedCache(UUID appId) {
     }
 
     private void assertIsEmailAggregationSupported(boolean app1, boolean app2) {
@@ -83,6 +89,7 @@ public class TemplateRepositoryTest {
 
         // Then we link an instant email template with event-type-1...
         InstantEmailTemplate createdTemplate = resourceHelpers.createInstantEmailTemplate(eventType1.getId(), subjectTemplate.getId(), bodyTemplate.getId(), true);
+        invalidateInstantEmailTemplatesCache(eventType1.getId());
         // ... and retrieve it from the DB using the repository.
         Optional<InstantEmailTemplate> instantTemplate = templateRepository.findInstantEmailTemplate(eventType1.getId());
 
@@ -94,6 +101,10 @@ public class TemplateRepositoryTest {
         assertTrue(templateRepository.findInstantEmailTemplate(eventType2.getId()).isEmpty());
 
         resourceHelpers.deleteEmailTemplatesById(createdTemplate.getId());
+    }
+
+    @CacheInvalidate(cacheName = "instant-email-templates")
+    void invalidateInstantEmailTemplatesCache(UUID eventTypeId) {
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/TemplateRepositoryTest.java
@@ -14,7 +14,6 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -72,8 +71,8 @@ public class TemplateRepositoryTest {
     }
 
     private void assertIsEmailAggregationSupported(boolean app1, boolean app2) {
-        assertEquals(app1, templateRepository.isEmailAggregationSupported(bundle.getName(), this.app1.getName(), List.of(DAILY)));
-        assertEquals(app2, templateRepository.isEmailAggregationSupported(bundle.getName(), this.app2.getName(), List.of(DAILY)));
+        assertEquals(app1, templateRepository.isEmailAggregationSupported(this.app1.getId()));
+        assertEquals(app2, templateRepository.isEmailAggregationSupported(this.app2.getId()));
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -249,6 +249,7 @@ class EmailSubscriptionTypeProcessorTest {
             Bundle bundle = new Bundle();
             bundle.setName("rhel");
             Application application = new Application();
+            application.setId(UUID.randomUUID());
             application.setName("policies");
             application.setBundle(bundle);
             EventType eventType = new EventType();


### PR DESCRIPTION
This PR introduces caching for DB data that rarely changes such as event types and templates.

It also suppresses unneeded calls to IT/RBAC/BOP when users from an org do not need to be retrieved.