### PR TITLE
 RHCLOUD-21638 | feature: include the roles when returning applications

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/InternalRoleAccessRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/InternalRoleAccessRepository.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.models.InternalRoleAccess;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
 import jakarta.transaction.Transactional;
 
 import java.util.Collection;
@@ -21,6 +22,31 @@ public class InternalRoleAccessRepository {
         return entityManager.createQuery(query, InternalRoleAccess.class)
                 .setParameter("applicationId", applicationId)
                 .getResultList();
+    }
+
+    /**
+     * Get a single role for the given application.
+     * @param applicationId the application to look the role for.
+     * @return the associated role for the application or {code null}.
+     */
+    public InternalRoleAccess findOneByApplicationUUID(final UUID applicationId) {
+        final String query =
+            "FROM " +
+                "InternalRoleAccess " +
+            "WHERE " +
+                "application.id = :applicationId " +
+            "ORDER BY " +
+                "id " +
+            "DESC " +
+            "LIMIT 1";
+
+        try {
+            return this.entityManager.createQuery(query, InternalRoleAccess.class)
+                .setParameter("applicationId", applicationId)
+                .getSingleResult();
+        } catch (NoResultException e) {
+            return null;
+        }
     }
 
     public List<InternalRoleAccess> getAll() {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/UpdateApplicationRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/UpdateApplicationRequest.java
@@ -1,0 +1,14 @@
+package com.redhat.cloud.notifications.routers.internal.models;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+/**
+ * Represents the expected payload for an "update application" request.
+ */
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UpdateApplicationRequest {
+    public String name;
+    public String displayName;
+    public String ownerRole;
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/dto/ApplicationDTO.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/dto/ApplicationDTO.java
@@ -1,0 +1,27 @@
+package com.redhat.cloud.notifications.routers.internal.models.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import java.util.UUID;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ApplicationDTO {
+    public UUID id;
+
+    @NotNull
+    @Pattern(regexp = "[a-z][a-z_0-9-]*")
+    public String name;
+
+    @NotNull
+    public String displayName;
+
+    @NotNull
+    public UUID bundleId;
+
+    public String ownerRole;
+
+    public String created;
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/transformer/ApplicationDTOTransformer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/transformer/ApplicationDTOTransformer.java
@@ -1,0 +1,32 @@
+package com.redhat.cloud.notifications.routers.internal.models.transformer;
+
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.InternalRoleAccess;
+import com.redhat.cloud.notifications.routers.internal.models.dto.ApplicationDTO;
+
+import java.time.format.DateTimeFormatter;
+
+public class ApplicationDTOTransformer {
+    /**
+     * Takes an application and its associated role and transforms them into
+     * the payload for the response.
+     * @param application the application to be transformed.
+     * @param associatedRole the role to be transformed.
+     * @return a DTO with the structure of the response.
+     */
+    public static ApplicationDTO toDTO(final Application application, final InternalRoleAccess associatedRole) {
+        final ApplicationDTO applicationDTO = new ApplicationDTO();
+
+        applicationDTO.id = application.getId();
+        applicationDTO.name = application.getName();
+        applicationDTO.displayName = application.getDisplayName();
+        applicationDTO.bundleId = application.getBundleId();
+        applicationDTO.created = application.getCreated().format(DateTimeFormatter.ISO_DATE_TIME);
+
+        if (associatedRole != null) {
+            applicationDTO.ownerRole = associatedRole.getRole();
+        }
+
+        return applicationDTO;
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/InternalRoleAccessRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/InternalRoleAccessRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.InternalRoleAccess;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+@QuarkusTest
+public class InternalRoleAccessRepositoryTest {
+    @Inject
+    InternalRoleAccessRepository internalRoleAccessRepository;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    /**
+     * Tests that the function under test is able to find the associated
+     * internal role access object of the application.
+     */
+    @Test
+    void testFindOneByApplicationUUID() {
+        // Prepare the fixtures.
+        final Bundle bundle = this.resourceHelpers.createBundle("test-find-one-application-uuid");
+        final Application application = this.resourceHelpers.createApplication(bundle.getId());
+
+        final InternalRoleAccess internalRoleAccess = new InternalRoleAccess();
+        internalRoleAccess.setApplication(application);
+        internalRoleAccess.setApplicationId(application.getId());
+        internalRoleAccess.setRole("test-internal-role-access");
+
+        this.internalRoleAccessRepository.addAccess(internalRoleAccess);
+
+        // Call the function under test.
+        final InternalRoleAccess result = this.internalRoleAccessRepository.findOneByApplicationUUID(application.getId());
+
+        // Assert that the correct internal role was found in the database.
+        Assertions.assertEquals(internalRoleAccess.getId(), result.getId(), "the function under test found an internal access role with an unexpected ID");
+        Assertions.assertEquals(internalRoleAccess.getApplication(), result.getApplication(), "the function under test found an internal access role with an unexpected application");
+        Assertions.assertEquals(internalRoleAccess.getApplicationId(), result.getApplicationId(), "the function under test found an internal access role with an unexpected application ID");
+        Assertions.assertEquals(internalRoleAccess.getInternalRole(), result.getInternalRole(), "the function under test found an internal access role with an unexpected internal role");
+    }
+
+    /**
+     * Tests that when there is no internal role associated to an application,
+     * then the function under test returns null.
+     */
+    @Test
+    void testFindOneByApplicationUUIDNull() {
+        // Call the function under test.
+        final InternalRoleAccess result = this.internalRoleAccessRepository.findOneByApplicationUUID(UUID.randomUUID());
+
+        // Assert that no role was found in the database.
+        Assertions.assertNull(result, "the function under test found an internal access role when none should have been found");
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/models/transformer/ApplicationDTOTransformerTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/models/transformer/ApplicationDTOTransformerTest.java
@@ -1,0 +1,57 @@
+package com.redhat.cloud.notifications.routers.internal.models.transformer;
+
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.InternalRoleAccess;
+import com.redhat.cloud.notifications.routers.internal.models.dto.ApplicationDTO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class ApplicationDTOTransformerTest {
+
+    /**
+     * Tests that the DTO transformer correctly transforms an application and
+     * an internal role from the internal model to the DTO.
+     * @throws IllegalAccessException if the "created" field of the application
+     * object cannot be set via reflection.
+     * @throws NoSuchFieldException if the "created" field of the application
+     * object cannot be found.
+     */
+    @Test
+    void testToDTO() throws IllegalAccessException, NoSuchFieldException {
+        // Create the application to be transformed.
+        final Application application = new Application();
+        application.setId(UUID.randomUUID());
+        application.setName("application-name");
+        application.setDisplayName("application-display-name");
+        application.setBundleId(UUID.randomUUID());
+
+        // Set the created field via reflection because the "created" field is
+        // loaded from the database, and there is no other option of populating
+        // it.
+        final Field createdField = application
+            .getClass()
+            .getSuperclass() // CreationUpdateTimestamped
+            .getSuperclass() // CreationTimestamped
+            .getDeclaredField("created");
+        createdField.setAccessible(true);
+        createdField.set(application, LocalDateTime.now());
+
+        // Create the associated internal role for the application.
+        final InternalRoleAccess internalRoleAccess = new InternalRoleAccess();
+        internalRoleAccess.setRole("internal-role-access");
+
+        // Call the function under test.
+        final ApplicationDTO result = ApplicationDTOTransformer.toDTO(application, internalRoleAccess);
+
+        Assertions.assertEquals(result.id, application.getId(), "the application's ID property was not properly transformed to the DTO");
+        Assertions.assertEquals(result.name, application.getName(), "the application's name property was not properly transformed to the DTO");
+        Assertions.assertEquals(result.displayName, application.getDisplayName(), "the application's display name property was not properly transformed to the DTO");
+        Assertions.assertEquals(result.bundleId, application.getBundleId(), "the application's bundle ID property was not properly transformed to the DTO");
+        Assertions.assertEquals(result.created, application.getCreated().toString(), "the application's created property was not properly transformed to the DTO");
+        Assertions.assertEquals(result.ownerRole, internalRoleAccess.getRole(), "the internal role was not properly transformed to the DTO");
+    }
+}


### PR DESCRIPTION
The front end requires visualizing the owner roles for the applications. These changes satisfy that requirement.

## Jira ticket.
[[RHCLOUD-21638]](https://issues.redhat.com/browse/RHCLOUD-21638)