### PR TITLE
RHCLOUD-28097 | feature: update Grafana dashboard for the email connector

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
@@ -27,6 +27,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
+      "id": 348544,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -2176,6 +2177,99 @@ data:
             "type": "prometheus",
             "uid": "$datasource"
           },
+          "description": "Number of running pods in the environment",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 3,
+            "y": 22
+          },
+          "id": 273,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum(up{container=\"notifications-connector-email-service\"})",
+              "legendFormat": "Up",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Email - UPs",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "description": "Number of current restarts (since pod deployment)",
           "fieldConfig": {
             "defaults": {
@@ -2239,6 +2333,99 @@ data:
           ],
           "title": "Webhook - Restarts",
           "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Number of pod restarts since the last deployment",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 3,
+            "y": 26
+          },
+          "id": 275,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum(kube_pod_container_status_restarts_total{container=\"notifications-connector-email-service\"})",
+              "legendFormat": "Restarts",
+              "range": true,
+              "refId": "Number of restarts"
+            }
+          ],
+          "title": "Email - Restarts",
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -2330,6 +2517,99 @@ data:
             }
           ],
           "title": "Webhook - Memory leak detection",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Graph that helps identifying if any memory leaks have occurred.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 3,
+            "y": 30
+          },
+          "id": 271,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "jvm_memory_used_bytes{service=\"notifications-connector-email-service\", area=\"heap\", id=\"Tenured Gen\"}",
+              "legendFormat": "{{pod}}",
+              "range": true,
+              "refId": "Memory leak detection"
+            }
+          ],
+          "title": "Email - Memory leak detection",
           "type": "timeseries"
         },
         {
@@ -3067,7 +3347,7 @@ data:
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "description": "",
+          "description": "Gives information regarding the rate of successes, failures and retries for the email connector.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3079,7 +3359,7 @@ data:
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "drawStyle": "bars",
+                "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
                 "hideFrom": {
@@ -3093,7 +3373,7 @@ data:
                 "scaleDistribution": {
                   "type": "linear"
                 },
-                "showPoints": "never",
+                "showPoints": "auto",
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -3104,64 +3384,21 @@ data:
                 }
               },
               "mappings": [],
-              "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
               }
             },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Success"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "green",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Failure"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "red",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Retry"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "yellow",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -3169,7 +3406,7 @@ data:
             "x": 6,
             "y": 48
           },
-          "id": 250,
+          "id": 269,
           "options": {
             "legend": {
               "calcs": [],
@@ -3182,16 +3419,14 @@ data:
               "sort": "none"
             }
           },
-          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
+                "type": "prometheus",
                 "uid": "$datasource"
               },
               "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(camel_exchanges_succeeded_total{service=\"notifications-connector-google-chat-service\", routeId=\"google_chat\"}[5m]))",
-              "instant": false,
+              "expr": "sum(increase(camel_exchanges_succeeded_total{service=\"notifications-connector-email\", routeId=\"email_subscription\"}[5m]))",
               "legendFormat": "Success",
               "range": true,
               "refId": "Success"
@@ -3202,9 +3437,8 @@ data:
                 "uid": "$datasource"
               },
               "editorMode": "code",
-              "expr": "sum(increase(camel_exchanges_failures_handled_total{service=\"notifications-connector-google-chat-service\", routeId=\"google_chat\"}[5m]))",
+              "expr": "sum(increase(camel_exchanges_failures_handled_total{service=\"notifications-connector-email\", routeId=\"email_subscription\"}[5m]))",
               "hide": false,
-              "interval": "",
               "legendFormat": "Failure",
               "range": true,
               "refId": "Failure"
@@ -3215,17 +3449,14 @@ data:
                 "uid": "$datasource"
               },
               "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(camel_google_chat_retry_counter_total[5m]))",
+              "expr": "sum(increase(camel_email_retry_counter_total[5m]))",
               "hide": false,
-              "instant": false,
-              "interval": "",
               "legendFormat": "Retry",
               "range": true,
               "refId": "Retry"
             }
           ],
-          "title": "Google Chat",
+          "title": "Email connector",
           "type": "timeseries"
         },
         {
@@ -3767,6 +3998,7 @@ data:
                 }
               },
               "mappings": [],
+              "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -3831,7 +4063,7 @@ data:
             "x": 6,
             "y": 56
           },
-          "id": 258,
+          "id": 250,
           "options": {
             "legend": {
               "calcs": [],
@@ -3852,7 +4084,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(increase(camel_exchanges_succeeded_total{service=\"notifications-connector-splunk-service\", routeId=\"splunk\"}[5m]))",
+              "expr": "sum(increase(camel_exchanges_succeeded_total{service=\"notifications-connector-google-chat-service\", routeId=\"google_chat\"}[5m]))",
               "instant": false,
               "legendFormat": "Success",
               "range": true,
@@ -3864,7 +4096,7 @@ data:
                 "uid": "$datasource"
               },
               "editorMode": "code",
-              "expr": "sum(increase(camel_exchanges_failures_handled_total{service=\"notifications-connector-splunk-service\", routeId=\"splunk\"}[5m]))",
+              "expr": "sum(increase(camel_exchanges_failures_handled_total{service=\"notifications-connector-google-chat-service\", routeId=\"google_chat\"}[5m]))",
               "hide": false,
               "interval": "",
               "legendFormat": "Failure",
@@ -3878,7 +4110,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(increase(camel_splunk_retry_counter_total[5m]))",
+              "expr": "sum(increase(camel_google_chat_retry_counter_total[5m]))",
               "hide": false,
               "instant": false,
               "interval": "",
@@ -3887,7 +4119,7 @@ data:
               "refId": "Retry"
             }
           ],
-          "title": "Splunk",
+          "title": "Google Chat",
           "type": "timeseries"
         },
         {
@@ -4222,12 +4454,177 @@ data:
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Failure"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Retry"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 1,
+            "y": 64
+          },
+          "id": 258,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(increase(camel_exchanges_succeeded_total{service=\"notifications-connector-splunk-service\", routeId=\"splunk\"}[5m]))",
+              "instant": false,
+              "legendFormat": "Success",
+              "range": true,
+              "refId": "Success"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(camel_exchanges_failures_handled_total{service=\"notifications-connector-splunk-service\", routeId=\"splunk\"}[5m]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Failure",
+              "range": true,
+              "refId": "Failure"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(increase(camel_splunk_retry_counter_total[5m]))",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Retry",
+              "range": true,
+              "refId": "Retry"
+            }
+          ],
+          "title": "Splunk",
+          "type": "timeseries"
+        },
+        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 64
+            "y": 72
           },
           "id": 228,
           "panels": [],
@@ -4248,7 +4645,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 65
+            "y": 73
           },
           "hiddenSeries": false,
           "id": 201,
@@ -4380,7 +4777,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 65
+            "y": 73
           },
           "id": 254,
           "options": {
@@ -4439,7 +4836,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 65
+            "y": 73
           },
           "id": 205,
           "options": {
@@ -4448,7 +4845,7 @@ data:
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
+             "calcs": [
                 "lastNotNull"
               ],
               "fields": "",
@@ -4481,7 +4878,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 73
+            "y": 81
           },
           "id": 188,
           "panels": [],
@@ -4502,7 +4899,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 74
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 153,
@@ -4593,7 +4990,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 74
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 161,
@@ -4726,7 +5123,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 74
+            "y": 82
           },
           "id": 252,
           "links": [
@@ -4870,7 +5267,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 82
+            "y": 90
           },
           "id": 179,
           "panels": [],
@@ -4936,7 +5333,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 83
+            "y": 91
           },
           "id": 174,
           "options": {
@@ -5028,7 +5425,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 83
+            "y": 91
           },
           "id": 208,
           "options": {
@@ -5120,7 +5517,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 83
+            "y": 91
           },
           "id": 189,
           "options": {
@@ -5167,7 +5564,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 91
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 113,
@@ -5252,7 +5649,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 91
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 175,
@@ -5337,7 +5734,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 91
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 176,
@@ -5431,7 +5828,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 91
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 177,
@@ -5530,7 +5927,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 99
+            "y": 107
           },
           "id": 24,
           "panels": [],
@@ -5558,7 +5955,7 @@ data:
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 100
+            "y": 108
           },
           "hiddenSeries": false,
           "id": 22,
@@ -5593,15 +5990,11 @@ data:
               "format": "time_series",
               "groupBy": [
                 {
-                  "params": [
-                    "$__interval"
-                  ],
+                  "params": ["$__interval"],
                   "type": "time"
                 },
                 {
-                  "params": [
-                    "null"
-                  ],
+                  "params": ["null"],
                   "type": "fill"
                 }
               ],
@@ -5614,9 +6007,7 @@ data:
               "select": [
                 [
                   {
-                    "params": [
-                      "value"
-                    ],
+                    "params": ["value"],
                     "type": "field"
                   },
                   {
@@ -5692,7 +6083,7 @@ data:
             "h": 9,
             "w": 16,
             "x": 8,
-            "y": 100
+            "y": 108
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -5747,15 +6138,11 @@ data:
               "format": "heatmap",
               "groupBy": [
                 {
-                  "params": [
-                    "$__interval"
-                  ],
+                  "params": ["$__interval"],
                   "type": "time"
                 },
                 {
-                  "params": [
-                    "null"
-                  ],
+                  "params": ["null"],
                   "type": "fill"
                 }
               ],
@@ -5769,9 +6156,7 @@ data:
               "select": [
                 [
                   {
-                    "params": [
-                      "value"
-                    ],
+                    "params": ["value"],
                     "type": "field"
                   },
                   {
@@ -5819,7 +6204,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 109
+            "y": 117
           },
           "hiddenSeries": false,
           "id": 85,
@@ -5863,15 +6248,11 @@ data:
               "format": "time_series",
               "groupBy": [
                 {
-                  "params": [
-                    "$__interval"
-                  ],
+                  "params": ["$__interval"],
                   "type": "time"
                 },
                 {
-                  "params": [
-                    "null"
-                  ],
+                  "params": ["null"],
                   "type": "fill"
                 }
               ],
@@ -5885,9 +6266,7 @@ data:
               "select": [
                 [
                   {
-                    "params": [
-                      "value"
-                    ],
+                    "params": ["value"],
                     "type": "field"
                   },
                   {
@@ -5945,16 +6324,14 @@ data:
       "refresh": "15m",
       "schemaVersion": 37,
       "style": "dark",
-      "tags": [
-        "notifications"
-      ],
+      "tags": ["notifications"],
       "templating": {
         "list": [
           {
             "current": {
-              "selected": true,
-              "text": "stage",
-              "value": "crcs02ue1-prometheus"
+              "selected": false,
+              "text": "prod",
+              "value": "crcp01ue1-prometheus"
             },
             "hide": 0,
             "includeAll": false,
@@ -5963,12 +6340,12 @@ data:
             "name": "datasource",
             "options": [
               {
-                "selected": true,
+                "selected": false,
                 "text": "stage",
                 "value": "crcs02ue1-prometheus"
               },
               {
-                "selected": false,
+                "selected": true,
                 "text": "prod",
                 "value": "crcp01ue1-prometheus"
               }
@@ -5997,22 +6374,12 @@ data:
           "2h",
           "1d"
         ],
-        "time_options": [
-          "5m",
-          "15m",
-          "1h",
-          "6h",
-          "12h",
-          "24h",
-          "2d",
-          "7d",
-          "30d"
-        ]
+        "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
       },
       "timezone": "",
       "title": "Notifications Dashboard",
       "uid": "KQIVyFuMk",
-      "version": 1,
+      "version": 4,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
The idea is to be able to check the status of the connector easily in the dashboard.

## Jira tickets
* [[RHCLOUD-28097]](https://issues.redhat.com/browse/RHCLOUD-28097)
* [[RHCLOUD-28096]](https://issues.redhat.com/browse/RHCLOUD-28096)