### PR TITLE
RHCLOUD-29035 Stop calling BOP with an empty recipients list

### DIFF
--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
@@ -46,7 +46,7 @@ public class EmailRouteBuilderTest extends CamelQuarkusTestSupport {
     }
 
     /**
-     * Disables the rout builder to ensure that the Camel Context does not get
+     * Disables the route builder to ensure that the Camel Context does not get
      * started before the routes have been advised. More information is
      * available at the <a href="https://people.apache.org/~dkulp/camel/camel-test.html">dkulp's Apache Camel Test documentation page</a>.
      * @return {@code false} in order to stop the Camel Context from booting

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmptyRecipientsTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmptyRecipientsTest.java
@@ -1,0 +1,64 @@
+package com.redhat.cloud.notifications.connector.email;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+
+import static com.redhat.cloud.notifications.connector.ConnectorToEngineRouteBuilder.SUCCESS;
+import static com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty.FILTERED_USERS;
+import static com.redhat.cloud.notifications.connector.email.constants.Routes.SEND_EMAIL_BOP;
+import static com.redhat.cloud.notifications.connector.email.constants.Routes.SEND_EMAIL_BOP_CHOICE;
+import static com.redhat.cloud.notifications.connector.email.constants.Routes.SEND_EMAIL_BOP_SINGLE_PER_USER;
+import static org.apache.camel.builder.AdviceWith.adviceWith;
+
+@QuarkusTest
+public class EmptyRecipientsTest extends CamelQuarkusTestSupport {
+
+    @Inject
+    ProducerTemplate producerTemplate;
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    void test() throws Exception {
+
+        Exchange exchange = createExchangeWithBody("");
+        exchange.setProperty(FILTERED_USERS, new HashSet<>());
+
+        adviceWith(SEND_EMAIL_BOP_CHOICE, context(), new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                mockEndpointsAndSkip(
+                        "direct:" + SEND_EMAIL_BOP_SINGLE_PER_USER,
+                        "direct:" + SEND_EMAIL_BOP,
+                        "direct:" + SUCCESS
+                );
+            }
+        });
+
+        MockEndpoint sendEmailBopSinglePerUserEndpoint = getMockEndpoint("mock:direct:" + SEND_EMAIL_BOP_SINGLE_PER_USER);
+        sendEmailBopSinglePerUserEndpoint.expectedMessageCount(0);
+
+        MockEndpoint sendEmailBopEndpoint = getMockEndpoint("mock:direct:" + SEND_EMAIL_BOP);
+        sendEmailBopEndpoint.expectedMessageCount(0);
+
+        MockEndpoint successEndpoint = getMockEndpoint("mock:direct:" + SUCCESS);
+        successEndpoint.expectedMessageCount(1);
+
+        producerTemplate.send("direct:" + SEND_EMAIL_BOP_CHOICE, exchange);
+
+        sendEmailBopSinglePerUserEndpoint.assertIsSatisfied();
+        sendEmailBopEndpoint.assertIsSatisfied();
+        successEndpoint.assertIsSatisfied();
+    }
+}


### PR DESCRIPTION
The recent 400s returned by BOP were caused by payloads we sent to BOP with an empty recipients list.

We have a check in `engine` which skips the call to the email connector if engine doesn't find any recipients in the DB and the users preferences are not ignored. However, when there are non-admin subscribers in the DB and the notification is targeting admins only, the connector was sending payloads with empty recipients to BOP, causing the 400.