### PR TITLE
Use Maven's --also-make option in Docker files

### DIFF
--- a/docker/Dockerfile.notifications-aggregator.jvm
+++ b/docker/Dockerfile.notifications-aggregator.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-common-aggregator,:notifications-database,:notifications-aggregator --no-transfer-progress
+RUN ./mvnw clean package -DskipTests -pl :notifications-aggregator -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-backend.jvm
+++ b/docker/Dockerfile.notifications-backend.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-common,:notifications-common-aggregator,:notifications-database,:notifications-backend --no-transfer-progress
+RUN ./mvnw clean package -DskipTests -pl :notifications-backend -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-connector-drawer.jvm
+++ b/docker/Dockerfile.notifications-connector-drawer.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-drawer --no-transfer-progress
+RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-drawer -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-connector-email.jvm
+++ b/docker/Dockerfile.notifications-connector-email.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-email --no-transfer-progress
+RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-email -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-connector-google-chat.jvm
+++ b/docker/Dockerfile.notifications-connector-google-chat.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-google-chat --no-transfer-progress
+RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-google-chat -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
+++ b/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-microsoft-teams --no-transfer-progress
+RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-microsoft-teams -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-connector-servicenow.jvm
+++ b/docker/Dockerfile.notifications-connector-servicenow.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-servicenow --no-transfer-progress
+RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-servicenow -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-connector-slack.jvm
+++ b/docker/Dockerfile.notifications-connector-slack.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-slack --no-transfer-progress
+RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-slack -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-connector-splunk.jvm
+++ b/docker/Dockerfile.notifications-connector-splunk.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-splunk --no-transfer-progress
+RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-splunk -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-connector-webhook.jvm
+++ b/docker/Dockerfile.notifications-connector-webhook.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-connector-common,:notifications-connector-webhook --no-transfer-progress
+RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-webhook -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests --projects :checkstyle,:notifications-common,:notifications-common-aggregator,:notifications-database,:notifications-engine --no-transfer-progress
+RUN ./mvnw clean package -DskipTests -pl :notifications-engine -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest

--- a/docker/Dockerfile.notifications-recipients-resolver.jvm
+++ b/docker/Dockerfile.notifications-recipients-resolver.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip --projects :notifications-recipients-resolver --no-transfer-progress
+RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-recipients-resolver -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:latest


### PR DESCRIPTION
When `-am` is used, Maven will automatically build modules that are dependencies of the current module.