### PR TITLE
Update build deploy script.

### DIFF
--- a/.rhcicd/build_deploy.sh
+++ b/.rhcicd/build_deploy.sh
@@ -11,6 +11,7 @@ DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
 
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
 
 function buildAndDeploy() {
     IMAGE_NAME=$1
@@ -18,10 +19,15 @@ function buildAndDeploy() {
     docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
     docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" . -f docker/Dockerfile.${IMAGE_NAME}.jvm
     docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
-    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
-    docker --config="$DOCKER_CONF" push "${IMAGE}:qa"
-    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
-    docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
+    if [[ $GIT_BRANCH == *"security-compliance"* ]]; then
+        docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
+        docker --config="$DOCKER_CONF" push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
+    else
+        docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
+        docker --config="$DOCKER_CONF" push "${IMAGE}:qa"
+        docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
+        docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
+    fi
 }
 
 buildAndDeploy "notifications-aggregator"


### PR DESCRIPTION
## Overview
- Updates build deploy script to utilize `security compliance` image tag with format `sc-date-hash` this will make it easier to link the image tags. 
- Example: `sc-092723-7daece1`