### PR TITLE
RHCLOUD-29084 Get rid of isOptIn for good

### DIFF
--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/recipients/RecipientsResolverPreparer.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/recipients/RecipientsResolverPreparer.java
@@ -27,14 +27,14 @@ public class RecipientsResolverPreparer implements Processor {
         List<String> subscribers = exchange.getProperty(ExchangeProperty.SUBSCRIBERS, List.class);
         final String orgId = exchange.getProperty(ORG_ID, String.class);
 
-        RecipientsQuery recipientsResolversQuery = new RecipientsQuery();
-        recipientsResolversQuery.setSubscribers(Set.copyOf(subscribers));
-        recipientsResolversQuery.setOrgId(orgId);
-        recipientsResolversQuery.setRecipientSettings(Set.copyOf(recipientSettings));
-        recipientsResolversQuery.setOptIn(true);
+        RecipientsQuery recipientsQuery = new RecipientsQuery();
+        recipientsQuery.subscribers = Set.copyOf(subscribers);
+        recipientsQuery.orgId = orgId;
+        recipientsQuery.recipientSettings = Set.copyOf(recipientSettings);
+        recipientsQuery.subscribedByDefault = false;
 
         // Serialize the payload.
-        exchange.getMessage().setBody(objectMapper.writeValueAsString(recipientsResolversQuery));
+        exchange.getMessage().setBody(objectMapper.writeValueAsString(recipientsQuery));
 
         // Set the "Accept" header for the incoming payload.
         exchange.getMessage().setHeader("Accept", "application/json");

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/recipients/pojo/RecipientsQuery.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/recipients/pojo/RecipientsQuery.java
@@ -1,64 +1,23 @@
 package com.redhat.cloud.notifications.connector.email.processors.recipients.pojo;
 
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.connector.email.model.settings.RecipientSettings;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.Objects;
 import java.util.Set;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
 public class RecipientsQuery {
+
+    @NotBlank
+    public String orgId;
+
     @NotNull
-    String orgId;
-    @NotNull
-    Set<RecipientSettings> recipientSettings;
-    Set<String> subscribers;
-    boolean isOptIn;
+    public Set<RecipientSettings> recipientSettings;
 
-    public void setOrgId(String orgId) {
-        this.orgId = orgId;
-    }
+    public Set<String> subscribers;
 
-    public void setRecipientSettings(Set<RecipientSettings> recipientSettings) {
-        this.recipientSettings = recipientSettings;
-    }
-
-    public void setSubscribers(Set<String> subscribers) {
-        this.subscribers = subscribers;
-    }
-
-    public void setOptIn(boolean optIn) {
-        isOptIn = optIn;
-    }
-
-    public String getOrgId() {
-        return orgId;
-    }
-
-    public Set<RecipientSettings> getRecipientSettings() {
-        return recipientSettings;
-    }
-
-    public Set<String> getSubscribers() {
-        return subscribers;
-    }
-
-    public boolean isOptIn() {
-        return isOptIn;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        RecipientsQuery that = (RecipientsQuery) o;
-        return isOptIn == that.isOptIn && orgId.equals(that.orgId) && recipientSettings.equals(that.recipientSettings) && Objects.equals(subscribers, that.subscribers);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(orgId, recipientSettings, subscribers, isOptIn);
-    }
+    public boolean subscribedByDefault;
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/SystemEndpointTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/SystemEndpointTypeProcessor.java
@@ -38,7 +38,7 @@ public abstract class SystemEndpointTypeProcessor extends EndpointTypeProcessor 
             subscribers = Set.copyOf(subscriptionRepository
                     .getSubscribers(event.getOrgId(), eventType.getId(), subscriptionType));
         }
-        return recipientResolver.recipientUsers(event.getOrgId(), requests, subscribers, !subscriptionType.isSubscribedByDefault());
+        return recipientResolver.recipientUsers(event.getOrgId(), requests, subscribers, subscriptionType.isSubscribedByDefault());
     }
 
     /**

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/RecipientResolver.java
@@ -30,22 +30,22 @@ public class RecipientResolver {
 
     public Set<User> recipientUsers(String orgId, Set<RecipientSettings> requests, Set<String> subscribers) {
         return requests.stream()
-            .flatMap(r -> recipientUsers(orgId, r, subscribers, true).stream())
+            .flatMap(r -> recipientUsers(orgId, r, subscribers, false).stream())
             .collect(Collectors.toSet());
     }
 
-    public Set<User> recipientUsers(String orgId, Set<RecipientSettings> requests, Set<String> subscribers, boolean isOptIn) {
+    public Set<User> recipientUsers(String orgId, Set<RecipientSettings> requests, Set<String> subscribers, boolean subscribedByDefault) {
         return requests.stream()
-                .flatMap(r -> recipientUsers(orgId, r, subscribers, isOptIn).stream())
+                .flatMap(r -> recipientUsers(orgId, r, subscribers, subscribedByDefault).stream())
                 .collect(Collectors.toSet());
     }
 
-    private Set<User> recipientUsers(String orgId, RecipientSettings request, Set<String> subscribers, boolean isOptIn) {
+    private Set<User> recipientUsers(String orgId, RecipientSettings request, Set<String> subscribers, boolean subscribedByDefault) {
         /*
          If the subscription type is opt-in, the user preferences should NOT be ignored and the subscribers Set is empty,
          then we don't need to retrieve the users from RBAC/IT/BOP because we'll return an empty Set anyway.
          */
-        if (isOptIn && !request.isIgnoreUserPreferences() && subscribers.isEmpty()) {
+        if (!subscribedByDefault && !request.isIgnoreUserPreferences() && subscribers.isEmpty()) {
             usersCount.set(0);
             return Collections.emptySet();
         }
@@ -72,7 +72,7 @@ public class RecipientResolver {
         if (request.isIgnoreUserPreferences()) {
             users = Set.copyOf(users);
         } else {
-            if (isOptIn) {
+            if (!subscribedByDefault) {
                 // Otherwise, the recipients from RBAC who didn't subscribe to the event type are filtered out.
                 users = filterUsers(users, subscribers);
             } else {

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/recipientsresolver/ExternalRecipientsResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/recipientsresolver/ExternalRecipientsResolver.java
@@ -60,17 +60,17 @@ public class ExternalRecipientsResolver {
 
     @CacheResult(cacheName = "recipients-resolver-results")
     public Set<User> recipientUsers(String orgId, Set<RecipientSettings> recipientSettings, Set<String> subscribers, SubscriptionType subscriptionType) {
-        RecipientsQuery recipientsResolversQuery = new RecipientsQuery();
-        recipientsResolversQuery.setSubscribers(Set.copyOf(subscribers));
-        recipientsResolversQuery.setOrgId(orgId);
+        RecipientsQuery recipientsQuery = new RecipientsQuery();
+        recipientsQuery.subscribers = Set.copyOf(subscribers);
+        recipientsQuery.orgId = orgId;
         Set<com.redhat.cloud.notifications.processors.email.connector.dto.RecipientSettings> recipientSettingsSet = recipientSettings
             .stream()
             .map(com.redhat.cloud.notifications.processors.email.connector.dto.RecipientSettings::new)
             .collect(Collectors.toSet());
 
-        recipientsResolversQuery.setRecipientSettings(recipientSettingsSet);
-        recipientsResolversQuery.setOptIn(!subscriptionType.isSubscribedByDefault());
-        Set<User> recipientsList = retryOnError(() -> recipientsResolverService.getRecipients(recipientsResolversQuery));
+        recipientsQuery.recipientSettings = recipientSettingsSet;
+        recipientsQuery.subscribedByDefault = subscriptionType.isSubscribedByDefault();
+        Set<User> recipientsList = retryOnError(() -> recipientsResolverService.getRecipients(recipientsQuery));
         return recipientsList;
     }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/recipients/recipientsresolver/pojo/RecipientsQuery.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/recipients/recipientsresolver/pojo/RecipientsQuery.java
@@ -1,64 +1,23 @@
 package com.redhat.cloud.notifications.recipients.recipientsresolver.pojo;
 
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.processors.email.connector.dto.RecipientSettings;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.Objects;
 import java.util.Set;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
 public class RecipientsQuery {
+
+    @NotBlank
+    public String orgId;
+
     @NotNull
-    String orgId;
-    @NotNull
-    Set<RecipientSettings> recipientSettings;
-    Set<String> subscribers;
-    boolean isOptIn;
+    public Set<RecipientSettings> recipientSettings;
 
-    public void setOrgId(String orgId) {
-        this.orgId = orgId;
-    }
+    public Set<String> subscribers;
 
-    public void setRecipientSettings(Set<RecipientSettings> recipientSettings) {
-        this.recipientSettings = recipientSettings;
-    }
-
-    public void setSubscribers(Set<String> subscribers) {
-        this.subscribers = subscribers;
-    }
-
-    public void setOptIn(boolean optIn) {
-        isOptIn = optIn;
-    }
-
-    public String getOrgId() {
-        return orgId;
-    }
-
-    public Set<RecipientSettings> getRecipientSettings() {
-        return recipientSettings;
-    }
-
-    public Set<String> getSubscribers() {
-        return subscribers;
-    }
-
-    public boolean isOptIn() {
-        return isOptIn;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        RecipientsQuery that = (RecipientsQuery) o;
-        return isOptIn == that.isOptIn && orgId.equals(that.orgId) && recipientSettings.equals(that.recipientSettings) && Objects.equals(subscribers, that.subscribers);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(orgId, recipientSettings, subscribers, isOptIn);
-    }
+    public boolean subscribedByDefault;
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessorTest.java
@@ -123,7 +123,7 @@ class DrawerProcessorTest {
         user1.setId("bar");
         user2.setUsername("bar");
 
-        when(recipientResolver.recipientUsers(any(), any(), any(), eq(false)))
+        when(recipientResolver.recipientUsers(any(), any(), any(), eq(true)))
             .thenReturn(Set.of(user1, user2));
 
         Event createdEvent = createEvent(shouldUseConnector);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
@@ -115,7 +115,7 @@ class EmailAggregatorTest {
         if (featureFlipper.isUseRecipientsResolverClowdappForDailyDigestEnabled()) {
             when(recipientsResolverService.getRecipients(any(RecipientsQuery.class))).then(parameters -> {
                 RecipientsQuery query = parameters.getArgument(0);
-                Set<String> users = query.getSubscribers();
+                Set<String> users = query.subscribers;
                 return users.stream().map(usrStr -> {
                     User usr = new User();
                     usr.setEmail(usrStr);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessorTest.java
@@ -302,7 +302,7 @@ class EmailSubscriptionTypeProcessorTest {
             User user2 = new User();
             user2.setUsername("bar");
 
-            when(recipientResolver.recipientUsers(any(), any(), any(), eq(true)))
+            when(recipientResolver.recipientUsers(any(), any(), any(), eq(false)))
                 .thenReturn(Set.of(user1, user2));
 
             Bundle bundle = new Bundle();

--- a/engine/src/test/java/com/redhat/cloud/notifications/recipients/RecipientResolverTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/recipients/RecipientResolverTest.java
@@ -399,7 +399,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(false, false, null, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(user2, user3, admin2), users);
         verify(rbacRecipientUsersProvider, times(1)).getUsers(
@@ -416,7 +416,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(true, false, null, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(admin2), users);
         verify(rbacRecipientUsersProvider, times(1)).getUsers(
@@ -433,7 +433,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(false, true, null, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(user1, user2, user3, admin1, admin2), users);
         verify(rbacRecipientUsersProvider, times(1)).getUsers(
@@ -450,7 +450,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(true, true, null, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(admin1, admin2), users);
         verify(rbacRecipientUsersProvider, times(1)).getUsers(
@@ -469,7 +469,7 @@ public class RecipientResolverTest {
                 ))
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(user3), users);
 
@@ -489,7 +489,7 @@ public class RecipientResolverTest {
                 ))
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(user1, user3), users);
 
@@ -509,7 +509,7 @@ public class RecipientResolverTest {
                 ))
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(admin2), users);
 
@@ -529,7 +529,7 @@ public class RecipientResolverTest {
                 ))
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(admin1, admin2), users);
 
@@ -548,7 +548,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(true, true, null, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(user2, user3, admin1, admin2), users);
         verify(rbacRecipientUsersProvider, times(1)).getUsers(
@@ -570,7 +570,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(true, true, null, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(user1, user2, user3, admin1, admin2), users);
         verify(rbacRecipientUsersProvider, times(1)).getUsers(
@@ -591,7 +591,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(false, false, group1, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(), users);
         verify(rbacRecipientUsersProvider, times(1)).getGroupUsers(
@@ -609,7 +609,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(true, false, group1, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(), users);
         verify(rbacRecipientUsersProvider, times(1)).getGroupUsers(
@@ -627,7 +627,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(false, false, group2, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(user2, admin2), users);
         verify(rbacRecipientUsersProvider, times(1)).getGroupUsers(
@@ -645,7 +645,7 @@ public class RecipientResolverTest {
                 new TestRecipientSettings(false, true, group2, Set.of())
             ),
             unsubscribedUsers,
-            false
+            true
         );
         assertEquals(Set.of(user2, admin2), users);
         verify(rbacRecipientUsersProvider, times(1)).getGroupUsers(

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/RecipientsResolver.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/RecipientsResolver.java
@@ -21,19 +21,19 @@ public class RecipientsResolver {
 
 
     @CacheResult(cacheName = "find-recipients")
-    public List<User> findRecipients(String orgId, Set<RecipientSettings> recipientSettings, Set<String> subscribers, boolean isOptIn) {
+    public List<User> findRecipients(String orgId, Set<RecipientSettings> recipientSettings, Set<String> subscribers, boolean subscribedByDefault) {
         return recipientSettings.stream()
-            .flatMap(r -> recipientUsers(orgId, r, subscribers, isOptIn).stream())
+            .flatMap(r -> recipientUsers(orgId, r, subscribers, subscribedByDefault).stream())
             .collect(Collectors.toSet()).stream().toList();
     }
 
-    private Set<User> recipientUsers(String orgId, RecipientSettings request, Set<String> subscribers, boolean isOptIn) {
+    private Set<User> recipientUsers(String orgId, RecipientSettings request, Set<String> subscribers, boolean subscribedByDefault) {
 
          /*
          If the subscription type is opt-in, the user preferences should NOT be ignored and the subscribers Set is empty,
          then we don't need to retrieve the users from RBAC/IT/BOP because we'll return an empty Set anyway.
          */
-        if (isOptIn && !request.isIgnoreUserPreferences() && subscribers.isEmpty()) {
+        if (!subscribedByDefault && !request.isIgnoreUserPreferences() && subscribers.isEmpty()) {
             return Collections.emptySet();
         }
 
@@ -59,7 +59,7 @@ public class RecipientsResolver {
         if (request.isIgnoreUserPreferences()) {
             users = Set.copyOf(users);
         } else {
-            if (isOptIn) {
+            if (!subscribedByDefault) {
                 // Otherwise, the recipients from RBAC who didn't subscribe to the event type are filtered out.
                 users = filterUsers(users, subscribers);
             } else {

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/rest/RecipientsResolverResource.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/rest/RecipientsResolverResource.java
@@ -26,9 +26,9 @@ public class RecipientsResolverResource {
     @Produces(APPLICATION_JSON)
     public List<User> getRecipients(@NotNull @Valid RecipientsQuery resolversQuery) {
         return recipientsResolver.findRecipients(
-            resolversQuery.getOrgId(),
-            resolversQuery.getRecipientSettings(),
-            resolversQuery.getSubscribers(),
-            resolversQuery.isOptIn());
+            resolversQuery.orgId,
+            resolversQuery.recipientSettings,
+            resolversQuery.subscribers,
+            resolversQuery.subscribedByDefault);
     }
 }

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/rest/pojo/RecipientsQuery.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/rest/pojo/RecipientsQuery.java
@@ -1,46 +1,23 @@
 package com.redhat.cloud.notifications.recipients.rest.pojo;
 
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.recipients.model.RecipientSettings;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
 
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+
+@JsonNaming(SnakeCaseStrategy.class)
 public class RecipientsQuery {
+
+    @NotBlank
+    public String orgId;
+
     @NotNull
-    String orgId;
-    @NotNull
-    Set<RecipientSettings> recipientSettings;
-    Set<String> subscribers;
-    boolean isOptIn;
+    public Set<RecipientSettings> recipientSettings;
 
-    public String getOrgId() {
-        return orgId;
-    }
+    public Set<String> subscribers;
 
-    public void setOrgId(String orgId) {
-        this.orgId = orgId;
-    }
-
-    public Set<RecipientSettings> getRecipientSettings() {
-        return recipientSettings;
-    }
-
-    public void setRecipientSettings(Set<RecipientSettings> recipientSettings) {
-        this.recipientSettings = recipientSettings;
-    }
-
-    public Set<String> getSubscribers() {
-        return subscribers;
-    }
-
-    public void setSubscribers(Set<String> subscribers) {
-        this.subscribers = subscribers;
-    }
-
-    public boolean isOptIn() {
-        return isOptIn;
-    }
-
-    public void setOptIn(boolean optIn) {
-        isOptIn = optIn;
-    }
+    public boolean subscribedByDefault;
 }

--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/RecipientsResolverTest.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/RecipientsResolverTest.java
@@ -95,13 +95,13 @@ public class RecipientsResolverTest {
 
     @Test
     public void withPersonalizedEmailOn() {
-        boolean isOptIn = true;
+        boolean subscribedByDefault = false;
         // Default request, all subscribed users
         List<User> users = recipientsResolver.findRecipients(
                 ORG_ID,
                 Set.of(new RecipientSettings(false, false, null, Set.of())),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(admin1, user1), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -116,7 +116,7 @@ public class RecipientsResolverTest {
                 ORG_ID,
                 Set.of(new RecipientSettings(true, false, null, Set.of())),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(admin1), users);
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -131,7 +131,7 @@ public class RecipientsResolverTest {
                 ORG_ID,
                 Set.of(new RecipientSettings(false, true, null, Set.of())),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
 
         assertEquals(List.of(admin1, admin2, user1, user2, user3), sortListByUsername(users));
@@ -147,7 +147,7 @@ public class RecipientsResolverTest {
                 ORG_ID,
                 Set.of(new RecipientSettings(true, true, null, Set.of())),
                 subscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin1, admin2), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -166,7 +166,7 @@ public class RecipientsResolverTest {
                 ))
             ),
             subscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(user1), users);
 
@@ -186,7 +186,7 @@ public class RecipientsResolverTest {
                         ))
                 ),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(user1, user3), sortListByUsername(users));
 
@@ -206,7 +206,7 @@ public class RecipientsResolverTest {
                         ))
                 ),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(admin1), users);
 
@@ -226,7 +226,7 @@ public class RecipientsResolverTest {
                         ))
                 ),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(admin1, admin2), sortListByUsername(users));
 
@@ -245,7 +245,7 @@ public class RecipientsResolverTest {
                         new RecipientSettings(true, true, null, Set.of())
                 ),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(admin1, admin2, user1), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -267,7 +267,7 @@ public class RecipientsResolverTest {
                         new RecipientSettings(true, true, null, Set.of())
                 ),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(admin1, admin2, user1, user2, user3), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -288,7 +288,7 @@ public class RecipientsResolverTest {
                         new RecipientSettings(false, false, group1, Set.of())
                 ),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(admin1, user1), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getGroupUsers(
@@ -306,7 +306,7 @@ public class RecipientsResolverTest {
                         new RecipientSettings(true, false, group1, Set.of())
                 ),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(admin1), users);
         verify(fetchUsersFromExternalServices, times(1)).getGroupUsers(
@@ -324,7 +324,7 @@ public class RecipientsResolverTest {
                         new RecipientSettings(false, false, group2, Set.of())
                 ),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(), users);
         verify(fetchUsersFromExternalServices, times(1)).getGroupUsers(
@@ -342,7 +342,7 @@ public class RecipientsResolverTest {
                         new RecipientSettings(false, true, group2, Set.of())
                 ),
                 subscribedUsers,
-                isOptIn
+                subscribedByDefault
         );
         assertEquals(List.of(admin2, user2), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getGroupUsers(
@@ -357,7 +357,7 @@ public class RecipientsResolverTest {
 
     @Test
     public void withPersonalizedEmailOnOptOut() {
-        boolean isOptIn = false;
+        boolean subscribedByDefault = true;
 
         Set<String> unsubscribedUsers = subscribedUsers;
 
@@ -368,7 +368,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(false, false, null, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin2, user2, user3), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -385,7 +385,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(true, false, null, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin2), users);
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -402,7 +402,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(false, true, null, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin1, admin2, user1, user2, user3), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -419,7 +419,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(true, true, null, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin1, admin2), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -438,7 +438,7 @@ public class RecipientsResolverTest {
                 ))
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(user3), users);
 
@@ -458,7 +458,7 @@ public class RecipientsResolverTest {
                 ))
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(user1, user3), sortListByUsername(users));
 
@@ -478,7 +478,7 @@ public class RecipientsResolverTest {
                 ))
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin2), users);
 
@@ -498,7 +498,7 @@ public class RecipientsResolverTest {
                 ))
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin1, admin2), sortListByUsername(users));
 
@@ -517,7 +517,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(true, true, null, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin1, admin2, user2, user3), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -539,7 +539,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(true, true, null, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin1, admin2, user1, user2, user3), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getUsers(
@@ -560,7 +560,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(false, false, group1, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(), users);
         verify(fetchUsersFromExternalServices, times(1)).getGroupUsers(
@@ -578,7 +578,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(true, false, group1, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(), users);
         verify(fetchUsersFromExternalServices, times(1)).getGroupUsers(
@@ -596,7 +596,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(false, false, group2, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin2, user2), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getGroupUsers(
@@ -614,7 +614,7 @@ public class RecipientsResolverTest {
                 new RecipientSettings(false, true, group2, Set.of())
             ),
             unsubscribedUsers,
-            isOptIn
+            subscribedByDefault
         );
         assertEquals(List.of(admin2, user2), sortListByUsername(users));
         verify(fetchUsersFromExternalServices, times(1)).getGroupUsers(

--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/rest/RecipientResolverResourceTest.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/rest/RecipientResolverResourceTest.java
@@ -39,17 +39,17 @@ public class RecipientResolverResourceTest {
         getRecipients(null, 400);
         RecipientsQuery recipientQuery = new RecipientsQuery();
         getRecipients(recipientQuery, 400);
-        recipientQuery.setOrgId("123456");
+        recipientQuery.orgId = "123456";
         getRecipients(recipientQuery, 400);
-        recipientQuery.setRecipientSettings(new HashSet<>());
+        recipientQuery.recipientSettings = new HashSet<>();
         getRecipients(recipientQuery, 200);
     }
 
     @Test
     public void testGetRecipients() throws JsonProcessingException {
         RecipientsQuery recipientQuery = new RecipientsQuery();
-        recipientQuery.setRecipientSettings(new HashSet<>());
-        recipientQuery.setOrgId("123456");
+        recipientQuery.recipientSettings = new HashSet<>();
+        recipientQuery.orgId = "123456";
         List<User> userList = getRecipientsPage(recipientQuery);
         Assertions.assertNotNull(userList);
         Assertions.assertEquals(0, userList.size());


### PR DESCRIPTION
- `isOptIn` is now gone and replaced with `subscribedByDefault` everywhere
- recipients-resolver queries are simpler (getters, setters, equals and hashCode were not really needed)
- recipients-resolver queries are now serialized using snake case

⚠️ Keep in mind while reviewing that `isOptIn == !subscribedByDefault`.