### PR TITLE
RHCLOUD-28681 | fix: cache gets overwritten

### DIFF
--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
@@ -324,7 +324,7 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
             .routeId(Routes.SEND_EMAIL_BOP_SINGLE_PER_USER)
             // Clear all the headers that may come from the previous route.
             .removeHeaders("*")
-            .split(simpleF("${exchangeProperty.%s}", ExchangeProperty.USERNAMES))
+            .split(simpleF("${exchangeProperty.%s}", ExchangeProperty.FILTERED_USERNAMES))
                 .setProperty(ExchangeProperty.SINGLE_EMAIL_PER_USER, constant(true))
                 .to(direct(Routes.SEND_EMAIL_BOP))
             .end();

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
@@ -28,7 +28,7 @@ public class EmailConnectorConfig extends ConnectorConfig {
     private static final String RBAC_ELEMENTS_PAGE = "notifications.connector.user-provider.rbac.elements-per-page";
     private static final String RBAC_URL = "notifications.connector.user-provider.rbac.url";
     @Deprecated(forRemoval = true)
-    private static final String SINGLE_EMAIL_PER_USER = "notifications.connector.single-email-per-user.enabled";
+    public static final String SINGLE_EMAIL_PER_USER = "notifications.connector.single-email-per-user.enabled";
 
     // The following two keys are public in order to make it easier for
     // overriding them in the tests.

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/constants/ExchangeProperty.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/constants/ExchangeProperty.java
@@ -12,6 +12,11 @@ public class ExchangeProperty {
      */
     public static final String ELEMENTS_COUNT = "elements_count";
     /**
+     * Holds the filtered usernames. It is used in order to avoid the set of
+     * cached usernames from being modified.
+     */
+    public static final String FILTERED_USERNAMES = "usernames_filtered";
+    /**
      * Used to hold the received RBAC group's UUID.
      */
     public static final String GROUP_UUID = "group_uuid";

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparer.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparer.java
@@ -36,7 +36,7 @@ public class BOPRequestPreparer implements Processor {
         if (singleEmailPerUser != null && singleEmailPerUser) {
             recipients.add(exchange.getMessage().getBody(String.class));
         } else {
-            final Set<String> usernames = exchange.getProperty(ExchangeProperty.USERNAMES, Set.class);
+            final Set<String> usernames = exchange.getProperty(ExchangeProperty.FILTERED_USERNAMES, Set.class);
 
             recipients.addAll(usernames);
         }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/recipients/RecipientsFilter.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/recipients/RecipientsFilter.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 
+import java.util.HashSet;
 import java.util.Set;
 
 @ApplicationScoped
@@ -21,20 +22,26 @@ public class RecipientsFilter implements Processor {
         final RecipientSettings recipientSettings = exchange.getProperty(ExchangeProperty.CURRENT_RECIPIENT_SETTINGS, RecipientSettings.class);
         final Set<String> subscribers = (Set<String>) exchange.getProperty(ExchangeProperty.SUBSCRIBERS, Set.class);
         final Set<String> usernames = exchange.getProperty(ExchangeProperty.USERNAMES, Set.class);
+        // Use a new hash set to hold the usernames. The "usernames" set that
+        // comes from the user providers' responses is cached, but if we modify
+        // it directly, it also affects the cached list.
+        final Set<String> filteredUsernames = new HashSet<>(usernames);
 
         // If the request settings contains a list of usernames, then the
         // recipients from RBAC who are not included in the request users list
         // are filtered out. Otherwise, the full list of recipients from RBAC
         // will be processed by the next step.
         if (recipientSettings.getUsers() != null && recipientSettings.getUsers().size() > 0) {
-            usernames.retainAll(recipientSettings.getUsers());
+            filteredUsernames.retainAll(recipientSettings.getUsers());
         }
 
         // If the user preferences should be ignored, then we don't further
         // filter the recipients. Otherwise, we need to make sure that we only
         // send the notification to the subscribers of the event type.
         if (!recipientSettings.isIgnoreUserPreferences()) {
-            usernames.retainAll(subscribers);
+            filteredUsernames.retainAll(subscribers);
         }
+
+        exchange.setProperty(ExchangeProperty.FILTERED_USERNAMES, filteredUsernames);
     }
 }

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
@@ -62,7 +62,7 @@ public class EmailRouteBuilderTest extends CamelQuarkusTestSupport {
         final Set<String> usernames = Set.of("a", "b", "c", "d", "e");
 
         final Exchange exchange = this.createExchangeWithBody("");
-        exchange.setProperty(ExchangeProperty.USERNAMES, usernames);
+        exchange.setProperty(ExchangeProperty.FILTERED_USERNAMES, usernames);
 
         final MockEndpoint sendEmailBopEndpoint = this.getMockEndpoint(String.format("mock:direct:%s", Routes.SEND_EMAIL_BOP), false);
         sendEmailBopEndpoint.expectedMessageCount(5);

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparerTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparerTest.java
@@ -46,7 +46,7 @@ public class BOPRequestPreparerTest extends CamelQuarkusTestSupport {
         final Exchange exchange = this.createExchangeWithBody("");
         exchange.setProperty(ExchangeProperty.RENDERED_SUBJECT, emailSubject);
         exchange.setProperty(ExchangeProperty.RENDERED_BODY, emailBody);
-        exchange.setProperty(ExchangeProperty.USERNAMES, usernames);
+        exchange.setProperty(ExchangeProperty.FILTERED_USERNAMES, usernames);
 
         // Call the processor under test.
         this.bopRequestPreparer.process(exchange);

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/recipients/RecipientsFilterTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/recipients/RecipientsFilterTest.java
@@ -9,6 +9,7 @@ import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -63,9 +64,9 @@ public class RecipientsFilterTest extends CamelQuarkusTestSupport {
         expectedResult.add("a");
         expectedResult.add("c");
         expectedResult.add("e");
-        final Set<String> result = exchange.getProperty(ExchangeProperty.USERNAMES, Set.class);
+        final Set<String> result = exchange.getProperty(ExchangeProperty.FILTERED_USERNAMES, Set.class);
 
-        Assertions.assertIterableEquals(expectedResult, result);
+        assertUsernameCollectionsEqualsIgnoreOrder(expectedResult, result);
     }
 
     /**
@@ -97,9 +98,9 @@ public class RecipientsFilterTest extends CamelQuarkusTestSupport {
         this.recipientsFilter.process(exchange);
 
         // Assert that the list contains the expected elements.
-        final Set<String> result = exchange.getProperty(ExchangeProperty.USERNAMES, Set.class);
+        final Set<String> result = exchange.getProperty(ExchangeProperty.FILTERED_USERNAMES, Set.class);
 
-        Assertions.assertIterableEquals(usernames, result);
+        assertUsernameCollectionsEqualsIgnoreOrder(usernames, result);
     }
 
     /**
@@ -143,8 +144,23 @@ public class RecipientsFilterTest extends CamelQuarkusTestSupport {
         expectedResult.add("b");
         expectedResult.add("c");
         expectedResult.add("e");
-        final Set<String> result = exchange.getProperty(ExchangeProperty.USERNAMES, Set.class);
+        final Set<String> result = exchange.getProperty(ExchangeProperty.FILTERED_USERNAMES, Set.class);
 
-        Assertions.assertIterableEquals(expectedResult, result);
+        assertUsernameCollectionsEqualsIgnoreOrder(expectedResult, result);
+    }
+
+    /**
+     * Asserts that the username collections contain the usernames, regardless
+     * of the order. We use this function instead of the {@link Assertions#assertIterableEquals(Iterable, Iterable)}
+     * one because that one does check that the order is correct.
+     * @param expected expected username collection to end up with.
+     * @param actual the actual result from the test.
+     */
+    public static void assertUsernameCollectionsEqualsIgnoreOrder(final Collection<String> expected, final Collection<String> actual) {
+        Assertions.assertEquals(expected.size(), actual.size(), String.format("the given username collections differ in size. Expected collection: %s . Actual collection: %s", expected, actual));
+
+        for (final String expectedUsername : expected) {
+            Assertions.assertTrue(actual.contains(expectedUsername), String.format("expected username '%s' not found in collection %s", expectedUsername, actual));
+        }
     }
 }


### PR DESCRIPTION
Basically the users cache was getting overwritten because we were modifying the users' collection directly when filtering it. Summarizing:

1) We created a collection for collecting the users.
2) Cached it.
3) Modified it in the recipients filter.

Since all this was made to the same collection, the cache was modified as a result.

Copying the collections fixes the issue.

## Jira ticket
[[RHCLOUD-28681]](https://issues.redhat.com/browse/RHCLOUD-28681)