### PR TITLE
RHCLOUD-29101 Introduce recipients.emails field

### DIFF
--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailCloudEventDataExtractor.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailCloudEventDataExtractor.java
@@ -3,12 +3,14 @@ package com.redhat.cloud.notifications.connector.email;
 import com.redhat.cloud.notifications.connector.CloudEventDataExtractor;
 import com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty;
 import com.redhat.cloud.notifications.connector.email.model.settings.RecipientSettings;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.Exchange;
 
 import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
 
 @ApplicationScoped
 public class EmailCloudEventDataExtractor extends CloudEventDataExtractor {
@@ -20,23 +22,26 @@ public class EmailCloudEventDataExtractor extends CloudEventDataExtractor {
      */
     @Override
     public void extract(final Exchange exchange, final JsonObject cloudEventData) {
-        final JsonArray settings = cloudEventData.getJsonArray("recipient_settings");
 
-        final List<RecipientSettings> recipientSettings = settings
+        final List<RecipientSettings> recipientSettings = cloudEventData.getJsonArray("recipient_settings")
             .stream()
             .map(JsonObject.class::cast)
             .map(jsonSetting -> jsonSetting.mapTo(RecipientSettings.class))
             .toList();
 
-        final JsonArray subs = cloudEventData.getJsonArray("subscribers");
-        final List<String> subscribers = subs
+        final List<String> subscribers = cloudEventData.getJsonArray("subscribers")
             .stream()
             .map(String.class::cast)
             .toList();
+
+        final Set<String> emails = recipientSettings.stream()
+                .flatMap(settings -> settings.getEmails().stream())
+                .collect(toSet());
 
         exchange.setProperty(ExchangeProperty.RENDERED_BODY, cloudEventData.getString("email_body"));
         exchange.setProperty(ExchangeProperty.RENDERED_SUBJECT, cloudEventData.getString("email_subject"));
         exchange.setProperty(ExchangeProperty.RECIPIENT_SETTINGS, recipientSettings);
         exchange.setProperty(ExchangeProperty.SUBSCRIBERS, subscribers);
+        exchange.setProperty(ExchangeProperty.EMAIL_RECIPIENTS, emails);
     }
 }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/constants/ExchangeProperty.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/constants/ExchangeProperty.java
@@ -55,4 +55,10 @@ public class ExchangeProperty {
      * notification through email.
      */
     public static final String USERS = "users";
+    /**
+     * Email recipients initially included in the payload received by notifications-engine.
+     * The subscriptions of these recipients are not checked.
+     * They are simply added to the list of recipients retrieved from notifications-recipients-resolver.
+     */
+    public static final String EMAIL_RECIPIENTS = "email_recipients";
 }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/settings/RecipientSettings.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/settings/RecipientSettings.java
@@ -14,6 +14,7 @@ public class RecipientSettings {
     private boolean ignoreUserPreferences;
     private UUID groupUUID;
     private Set<String> users;
+    private Set<String> emails;
 
     /**
      * Default constructor for the automatic deserialization of objects.
@@ -26,12 +27,14 @@ public class RecipientSettings {
      * @param ignoreUserPreferences should we ignore user preferences?
      * @param groupUUID should we notify the entire group?
      * @param usernames the set of usernames we need to notify.
+     * @param emails the set of emails we need to notify.
      */
-    public RecipientSettings(final boolean adminsOnly, final boolean ignoreUserPreferences, final UUID groupUUID, final Set<String> usernames) {
+    public RecipientSettings(final boolean adminsOnly, final boolean ignoreUserPreferences, final UUID groupUUID, final Set<String> usernames, final Set<String> emails) {
         this.adminsOnly = adminsOnly;
         this.ignoreUserPreferences = ignoreUserPreferences;
         this.groupUUID = groupUUID;
         this.users = usernames;
+        this.emails = emails;
     }
 
     public boolean isAdminsOnly() {
@@ -50,6 +53,10 @@ public class RecipientSettings {
         return this.users;
     }
 
+    public Set<String> getEmails() {
+        return emails;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -64,16 +71,12 @@ public class RecipientSettings {
         return Objects.equals(this.adminsOnly, that.adminsOnly) &&
             Objects.equals(this.ignoreUserPreferences, that.ignoreUserPreferences) &&
             Objects.equals(this.groupUUID, that.groupUUID) &&
-            Objects.equals(this.users, that.users);
+            Objects.equals(this.users, that.users) &&
+            Objects.equals(this.emails, that.emails);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-            this.adminsOnly ? 1 : 0,
-            this.ignoreUserPreferences ? 1 : 0,
-            (this.groupUUID != null ? groupUUID.hashCode() : 0),
-            (this.users != null ? users.hashCode() : 0)
-        );
+        return Objects.hash(adminsOnly, ignoreUserPreferences, groupUUID, users, emails);
     }
 }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparer.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparer.java
@@ -48,6 +48,8 @@ public class BOPRequestPreparer implements Processor {
             final Set<User> users = exchange.getProperty(ExchangeProperty.FILTERED_USERS, Set.class);
             if (emailConnectorConfig.isSkipBopUsersResolution()) {
                 recipients = users.stream().map(User::getEmail).collect(toSet());
+                Set<String> emails = exchange.getProperty(ExchangeProperty.EMAIL_RECIPIENTS, Set.class);
+                recipients.addAll(emails);
             } else {
                 recipients = users.stream().map(User::getUsername).collect(toSet());
             }

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailCloudEventDataExtractorTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailCloudEventDataExtractorTest.java
@@ -1,19 +1,26 @@
 package com.redhat.cloud.notifications.connector.email;
 
-import com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty;
 import com.redhat.cloud.notifications.connector.email.model.settings.RecipientSettings;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
 import org.apache.camel.Exchange;
 import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import static com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty.EMAIL_RECIPIENTS;
+import static com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty.RECIPIENT_SETTINGS;
+import static com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty.RENDERED_BODY;
+import static com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty.RENDERED_SUBJECT;
+import static com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty.SUBSCRIBERS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 @QuarkusTest
 public class EmailCloudEventDataExtractorTest extends CamelQuarkusTestSupport {
@@ -32,7 +39,8 @@ public class EmailCloudEventDataExtractorTest extends CamelQuarkusTestSupport {
             true,
             true,
             UUID.randomUUID(),
-            users
+            users,
+            Collections.emptySet()
         );
 
         final Set<String> users2 = Set.of("d", "e", "f");
@@ -40,7 +48,8 @@ public class EmailCloudEventDataExtractorTest extends CamelQuarkusTestSupport {
             true,
             true,
             UUID.randomUUID(),
-            users2
+            users2,
+            Set.of("foo@bar.com", "bar@foo.com")
         );
 
         final Set<String> users3 = Set.of("g", "h", "i");
@@ -48,7 +57,8 @@ public class EmailCloudEventDataExtractorTest extends CamelQuarkusTestSupport {
             true,
             true,
             UUID.randomUUID(),
-            users3
+            users3,
+            Set.of("john@doe.com")
         );
 
         final List<RecipientSettings> recipientSettingsList = new ArrayList<>();
@@ -75,9 +85,10 @@ public class EmailCloudEventDataExtractorTest extends CamelQuarkusTestSupport {
         this.emailCloudEventDataExtractor.extract(exchange, new JsonObject(payload.encode()));
 
         // Assert that the extracted data is correct.
-        Assertions.assertEquals(emailBody, exchange.getProperty(ExchangeProperty.RENDERED_BODY, String.class));
-        Assertions.assertEquals(emailSubject, exchange.getProperty(ExchangeProperty.RENDERED_SUBJECT, String.class));
-        Assertions.assertIterableEquals(recipientSettingsList, exchange.getProperty(ExchangeProperty.RECIPIENT_SETTINGS, List.class));
-        Assertions.assertIterableEquals(subscribers, exchange.getProperty(ExchangeProperty.SUBSCRIBERS, List.class));
+        assertEquals(emailBody, exchange.getProperty(RENDERED_BODY, String.class));
+        assertEquals(emailSubject, exchange.getProperty(RENDERED_SUBJECT, String.class));
+        assertIterableEquals(recipientSettingsList, exchange.getProperty(RECIPIENT_SETTINGS, List.class));
+        assertIterableEquals(subscribers, exchange.getProperty(SUBSCRIBERS, List.class));
+        assertEquals(Set.of("foo@bar.com", "bar@foo.com", "john@doe.com"), exchange.getProperty(EMAIL_RECIPIENTS, Set.class));
     }
 }

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderRHCLOUD28631SingleEmailPerUserTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderRHCLOUD28631SingleEmailPerUserTest.java
@@ -60,7 +60,8 @@ public class EmailRouteBuilderRHCLOUD28631SingleEmailPerUserTest extends CamelQu
             true,
             true,
             null,
-            users
+            users,
+            null
         );
         final Set<String> users2 = Set.of("johndoe", "janedoe");
 
@@ -68,7 +69,8 @@ public class EmailRouteBuilderRHCLOUD28631SingleEmailPerUserTest extends CamelQu
             true,
             true,
             null,
-            users2
+            users2,
+            null
         );
 
         // Create the exchange that we will use in this test.

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderRHCLOUD28631Test.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderRHCLOUD28631Test.java
@@ -64,7 +64,8 @@ public class EmailRouteBuilderRHCLOUD28631Test extends CamelQuarkusTestSupport {
             true,
             true,
             null,
-            users
+            users,
+            null
         );
         final Set<String> users2 = Set.of("johndoe", "janedoe");
 
@@ -78,7 +79,8 @@ public class EmailRouteBuilderRHCLOUD28631Test extends CamelQuarkusTestSupport {
             true,
             true,
             null,
-            users2
+            users2,
+            null
         );
 
         // Create the exchange that we will use in this test.

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/it/ITUserRequestPreparerTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/it/ITUserRequestPreparerTest.java
@@ -38,6 +38,7 @@ public class ITUserRequestPreparerTest extends CamelQuarkusTestSupport {
             true,
             true,
             null,
+            null,
             null
         );
 

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACPrincipalsRequestPreparerProcessorTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACPrincipalsRequestPreparerProcessorTest.java
@@ -31,6 +31,7 @@ public class RBACPrincipalsRequestPreparerProcessorTest extends CamelQuarkusTest
             true,
             true,
             null,
+            null,
             null
         );
         final int offset = 25;

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACUsersProcessorTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/rbac/RBACUsersProcessorTest.java
@@ -46,6 +46,7 @@ public class RBACUsersProcessorTest extends CamelQuarkusTestSupport {
             true,
             true,
             null,
+            null,
             null
         );
         exchange.setProperty(ExchangeProperty.CURRENT_RECIPIENT_SETTINGS, recipientSettings);
@@ -83,6 +84,7 @@ public class RBACUsersProcessorTest extends CamelQuarkusTestSupport {
         final RecipientSettings recipientSettings = new RecipientSettings(
             true,
             true,
+            null,
             null,
             null
         );
@@ -129,6 +131,7 @@ public class RBACUsersProcessorTest extends CamelQuarkusTestSupport {
             true,
             true,
             UUID.randomUUID(),
+            null,
             null
         );
         exchange.setProperty(ExchangeProperty.CURRENT_RECIPIENT_SETTINGS, recipientSettings);

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/recipients/RecipientsFilterTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/processors/recipients/RecipientsFilterTest.java
@@ -41,7 +41,8 @@ public class RecipientsFilterTest extends CamelQuarkusTestSupport {
             // as true, in order for the logic not to further modify the set.
             true,
             UUID.randomUUID(),
-            recipientUsers
+            recipientUsers,
+            null
         );
 
         // Prepare the exchange.
@@ -75,6 +76,7 @@ public class RecipientsFilterTest extends CamelQuarkusTestSupport {
             // as true, in order for the logic not to further modify the set.
             true,
             UUID.randomUUID(),
+            null,
             null
         );
 
@@ -109,6 +111,7 @@ public class RecipientsFilterTest extends CamelQuarkusTestSupport {
             // users.
             false,
             UUID.randomUUID(),
+            null,
             null
         );
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -148,7 +148,7 @@ public class EmailAggregator {
                 return recipients.stream().map(r -> {
                     JsonObject recipient = (JsonObject) r;
                     return recipient.mapTo(Recipient.class);
-                }).map(r -> new ActionRecipientSettings(r.getOnlyAdmins(), r.getIgnoreUserPreferences(), r.getUsers())).collect(Collectors.toList());
+                }).map(r -> new ActionRecipientSettings(r.getOnlyAdmins(), r.getIgnoreUserPreferences(), r.getUsers(), r.getEmails())).collect(Collectors.toList());
             }
 
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/connector/dto/RecipientSettings.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/connector/dto/RecipientSettings.java
@@ -18,12 +18,14 @@ public class RecipientSettings {
     private final boolean ignoreUserPreferences;
     private final UUID groupUUID;
     private final Set<String> users;
+    private final Set<String> emails;
 
-    public RecipientSettings(final boolean adminsOnly, final boolean ignoreUserPreferences, final UUID groupUUID, final Set<String> users) {
+    public RecipientSettings(final boolean adminsOnly, final boolean ignoreUserPreferences, final UUID groupUUID, final Set<String> users, final Set<String> emails) {
         this.adminsOnly = adminsOnly;
         this.ignoreUserPreferences = ignoreUserPreferences;
         this.groupUUID = groupUUID;
         this.users = users;
+        this.emails = emails;
     }
 
     public RecipientSettings(final com.redhat.cloud.notifications.recipients.RecipientSettings recipientSettings) {
@@ -31,6 +33,7 @@ public class RecipientSettings {
         this.ignoreUserPreferences = recipientSettings.isIgnoreUserPreferences();
         this.groupUUID = recipientSettings.getGroupId();
         this.users = recipientSettings.getUsers();
+        this.emails = recipientSettings.getEmails();
     }
 
     public boolean isAdminsOnly() {
@@ -49,6 +52,10 @@ public class RecipientSettings {
         return this.users;
     }
 
+    public Set<String> getEmails() {
+        return emails;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -64,16 +71,12 @@ public class RecipientSettings {
         return this.adminsOnly == that.adminsOnly
             && this.ignoreUserPreferences == that.ignoreUserPreferences
             && Objects.equals(this.groupUUID, that.groupUUID)
-            && Objects.equals(this.users, that.users);
+            && Objects.equals(this.users, that.users)
+            && Objects.equals(this.emails, that.emails);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-            this.adminsOnly ? 1 : 0,
-            this.ignoreUserPreferences ? 1 : 0,
-            this.groupUUID != null ? this.groupUUID.hashCode() : 0,
-            this.users != null ? this.users.hashCode() : 0
-        );
+        return Objects.hash(adminsOnly, ignoreUserPreferences, groupUUID, users, emails);
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientSettings.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientSettings.java
@@ -14,6 +14,8 @@ public abstract class RecipientSettings {
 
     public abstract Set<String> getUsers();
 
+    public abstract Set<String> getEmails();
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -26,12 +28,13 @@ public abstract class RecipientSettings {
 
         RecipientSettings that = (RecipientSettings) o;
         return this.isOnlyAdmins() == that.isOnlyAdmins() && this.isIgnoreUserPreferences() == that.isIgnoreUserPreferences() &&
-                Objects.equals(this.getGroupId(), that.getGroupId()) && Objects.equals(this.getUsers(), that.getUsers());
+                Objects.equals(this.getGroupId(), that.getGroupId()) && Objects.equals(this.getUsers(), that.getUsers()) &&
+                Objects.equals(this.getEmails(), that.getEmails());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isOnlyAdmins(), isIgnoreUserPreferences(), getGroupId(), getUsers());
+        return Objects.hash(isOnlyAdmins(), isIgnoreUserPreferences(), getGroupId(), getUsers(), getEmails());
     }
 
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/request/ActionRecipientSettings.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/request/ActionRecipientSettings.java
@@ -20,11 +20,13 @@ public class ActionRecipientSettings extends RecipientSettings {
     private final boolean adminsOnly;
     private final boolean ignorePreferences;
     private final Set<String> users;
+    private final Set<String> emails;
 
-    public ActionRecipientSettings(boolean adminsOnly, boolean ignorePreferences, Collection<String> users) {
+    public ActionRecipientSettings(boolean adminsOnly, boolean ignorePreferences, Collection<String> users, Collection<String> emails) {
         this.adminsOnly = adminsOnly;
         this.ignorePreferences = ignorePreferences;
         this.users = Set.copyOf(users);
+        this.emails = Set.copyOf(emails);
     }
 
     @Override
@@ -47,12 +49,17 @@ public class ActionRecipientSettings extends RecipientSettings {
         return users;
     }
 
+    @Override
+    public Set<String> getEmails() {
+        return emails;
+    }
+
     public static List<ActionRecipientSettings> fromEventWrapper(EventWrapper<?, ?> eventWrapper) {
         if (eventWrapper.getEvent() instanceof Action) {
             return ((Action) eventWrapper.getEvent())
                     .getRecipients()
                     .stream()
-                    .map(r -> new ActionRecipientSettings(r.getOnlyAdmins(), r.getIgnoreUserPreferences(), r.getUsers()))
+                    .map(r -> new ActionRecipientSettings(r.getOnlyAdmins(), r.getIgnoreUserPreferences(), r.getUsers(), r.getEmails()))
                     .collect(Collectors.toList());
         } else if (eventWrapper.getEvent() instanceof NotificationsConsoleCloudEvent cloudEvent) {
             Optional<Recipients> recipients = cloudEvent.getRecipients();
@@ -60,7 +67,8 @@ public class ActionRecipientSettings extends RecipientSettings {
                 return List.of(new ActionRecipientSettings(
                         recipients.get().getOnlyAdmins(),
                         recipients.get().getIgnoreUserPreferences(),
-                        Arrays.asList(recipients.get().getUsers())
+                        Arrays.asList(recipients.get().getUsers()),
+                        Arrays.asList(recipients.get().getEmails())
                 ));
             }
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/request/EndpointRecipientSettings.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/request/EndpointRecipientSettings.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
 import com.redhat.cloud.notifications.recipients.RecipientSettings;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 
@@ -32,6 +33,11 @@ public class EndpointRecipientSettings extends RecipientSettings {
 
     @Override
     public Set<String> getUsers() {
-        return Set.of();
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> getEmails() {
+        return Collections.emptySet();
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailProcessorTest.java
@@ -64,11 +64,13 @@ public class EmailProcessorTest {
      */
     private Event setUpStubEvent() {
         final String[] users = {"foo", "bar", "baz"};
+        final String[] emails = {"john@doe.com", "jane@doe.com"};
 
         final Recipients recipients = new Recipients();
         recipients.setIgnoreUserPreferences(true);
         recipients.setOnlyAdmins(true);
         recipients.setUsers(users);
+        recipients.setEmails(emails);
 
         final NotificationsConsoleCloudEvent notificationsConsoleCloudEvent = Mockito.mock(NotificationsConsoleCloudEvent.class);
         // The type is required for the event wrapper.
@@ -376,7 +378,8 @@ public class EmailProcessorTest {
                     jsonRs.getBoolean("admins_only"),
                     jsonRs.getBoolean("ignore_user_preferences"),
                     (groupUUID == null) ? null : UUID.fromString(groupUUID),
-                    jsonRs.getJsonArray("users").stream().map(String.class::cast).collect(Collectors.toSet())
+                    jsonRs.getJsonArray("users").stream().map(String.class::cast).collect(Collectors.toSet()),
+                    jsonRs.getJsonArray("emails").stream().map(String.class::cast).collect(Collectors.toSet())
                 );
             }).collect(Collectors.toSet());
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/recipients/RecipientResolverTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/recipients/RecipientResolverTest.java
@@ -6,6 +6,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -58,6 +59,11 @@ public class RecipientResolverTest {
         @Override
         public Set<String> getUsers() {
             return users;
+        }
+
+        @Override
+        public Set<String> getEmails() {
+            return Collections.emptySet();
         }
     }
 

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/model/RecipientSettings.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/model/RecipientSettings.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.recipients.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.Objects;
@@ -7,6 +8,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RecipientSettings {
 
     private boolean adminsOnly;


### PR DESCRIPTION
`recipients.emails` will only be used when the email connector is active and `NOTIFICATIONS_CONNECTOR_BOP_SKIP_USERS_RESOLUTION == true`. I'm not updating the old email logic in `engine`.