### PR TITLE
RHCLOUD-28138 | feature: cache the group principals results

### DIFF
--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
@@ -125,6 +125,17 @@ public class EmailRouteBuilderTest extends CamelQuarkusTestSupport {
     }
 
     /**
+     * Tests that the correct cache format is computed for the Caffeine cache
+     * keys.
+     */
+    @Test
+    void testComputeGroupsPrincipalCacheKey() {
+        final Expression cacheKey = this.emailRouteBuilder.computeGroupPrincipalsCacheKey();
+
+        Assertions.assertEquals("simple{${exchangeProperty.orgId}-${exchangeProperty.group_uuid}}", cacheKey.toString(), "unexpected cache key generated");
+    }
+
+    /**
      * Tests that the Caffeine cache component has the configurations that we
      * expect.
      * @throws IOException if an unexpected error occurs when fetching the


### PR DESCRIPTION
The group principals results need to be cached as well to avoid calling RBAC too many times.

## Jira ticket
[[RHCLOUD-28138]](https://issues.redhat.com/browse/RHCLOUD-28138)