### PR TITLE
Fix OpenTelemetry configuration keys

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -140,10 +140,12 @@ objects:
           value: ${SENTRY_DSN}${ENV_NAME}
         - name: QUARKUS_LOG_SENTRY_ENVIRONMENT
           value: ${ENV_NAME}
-        - name: QUARKUS_OPENTELEMETRY_ENABLED
-          value: ${QUARKUS_OPENTELEMETRY_ENABLED}
-        - name: QUARKUS_OPENTELEMETRY_TRACER_EXPORTER_OTLP_ENDPOINT
-          value: ${QUARKUS_OPENTELEMETRY_ENDPOINT}
+        - name: QUARKUS_OTEL_SDK_DISABLED
+          value: ${QUARKUS_OTEL_SDK_DISABLED}
+        - name: QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: ${QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}
+        - name: QUARKUS_DATASOURCE_JDBC_TELEMETRY
+          value: ${QUARKUS_DATASOURCE_JDBC_TELEMETRY}
         - name: NOTIFICATIONS_USE_DEFAULT_TEMPLATE
           value: ${NOTIFICATIONS_USE_DEFAULT_TEMPLATE}
         - name: NOTIFICATIONS_USE_SOURCES_SECRETS_BACKEND
@@ -314,10 +316,12 @@ parameters:
 - name: SENTRY_ENABLED
   description: Enable Sentry (or not)
   value: "false"
-- name: QUARKUS_OPENTELEMETRY_ENABLED
-  value: "false"
-- name: QUARKUS_OPENTELEMETRY_ENDPOINT
+- name: QUARKUS_OTEL_SDK_DISABLED
+  value: "true"
+- name: QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
   value: "http://localhost:4317"
+- name: QUARKUS_DATASOURCE_JDBC_TELEMETRY
+  value: "false"
 - description: bucket secret name
   name: FLOORIST_BUCKET_SECRET_NAME
   required: true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,9 +9,8 @@ quarkus.http.port=8085
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
 quarkus.datasource.password=postgres
-quarkus.datasource.jdbc.url=jdbc:otel:postgresql://127.0.0.1:5432/notifications
-quarkus.datasource.jdbc.driver=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
+quarkus.datasource.jdbc.url=jdbc:postgresql://127.0.0.1:5432/notifications
+quarkus.datasource.jdbc.telemetry=false
 
 quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.notifications.db.naming.SnakeCasePhysicalNamingStrategy
 
@@ -87,8 +86,9 @@ quarkus.rest-client.sources.trust-store-password=${clowder.endpoints.sources-api
 quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OpenTelemetry -- see also jdbc driver above.
-quarkus.opentelemetry.enabled=false
-quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317
+quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317
+quarkus.otel.sdk.disabled=true
+quarkus.otel.service.name=notifications-backend
 
 # Sources' development PSK value. Specified here to avoid Quarkus from complaining that the configuration parameter
 # is missing. In the case that you are using a real Sources application to test the integration, you will need to

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -55,10 +55,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
         postgreSQLContainer = new PostgreSQLContainer<>("postgres:15");
         postgreSQLContainer.start();
         // Now that postgres is started, we need to get its URL and tell Quarkus
-        // quarkus.datasource.driver=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
-        // JdbcURL needs a 'otel' in the middle like jdbc:otel:postgresql://localhost:5432/postgres
         String jdbcUrl = postgreSQLContainer.getJdbcUrl();
-        jdbcUrl = "jdbc:otel:" + jdbcUrl.substring(5);
         props.put("quarkus.datasource.jdbc.url", jdbcUrl);
         props.put("quarkus.datasource.username", "test");
         props.put("quarkus.datasource.password", "test");

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -88,9 +88,8 @@ mp.messaging.outgoing.drawer.cloud-events-mode=structured
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
 quarkus.datasource.password=postgres
-quarkus.datasource.jdbc.url=jdbc:otel:postgresql://127.0.0.1:5432/notifications
-quarkus.datasource.jdbc.driver=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
+quarkus.datasource.jdbc.url=jdbc:postgresql://127.0.0.1:5432/notifications
+quarkus.datasource.jdbc.telemetry=false
 
 # Flyway must NOT migrate the DB when the 'prod' profile is active, this is the responsibility of notifications-backend.
 %dev.quarkus.flyway.migrate-at-start=true
@@ -173,8 +172,9 @@ quarkus.rest-client.sources.trust-store=${clowder.endpoints.sources-api-svc.trus
 quarkus.rest-client.sources.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
 quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
-quarkus.opentelemetry.enabled=false
-quarkus.opentelemetry.tracer.exporter.otlp.endpoint=http://localhost:4317
+quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317
+quarkus.otel.sdk.disabled=true
+quarkus.otel.service.name=notifications-engine
 
 # Sources' development PSK value. Specified here to avoid Quarkus from complaining that the configuration parameter
 # is missing. In the case that you are using a real Sources application to test the integration, you will need to

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -80,10 +80,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
         postgreSQLContainer = new PostgreSQLContainer<>("postgres:15");
         postgreSQLContainer.start();
         // Now that postgres is started, we need to get its URL and tell Quarkus
-        // quarkus.datasource.driver=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
-        // Driver needs a 'otel' in the middle like jdbc:otel:postgresql://localhost:5432/postgres
         String jdbcUrl = postgreSQLContainer.getJdbcUrl();
-        jdbcUrl = "jdbc:otel:" + jdbcUrl.substring(5);
         props.put("quarkus.datasource.jdbc.url", jdbcUrl);
         props.put("quarkus.datasource.username", "test");
         props.put("quarkus.datasource.password", "test");


### PR DESCRIPTION
This PR fixes warnings we've had in Sentry since the bump to Quarkus 3:
```
2023-09-27 15:53:37,476 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.opentelemetry.tracer.exporter.otlp.endpoint" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
2023-09-27 15:53:37,479 WARN  [io.qua.config] (main) Unrecognized configuration key "quarkus.opentelemetry.enabled" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```
https://quarkus.io/version/3.2/guides/opentelemetry