### PR TITLE
RHCLOUD-28244 | fix: IT service's URL generation

### DIFF
--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
@@ -88,4 +88,21 @@ public class EmailRouteBuilderTest extends CamelQuarkusTestSupport {
             Assertions.assertTrue(bopEndpointURI.contains("x509HostnameVerifier=NO_OP"), "the base URI does not contain a mention to the NO_OP hostname verifier");
         }
     }
+
+    /**
+     * Tests that the function under test creates the IT endpoint with custom
+     * key store, the custom trust manager and the custom SSL context
+     * parameters.
+     * @throws Exception if the endpoint could not be created.
+     */
+    @Test
+    void testBuildITEndpoint() throws Exception {
+        try (Endpoint bopEndpoint = this.emailRouteBuilder.setUpITEndpoint().resolve(this.context)) {
+            Assertions.assertEquals(this.emailConnectorConfig.getItUserServiceURL(), bopEndpoint.getEndpointBaseUri(), "the base URI of the endpoint is not the same as the one set through the properties");
+
+            final String itEndpointUri = bopEndpoint.getEndpointUri();
+            Assertions.assertTrue(itEndpointUri.contains("TrustManagerType%5BkeyStore"), "the trust manager type for the IT endpoint is not set to \"keyStore\"");
+            Assertions.assertTrue(itEndpointUri.contains("password%3D********"), "the URI does not contain a reference to the key store's password");
+        }
+    }
 }


### PR DESCRIPTION
Similar to how the BOP endpoint gets built, the IT endpoint needs to strip the schema from the URL in order to be able to build it properly, since otherwise the endpoint throws an exception once it gets used.

## Jira ticket
[[RHCLOUD-28244]](https://issues.redhat.com/browse/RHCLOUD-28244)