### PR TITLE
Use an intersection of users in recipients-resolver

### DIFF
--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/RecipientsResolverTest.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/RecipientsResolverTest.java
@@ -523,6 +523,57 @@ public class RecipientsResolverTest {
         verifyNoMoreInteractions(fetchUsersFromExternalServices);
     }
 
+    @Test
+    void testRequestUsersIntersection() {
+        Set<User> recipients = recipientsResolver.findRecipients(
+                ORG_ID,
+                Set.of(
+                        new RecipientSettings(false, false, null, emptySet()),
+                        new RecipientSettings(false, false, null, Set.of(user2.getUsername(), user3.getUsername()))
+                ),
+                Set.of("user1", "user2", "user3", "admin1", "admin2"),
+                emptySet(),
+                false
+        );
+        assertEquals(Set.of(user2, user3), recipients);
+        verify(fetchUsersFromExternalServices, times(2)).getUsers(eq(ORG_ID), eq(false));
+        verifyNoMoreInteractions(fetchUsersFromExternalServices);
+    }
+
+    @Test
+    void testRequestUsersIntersectionAndIgnoreUserPreferences() {
+        Set<User> recipients = recipientsResolver.findRecipients(
+                ORG_ID,
+                Set.of(
+                        new RecipientSettings(false, true, null, emptySet()),
+                        new RecipientSettings(false, true, null, Set.of(user2.getUsername(), user3.getUsername()))
+                ),
+                Set.of("user1", "user3"),
+                emptySet(),
+                false
+        );
+        assertEquals(Set.of(user2, user3), recipients);
+        verify(fetchUsersFromExternalServices, times(2)).getUsers(eq(ORG_ID), eq(false));
+        verifyNoMoreInteractions(fetchUsersFromExternalServices);
+    }
+
+    @Test
+    void testRequestUsersIntersectionAndDisjointSets() {
+        Set<User> recipients = recipientsResolver.findRecipients(
+                ORG_ID,
+                Set.of(
+                        new RecipientSettings(false, false, null, Set.of(user1.getUsername())),
+                        new RecipientSettings(false, false, null, Set.of(user2.getUsername(), user3.getUsername()))
+                ),
+                Set.of("user1", "user2", "user3", "admin1", "admin2"),
+                emptySet(),
+                false
+        );
+        assertTrue(recipients.isEmpty());
+        verify(fetchUsersFromExternalServices, times(2)).getUsers(eq(ORG_ID), eq(false));
+        verifyNoMoreInteractions(fetchUsersFromExternalServices);
+    }
+
     public User createUser(String username, boolean isAdmin) {
         User user = new User();
         user.setUsername(username);


### PR DESCRIPTION
When an application such as OCM provides a list of users (recipients) in its JSON payload, the `recipients-resolver` module will receive two `RecipientSettings` objects when an email is being sent: one for the email endpoint and the other one for the action built from the JSON payload. The former will contain an empty `users` field and the latter will contain the list provided in the payload.

Before this PR, `recipients-resolver` retrieved all users from the org regardless of the `users` field from the payload because of the empty `users` field from the email endpoint.

After this PR, the intersection of all `users` fields is first determined. Then, that intersection is used for all `RecipientSettings` objects, including the one from the email endpoint.