### PR TITLE
RHCLOUD-28690 | fix: cookie policy warning

### DIFF
--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
@@ -390,7 +390,11 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
         // Remove the schema from the url to avoid the
         // "ResolveEndpointFailedException", which complaints about specifying
         // the schema twice.
-        final String fullURL = this.emailConnectorConfig.getItUserServiceURL();
+        //
+        // Set the cookie specification to "ignore" to avoid getting "cookie
+        // rejected" warnings for having a strict cookie policy, specially when
+        // we don't really use those cookies for much.
+        final String fullURL = String.format("%s?httpClient.cookieSpec=ignoreCookies", this.emailConnectorConfig.getItUserServiceURL());
         if (fullURL.startsWith("https")) {
             return https(fullURL.replace("https://", ""))
                 .sslContextParameters(sslContextParameters);

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
@@ -106,6 +106,7 @@ public class EmailRouteBuilderTest extends CamelQuarkusTestSupport {
             Assertions.assertEquals(this.emailConnectorConfig.getItUserServiceURL(), bopEndpoint.getEndpointBaseUri(), "the base URI of the endpoint is not the same as the one set through the properties");
 
             final String itEndpointUri = bopEndpoint.getEndpointUri();
+            Assertions.assertTrue(itEndpointUri.contains("cookieSpec=ignoreCookies"), "the cookie policy was not set to 'ignoreCookies' as expected");
             Assertions.assertTrue(itEndpointUri.contains("keyManagers%3DKeyManagersParameters"), "the key manager was not set in the endpoint");
             Assertions.assertTrue(itEndpointUri.contains("keyStore%3DKeyStoreParameters"), "the key store parameters were not set in the endpoint");
             Assertions.assertTrue(itEndpointUri.contains("sslContextParameters=SSLContextParameters"), "the SSL context parameters were not set in the endpoint");


### PR DESCRIPTION
The connector issues a warning when sending requests to IT, because they try to set a cookie for a different domain which is also part of IT. Changing the cookie policy to "browser compatibility" might solve the issue.

## Jira ticket
[[RHCLOUD-28690]](https://issues.redhat.com/browse/RHCLOUD-28690)