### PR TITLE
RHCLOUD-24734 | feature: disable unmigratable endpoints

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/SourcesSecretsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/SourcesSecretsMigrationService.java
@@ -90,6 +90,9 @@ public class SourcesSecretsMigrationService {
                     Log.errorf("[endpoint_id: %s] error when migrating the endpoint secrets: unable to create the secrets for the endpoint: %s", eligibleEndpoint.getKey(), e.getMessage());
                 }
 
+                this.endpointRepository.disableEndpoint(eligibleEndpoint.getValue(), eligibleEndpoint.getKey());
+                Log.infof("[endpoint_id: %s] endpoint disabled");
+
                 errorCounter++;
 
                 continue;

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/SourcesSecretsMigrationServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/SourcesSecretsMigrationServiceTest.java
@@ -291,6 +291,8 @@ public class SourcesSecretsMigrationServiceTest {
             final Endpoint endpoint = this.endpointRepository.getEndpoint(entry.getValue().getOrgId(), entry.getKey());
             Assertions.assertNotNull(endpoint, "the endpoint was not fetched from the database");
 
+            Assertions.assertFalse(endpoint.isEnabled(), "the endpoint should have been disabled after not being able to create the secrets in Sources");
+
             final EndpointProperties endpointProperties = endpoint.getProperties();
             if (endpointProperties instanceof SourcesSecretable properties) {
                 Assertions.assertNull(properties.getBasicAuthenticationSourcesId(), "the basic authentication Sources secret reference should not have been saved in the database");


### PR DESCRIPTION
The team decided that we are going to run the migrations again but disabling endpoints this time, so that if clients want to keep using the, what now are invalid endpoints, will have to enable them manually and correct the bits that are incorrect.

## Jira ticket
[[RHCLOUD-24734]](https://issues.redhat.com/browse/RHCLOUD-24734)