### PR TITLE
Fix aggregator ClowdApp template

### DIFF
--- a/.rhcicd/clowdapp-aggregator.yaml
+++ b/.rhcicd/clowdapp-aggregator.yaml
@@ -16,6 +16,10 @@ objects:
     - notifications-backend
     database:
       sharedDbAppName: notifications-backend
+    kafkaTopics:
+    - topicName: platform.notifications.ingress
+      partitions: 3
+      replicas: 3
     jobs:
     - name: cronjob
       schedule: ${CRONTAB_AGGREGATION_JOB}


### PR DESCRIPTION
#2218 removed Kafka entirely from the ClowdApp template while we still need the `ingress` topic.