### PR TITLE
Run the aggregation process from a worker thread

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -44,6 +44,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 
@@ -114,6 +115,10 @@ public class EmailSubscriptionTypeProcessor extends SystemEndpointTypeProcessor 
 
     @Inject
     EventRepository eventRepository;
+
+    // This executor is used to run a task asynchronously using a worker thread from a threads pool managed by Quarkus.
+    @Inject
+    ManagedExecutor managedExecutor;
 
     private Counter rejectedAggregationCommandCount;
     private Counter processedAggregationCommandCount;
@@ -194,45 +199,51 @@ public class EmailSubscriptionTypeProcessor extends SystemEndpointTypeProcessor 
     }
 
     public void processAggregation(Event event) {
+        /*
+         * The aggregation process is long-running task. To avoid blocking the thread used to consume
+         * Kafka messages from the ingress topic, we're performing the aggregation from a worker thread.
+         */
+        managedExecutor.submit(() -> {
 
-        AggregationCommand aggregationCommand = null;
-        Timer.Sample consumedTimer = Timer.start(registry);
+            AggregationCommand aggregationCommand;
+            Timer.Sample consumedTimer = Timer.start(registry);
 
-        try {
-            Action action = actionParser.fromJsonString(event.getPayload());
-            Map<String, Object> map = action.getEvents().get(0).getPayload().getAdditionalProperties();
-            aggregationCommand = objectMapper.convertValue(map, AggregationCommand.class);
-        } catch (Exception e) {
-            Log.error("Kafka aggregation payload parsing failed for event " + event.getId(), e);
-            rejectedAggregationCommandCount.increment();
-            return;
-        }
-
-        Log.infof("Processing received aggregation command: %s", aggregationCommand);
-        processedAggregationCommandCount.increment();
-
-        try {
-            Optional<Application> app = applicationRepository.getApplication(aggregationCommand.getAggregationKey().getBundle(), aggregationCommand.getAggregationKey().getApplication());
-            if (app.isPresent()) {
-                event.setEventTypeDisplayName(
-                    String.format("%s - %s - %s",
-                        event.getEventTypeDisplayName(),
-                        app.get().getDisplayName(),
-                        app.get().getBundle().getDisplayName())
-                );
-                eventRepository.updateEventDisplayName(event);
+            try {
+                Action action = actionParser.fromJsonString(event.getPayload());
+                Map<String, Object> map = action.getEvents().get(0).getPayload().getAdditionalProperties();
+                aggregationCommand = objectMapper.convertValue(map, AggregationCommand.class);
+            } catch (Exception e) {
+                Log.error("Kafka aggregation payload parsing failed for event " + event.getId(), e);
+                rejectedAggregationCommandCount.increment();
+                return;
             }
-            processAggregateEmailsByAggregationKey(aggregationCommand, Optional.of(event));
-        } catch (Exception e) {
-            Log.warn("Error while processing aggregation", e);
-            failedAggregationCommandCount.increment();
-        } finally {
-            consumedTimer.stop(registry.timer(
-                AGGREGATION_CONSUMED_TIMER_NAME,
-                TAG_KEY_BUNDLE, aggregationCommand.getAggregationKey().getBundle(),
-                TAG_KEY_APPLICATION, aggregationCommand.getAggregationKey().getApplication()
-            ));
-        }
+
+            Log.infof("Processing received aggregation command: %s", aggregationCommand);
+            processedAggregationCommandCount.increment();
+
+            try {
+                Optional<Application> app = applicationRepository.getApplication(aggregationCommand.getAggregationKey().getBundle(), aggregationCommand.getAggregationKey().getApplication());
+                if (app.isPresent()) {
+                    event.setEventTypeDisplayName(
+                            String.format("%s - %s - %s",
+                                    event.getEventTypeDisplayName(),
+                                    app.get().getDisplayName(),
+                                    app.get().getBundle().getDisplayName())
+                    );
+                    eventRepository.updateEventDisplayName(event);
+                }
+                processAggregateEmailsByAggregationKey(aggregationCommand, Optional.of(event));
+            } catch (Exception e) {
+                Log.warn("Error while processing aggregation", e);
+                failedAggregationCommandCount.increment();
+            } finally {
+                consumedTimer.stop(registry.timer(
+                        AGGREGATION_CONSUMED_TIMER_NAME,
+                        TAG_KEY_BUNDLE, aggregationCommand.getAggregationKey().getBundle(),
+                        TAG_KEY_APPLICATION, aggregationCommand.getAggregationKey().getApplication()
+                ));
+            }
+        });
     }
 
     @Incoming(AGGREGATION_CHANNEL)

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -67,6 +67,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -207,7 +208,7 @@ class EmailSubscriptionTypeProcessorTest {
             micrometerAssertionHelper.assertCounterIncrement(AGGREGATION_COMMAND_ERROR_COUNTER_NAME, 0);
 
             // Let's check that EndpointEmailSubscriptionResources#sendEmail was called for each aggregation.
-            verify(emailAggregationRepository, times(1)).getEmailAggregation(
+            verify(emailAggregationRepository, timeout(5000L).times(1)).getEmailAggregation(
                 eq(aggregationCommand1.getAggregationKey()),
                 eq(aggregationCommand1.getStart()),
                 eq(aggregationCommand1.getEnd()),
@@ -215,29 +216,29 @@ class EmailSubscriptionTypeProcessorTest {
                 anyInt()
             );
 
-            verify(emailAggregationRepository, times(1)).purgeOldAggregation(
+            verify(emailAggregationRepository, timeout(5000L).times(1)).purgeOldAggregation(
                 eq(aggregationCommand1.getAggregationKey()),
                 eq(aggregationCommand1.getEnd())
             );
-            verify(emailAggregationRepository, times(1)).getEmailAggregation(
+            verify(emailAggregationRepository, timeout(5000L).times(1)).getEmailAggregation(
                 eq(aggregationCommand2.getAggregationKey()),
                 eq(aggregationCommand2.getStart()),
                 eq(aggregationCommand2.getEnd()),
                 eq(0),
                 anyInt()
             );
-            verify(emailAggregationRepository, times(1)).purgeOldAggregation(
+            verify(emailAggregationRepository, timeout(5000L).times(1)).purgeOldAggregation(
                 eq(aggregationCommand2.getAggregationKey()),
                 eq(aggregationCommand2.getEnd())
             );
 
             if (featureFlipper.isSendSingleEmailForMultipleRecipientsEnabled()) {
-                verify(sender, times(1)).sendEmail(eq(Set.of(user1, user2)), any(), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
-                verify(sender, times(1)).sendEmail(eq(Set.of(user3)), any(), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
+                verify(sender, timeout(5000L).times(1)).sendEmail(eq(Set.of(user1, user2)), any(), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
+                verify(sender, timeout(5000L).times(1)).sendEmail(eq(Set.of(user3)), any(), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
             } else {
-                verify(sender, times(1)).sendEmail(eq(user1), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
-                verify(sender, times(1)).sendEmail(eq(user2), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
-                verify(sender, times(1)).sendEmail(eq(user3), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
+                verify(sender, timeout(5000L).times(1)).sendEmail(eq(user1), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
+                verify(sender, timeout(5000L).times(1)).sendEmail(eq(user2), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
+                verify(sender, timeout(5000L).times(1)).sendEmail(eq(user3), any(Event.class), any(TemplateInstance.class), any(TemplateInstance.class), anyBoolean(), any(Endpoint.class));
             }
             getEventHistory(channel);
         } finally {


### PR DESCRIPTION
:warning: Check the `Hide whitespace` option for a much easier review.

We recently moved the aggregation process from the `aggregation` topic to the `ingress` topic. The aggregation process is already slow and is bound to become even slower. We need to make sure it won't have any impact on our throughput and will never slow down our consumption rate with the `ingress` topic.