### PR TITLE
Skip PlatSec scans on drafts

### DIFF
--- a/.github/workflows/platsec-aggregator.yml
+++ b/.github/workflows/platsec-aggregator.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-backend.yml
+++ b/.github/workflows/platsec-backend.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-connector-drawer.yml
+++ b/.github/workflows/platsec-connector-drawer.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-connector-email.yml
+++ b/.github/workflows/platsec-connector-email.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile.notifications-connector-email.jvm' for the Dockerfile.notifications-connector-email.jvm name.

--- a/.github/workflows/platsec-connector-google-chat.yml
+++ b/.github/workflows/platsec-connector-google-chat.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-connector-microsoft-teams.yml
+++ b/.github/workflows/platsec-connector-microsoft-teams.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-connector-servicenow.yml
+++ b/.github/workflows/platsec-connector-servicenow.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-connector-slack.yml
+++ b/.github/workflows/platsec-connector-slack.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-connector-splunk.yml
+++ b/.github/workflows/platsec-connector-splunk.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-connector-webhook.yml
+++ b/.github/workflows/platsec-connector-webhook.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-engine.yml
+++ b/.github/workflows/platsec-engine.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.

--- a/.github/workflows/platsec-recipients-resolver.yml
+++ b/.github/workflows/platsec-recipients-resolver.yml
@@ -26,10 +26,13 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "master", "security-compliance" ]
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # The following line adds "ready_for_review" to the activity types which trigger workflows by default.
+    types: ["opened", "synchronize", "reopened", "ready_for_review"]
 
 jobs:
   PlatSec-Security-Workflow:
-    if: github.repository == 'RedHatInsights/notifications-backend'
+    if: github.repository == 'RedHatInsights/notifications-backend' && github.event.pull_request.draft == false
     uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
     ## The optional parameters below are used if you are using something other than the
     ## the defaults of root '.' for the path and 'Dockerfile' for the Dockerfile name.


### PR DESCRIPTION
This PR changes the way PlatSec scans are triggered:
- they are disabled in drafts
- as soon as a draft is marked as ready for review, the PlatSec scans are executed

This lowers the number of GitHub actions runners we're using in drafts while still making sure PRs are scanned before they're merged.