### PR TITLE
Simplify recipients-resolver logic

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -63,37 +63,12 @@ objects:
           successThreshold: 1
           failureThreshold: 5
         env:
-        - name: NOTIFICATIONS_USE_RBAC_FOR_FETCHING_USERS
-          value: ${NOTIFICATIONS_USE_RBAC_FOR_FETCHING_USERS}
-        - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE
-          value: ${IT_SERVICE_TO_SERVICE_KEY_STORE}
-        - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: it-services
-              key: it-services-keystorepassword
-              optional: true
-        - name: QUARKUS_REST_CLIENT_IT_S2S_URL
-          valueFrom:
-            secretKeyRef:
-              name: it-services
-              key: url
-              optional: true
-        - name: QUARKUS_REST_CLIENT_RBAC_S2S_READ_TIMEOUT
-          value: ${RBAC_S2S_READ_TIMEOUT}
-        - name: RBAC_SERVICE_TO_SERVICE_APPLICATION
-          value: ${RBAC_SERVICE_TO_SERVICE_APP}
-        - name: RBAC_SERVICE_TO_SERVICE_SECRET_MAP
-          valueFrom:
-            secretKeyRef:
-              name: rbac-psks
-              key: psks.json
-        - name: RECIPIENT_PROVIDER_IT_MAX_RESULTS_PER_PAGE
-          value: ${RECIPIENT_PROVIDER_IT_MAX_RESULTS_PER_PAGE}
-        - name: RECIPIENT_PROVIDER_RBAC_ELEMENTS_PER_PAGE
-          value: ${RECIPIENT_PROVIDER_RBAC_ELEMENTS_PER_PAGE}
-        - name: RECIPIENT_PROVIDER_USE_IT_IMPL
-          value: ${RECIPIENT_PROVIDER_USE_IT_IMPL}
+        - name: NOTIFICATIONS_RECIPIENTS_RESOLVER_MAX_RESULTS_PER_PAGE
+          value: ${NOTIFICATIONS_RECIPIENTS_RESOLVER_MAX_RESULTS_PER_PAGE}
+        - name: NOTIFICATIONS_RECIPIENTS_RESOLVER_FETCH_USERS_MBOP_ENABLED
+          value: ${NOTIFICATIONS_RECIPIENTS_RESOLVER_FETCH_USERS_MBOP_ENABLED}
+        - name: NOTIFICATIONS_RECIPIENTS_RESOLVER_FETCH_USERS_RBAC_ENABLED
+          value: ${NOTIFICATIONS_RECIPIENTS_RESOLVER_FETCH_USERS_RBAC_ENABLED}
         - name: QUARKUS_CACHE_CAFFEINE_RBAC_RECIPIENT_USERS_PROVIDER_GET_USERS_EXPIRE_AFTER_WRITE
           value: ${RBAC_USERS_RETENTION_DELAY}
         - name: QUARKUS_CACHE_CAFFEINE_RBAC_RECIPIENT_USERS_PROVIDER_GET_GROUP_USERS_EXPIRE_AFTER_WRITE
@@ -102,6 +77,8 @@ objects:
           value: "9000"
         - name: QUARKUS_LOG_CATEGORY__COM_REDHAT_CLOUD_NOTIFICATIONS__LEVEL
           value: ${NOTIFICATIONS_LOG_LEVEL}
+        - name: QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL
+          value: ${QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL}
         - name: QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT
           value: ${QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT}
         - name: QUARKUS_LOG_CLOUDWATCH_BATCH_PERIOD
@@ -122,12 +99,31 @@ objects:
           value: ${SENTRY_DSN}${ENV_NAME}
         - name: QUARKUS_LOG_SENTRY_ENVIRONMENT
           value: ${ENV_NAME}
+        - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE
+          value: ${IT_SERVICE_TO_SERVICE_KEY_STORE}
+        - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: it-services
+              key: it-services-keystorepassword
+              optional: true
+        - name: QUARKUS_REST_CLIENT_IT_S2S_URL
+          valueFrom:
+            secretKeyRef:
+              name: it-services
+              key: url
+              optional: true
         - name: QUARKUS_REST_CLIENT_LOGGING_SCOPE
           value: ${QUARKUS_REST_CLIENT_LOGGING_SCOPE}
-        - name: QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL
-          value: ${QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL}
-        - name: NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS
-          value: ${NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS}
+        - name: QUARKUS_REST_CLIENT_RBAC_S2S_READ_TIMEOUT
+          value: ${RBAC_S2S_READ_TIMEOUT}
+        - name: RBAC_SERVICE_TO_SERVICE_APPLICATION
+          value: ${RBAC_SERVICE_TO_SERVICE_APP}
+        - name: RBAC_SERVICE_TO_SERVICE_SECRET_MAP
+          valueFrom:
+            secretKeyRef:
+              name: rbac-psks
+              key: psks.json
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
@@ -146,6 +142,11 @@ parameters:
   value: quay.io/cloudservices/notifications-recipient-resolver
 - name: IMAGE_TAG
   value: latest
+- name: IO_SMALLRYE_REACTIVE_MESSAGING_LOG_LEVEL
+  value: INFO
+- name: IT_SERVICE_TO_SERVICE_KEY_STORE
+  description: "Key store for secured connection if communicating with IT. It should be set to file:/mnt/secrets/clientkeystore.jks"
+  value: ""
 - name: MEMORY_LIMIT
   description: Memory limit
   value: 500Mi
@@ -156,6 +157,18 @@ parameters:
   value: "3"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
+  value: INFO
+- name: NOTIFICATIONS_RECIPIENTS_RESOLVER_MAX_RESULTS_PER_PAGE
+  description: Limit value sent to the external users service while querying users.
+  value: "1000"
+- name: NOTIFICATIONS_RECIPIENTS_RESOLVER_FETCH_USERS_MBOP_ENABLED
+  description: Users from an organization will be retrieved from MBOP if true
+  value: "false"
+- name: NOTIFICATIONS_RECIPIENTS_RESOLVER_FETCH_USERS_RBAC_ENABLED
+  description: Users from an organization will be retrieved from RBAC if true
+  value: "true"
+- name: QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL
+  description: When QUARKUS_REST_CLIENT_LOGGING_SCOPE is set to 'request-response', this logger level needs to be set to DEBUG
   value: INFO
 - name: QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT
   description: Amount of time to allow the CloudWatch client to complete the execution of an API call expressed with the ISO-8601 duration format PnDTnHnMn.nS.
@@ -169,45 +182,23 @@ parameters:
 - name: QUARKUS_LOG_CLOUDWATCH_MAX_QUEUE_SIZE
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
-- name: RBAC_S2S_READ_TIMEOUT
-  description: Delay in milliseconds before an RBAC S2S query is interrupted
-  value: "120000"
+- name: QUARKUS_REST_CLIENT_LOGGING_SCOPE
+  description: When set to 'request-response', rest-client will log the request and response contents
+  value: ""
 - name: RBAC_GROUP_USERS_RETENTION_DELAY
   description: RBAC group users data cache retention delay. It must be expressed with the ISO-8601 duration format PnDTnHnMn.nS.
   value: PT10M
+- name: RBAC_S2S_READ_TIMEOUT
+  description: Delay in milliseconds before an RBAC S2S query is interrupted
+  value: "120000"
 - name: RBAC_SERVICE_TO_SERVICE_APP
   description: RBAC application name to use for service-to-service communication
   value: notifications
 - name: RBAC_USERS_RETENTION_DELAY
   description: RBAC users data cache retention delay. It must be expressed with the ISO-8601 duration format PnDTnHnMn.nS.
   value: PT10M
-- name: RECIPIENT_PROVIDER_IT_MAX_RESULTS_PER_PAGE
-  description: Limit value sent to the IT API while querying users.
-  value: "1000"
-- name: RECIPIENT_PROVIDER_RBAC_ELEMENTS_PER_PAGE
-  description: Limit value sent as a query param to the RBAC REST API while querying RBAC users.
-  value: "1000"
-- name: RECIPIENT_PROVIDER_USE_IT_IMPL
-  description: Temporary recipients retrieval switch between RBAC and IT
-  value: "false"
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED
   description: Enable Sentry (or not)
-  value: "false"
-- name: NOTIFICATIONS_USE_RBAC_FOR_FETCHING_USERS
-  description: Users from an organization will be retrieved from RBAC if true or from the IT users service otherwise.
-  value: "true"
-- name: IT_SERVICE_TO_SERVICE_KEY_STORE
-  description: "Key store for secured connection if communicating with IT. It should be set to file:/mnt/secrets/clientkeystore.jks"
-  value: ""
-- name: IO_SMALLRYE_REACTIVE_MESSAGING_LOG_LEVEL
-  value: INFO
-- name: QUARKUS_REST_CLIENT_LOGGING_SCOPE
-  description: When set to 'request-response', rest-client will log the request and response contents
-  value: ""
-- name: QUARKUS_LOG_CATEGORY__ORG_JBOSS_RESTEASY_REACTIVE_CLIENT_LOGGING__LEVEL
-  description: When QUARKUS_REST_CLIENT_LOGGING_SCOPE is set to 'request-response', this logger level needs to be set to DEBUG
-  value: INFO
-- name: NOTIFICATIONS_USE_MBOP_FOR_FETCHING_USERS
   value: "false"

--- a/recipients-resolver/pom.xml
+++ b/recipients-resolver/pom.xml
@@ -12,41 +12,19 @@
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <profiles>
-
-        <!--
-        When Maven compiles a project with the "-Dmaven.test.skip" option, the tests compilation and execution are skipped
-        but Maven still resolves the dependencies from the "test" scope and fails if these dependencies cannot be found.
-        This is considered a Maven bug by many users and even though it was reported as such several years ago, it's never
-        been fixed. The following profile works around that limitation and makes the compilation successful when tests are
-        skipped even if the listed test dependencies are not available.
-        -->
-        <profile>
-            <id>resolve-test-jars-if-tests-are-not-skipped</id>
-            <activation>
-                <property>
-                    <name>maven.test.skip</name>
-                    <value>!true</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.redhat.cloud.notifications</groupId>
-                    <artifactId>notifications-common</artifactId>
-                    <version>${project.version}</version>
-                    <type>test-jar</type>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-    </profiles>
-
     <dependencies>
 
         <!-- Scope: compile -->
 
         <!-- Quarkus -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
@@ -59,14 +37,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-cache</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-validator</artifactId>
-        </dependency>
+
         <!-- Quarkiverse -->
         <dependency>
             <groupId>io.quarkiverse.logging.cloudwatch</groupId>

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/config/RecipientsResolverConfig.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/config/RecipientsResolverConfig.java
@@ -10,47 +10,23 @@ import java.time.Duration;
 @ApplicationScoped
 public class RecipientsResolverConfig {
 
-    @ConfigProperty(name = "notifications.connector.fetch.users.rbac.enabled", defaultValue = "false")
+    @ConfigProperty(name = "notifications.recipients-resolver.fetch.users.rbac.enabled", defaultValue = "false")
     boolean fetchUsersWithRBAC;
 
-    @ConfigProperty(name = "notifications.connector.fetch.users.mbop.enabled", defaultValue = "false")
+    @ConfigProperty(name = "notifications.recipients-resolver.fetch.users.mbop.enabled", defaultValue = "false")
     boolean fetchUsersWithMbop;
 
-    @ConfigProperty(name = "recipients-provider.rbac.elements-per-page", defaultValue = "1000")
-    int rbacMaxResultsPerPage;
+    @ConfigProperty(name = "notifications.recipients-resolver.max-results-per-page", defaultValue = "1000")
+    int maxResultsPerPage;
 
-    @ConfigProperty(name = "recipients-provider.it.max-results-per-page", defaultValue = "1000")
-    int itMaxResultsPerPage;
+    @ConfigProperty(name = "notifications.recipients-resolver.retry.max-attempts", defaultValue = "3")
+    int maxRetryAttempts;
 
-    @ConfigProperty(name = "recipients-provider.mbop.max-results-per-page", defaultValue = "1000")
-    int MBOPMaxResultsPerPage;
+    @ConfigProperty(name = "notifications.recipients-resolver.retry.initial-backoff", defaultValue = "0.1S")
+    Duration initialRetryBackoff;
 
-    @ConfigProperty(name = "rbac.retry.max-attempts", defaultValue = "3")
-    int rbacMaxRetryAttempts;
-
-    @ConfigProperty(name = "it.retry.max-attempts", defaultValue = "3")
-    int itMaxRetryAttempts;
-
-    @ConfigProperty(name = "mbop.retry.max-attempts", defaultValue = "3")
-    int MBOPMaxRetryAttempts;
-
-    @ConfigProperty(name = "it.retry.back-off.initial-value", defaultValue = "0.1S")
-    Duration itInitialBackOff;
-
-    @ConfigProperty(name = "it.retry.back-off.max-value", defaultValue = "1S")
-    Duration itMaxBackOff;
-
-    @ConfigProperty(name = "rbac.retry.back-off.initial-value", defaultValue = "0.1S")
-    Duration rbacInitialBackOff;
-
-    @ConfigProperty(name = "rbac.retry.back-off.max-value", defaultValue = "1S")
-    Duration rbacMaxBackOff;
-
-    @ConfigProperty(name = "mbop.retry.back-off.initial-value", defaultValue = "0.1S")
-    Duration MBOPInitialBackOff;
-
-    @ConfigProperty(name = "mbop.retry.back-off.max-value", defaultValue = "1S")
-    Duration MBOPMaxBackOff;
+    @ConfigProperty(name = "notifications.recipients-resolver.retry.max-backoff", defaultValue = "1S")
+    Duration maxRetryBackoff;
 
     @ConfigProperty(name = "mbop.apitoken", defaultValue = "na")
     String mbopApiToken;
@@ -66,18 +42,10 @@ public class RecipientsResolverConfig {
         Log.infof("The fetching users with Rbac is %s", fetchUsersWithRBAC ? "enabled" : "disabled");
         Log.infof("The fetching users with Mbop is %s", fetchUsersWithMbop ? "enabled" : "disabled");
         Log.infof("The fetching users with IT Service is %s", !(fetchUsersWithRBAC || fetchUsersWithMbop) ? "enabled" : "disabled");
-        Log.infof("The max result per page for IT Service is %s", itMaxResultsPerPage);
-        Log.infof("The max result per page for Mbop is %s", MBOPMaxResultsPerPage);
-        Log.infof("The max result per page for Rbac is %s", rbacMaxResultsPerPage);
-        Log.infof("The max retry attempts for IT Service is %s", itMaxRetryAttempts);
-        Log.infof("The max retry attempts for Mbop is %s", MBOPMaxRetryAttempts);
-        Log.infof("The max retry attempts for Rbac is %s", rbacMaxRetryAttempts);
-        Log.infof("The retry back-off initial value for IT Service is %s", itInitialBackOff);
-        Log.infof("The retry back-off initial value for Mbop is %s", MBOPInitialBackOff);
-        Log.infof("The retry back-off initial value for Rbac is %s", rbacInitialBackOff);
-        Log.infof("The max retry back-off value for IT Service is %s", itMaxBackOff);
-        Log.infof("The max retry back-off value for MBOP is %s", MBOPMaxBackOff);
-        Log.infof("The max retry back-off value for rbac is %s", rbacMaxBackOff);
+        Log.infof("The max result per page is %s", maxResultsPerPage);
+        Log.infof("The max retry attempts is %s", maxRetryAttempts);
+        Log.infof("The retry back-off initial value is %s", initialRetryBackoff);
+        Log.infof("The max retry back-off value is %s", maxRetryBackoff);
         Log.infof("The MBOP env is %s", mbopEnv);
     }
 
@@ -97,52 +65,20 @@ public class RecipientsResolverConfig {
         this.fetchUsersWithMbop = fetchUsersWithMbop;
     }
 
-    public Integer getRbacMaxResultsPerPage() {
-        return rbacMaxResultsPerPage;
+    public int getMaxResultsPerPage() {
+        return maxResultsPerPage;
     }
 
-    public int getItMaxResultsPerPage() {
-        return itMaxResultsPerPage;
+    public int getMaxRetryAttempts() {
+        return maxRetryAttempts;
     }
 
-    public int getMBOPMaxResultsPerPage() {
-        return MBOPMaxResultsPerPage;
+    public Duration getInitialRetryBackoff() {
+        return initialRetryBackoff;
     }
 
-    public int getRbacMaxRetryAttempts() {
-        return rbacMaxRetryAttempts;
-    }
-
-    public int getItMaxRetryAttempts() {
-        return itMaxRetryAttempts;
-    }
-
-    public int getMBOPMaxRetryAttempts() {
-        return MBOPMaxRetryAttempts;
-    }
-
-    public Duration getItInitialBackOff() {
-        return itInitialBackOff;
-    }
-
-    public Duration getItMaxBackOff() {
-        return itMaxBackOff;
-    }
-
-    public Duration getRbacInitialBackOff() {
-        return rbacInitialBackOff;
-    }
-
-    public Duration getRbacMaxBackOff() {
-        return rbacMaxBackOff;
-    }
-
-    public Duration getMBOPInitialBackOff() {
-        return MBOPInitialBackOff;
-    }
-
-    public Duration getMBOPMaxBackOff() {
-        return MBOPMaxBackOff;
+    public Duration getMaxRetryBackoff() {
+        return maxRetryBackoff;
     }
 
     public String getMbopApiToken() {

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/model/User.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/model/User.java
@@ -6,8 +6,7 @@ public class User {
 
     private String id;
     private String username;
-    private Boolean isActive;
-    private Boolean isAdmin;
+    private boolean admin;
 
     public String getId() {
         return id;
@@ -25,20 +24,12 @@ public class User {
         this.username = username;
     }
 
-    public Boolean isActive() {
-        return isActive;
+    public boolean isAdmin() {
+        return admin;
     }
 
-    public void setActive(Boolean active) {
-        isActive = active;
-    }
-
-    public Boolean isAdmin() {
-        return isAdmin;
-    }
-
-    public void setAdmin(Boolean admin) {
-        isAdmin = admin;
+    public void setAdmin(boolean admin) {
+        this.admin = admin;
     }
 
     @Override

--- a/recipients-resolver/src/main/resources/application.properties
+++ b/recipients-resolver/src/main/resources/application.properties
@@ -47,4 +47,4 @@ mbop.env=qa
 # Quarkus caches
 quarkus.cache.caffeine.recipients-users-provider-get-users.expire-after-write=PT10M
 quarkus.cache.caffeine.recipients-users-provider-get-group-users.expire-after-write=PT10M
-quarkus.cache.caffeine.find-recipients=PT10M
+quarkus.cache.caffeine.find-recipients.expire-after-write=PT10M

--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/RecipientsResolverTest.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/RecipientsResolverTest.java
@@ -631,7 +631,6 @@ public class RecipientsResolverTest {
         User user = new User();
         user.setUsername(username);
         user.setAdmin(isAdmin);
-        user.setActive(true);
         return user;
     }
 

--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/itservice/ITUserServiceTest.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/itservice/ITUserServiceTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -71,7 +70,6 @@ public class ITUserServiceTest {
         when(itUserService.getUsers(any(ITUserRequest.class))).thenReturn(itUserResponses);
 
         final List<User> someAccountId = rbacRecipientUsersProvider.getUsers("someOrgId", true);
-        assertTrue(someAccountId.get(0).isActive());
     }
 
     @Test
@@ -85,16 +83,13 @@ public class ITUserServiceTest {
 
         final User user = users.get(0);
         assertEquals("userName", user.getUsername());
-        assertTrue(user.isActive());
         assertFalse(user.isAdmin());
     }
 
     private User createNonAdminMockedUser() {
         User mockedUser = new User();
-        mockedUser.setActive(true);
         mockedUser.setUsername("userName");
         mockedUser.setAdmin(false);
-        mockedUser.setActive(true);
         return mockedUser;
     }
 }

--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/rest/RecipientResolverResourceTest.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/rest/RecipientResolverResourceTest.java
@@ -90,7 +90,6 @@ public class RecipientResolverResourceTest {
         User user = new User();
         user.setId(UUID.randomUUID().toString());
         user.setUsername("username-" + index);
-        user.setActive(true);
         return user;
     }
 }


### PR DESCRIPTION
- Shared retry policy declaration for all external services
- Shared failure counter var for all external services
- Shared configuration values for all external services
- `User#isActive` is gone
- `User#isAdmin` is primitive now (and renamed)
- ClowdApp template cleanup
- The `test` dependency on `notifications-common` is gone