### PR TITLE
RHCLOUD-28708 | fix: Floorist queries give index error

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -188,10 +188,10 @@ objects:
     - prefix: insights/notifications/endpoint_types
       query: >-
         SELECT
-          sub."Endpoint type",
+          sub."Endpoint type"::TEXT,
           COUNT(*) AS "Count",
-          sub."Enabled",
-          sub."Actively used"
+          sub."Enabled"::TEXT,
+          sub."Actively used"::TEXT
         FROM
           (
             SELECT
@@ -229,10 +229,10 @@ objects:
     - prefix: insights/notifications/email_subscriptions
       query: >-
         SELECT
-          b.display_name AS "Bundle",
-          a.display_name AS "Application",
-          et.display_name AS "Event type",
-          es.subscription_type AS "Subscription type",
+          b.display_name::TEXT AS "Bundle",
+          a.display_name::TEXT AS "Application",
+          et.display_name::TEXT AS "Event type",
+          es.subscription_type::TEXT AS "Subscription type",
           COUNT(es.*) AS "Count"
         FROM
           email_subscriptions AS es


### PR DESCRIPTION
The Floorist queries are giving indexing errors, apparently because some of the columns need to be converted to strings.

## Jira tickets
[[RHCLOUD-28708]](https://issues.redhat.com/browse/RHCLOUD-28708)