### PR TITLE
Use ClowdApp templates from stage in ephemeral

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -29,6 +29,8 @@ buildAndPushToQuay "notifications-recipients-resolver"
 # Deploy all images on ephemeral
 export APP_NAME="notifications"
 export COMPONENT_NAME="notifications-backend"
+# ClowdApp templates from stage will be used in ephemeral, meaning that breaking template changes don't have to be deployed in production to fix ephemeral deployments
+export REF_ENV="insights-stage"
 export IMAGE="quay.io/cloudservices/notifications-backend"
 export DEPLOY_TIMEOUT="1200"
 export EXTRA_DEPLOY_ARGS="--set-parameter notifications-engine/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-email/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-google-chat/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-microsoft-teams/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-servicenow/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-slack/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-splunk/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-webhook/IMAGE_TAG=${IMAGE_TAG} --no-remove-resources historical-system-profiles --no-remove-resources system-baseline"


### PR DESCRIPTION
Until now, whenever we introduced a breaking change in a ClowdApp template and it broke some deployment in ephemeral, we had to deploy that template up to production before ephemeral could be fixed.

Starting now, deploying the new template in stage will be enough to fix ephemeral.