### PR TITLE
RHCLOUD-27242 Move SEDA logic to connector-common module

### DIFF
--- a/connector-common/pom.xml
+++ b/connector-common/pom.xml
@@ -71,6 +71,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-microprofile-health</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-seda</artifactId>
+        </dependency>
 
         <!-- Quarkus -->
         <dependency>

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
@@ -26,6 +26,9 @@ public class ConnectorConfig {
     private static final String REDELIVERY_COUNTER_NAME = "notifications.connector.redelivery.counter-name";
     private static final String REDELIVERY_DELAY = "notifications.connector.redelivery.delay";
     private static final String REDELIVERY_MAX_ATTEMPTS = "notifications.connector.redelivery.max-attempts";
+    private static final String SEDA_CONCURRENT_CONSUMERS = "notifications.connector.seda.concurrent-consumers";
+    private static final String SEDA_ENABLED = "notifications.connector.seda.enabled";
+    private static final String SEDA_QUEUE_SIZE = "notifications.connector.seda.queue-size";
 
     @ConfigProperty(name = ENDPOINT_CACHE_MAX_SIZE, defaultValue = "100")
     int endpointCacheMaxSize;
@@ -62,6 +65,17 @@ public class ConnectorConfig {
     @ConfigProperty(name = REDELIVERY_MAX_ATTEMPTS, defaultValue = "2")
     int redeliveryMaxAttempts;
 
+    // https://camel.apache.org/components/4.0.x/seda-component.html#_component_option_concurrentConsumers
+    @ConfigProperty(name = SEDA_CONCURRENT_CONSUMERS, defaultValue = "1")
+    int sedaConcurrentConsumers;
+
+    @ConfigProperty(name = SEDA_ENABLED, defaultValue = "false")
+    boolean sedaEnabled;
+
+    // https://camel.apache.org/components/4.0.x/seda-component.html#_component_option_queueSize
+    @ConfigProperty(name = SEDA_QUEUE_SIZE, defaultValue = "1000")
+    int sedaQueueSize;
+
     public void log() {
         log(Collections.emptyMap());
     }
@@ -80,6 +94,9 @@ public class ConnectorConfig {
         config.put(REDELIVERY_COUNTER_NAME, redeliveryCounterName);
         config.put(REDELIVERY_DELAY, redeliveryDelay);
         config.put(REDELIVERY_MAX_ATTEMPTS, redeliveryMaxAttempts);
+        config.put(SEDA_CONCURRENT_CONSUMERS, sedaConcurrentConsumers);
+        config.put(SEDA_ENABLED, sedaEnabled);
+        config.put(SEDA_QUEUE_SIZE, sedaQueueSize);
         config.putAll(additionalConfig);
 
         Log.info("=== Connector configuration ===");
@@ -130,5 +147,17 @@ public class ConnectorConfig {
 
     public int getRedeliveryMaxAttempts() {
         return redeliveryMaxAttempts;
+    }
+
+    public int getSedaConcurrentConsumers() {
+        return sedaConcurrentConsumers;
+    }
+
+    public boolean isSedaEnabled() {
+        return sedaEnabled;
+    }
+
+    public int getSedaQueueSize() {
+        return sedaQueueSize;
     }
 }

--- a/connector-webhook/pom.xml
+++ b/connector-webhook/pom.xml
@@ -69,10 +69,6 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-http</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-seda</artifactId>
-        </dependency>
 
         <!-- Scope: test -->
         <!-- Some test dependencies are declared in the "profiles" section of this POM. -->

--- a/connector-webhook/src/main/java/com/redhat/cloud/notifications/connector/webhook/WebhookConnectorConfig.java
+++ b/connector-webhook/src/main/java/com/redhat/cloud/notifications/connector/webhook/WebhookConnectorConfig.java
@@ -15,8 +15,6 @@ public class WebhookConnectorConfig extends ConnectorConfig {
     private static final String HTTP_MAX_TOTAL_CONNECTIONS = "notifications.connector.http.max-total-connections";
     private static final String HTTP_SOCKET_TIMEOUT_MS = "notifications.connector.http.socket-timeout-ms";
     private static final String ALTERNATIVE_NAMES = "notifications.connector.alternative.names";
-    private static final String SEDA_CONCURRENT_CONSUMERS = "notifications.connector.seda.concurrent-consumers";
-    private static final String SEDA_QUEUE_SIZE = "notifications.connector.seda.queue-size";
 
     @ConfigProperty(name = HTTP_CONNECT_TIMEOUT_MS, defaultValue = "2500")
     int httpConnectTimeout;
@@ -33,12 +31,6 @@ public class WebhookConnectorConfig extends ConnectorConfig {
     @ConfigProperty(name = ALTERNATIVE_NAMES, defaultValue = "ansible")
     List<String> alternativeNames;
 
-    @ConfigProperty(name = SEDA_CONCURRENT_CONSUMERS, defaultValue = "20")
-    int sedaConcurrentConsumers;
-
-    @ConfigProperty(name = SEDA_QUEUE_SIZE, defaultValue = "20")
-    int sedaQueueSize;
-
     @Override
     public void log() {
         Map<String, Object> additionalEntries = Map.of(
@@ -46,9 +38,7 @@ public class WebhookConnectorConfig extends ConnectorConfig {
                 HTTP_CONNECTIONS_PER_ROUTE, httpConnectionsPerRoute,
                 HTTP_MAX_TOTAL_CONNECTIONS, httpMaxTotalConnections,
                 HTTP_SOCKET_TIMEOUT_MS, httpSocketTimeout,
-                ALTERNATIVE_NAMES, alternativeNames,
-                SEDA_CONCURRENT_CONSUMERS, sedaConcurrentConsumers,
-                SEDA_QUEUE_SIZE, sedaQueueSize
+                ALTERNATIVE_NAMES, alternativeNames
         );
         log(additionalEntries);
     }
@@ -71,13 +61,5 @@ public class WebhookConnectorConfig extends ConnectorConfig {
 
     public List<String> getAlternativeNames() {
         return alternativeNames;
-    }
-
-    public int getSedaConcurrentConsumers() {
-        return sedaConcurrentConsumers;
-    }
-
-    public int getSedaQueueSize() {
-        return sedaQueueSize;
     }
 }

--- a/connector-webhook/src/main/resources/application.properties
+++ b/connector-webhook/src/main/resources/application.properties
@@ -4,6 +4,11 @@ notifications.connector.kafka.outgoing.topic=${mp.messaging.fromcamel.topic}
 notifications.connector.name=webhook
 notifications.connector.redelivery.counter-name=camel.webhook.retry.counter
 notifications.connector.alternative.names=ansible
+# The following value matches the default value of the `connectionsPerRoute` option from the Camel `http` component.
+notifications.connector.seda.concurrent-consumers=20
+notifications.connector.seda.enabled=true
+# The following value matches the default value of the `connectionsPerRoute` option from the Camel `http` component.
+notifications.connector.seda.queue-size=20
 
 quarkus.http.port=9006
 


### PR DESCRIPTION
After this PR, each connector can be migrated to SEDA separately with almost no effort.