### PR TITLE
RHCLOUD-28235 Unify how org ID is passed to connectors (snake case)

### DIFF
--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
@@ -43,7 +43,10 @@ public class IncomingCloudEventProcessor implements Processor {
         exchange.setProperty(RETURN_SOURCE, connectorConfig.getConnectorName());
 
         JsonObject data = cloudEvent.getJsonObject(CLOUD_EVENT_DATA);
-        exchange.setProperty(ORG_ID, data.getString("orgId"));
+        exchange.setProperty(ORG_ID, data.getString("org_id"));
+        if (exchange.getProperty(ORG_ID, String.class) == null) { // TODO For migration purposes, remove ASAP.
+            exchange.setProperty(ORG_ID, data.getString("orgId"));
+        }
 
         cloudEventDataExtractor.extract(exchange, data);
     }

--- a/connector-servicenow/src/main/java/com/redhat/cloud/notifications/connector/servicenow/ServiceNowCloudEventDataExtractor.java
+++ b/connector-servicenow/src/main/java/com/redhat/cloud/notifications/connector/servicenow/ServiceNowCloudEventDataExtractor.java
@@ -7,7 +7,6 @@ import org.apache.camel.Exchange;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.http.ProtocolException;
 
-import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.TARGET_URL;
 import static com.redhat.cloud.notifications.connector.servicenow.ExchangeProperty.ACCOUNT_ID;
 import static com.redhat.cloud.notifications.connector.servicenow.ExchangeProperty.AUTHENTICATION_TOKEN;
@@ -26,8 +25,6 @@ public class ServiceNowCloudEventDataExtractor extends CloudEventDataExtractor {
     @Override
     public void extract(Exchange exchange, JsonObject cloudEventData) throws Exception {
 
-        // TODO Rely on the org ID parsing from IncomingCloudEventProcessor?
-        exchange.setProperty(ORG_ID, cloudEventData.getString("org_id"));
         exchange.setProperty(ACCOUNT_ID, cloudEventData.getString("account_id"));
 
         JsonObject metadata = cloudEventData.getJsonObject(NOTIF_METADATA);

--- a/connector-servicenow/src/test/java/com/redhat/cloud/notifications/connector/servicenow/ServiceNowCloudEventDataExtractorTest.java
+++ b/connector-servicenow/src/test/java/com/redhat/cloud/notifications/connector/servicenow/ServiceNowCloudEventDataExtractorTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
-import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.TARGET_URL;
 import static com.redhat.cloud.notifications.connector.servicenow.ExchangeProperty.ACCOUNT_ID;
 import static com.redhat.cloud.notifications.connector.servicenow.ExchangeProperty.AUTHENTICATION_TOKEN;
@@ -118,7 +117,6 @@ public class ServiceNowCloudEventDataExtractorTest extends CamelQuarkusTestSuppo
         JsonObject cloudEventDataCopy = cloudEventData.copy();
         serviceNowCloudEventDataExtractor.extract(exchange, cloudEventData);
 
-        assertEquals(cloudEventDataCopy.getString("org_id"), exchange.getProperty(ORG_ID, String.class));
         assertEquals(cloudEventDataCopy.getString("account_id"), exchange.getProperty(ACCOUNT_ID, String.class));
         assertEquals(cloudEventDataCopy.getJsonObject(NOTIF_METADATA).getString("url"), exchange.getProperty(TARGET_URL, String.class));
         assertTrue(cloudEventDataCopy.getJsonObject(NOTIF_METADATA).getString("url").endsWith(exchange.getProperty(TARGET_URL_NO_SCHEME, String.class)));

--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractor.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractor.java
@@ -7,7 +7,6 @@ import org.apache.camel.Exchange;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.http.ProtocolException;
 
-import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.TARGET_URL;
 import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.ACCOUNT_ID;
 import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.AUTHENTICATION_TOKEN;
@@ -31,8 +30,6 @@ public class SplunkCloudEventDataExtractor extends CloudEventDataExtractor {
     @Override
     public void extract(Exchange exchange, JsonObject cloudEventData) throws Exception {
 
-        // TODO Rely on the org ID parsing from IncomingCloudEventProcessor?
-        exchange.setProperty(ORG_ID, cloudEventData.getString("org_id"));
         exchange.setProperty(ACCOUNT_ID, cloudEventData.getString("account_id"));
 
         JsonObject metadata = cloudEventData.getJsonObject(NOTIF_METADATA);

--- a/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractorTest.java
+++ b/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkCloudEventDataExtractorTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
-import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.TARGET_URL;
 import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.ACCOUNT_ID;
 import static com.redhat.cloud.notifications.connector.splunk.ExchangeProperty.AUTHENTICATION_TOKEN;
@@ -140,7 +139,6 @@ public class SplunkCloudEventDataExtractorTest extends CamelQuarkusTestSupport {
         JsonObject cloudEventDataCopy = cloudEventData.copy();
         splunkCloudEventDataExtractor.extract(exchange, cloudEventData);
 
-        assertEquals(cloudEventDataCopy.getString("org_id"), exchange.getProperty(ORG_ID, String.class));
         assertEquals(cloudEventDataCopy.getString("account_id"), exchange.getProperty(ACCOUNT_ID, String.class));
         assertTrue(exchange.getProperty(TARGET_URL, String.class).endsWith(SERVICES_COLLECTOR_EVENT));
         // Trailing slashes should be removed before we modify the target URL path.

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
@@ -43,7 +43,8 @@ public class ConnectorSender {
     NotificationHistoryRepository notificationHistoryRepository;
 
     public void send(Event event, Endpoint endpoint, JsonObject payload) {
-        payload.put("orgId", event.getOrgId());
+        payload.put("org_id", event.getOrgId());
+        payload.put("orgId", event.getOrgId()); // TODO For migration purposes, remove ASAP.
 
         String connector = getConnector(endpoint);
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
@@ -107,7 +107,7 @@ public abstract class CamelProcessorTest {
 
         JsonObject notification = message.getPayload();
 
-        assertEquals(DEFAULT_ORG_ID, notification.getString("orgId"));
+        assertEquals(DEFAULT_ORG_ID, notification.getString("org_id"));
         assertEquals(WEBHOOK_URL, notification.getString("webhookUrl"));
         assertEquals(getExpectedMessage(), notification.getString("message"));
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessorTest.java
@@ -68,7 +68,7 @@ public class SlackProcessorTest extends CamelProcessorTest {
 
         JsonObject notification = message.getPayload();
 
-        assertEquals(DEFAULT_ORG_ID, notification.getString("orgId"));
+        assertEquals(DEFAULT_ORG_ID, notification.getString("org_id"));
         assertEquals(WEBHOOK_URL, notification.getString("webhookUrl"));
         assertEquals(CHANNEL, notification.getString("channel"));
         assertEquals(SLACK_EXPECTED_MSG, notification.getString("message"));


### PR DESCRIPTION
Camel case doesn't work well with Splunk and SNow, so we're switching to snake case in all connectors.