### PR TITLE
Remove aggregation config values from application.properties

### DIFF
--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -10,14 +10,6 @@ quarkus.http.port=8087
 %test.quarkus.http.test-port=9087
 %test.quarkus.devservices.enabled=true
 
-# Input aggregation queue
-mp.messaging.incoming.aggregation.connector=smallrye-kafka
-mp.messaging.incoming.aggregation.topic=platform.notifications.aggregation
-mp.messaging.incoming.aggregation.group.id=integrations
-mp.messaging.incoming.aggregation.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-mp.messaging.incoming.aggregation.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-mp.messaging.incoming.aggregation.cloud-events=false
-
 # Input queue
 mp.messaging.incoming.ingress.connector=smallrye-kafka
 mp.messaging.incoming.ingress.topic=platform.notifications.ingress


### PR DESCRIPTION
This will fix:
```
2023-10-24 08:26:03,201 WARN  [io.sma.rea.mes.provider] (main) SRMSG00208: The connector 'IncomingConnector{channel:'aggregation', attribute:'mp.messaging.incoming.aggregation'}' has no downstreams
2023-10-24 08:26:03,805 WARN  [io.sma.rea.mes.provider] (main) SRMSG00207: Some components are not connected to either downstream consumers or upstream producers:
	- IncomingConnector{channel:'aggregation', attribute:'mp.messaging.incoming.aggregation'} has no downstream
```