### PR TITLE
RHCLOUD-29084 Introduce EventType#subscribedByDefault

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -180,12 +180,13 @@ public class ApplicationRepository {
 
     @Transactional
     public int updateEventType(UUID id, EventType eventType) {
-        String eventTypeQuery = "UPDATE EventType SET name = :name, displayName = :displayName, description = :description, fullyQualifiedName = :fullyQualifiedName WHERE id = :id";
+        String eventTypeQuery = "UPDATE EventType SET name = :name, displayName = :displayName, description = :description, fullyQualifiedName = :fullyQualifiedName, subscribedByDefault = :subscribedByDefault WHERE id = :id";
         int rowCount = entityManager.createQuery(eventTypeQuery)
                 .setParameter("name", eventType.getName())
                 .setParameter("fullyQualifiedName", eventType.getFullyQualifiedName())
                 .setParameter("displayName", eventType.getDisplayName())
                 .setParameter("description", eventType.getDescription())
+                .setParameter("subscribedByDefault", eventType.isSubscribedByDefault())
                 .setParameter("id", id)
                 .executeUpdate();
         String eventQuery = "UPDATE Event SET eventTypeDisplayName = :displayName WHERE eventType.id = :eventTypeId";

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
@@ -215,8 +215,8 @@ public class UserConfigResource {
                     if (featureFlipper.isInstantEmailsEnabled() || subscriptionType != INSTANT) {
                         boolean supported = templateRepository.isEmailSubscriptionSupported(bundle.getName(), application.getName(), subscriptionType);
                         if (supported) {
-                            boolean subscribed = subscriptionType.isSubscribedByDefault() || eventType.isSubscribedByDefault();
-                            eventTypeSettingsValue.emailSubscriptionTypes.put(subscriptionType, subscribed);
+                            boolean subscribedByDefault = subscriptionType.isSubscribedByDefault() || eventType.isSubscribedByDefault();
+                            eventTypeSettingsValue.emailSubscriptionTypes.put(subscriptionType, subscribedByDefault);
                         }
                     }
                 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/UserConfigResource.java
@@ -110,11 +110,11 @@ public class UserConfigResource {
                             // for each email subscription
                             eventTypeValue.emailSubscriptionTypes.forEach((subscriptionType, subscribed) -> {
                                 if (subscribed) {
-                                    subscriptionRepository.subscribeEventType(
+                                    subscriptionRepository.subscribe(
                                         orgId, userName, eventType.get().getId(), subscriptionType
                                     );
                                 } else {
-                                    subscriptionRepository.unsubscribeEventType(
+                                    subscriptionRepository.unsubscribe(
                                         orgId, userName, eventType.get().getId(), subscriptionType
                                     );
                                 }
@@ -215,7 +215,8 @@ public class UserConfigResource {
                     if (featureFlipper.isInstantEmailsEnabled() || subscriptionType != INSTANT) {
                         boolean supported = templateRepository.isEmailSubscriptionSupported(bundle.getName(), application.getName(), subscriptionType);
                         if (supported) {
-                            eventTypeSettingsValue.emailSubscriptionTypes.put(subscriptionType, subscriptionType.isSubscribedByDefault());
+                            boolean subscribed = subscriptionType.isSubscribedByDefault() || eventType.isSubscribedByDefault();
+                            eventTypeSettingsValue.emailSubscriptionTypes.put(subscriptionType, subscribed);
                         }
                     }
                 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/CrudTestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/CrudTestHelpers.java
@@ -293,7 +293,7 @@ public abstract class CrudTestHelpers {
         }
     }
 
-    public static EventType buildEventType(String appId, String name, String displayName, String description) {
+    public static EventType buildEventType(String appId, String name, String displayName, String description, boolean subscribedByDefault) {
         EventType eventType = new EventType();
         if (appId != null) {
             eventType.setApplicationId(UUID.fromString(appId));
@@ -301,11 +301,12 @@ public abstract class CrudTestHelpers {
         eventType.setName(name);
         eventType.setDisplayName(displayName);
         eventType.setDescription(description);
+        eventType.setSubscribedByDefault(subscribedByDefault);
         return eventType;
     }
 
-    public static Optional<String> createEventType(Header identity, String appId, String name, String displayName, String description, int expectedStatusCode) {
-        EventType eventType = buildEventType(appId, name, displayName, description);
+    public static Optional<String> createEventType(Header identity, String appId, String name, String displayName, String description, boolean subscribedByDefault, int expectedStatusCode) {
+        EventType eventType = buildEventType(appId, name, displayName, description, subscribedByDefault);
         return createEventType(identity, eventType, expectedStatusCode);
     }
 
@@ -329,6 +330,7 @@ public abstract class CrudTestHelpers {
             assertEquals(eventType.getName(), jsonEventType.getString("name"));
             assertEquals(eventType.getDisplayName(), jsonEventType.getString("display_name"));
             assertEquals(eventType.getDescription(), jsonEventType.getString("description"));
+            assertEquals(eventType.isSubscribedByDefault(), jsonEventType.getBoolean("subscribed_by_default"));
 
             return Optional.of(jsonEventType.getString("id"));
         } else {
@@ -358,8 +360,8 @@ public abstract class CrudTestHelpers {
         }
     }
 
-    public static void updateEventType(Header identity, String appId, String eventTypeId, String name, String displayName, String description, int expectedStatusCode) {
-        EventType eventType = buildEventType(appId, name, displayName, description);
+    public static void updateEventType(Header identity, String appId, String eventTypeId, String name, String displayName, String description, boolean subscribedByDefault, int expectedStatusCode) {
+        EventType eventType = buildEventType(appId, name, displayName, description, subscribedByDefault);
 
         given()
                 .contentType(JSON)
@@ -389,6 +391,7 @@ public abstract class CrudTestHelpers {
                     assertEquals(eventType.getName(), jsonEventType.getString("name"));
                     assertEquals(eventType.getDisplayName(), jsonEventType.getString("display_name"));
                     assertEquals(eventType.getDescription(), jsonEventType.getString("description"));
+                    assertEquals(eventType.isSubscribedByDefault(), jsonEventType.getBoolean("subscribed_by_default"));
                     break;
                 }
                 if (i == jsonEventTypes.size() - 1) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/UserConfigResourceTest.java
@@ -271,11 +271,13 @@ public class UserConfigResourceTest extends DbIsolatedTest {
 
         // Fail if we have unknown event type on subscribe, but nothing will be added on database
         assertThrows(PersistenceException.class, () -> {
-            subscriptionRepository.subscribeEventType(orgId, username, UUID.randomUUID(), DAILY);
+            subscriptionRepository.subscribe(orgId, username, UUID.randomUUID(), DAILY);
         });
 
-        // not fail if we have unknown event type on unsubscibe, but nb affected rows must be 0
-        assertEquals(0, subscriptionRepository.unsubscribeEventType(orgId, username, UUID.randomUUID(), DAILY));
+        // Fail if we have unknown event type on unsubscribe, but nothing will be added on database
+        assertThrows(PersistenceException.class, () -> {
+            subscriptionRepository.unsubscribe(orgId, username, UUID.randomUUID(), DAILY);
+        });
 
         // does not add if we try to create unknown bundle/apps
         settingsValues = createSettingsValue("not-found-bundle-2", "not-found-app-2", eventType, true, true, true);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionsServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalPermissionsServiceTest.java
@@ -60,7 +60,7 @@ public class InternalPermissionsServiceTest extends DbIsolatedTest {
         assertEquals(List.of(appRole, otherRole), permissions.getRoles());
 
         // Can't create an event type without the permission
-        CrudTestHelpers.createEventType(turnpikeAppDev, appId, "my-event", "My event", "Event description", 403);
+        CrudTestHelpers.createEventType(turnpikeAppDev, appId, "my-event", "My event", "Event description", false, 403);
 
         // non admins can't create a role
         CrudTestHelpers.createInternalRoleAccess(turnpikeAppDev, appRole, appId, 403);
@@ -79,7 +79,7 @@ public class InternalPermissionsServiceTest extends DbIsolatedTest {
         assertEquals(List.of(appRole, otherRole), permissions.getRoles());
 
         // We can create the event type now
-        String eventTypeId = CrudTestHelpers.createEventType(turnpikeAppDev, appId, "my-event", "My event", "Event description", 200).get();
+        String eventTypeId = CrudTestHelpers.createEventType(turnpikeAppDev, appId, "my-event", "My event", "Event description", false, 200).get();
 
         List<Map> roleAccessList = given()
                 .header(turnpikeAdminHeader)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/TemplateResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/TemplateResourceTest.java
@@ -106,10 +106,10 @@ public class TemplateResourceTest extends DbIsolatedTest {
         // First, we need a bundle, an app and an event type in the DB.
         String bundleId = createBundle(adminIdentity, "bundle-name", "Bundle", OK).get();
         String appId = createApp(adminIdentity, bundleId, "app-name", "App", null, OK).get();
-        String eventTypeId = createEventType(adminIdentity, appId, "event-type-name", "Event type", "Event type description", OK).get();
+        String eventTypeId = createEventType(adminIdentity, appId, "event-type-name", "Event type", "Event type description", false, OK).get();
 
         String appId2 = createApp(adminIdentity, bundleId, "app-name-2", "App2", null, OK).get();
-        String eventTypeId2 = createEventType(adminIdentity, appId2, "event-type-name-2", "Event type 2", "Event type description", OK).get();
+        String eventTypeId2 = createEventType(adminIdentity, appId2, "event-type-name-2", "Event type 2", "Event type description", false, OK).get();
 
         // We also need templates that will be linked with the instant email template tested below.
         Template subjectTemplate = CrudTestHelpers.buildTemplate("subject-template-name", "template-data");

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -78,6 +78,8 @@ public class EventType {
     @JsonIgnore
     private boolean visible = true;
 
+    @JsonIgnore
+    private boolean subscribedByDefault;
 
     @OneToMany(mappedBy = "eventType", cascade = CascadeType.REMOVE)
     @JsonIgnore
@@ -161,6 +163,14 @@ public class EventType {
 
     public boolean isVisible() {
         return visible;
+    }
+
+    public boolean isSubscribedByDefault() {
+        return subscribedByDefault;
+    }
+
+    public void setSubscribedByDefault(boolean subscribedByDefault) {
+        this.subscribedByDefault = subscribedByDefault;
     }
 
     @Override

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EventType.java
@@ -78,7 +78,6 @@ public class EventType {
     @JsonIgnore
     private boolean visible = true;
 
-    @JsonIgnore
     private boolean subscribedByDefault;
 
     @OneToMany(mappedBy = "eventType", cascade = CascadeType.REMOVE)

--- a/database/src/main/resources/db/migration/V1.87.0__RHCLOUD-29084_event_types_subscribed_by_default.sql
+++ b/database/src/main/resources/db/migration/V1.87.0__RHCLOUD-29084_event_types_subscribed_by_default.sql
@@ -1,0 +1,2 @@
+ALTER TABLE event_type
+    ADD COLUMN subscribed_by_default BOOLEAN NOT NULL DEFAULT FALSE;

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/SubscriptionRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/SubscriptionRepository.java
@@ -17,19 +17,29 @@ public class SubscriptionRepository {
     @Inject
     EntityManager entityManager;
 
-    public List<String> getSubscribersByEventType(String orgId, UUID eventTypeId, SubscriptionType subscriptionType) {
+    public List<String> getSubscribers(String orgId, UUID eventTypeId, SubscriptionType subscriptionType) {
+        return getSubscriptions(orgId, eventTypeId, subscriptionType, true);
+    }
+
+    public List<String> getUnsubscribers(String orgId, UUID eventTypeId, SubscriptionType subscriptionType) {
+        return getSubscriptions(orgId, eventTypeId, subscriptionType, false);
+    }
+
+    private List<String> getSubscriptions(String orgId, UUID eventTypeId, SubscriptionType subscriptionType, boolean subscribed) {
         String hql = "SELECT id.userId FROM EventTypeEmailSubscription WHERE id.orgId = :orgId AND id.subscriptionType = :subscriptionType " +
-                "AND eventType.id = :eventTypeId";
+                "AND eventType.id = :eventTypeId AND subscribed = :subscribed";
         return entityManager.createQuery(hql, String.class)
                 .setParameter("orgId", orgId)
                 .setParameter("subscriptionType", subscriptionType)
                 .setParameter("eventTypeId", eventTypeId)
+                .setParameter("subscribed", subscribed)
                 .getResultList();
     }
 
     public Map<String, Set<String>> getEmailSubscribersUserIdGroupedByEventType(String orgId, String bundleName, String applicationName, SubscriptionType subscriptionType) {
+        // TODO Replace `subscribed` with `subscribed IS TRUE` when Quarkus depends on Hibernate ORM 6.3.0 or newer.
         String query = "SELECT eventType.name, es.id.userId FROM EventTypeEmailSubscription es WHERE id.orgId = :orgId AND eventType.application.bundle.name = :bundleName " +
-            "AND eventType.application.name = :applicationName AND id.subscriptionType = :subscriptionType";
+            "AND eventType.application.name = :applicationName AND id.subscriptionType = :subscriptionType AND subscribed";
 
         List<Object[]> records = entityManager.createQuery(query)
             .setParameter("orgId", orgId)

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/SystemEndpointTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/SystemEndpointTypeProcessor.java
@@ -30,8 +30,14 @@ public abstract class SystemEndpointTypeProcessor extends EndpointTypeProcessor 
 
         final Set<RecipientSettings> requests = extractRecipientSettings(event, endpoints);
 
-        Set<String> subscribers = Set.copyOf(subscriptionRepository
-                    .getSubscribersByEventType(event.getOrgId(), eventType.getId(), subscriptionType));
+        Set<String> subscribers;
+        if (subscriptionType.isSubscribedByDefault()) {
+            subscribers = Set.copyOf(subscriptionRepository
+                    .getUnsubscribers(event.getOrgId(), eventType.getId(), subscriptionType));
+        } else {
+            subscribers = Set.copyOf(subscriptionRepository
+                    .getSubscribers(event.getOrgId(), eventType.getId(), subscriptionType));
+        }
         return recipientResolver.recipientUsers(event.getOrgId(), requests, subscribers, !subscriptionType.isSubscribedByDefault());
     }
 
@@ -75,10 +81,10 @@ public abstract class SystemEndpointTypeProcessor extends EndpointTypeProcessor 
     protected List<String> getSubscribers(final Event event, final SubscriptionType subscriptionType) {
         final EventType eventType = event.getEventType();
 
-        return this.subscriptionRepository.getSubscribersByEventType(
-            event.getOrgId(),
-            eventType.getId(),
-            subscriptionType
-        );
+        if (subscriptionType.isSubscribedByDefault()) {
+            return subscriptionRepository.getUnsubscribers(event.getOrgId(), eventType.getId(), subscriptionType);
+        } else {
+            return subscriptionRepository.getSubscribers(event.getOrgId(), eventType.getId(), subscriptionType);
+        }
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailProcessorTest.java
@@ -272,7 +272,7 @@ public class EmailProcessorTest {
         // Do not return any subscribers for this test, so that the other
         // condition to remove the resulting recipient settings from the set
         // in the email processor is met.
-        Mockito.when(this.subscriptionRepository.getSubscribersByEventType(event.getOrgId(), event.getEventType().getId(), SubscriptionType.INSTANT)).thenReturn(List.of());
+        Mockito.when(this.subscriptionRepository.getSubscribers(event.getOrgId(), event.getEventType().getId(), SubscriptionType.INSTANT)).thenReturn(List.of());
 
         // Call the processor under test.
         this.emailProcessor.process(event, endpoints);
@@ -329,7 +329,7 @@ public class EmailProcessorTest {
         // Mock a list of subscribers that simulate the ones that should be
         // notified for the event.
         final List<String> subscribers = List.of("subscriber-a", "subscriber-b", "subscriber-c");
-        Mockito.when(this.subscriptionRepository.getSubscribersByEventType(event.getOrgId(), event.getEventType().getId(), SubscriptionType.INSTANT)).thenReturn(subscribers);
+        Mockito.when(this.subscriptionRepository.getSubscribers(event.getOrgId(), event.getEventType().getId(), SubscriptionType.INSTANT)).thenReturn(subscribers);
 
         // Mock the endpoint that should get pulled from the database using
         // the endpoint repository.


### PR DESCRIPTION
This PR introduces `EventType#subscribedByDefault` but does not make use of that field yet. The intent here is to keep the existing email or drawer behaviors unchanged while preparing for the event types subscribed by default.

Here are the major changes you'll find while reviewing:
- The event types can be created/updated from the internal REST API to set `subscribedByDefault` to `true`.
- If an event type is subscribed by default in the DB, the user preferences will reflect that immediately. But we won't do that until everything's ready (next PR).
- `SubscriptionType#subscribedByDefault` has precedence over `EventType#subscribedByDefault`. This could be debated (or changed later) but for the time being, it will work for all our use cases.
- We no longer delete from the DB any `emails_subscriptions` records. Instead, the records are created/updated with a Postgres upsert query (insert if PK not found, update otherwise). The changes in this table should be completely compatible with the existing DB data.

The next PR will propagate `EventType#subscribedByDefault` into the drawer and email (instant and daily) logics.