### PR TITLE
RHCLOUD-28244 | fix: backoffice proxy's path

### DIFF
--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -101,7 +101,9 @@ objects:
               name: backoffice
               key: client-id
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_ENV
-          value: ${NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_ENV}
+          value: ${BACKOFFICE_CLIENT_ENV}
+        - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_URL
+          value: ${BACKOFFICE_SCHEME}://${BACKOFFICE_HOST}
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_RBAC_APPLICATION_KEY
           value: ${NOTIFICATIONS_CONNECTOR_USER_PROVIDER_RBAC_APPLICATION_KEY}
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_RBAC_PSKS
@@ -150,6 +152,16 @@ objects:
         - name: QUARKUS_LOG_SENTRY_ENVIRONMENT
           value: ${ENV_NAME}
 parameters:
+- name: BACKOFFICE_CLIENT_ENV
+  description: Back-office client environment
+  value: qa
+- name: BACKOFFICE_HOST
+  description: The host of the backoffice proxy
+  value: backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
+- name: BACKOFFICE_SCHEME
+  description: The scheme for the backoffice proxy host's URL
+  value: "https"
+
 - name: CPU_LIMIT
   description: CPU limit
   value: 200m
@@ -210,9 +222,6 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_SINGLE_EMAIL_PER_USER_ENABLED
   description: Is sending a single email per user enabled?
   value: "false"
-- name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_ENV
-  description: The back office proxy's environment.
-  value: "qa"
 - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_RBAC_APPLICATION_KEY
   description: The application's key which will be used to authenticate to RBAC.
   value: "notifications"

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparer.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparer.java
@@ -56,6 +56,9 @@ public class BOPRequestPreparer implements Processor {
         // Specify the request's method.
         exchange.getMessage().setHeader(Exchange.HTTP_METHOD, HttpMethods.POST);
 
+        // Specify the request's path.
+        exchange.getMessage().setHeader(Exchange.HTTP_PATH, "/v1/sendEmails");
+
         // Specify the payload's content type.
         exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, "application/json");
 

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparerTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparerTest.java
@@ -54,6 +54,7 @@ public class BOPRequestPreparerTest extends CamelQuarkusTestSupport {
         // Assert that the headers are correct.
         final Map<String, Object> headers = exchange.getMessage().getHeaders();
         Assertions.assertEquals(HttpMethods.POST, headers.get(Exchange.HTTP_METHOD));
+        Assertions.assertEquals("/v1/sendEmails", headers.get(Exchange.HTTP_PATH));
         Assertions.assertEquals("application/json", headers.get(Exchange.CONTENT_TYPE));
         Assertions.assertEquals(this.emailConnectorConfig.getBopApiToken(), headers.get(Constants.BOP_API_TOKEN_HEADER));
         Assertions.assertEquals(this.emailConnectorConfig.getBopClientId(), headers.get(Constants.BOP_CLIENT_ID_HEADER));
@@ -92,6 +93,7 @@ public class BOPRequestPreparerTest extends CamelQuarkusTestSupport {
         // Assert that the headers are correct.
         final Map<String, Object> headers = exchange.getMessage().getHeaders();
         Assertions.assertEquals(HttpMethods.POST, headers.get(Exchange.HTTP_METHOD));
+        Assertions.assertEquals("/v1/sendEmails", headers.get(Exchange.HTTP_PATH));
         Assertions.assertEquals("application/json", headers.get(Exchange.CONTENT_TYPE));
         Assertions.assertEquals(this.emailConnectorConfig.getBopApiToken(), headers.get(Constants.BOP_API_TOKEN_HEADER));
         Assertions.assertEquals(this.emailConnectorConfig.getBopClientId(), headers.get(Constants.BOP_CLIENT_ID_HEADER));


### PR DESCRIPTION
The backoffice proxy is returning a 404 at the moment because the path of the endpoint to send emails is wrong.

The reason for using those environment variable names which don't have the "NOTIFICATIONS_CONNECTOR" prefix is that they get set in AppInterface, and therefore we must honor that naming so that they get properly replaced when the connector gets deployed to stage or production.

## Jira ticket
[[RHCLOUD-28244]](https://issues.redhat.com/browse/RHCLOUD-28244)