### PR TITLE
Increase max.request.size for platform.notifications.tocamel

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -106,6 +106,8 @@ objects:
           value: ${MP_MESSAGING_INCOMING_INGRESS_THROTTLED_UNPROCESSED_RECORD_MAX_AGE_MS}
         - name: MP_MESSAGING_OUTGOING_TOCAMEL_ENABLED
           value: ${MP_MESSAGING_OUTGOING_TOCAMEL_ENABLED}
+        - name: MP_MESSAGING_OUTGOING_TOCAMEL_MAX_REQUEST_SIZE
+          value: ${MP_MESSAGING_OUTGOING_TOCAMEL_MAX_REQUEST_SIZE}
         - name: MP_MESSAGING_OUTGOING_DRAWER_ENABLED
           value: ${MP_MESSAGING_OUTGOING_DRAWER_ENABLED}
         - name: NOTIFICATIONS_AGGREGATION_MAX_PAGE_SIZE
@@ -310,6 +312,9 @@ parameters:
   value: "60000"
 - name: MP_MESSAGING_OUTGOING_TOCAMEL_ENABLED
   value: "true"
+- name: MP_MESSAGING_OUTGOING_TOCAMEL_MAX_REQUEST_SIZE
+  description: Maximum size of a request (which can include several messages) in bytes (default is 1048576). Uncompressed messages that exceed this value will trigger a RecordTooLargeException, even if their size after compression is lower than the value.
+  value: "10485760"
 - name: MP_MESSAGING_OUTGOING_DRAWER_ENABLED
   value: "false"
 - name: NOTIFICATIONS_AGGREGATION_MAX_PAGE_SIZE


### PR DESCRIPTION
This should help fix:
```
RecordTooLargeException
The message is 4021051 bytes when serialized which is larger than 1048576, which is the value of the max.request.size configuration.
```
The size of each message is checked _before_ it is compressed and if it exceeds the `max.request.size` setting of the Kafka producer, the exception is thrown. The thing is we are compressing messages sent to `platform.notifications.tocamel`, so we can allow larger messages.

More details about this:
https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#max-request-size
https://issues.apache.org/jira/browse/KAFKA-4169