### PR TITLE
Fix startup exceptions in special environment

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/StartupUtils.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/StartupUtils.java
@@ -56,7 +56,8 @@ public class StartupUtils {
     }
 
     public void logExternalServiceUrl(String configKey) {
-        Log.infof("%s=%s", configKey, ConfigProvider.getConfig().getValue(configKey, String.class));
+        String configValue = ConfigProvider.getConfig().getOptionalValue(configKey, String.class).orElse("");
+        Log.infof("%s=%s", configKey, configValue);
     }
 
     public void disableRestClientContextualErrors() {

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
@@ -64,10 +64,10 @@ public class EmailConnectorConfig extends ConnectorConfig {
     Integer itElementsPerPage;
 
     @ConfigProperty(name = IT_KEYSTORE_LOCATION)
-    String itKeyStoreLocation;
+    Optional<String> itKeyStoreLocation;
 
     @ConfigProperty(name = IT_KEYSTORE_PASSWORD)
-    String itKeyStorePassword;
+    Optional<String> itKeyStorePassword;
 
     @ConfigProperty(name = IT_USER_SERVICE_URL)
     String itUserServiceURL;
@@ -122,7 +122,7 @@ public class EmailConnectorConfig extends ConnectorConfig {
         additionalEntries.put(BOP_URL, this.bopURL);
         additionalEntries.put(FETCH_USERS_RBAC_ENABLED, this.fetchUsersWithRBAC);
         additionalEntries.put(IT_ELEMENTS_PAGE, this.itElementsPerPage);
-        additionalEntries.put(IT_KEYSTORE_LOCATION, this.itKeyStoreLocation);
+        additionalEntries.put(IT_KEYSTORE_LOCATION, this.itKeyStoreLocation.orElse(""));
         additionalEntries.put(RBAC_APPLICATION_KEY, this.rbacApplicationKey);
         additionalEntries.put(RBAC_ELEMENTS_PAGE, this.rbacElementsPerPage);
         additionalEntries.put(RBAC_URL, this.rbacURL);
@@ -164,11 +164,11 @@ public class EmailConnectorConfig extends ConnectorConfig {
         return this.itElementsPerPage;
     }
 
-    public String getItKeyStoreLocation() {
+    public Optional<String> getItKeyStoreLocation() {
         return this.itKeyStoreLocation;
     }
 
-    public String getItKeyStorePassword() {
+    public Optional<String> getItKeyStorePassword() {
         return this.itKeyStorePassword;
     }
 

--- a/connector-email/src/main/resources/application.properties
+++ b/connector-email/src/main/resources/application.properties
@@ -43,8 +43,6 @@ notifications.connector.user-provider.bop.client_id=changeme
 notifications.connector.user-provider.bop.env=changeme
 notifications.connector.user-provider.bop.url=https://backoffice-proxy.apps.ext.spoke.preprod.us-west-2.aws.paas.redhat.com
 
-notifications.connector.user-provider.it.key-store-location=changeme
-notifications.connector.user-provider.it.key-store-password=changeme
 notifications.connector.user-provider.it.url=https://ci.cloud.redhat.com
 
 notifications.connector.user-provider.rbac.url=${clowder.endpoints.rbac-service.url:http://localhost:9999}


### PR DESCRIPTION
Fixes several exceptions, including:
```
Caused by: java.util.NoSuchElementException: SRCFG00040: The config property quarkus.rest-client.export-service.url is defined as the empty String ("") which the following Converter considered to be null: io.smallrye.config.Converters$BuiltInConverter
```