### PR TITLE
RHCLOUD-28138 | feature: cache the extracted usernames from IT and RBAC calls

### DIFF
--- a/connector-email/pom.xml
+++ b/connector-email/pom.xml
@@ -64,6 +64,14 @@
         <!-- Camel -->
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-bean</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-http</artifactId>
         </dependency>
 


### PR DESCRIPTION
Calling to IT and RBAC services is a really expensive operation, and usually the responses are quite static. It makes sense to use caching for these usernames in order to avoid having to call for that data each time we need to send an email, specially when there is a huge batch of emails to be sent.

## Jira ticket
[[RHCLOUD-28138]](https://issues.redhat.com/browse/RHCLOUD-28138)