### PR TITLE
RHCLOUD-28235 Unify how org ID is passed to connectors (phase 2)

### DIFF
--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
@@ -44,9 +44,6 @@ public class IncomingCloudEventProcessor implements Processor {
 
         JsonObject data = cloudEvent.getJsonObject(CLOUD_EVENT_DATA);
         exchange.setProperty(ORG_ID, data.getString("org_id"));
-        if (exchange.getProperty(ORG_ID, String.class) == null) { // TODO For migration purposes, remove ASAP.
-            exchange.setProperty(ORG_ID, data.getString("orgId"));
-        }
 
         cloudEventDataExtractor.extract(exchange, data);
     }

--- a/connector-webhook/src/main/java/com/redhat/cloud/notifications/connector/webhook/WebhookCloudEventDataExtractor.java
+++ b/connector-webhook/src/main/java/com/redhat/cloud/notifications/connector/webhook/WebhookCloudEventDataExtractor.java
@@ -10,7 +10,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.MissingResourceException;
 
-import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.TARGET_URL;
 import static com.redhat.cloud.notifications.connector.webhook.ExchangeProperty.BASIC_AUTH_PASSWORD;
 import static com.redhat.cloud.notifications.connector.webhook.ExchangeProperty.BASIC_AUTH_USERNAME;
@@ -43,12 +42,6 @@ public class WebhookCloudEventDataExtractor extends CloudEventDataExtractor {
         if (basicAuth != null) {
             exchange.setProperty(BASIC_AUTH_USERNAME, basicAuth.getString("username"));
             exchange.setProperty(BASIC_AUTH_PASSWORD, basicAuth.getString("password"));
-        }
-
-        if (cloudEventData.getJsonObject(PAYLOAD).containsKey("org_id")) {
-            exchange.setProperty(ORG_ID, cloudEventData.getJsonObject(PAYLOAD).getString("org_id"));
-        } else if (cloudEventData.getJsonObject(PAYLOAD).containsKey("redhatorgid")) {
-            exchange.setProperty(ORG_ID, cloudEventData.getJsonObject(PAYLOAD).getString("redhatorgid"));
         }
 
         exchange.getIn().setBody(cloudEventData.getJsonObject(PAYLOAD).encode());

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
@@ -44,7 +44,6 @@ public class ConnectorSender {
 
     public void send(Event event, Endpoint endpoint, JsonObject payload) {
         payload.put("org_id", event.getOrgId());
-        payload.put("orgId", event.getOrgId()); // TODO For migration purposes, remove ASAP.
 
         String connector = getConnector(endpoint);
 


### PR DESCRIPTION
⚠️ This PR must NOT be merged before https://github.com/RedHatInsights/notifications-backend/commit/7a6f441fcde150ee1f1ee59026540ac6f44a6a66 has been deployed in production.

From now on, connectors should always consume the org ID which is set here:
https://github.com/RedHatInsights/notifications-backend/blob/7a6f441fcde150ee1f1ee59026540ac6f44a6a66/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java#L46