### PR TITLE
RHCLOUD-28244 | refactor: use key manager instead of a trust manager

### DIFF
--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
@@ -24,6 +24,7 @@ import jakarta.inject.Inject;
 import org.apache.camel.builder.PredicateBuilder;
 import org.apache.camel.builder.endpoint.dsl.HttpEndpointBuilderFactory;
 import org.apache.camel.http.base.HttpOperationFailedException;
+import org.apache.camel.support.jsse.KeyManagersParameters;
 import org.apache.camel.support.jsse.KeyStoreParameters;
 import org.apache.camel.support.jsse.SSLContextParameters;
 import org.apache.camel.support.jsse.TrustManagersParameters;
@@ -287,19 +288,18 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
      * Creates the endpoint for the IT Users service. It makes Apache Camel
      * trust the service's certificate.
      * @return the created endpoint.
-     * @throws Exception if the endpoint could not be created due to an
-     * unexpected error.
      */
     protected HttpEndpointBuilderFactory.HttpEndpointBuilder setUpITEndpoint() {
-        final KeyStoreParameters ksp = new KeyStoreParameters();
-        ksp.setResource(this.emailConnectorConfig.getItKeyStoreLocation());
-        ksp.setPassword(this.emailConnectorConfig.getItKeyStorePassword());
+        final KeyStoreParameters keyStoreParameters = new KeyStoreParameters();
+        keyStoreParameters.setResource(this.emailConnectorConfig.getItKeyStoreLocation());
+        keyStoreParameters.setPassword(this.emailConnectorConfig.getItKeyStorePassword());
 
-        final TrustManagersParameters tmp = new TrustManagersParameters();
-        tmp.setKeyStore(ksp);
+        final KeyManagersParameters keyManagersParameters = new KeyManagersParameters();
+        keyManagersParameters.setKeyPassword(this.emailConnectorConfig.getItKeyStorePassword());
+        keyManagersParameters.setKeyStore(keyStoreParameters);
 
-        final SSLContextParameters scp = new SSLContextParameters();
-        scp.setTrustManagers(tmp);
+        final SSLContextParameters sslContextParameters = new SSLContextParameters();
+        sslContextParameters.setKeyManagers(keyManagersParameters);
 
         // Remove the schema from the url to avoid the
         // "ResolveEndpointFailedException", which complaints about specifying
@@ -307,7 +307,7 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
         final String fullURL = this.emailConnectorConfig.getItUserServiceURL();
         if (fullURL.startsWith("https")) {
             return https(fullURL.replace("https://", ""))
-                .sslContextParameters(scp);
+                .sslContextParameters(sslContextParameters);
         } else {
             return http(fullURL.replace("http://", ""));
         }

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
@@ -101,7 +101,9 @@ public class EmailRouteBuilderTest extends CamelQuarkusTestSupport {
             Assertions.assertEquals(this.emailConnectorConfig.getItUserServiceURL(), bopEndpoint.getEndpointBaseUri(), "the base URI of the endpoint is not the same as the one set through the properties");
 
             final String itEndpointUri = bopEndpoint.getEndpointUri();
-            Assertions.assertTrue(itEndpointUri.contains("TrustManagerType%5BkeyStore"), "the trust manager type for the IT endpoint is not set to \"keyStore\"");
+            Assertions.assertTrue(itEndpointUri.contains("keyManagers%3DKeyManagersParameters"), "the key manager was not set in the endpoint");
+            Assertions.assertTrue(itEndpointUri.contains("keyStore%3DKeyStoreParameters"), "the key store parameters were not set in the endpoint");
+            Assertions.assertTrue(itEndpointUri.contains("sslContextParameters=SSLContextParameters"), "the SSL context parameters were not set in the endpoint");
             Assertions.assertTrue(itEndpointUri.contains("password%3D********"), "the URI does not contain a reference to the key store's password");
         }
     }


### PR DESCRIPTION
The Apache Camel documentation[1] states a different way of setting a custom key store for the connections, which might be why our IT connection is failing with PKI errors in stage.

[1]: https://camel.apache.org/components/next/http-component.html#_setting_up_ssl_for_http_client

## Jira ticket
[[RHCLOUD-28244]](https://issues.redhat.com/browse/RHCLOUD-28244)