### PR TITLE
RHCLOUD-28888 | feature: reinject failed Kafka messages to the channel

### DIFF
--- a/.rhcicd/clowdapp-connector-drawer.yaml
+++ b/.rhcicd/clowdapp-connector-drawer.yaml
@@ -142,7 +142,7 @@ parameters:
   value: "180000"
 - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
-  value: "3"
+  value: "0"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
   description: Number of concurrent threads processing exchanges with SEDA
   value: "20"

--- a/.rhcicd/clowdapp-connector-drawer.yaml
+++ b/.rhcicd/clowdapp-connector-drawer.yaml
@@ -67,6 +67,8 @@ objects:
           value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_POLL_ON_ERROR
           value: ${KAFKA_POLL_ON_ERROR}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
           value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
@@ -138,6 +140,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS
   description: Maximum time in milliseconds allowed to wait for HTTP data
   value: "180000"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+  description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
+  value: "3"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
   description: Number of concurrent threads processing exchanges with SEDA
   value: "20"

--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -180,7 +180,7 @@ parameters:
   value: "180000"
 - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
-  value: "3"
+  value: "0"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -69,6 +69,8 @@ objects:
           value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_POLL_ON_ERROR
           value: ${KAFKA_POLL_ON_ERROR}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -176,6 +178,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS
   description: Maximum time in milliseconds allowed to wait for HTTP data
   value: "180000"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+  description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
+  value: "3"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-google-chat.yaml
+++ b/.rhcicd/clowdapp-connector-google-chat.yaml
@@ -149,7 +149,7 @@ parameters:
   value: "2500"
 - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
-  value: "3"
+  value: "0"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-google-chat.yaml
+++ b/.rhcicd/clowdapp-connector-google-chat.yaml
@@ -67,6 +67,8 @@ objects:
           value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_POLL_ON_ERROR
           value: ${KAFKA_POLL_ON_ERROR}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -145,6 +147,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS
   description: Maximum time in milliseconds allowed to wait for HTTP data
   value: "2500"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+  description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
+  value: "3"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-microsoft-teams.yaml
+++ b/.rhcicd/clowdapp-connector-microsoft-teams.yaml
@@ -149,7 +149,7 @@ parameters:
   value: "2500"
 - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
-  value: "3"
+  value: "0"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-microsoft-teams.yaml
+++ b/.rhcicd/clowdapp-connector-microsoft-teams.yaml
@@ -67,6 +67,8 @@ objects:
           value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_POLL_ON_ERROR
           value: ${KAFKA_POLL_ON_ERROR}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -145,6 +147,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS
   description: Maximum time in milliseconds allowed to wait for HTTP data
   value: "2500"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+  description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
+  value: "3"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-servicenow.yaml
+++ b/.rhcicd/clowdapp-connector-servicenow.yaml
@@ -155,7 +155,7 @@ parameters:
   value: "2500"
 - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
-  value: "3"
+  value: "0"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-servicenow.yaml
+++ b/.rhcicd/clowdapp-connector-servicenow.yaml
@@ -73,6 +73,8 @@ objects:
           value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_POLL_ON_ERROR
           value: ${KAFKA_POLL_ON_ERROR}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -151,6 +153,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS
   description: Maximum time in milliseconds allowed to wait for HTTP data
   value: "2500"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+  description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
+  value: "3"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-slack.yaml
+++ b/.rhcicd/clowdapp-connector-slack.yaml
@@ -139,7 +139,7 @@ parameters:
   value: "100"
 - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
-  value: "3"
+  value: "0"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-slack.yaml
+++ b/.rhcicd/clowdapp-connector-slack.yaml
@@ -63,6 +63,8 @@ objects:
           value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_POLL_ON_ERROR
           value: ${KAFKA_POLL_ON_ERROR}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -135,6 +137,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
   description: Maximum size of the Camel endpoints cache
   value: "100"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+  description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
+  value: "3"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -155,7 +155,7 @@ parameters:
   value: "2500"
 - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
-  value: "3"
+  value: "0"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -73,6 +73,8 @@ objects:
           value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_POLL_ON_ERROR
           value: ${KAFKA_POLL_ON_ERROR}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -151,6 +153,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS
   description: Maximum time in milliseconds allowed to wait for HTTP data
   value: "2500"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+  description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
+  value: "3"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-webhook.yaml
+++ b/.rhcicd/clowdapp-connector-webhook.yaml
@@ -75,6 +75,8 @@ objects:
           value: ${KAFKA_MAX_POLL_RECORDS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_POLL_ON_ERROR
           value: ${KAFKA_POLL_ON_ERROR}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
           value: ${NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY}
         - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_MAX_ATTEMPTS
@@ -159,6 +161,9 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS
   description: Maximum time in milliseconds allowed to wait for HTTP data
   value: "30000"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
+  description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
+  value: "3"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/.rhcicd/clowdapp-connector-webhook.yaml
+++ b/.rhcicd/clowdapp-connector-webhook.yaml
@@ -163,7 +163,7 @@ parameters:
   value: "30000"
 - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
-  value: "3"
+  value: "0"
 - name: NOTIFICATIONS_CONNECTOR_REDELIVERY_DELAY
   description: Delay in milliseconds between two redelivery attempts
   value: "1000"

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
@@ -21,7 +21,7 @@ public class ConnectorConfig {
     private static final String KAFKA_INCOMING_MAX_POLL_RECORDS = "notifications.connector.kafka.incoming.max-poll-records";
     private static final String KAFKA_INCOMING_POLL_ON_ERROR = "notifications.connector.kafka.incoming.poll-on-error";
     private static final String KAFKA_INCOMING_TOPIC = "notifications.connector.kafka.incoming.topic";
-    private static final String KAFKA_MAXIMUM_REINJECTIONS = "notifications.connector.kafka.maximum.reinjections";
+    private static final String KAFKA_MAXIMUM_REINJECTIONS = "notifications.connector.kafka.maximum-reinjections";
     private static final String KAFKA_OUTGOING_TOPIC = "notifications.connector.kafka.outgoing.topic";
     private static final String NAME = "notifications.connector.name";
     private static final String REDELIVERY_COUNTER_NAME = "notifications.connector.redelivery.counter-name";

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
@@ -21,6 +21,7 @@ public class ConnectorConfig {
     private static final String KAFKA_INCOMING_MAX_POLL_RECORDS = "notifications.connector.kafka.incoming.max-poll-records";
     private static final String KAFKA_INCOMING_POLL_ON_ERROR = "notifications.connector.kafka.incoming.poll-on-error";
     private static final String KAFKA_INCOMING_TOPIC = "notifications.connector.kafka.incoming.topic";
+    private static final String KAFKA_MAXIMUM_REINJECTIONS = "notifications.connector.kafka.maximum.reinjections";
     private static final String KAFKA_OUTGOING_TOPIC = "notifications.connector.kafka.outgoing.topic";
     private static final String NAME = "notifications.connector.name";
     private static final String REDELIVERY_COUNTER_NAME = "notifications.connector.redelivery.counter-name";
@@ -32,6 +33,9 @@ public class ConnectorConfig {
 
     @ConfigProperty(name = ENDPOINT_CACHE_MAX_SIZE, defaultValue = "100")
     int endpointCacheMaxSize;
+
+    @ConfigProperty(name = KAFKA_MAXIMUM_REINJECTIONS, defaultValue = "3")
+    int kafkaMaximumReinjections;
 
     @ConfigProperty(name = KAFKA_INCOMING_GROUP_ID)
     String incomingKafkaGroupId;
@@ -91,6 +95,7 @@ public class ConnectorConfig {
         config.put(KAFKA_INCOMING_MAX_POLL_RECORDS, incomingKafkaMaxPollRecords);
         config.put(KAFKA_INCOMING_POLL_ON_ERROR, incomingKafkaPollOnError);
         config.put(KAFKA_INCOMING_TOPIC, incomingKafkaTopic);
+        config.put(KAFKA_MAXIMUM_REINJECTIONS, kafkaMaximumReinjections);
         config.put(KAFKA_OUTGOING_TOPIC, outgoingKafkaTopic);
         config.put(NAME, connectorName);
         config.put(REDELIVERY_COUNTER_NAME, redeliveryCounterName);
@@ -124,6 +129,10 @@ public class ConnectorConfig {
 
     public String getIncomingKafkaTopic() {
         return incomingKafkaTopic;
+    }
+
+    public int getKafkaMaximumReinjections() {
+        return this.kafkaMaximumReinjections;
     }
 
     public String getOutgoingKafkaTopic() {

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/EngineToConnectorRouteBuilder.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/EngineToConnectorRouteBuilder.java
@@ -4,12 +4,17 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
 
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.ID;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.KAFKA_REINJECTION_DELAY;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static org.apache.camel.LoggingLevel.DEBUG;
+import static org.apache.camel.LoggingLevel.INFO;
 import static org.apache.camel.builder.endpoint.dsl.KafkaEndpointBuilderFactory.KafkaEndpointConsumerBuilder;
 
 public abstract class EngineToConnectorRouteBuilder extends EndpointRouteBuilder {
 
     public static final String ENGINE_TO_CONNECTOR = "engine-to-connector";
+    public static final String KAFKA_REINJECTION = "kafka-reinjection";
 
     @Inject
     ConnectorConfig connectorConfig;
@@ -19,6 +24,16 @@ public abstract class EngineToConnectorRouteBuilder extends EndpointRouteBuilder
 
     @Inject
     IncomingCloudEventProcessor incomingCloudEventProcessor;
+
+    /**
+     * Responsible for extracting the reinjection count from the Kafka header,
+     * if it is present.
+     */
+    @Inject
+    IncomingKafkaReinjectionHeadersProcessor incomingKafkaReinjectionHeadersProcessor;
+
+    @Inject
+    KafkaReinjectionProcessor kafkaReinjectionProcessor;
 
     @Inject
     RedeliveryCounterProcessor redeliveryCounterProcessor;
@@ -56,11 +71,24 @@ public abstract class EngineToConnectorRouteBuilder extends EndpointRouteBuilder
                 .routeId(ENGINE_TO_CONNECTOR)
                 .to(log(getClass().getName()).level("DEBUG").showHeaders(true).showBody(true))
                 .filter(incomingCloudEventFilter)
+                .process(this.incomingKafkaReinjectionHeadersProcessor)
                 // Headers coming from Kafka must not be forwarded to external services.
                 .removeHeaders("*")
                 .process(incomingCloudEventProcessor)
                 .to(log(getClass().getName()).level("DEBUG").showProperties(true))
                 .to(seda(ENGINE_TO_CONNECTOR));
+
+        /*
+         * Defines a route to reinject the messages to the incoming queue,
+         * after determining a proper delay. The delay for the reinjection is
+         * asynchronously applied, so that we do not block the thread waiting.
+         */
+        from(direct(KAFKA_REINJECTION))
+            .routeId(KAFKA_REINJECTION)
+            .process(this.kafkaReinjectionProcessor)
+            .delay(simpleF("${exchangeProperty.%s}", KAFKA_REINJECTION_DELAY)).asyncDelayed()
+            .log(INFO, this.getClass().getName(), "[orgId=${exchangeProperty." + ORG_ID + "}, historyId=${exchangeProperty." + ID + "}, delay=${exchangeProperty." + KAFKA_REINJECTION_DELAY + "}] Message reinjected to Kafka")
+            .to(kafka(this.connectorConfig.getIncomingKafkaTopic()));
 
         configureRoutes();
     }

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/EngineToConnectorRouteBuilder.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/EngineToConnectorRouteBuilder.java
@@ -86,7 +86,9 @@ public abstract class EngineToConnectorRouteBuilder extends EndpointRouteBuilder
         from(direct(KAFKA_REINJECTION))
             .routeId(KAFKA_REINJECTION)
             .process(this.kafkaReinjectionProcessor)
-            .delay(simpleF("${exchangeProperty.%s}", KAFKA_REINJECTION_DELAY)).asyncDelayed()
+            .delay(simpleF("${exchangeProperty.%s}", KAFKA_REINJECTION_DELAY))
+                .asyncDelayed()
+            .end()
             .log(INFO, this.getClass().getName(), "[orgId=${exchangeProperty." + ORG_ID + "}, historyId=${exchangeProperty." + ID + "}, delay=${exchangeProperty." + KAFKA_REINJECTION_DELAY + "}] Message reinjected to Kafka")
             .to(kafka(this.connectorConfig.getIncomingKafkaTopic()));
 

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExceptionProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExceptionProcessor.java
@@ -9,7 +9,9 @@ import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 
 import static com.redhat.cloud.notifications.connector.ConnectorToEngineRouteBuilder.CONNECTOR_TO_ENGINE;
+import static com.redhat.cloud.notifications.connector.EngineToConnectorRouteBuilder.KAFKA_REINJECTION;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ID;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.KAFKA_REINJECTION_COUNT;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.OUTCOME;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.SUCCESSFUL;
@@ -30,6 +32,9 @@ import static org.apache.camel.Exchange.FATAL_FALLBACK_ERROR_HANDLER;
 public class ExceptionProcessor implements Processor {
 
     private static final String DEFAULT_LOG_MSG = "Message sending failed on %s: [orgId=%s, historyId=%s, targetUrl=%s]";
+
+    @Inject
+    ConnectorConfig connectorConfig;
 
     @Inject
     ProducerTemplate producerTemplate;
@@ -55,7 +60,18 @@ public class ExceptionProcessor implements Processor {
         exchangeCopy.removeProperty(FAILURE_ENDPOINT);
         exchangeCopy.removeProperty(FAILURE_ROUTE_ID);
         exchangeCopy.removeProperty(FATAL_FALLBACK_ERROR_HANDLER);
-        producerTemplate.send("direct:" + CONNECTOR_TO_ENGINE, exchangeCopy);
+
+        // Attempt reinjecting the message to the incoming Kafka queue as a way
+        // of improving our fault tolerance. After a few attempts we should
+        // give up and acknowledge the failure.
+        final String route;
+        if (exchange.getProperty(KAFKA_REINJECTION_COUNT, 0, Integer.class) < this.connectorConfig.getKafkaMaximumReinjections()) {
+            route = String.format("direct:%s", KAFKA_REINJECTION);
+        } else {
+            route = String.format("direct:%s", CONNECTOR_TO_ENGINE);
+        }
+
+        this.producerTemplate.send(route, exchangeCopy);
     }
 
     protected final void logDefault(Throwable t, Exchange exchange) {

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExceptionProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExceptionProcessor.java
@@ -65,7 +65,7 @@ public class ExceptionProcessor implements Processor {
         // of improving our fault tolerance. After a few attempts we should
         // give up and acknowledge the failure.
         final String route;
-        if (exchange.getProperty(KAFKA_REINJECTION_COUNT, 0, Integer.class) < this.connectorConfig.getKafkaMaximumReinjections()) {
+        if (exchange.getProperty(KAFKA_REINJECTION_COUNT, 0, int.class) < this.connectorConfig.getKafkaMaximumReinjections()) {
             route = String.format("direct:%s", KAFKA_REINJECTION);
         } else {
             route = String.format("direct:%s", CONNECTOR_TO_ENGINE);

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExchangeProperty.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExchangeProperty.java
@@ -3,7 +3,21 @@ package com.redhat.cloud.notifications.connector;
 public class ExchangeProperty {
 
     public static final String ID = "id";
+    /**
+     * Specifies the number of times the message was reinjected to the
+     * "incoming" Kafka topic.
+     */
+    public static final String KAFKA_REINJECTION_COUNT = "kafkaReinjectionCount";
+    /**
+     * Specifies the delay we want to apply for reinjecting the Kafka message.
+     */
+    public static final String KAFKA_REINJECTION_DELAY = "kafkaReinjectionDelay";
     public static final String ORG_ID = "orgId";
+    /**
+     * Holds the original Cloud Event as received from the  "incoming" Kafka
+     * topic.
+     */
+    public static final String ORIGINAL_CLOUD_EVENT = "originalCloudEvent";
     public static final String OUTCOME = "outcome";
     public static final String RETURN_SOURCE = "source";
     public static final String START_TIME = "startTime";

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
@@ -30,7 +30,7 @@ public class IncomingCloudEventProcessor implements Processor {
     public void process(Exchange exchange) throws Exception {
         JsonObject cloudEvent = new JsonObject(exchange.getIn().getBody(String.class));
 
-        exchange.setProperty(ORIGINAL_CLOUD_EVENT, exchange.getMessage().getBody());
+        exchange.setProperty(ORIGINAL_CLOUD_EVENT, exchange.getIn().getBody());
 
         exchange.setProperty(ID, cloudEvent.getString(CLOUD_EVENT_ID));
         exchange.setProperty(TYPE, cloudEvent.getString(CLOUD_EVENT_TYPE));

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
@@ -4,11 +4,11 @@ import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.camel.Exchange;
-import org.apache.camel.Message;
 import org.apache.camel.Processor;
 
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORIGINAL_CLOUD_EVENT;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.RETURN_SOURCE;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.START_TIME;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.TYPE;
@@ -28,10 +28,9 @@ public class IncomingCloudEventProcessor implements Processor {
 
     @Override
     public void process(Exchange exchange) throws Exception {
+        JsonObject cloudEvent = new JsonObject(exchange.getMessage().getBody(String.class));
 
-        Message in = exchange.getIn();
-
-        JsonObject cloudEvent = new JsonObject(in.getBody(String.class));
+        exchange.setProperty(ORIGINAL_CLOUD_EVENT, exchange.getMessage().getBody());
 
         exchange.setProperty(ID, cloudEvent.getString(CLOUD_EVENT_ID));
         exchange.setProperty(TYPE, cloudEvent.getString(CLOUD_EVENT_TYPE));

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
@@ -28,7 +28,7 @@ public class IncomingCloudEventProcessor implements Processor {
 
     @Override
     public void process(Exchange exchange) throws Exception {
-        JsonObject cloudEvent = new JsonObject(exchange.getMessage().getBody(String.class));
+        JsonObject cloudEvent = new JsonObject(exchange.getIn().getBody(String.class));
 
         exchange.setProperty(ORIGINAL_CLOUD_EVENT, exchange.getMessage().getBody());
 

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingKafkaReinjectionHeadersProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingKafkaReinjectionHeadersProcessor.java
@@ -13,7 +13,7 @@ public class IncomingKafkaReinjectionHeadersProcessor implements Processor {
      */
     @Override
     public void process(final Exchange exchange) {
-        final int reinjectionCount = exchange.getMessage().getHeader(KafkaHeader.REINJECTION_COUNT, 0, Integer.class);
+        final int reinjectionCount = exchange.getIn().getHeader(KafkaHeader.REINJECTION_COUNT, 0, int.class);
 
         exchange.setProperty(ExchangeProperty.KAFKA_REINJECTION_COUNT, reinjectionCount);
     }

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingKafkaReinjectionHeadersProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingKafkaReinjectionHeadersProcessor.java
@@ -1,0 +1,20 @@
+package com.redhat.cloud.notifications.connector;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+@ApplicationScoped
+public class IncomingKafkaReinjectionHeadersProcessor implements Processor {
+    /**
+     * Extracts the reinjection count from the Kafka header if it is present.
+     * It defaults the count to zero otherwise.
+     * @param exchange the exchange representing the Kafka message.
+     */
+    @Override
+    public void process(final Exchange exchange) {
+        final int reinjectionCount = exchange.getMessage().getHeader(KafkaHeader.REINJECTION_COUNT, 0, Integer.class);
+
+        exchange.setProperty(ExchangeProperty.KAFKA_REINJECTION_COUNT, reinjectionCount);
+    }
+}

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/KafkaHeader.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/KafkaHeader.java
@@ -1,0 +1,9 @@
+package com.redhat.cloud.notifications.connector;
+
+public class KafkaHeader {
+    /**
+     * Specifies the name of the header that we will use to hold the number of
+     * times a message got reinjected in the "incoming" topic.
+     */
+    public static final String REINJECTION_COUNT = "notifications-connector-reinjections-count";
+}

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/KafkaHeader.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/KafkaHeader.java
@@ -5,5 +5,5 @@ public class KafkaHeader {
      * Specifies the name of the header that we will use to hold the number of
      * times a message got reinjected in the "incoming" topic.
      */
-    public static final String REINJECTION_COUNT = "notifications-connector-reinjections-count";
+    public static final String REINJECTION_COUNT = "x-rh-notifications-connector-reinjections-count";
 }

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/KafkaReinjectionProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/KafkaReinjectionProcessor.java
@@ -1,0 +1,51 @@
+package com.redhat.cloud.notifications.connector;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.KAFKA_REINJECTION_COUNT;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.KAFKA_REINJECTION_DELAY;
+import static com.redhat.cloud.notifications.connector.IncomingCloudEventFilter.X_RH_NOTIFICATIONS_CONNECTOR_HEADER;
+
+@ApplicationScoped
+public class KafkaReinjectionProcessor implements Processor {
+    @Inject
+    ConnectorConfig connectorConfig;
+
+    /**
+     * Determines the reinjection delay from the reinjection count which should
+     * have been extracted from the incoming message's reinjection header. If
+     * for some reason we don't have that count, we default that count to zero.
+     *
+     * Also, it sets the original Cloud Event as the exchange's message body.
+     * @param exchange the incoming exchange from the previous routes or error
+     *                 handlers.
+     */
+    @Override
+    public void process(final Exchange exchange) {
+        final int reinjectionCount = exchange.getProperty(KAFKA_REINJECTION_COUNT, 0, Integer.class);
+
+        final long reinjectionDelay = switch (reinjectionCount) {
+            case 0 -> TimeUnit.SECONDS.toMillis(10);
+            case 1 -> TimeUnit.SECONDS.toMillis(30);
+            case 2 -> TimeUnit.MINUTES.toMillis(1);
+            default -> this.connectorConfig.getIncomingKafkaMaxPollIntervalMs() / 2;
+        };
+
+        exchange.setProperty(KAFKA_REINJECTION_DELAY, reinjectionDelay);
+
+        final Message message = exchange.getMessage();
+        message.setBody(exchange.getProperty(ExchangeProperty.ORIGINAL_CLOUD_EVENT));
+
+        message.setHeader(X_RH_NOTIFICATIONS_CONNECTOR_HEADER, this.connectorConfig.getConnectorName());
+        // The value of the header needs to be converted to string, since
+        // otherwise it does not get properly pushed to Kafka. When attempted
+        // to send the integer directly, the value simply was not there.
+        message.setHeader(KafkaHeader.REINJECTION_COUNT, String.valueOf(reinjectionCount + 1));
+    }
+}

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/KafkaReinjectionProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/KafkaReinjectionProcessor.java
@@ -28,7 +28,7 @@ public class KafkaReinjectionProcessor implements Processor {
      */
     @Override
     public void process(final Exchange exchange) {
-        final int reinjectionCount = exchange.getProperty(KAFKA_REINJECTION_COUNT, 0, Integer.class);
+        final int reinjectionCount = exchange.getProperty(KAFKA_REINJECTION_COUNT, 0, int.class);
 
         final long reinjectionDelay = switch (reinjectionCount) {
             case 0 -> TimeUnit.SECONDS.toMillis(10);

--- a/connector-common/src/test/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessorTest.java
+++ b/connector-common/src/test/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessorTest.java
@@ -1,0 +1,68 @@
+package com.redhat.cloud.notifications.connector;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.json.JsonObject;
+import jakarta.inject.Inject;
+import org.apache.camel.Exchange;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.ID;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORIGINAL_CLOUD_EVENT;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.RETURN_SOURCE;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.START_TIME;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.TYPE;
+import static com.redhat.cloud.notifications.connector.IncomingCloudEventProcessor.CLOUD_EVENT_DATA;
+import static com.redhat.cloud.notifications.connector.IncomingCloudEventProcessor.CLOUD_EVENT_ID;
+import static com.redhat.cloud.notifications.connector.IncomingCloudEventProcessor.CLOUD_EVENT_TYPE;
+
+@QuarkusTest
+public class IncomingCloudEventProcessorTest extends CamelQuarkusTestSupport {
+    @Inject
+    ConnectorConfig connectorConfig;
+
+    @Inject
+    IncomingCloudEventProcessor incomingCloudEventProcessor;
+
+    /**
+     * Tests that the incoming Cloud Event is properly processed.
+     * @throws Exception if any unexpected exception is thrown during the
+     * processing of the Cloud Event.
+     */
+    @Test
+    void processIncomingCloudEvent() throws Exception {
+        // Prepare the JSON payload.
+        final String cloudEventId = UUID.randomUUID().toString();
+        final String cloudEventType = "cloud-event-type";
+
+        final JsonObject incomingCloudEvent = new JsonObject();
+
+        incomingCloudEvent.put(CLOUD_EVENT_ID, cloudEventId);
+        incomingCloudEvent.put(CLOUD_EVENT_TYPE, cloudEventType);
+
+        // Cloud Event's data.
+        final String cloudEventOrgId = UUID.randomUUID().toString();
+        final JsonObject cloudEventData = new JsonObject();
+        cloudEventData.put("org_id", cloudEventOrgId);
+
+        incomingCloudEvent.put(CLOUD_EVENT_DATA, cloudEventData);
+
+        // Prepare the exchange.
+        final Exchange exchange = this.createExchangeWithBody(incomingCloudEvent.encode());
+
+        // Call the processor under test.
+        this.incomingCloudEventProcessor.process(exchange);
+
+        // Assert that the exchange contains the expected properties.
+        Assertions.assertEquals(incomingCloudEvent.encode(), exchange.getProperty(ORIGINAL_CLOUD_EVENT), "the original Cloud Event was not properly set in the exchange's property");
+        Assertions.assertEquals(cloudEventId, exchange.getProperty(ID), "the Cloud Event's ID was not properly extracted");
+        Assertions.assertEquals(cloudEventType, exchange.getProperty(TYPE), "the Cloud Event's type was not properly extracted");
+        Assertions.assertNotNull(exchange.getProperty(START_TIME), "the start time of the processing wsa not properly set in the exchange");
+        Assertions.assertEquals(this.connectorConfig.getConnectorName(), exchange.getProperty(RETURN_SOURCE), "the source of the CLoud Event was not properly set in the exchange");
+        Assertions.assertEquals(cloudEventOrgId, exchange.getProperty(ORG_ID), "the Cloud Event's ORG ID was not properly set in the exchange");
+    }
+}

--- a/connector-common/src/test/java/com/redhat/cloud/notifications/connector/IncomingKafkaReinjectionHeadersProcessorTest.java
+++ b/connector-common/src/test/java/com/redhat/cloud/notifications/connector/IncomingKafkaReinjectionHeadersProcessorTest.java
@@ -1,0 +1,45 @@
+package com.redhat.cloud.notifications.connector;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.apache.camel.Exchange;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class IncomingKafkaReinjectionHeadersProcessorTest extends CamelQuarkusTestSupport {
+    @Inject
+    IncomingKafkaReinjectionHeadersProcessor incomingKafkaReinjectionHeadersProcessor;
+
+    /**
+     * Test that the processor sets the reinjection count to zero if no
+     * reinjection count was present in the message's Kafka header.
+     */
+    @Test
+    void testProcessNoHeader() {
+        final Exchange exchange = this.createExchangeWithBody("");
+
+        // Call the processor under test.
+        this.incomingKafkaReinjectionHeadersProcessor.process(exchange);
+
+        Assertions.assertEquals(0, exchange.getProperty(ExchangeProperty.KAFKA_REINJECTION_COUNT), "when the header is not present, the reinjections count should be zero by default");
+    }
+
+    /**
+     * Test that the processor properly reads the reinjection count from a
+     * Kafka message's header if it is present.
+     */
+    @Test
+    void testProcess() {
+        final int reinjectionCount = 2;
+
+        final Exchange exchange = this.createExchangeWithBody("");
+        exchange.getMessage().setHeader(KafkaHeader.REINJECTION_COUNT, reinjectionCount);
+
+        // Call the processor under test.
+        this.incomingKafkaReinjectionHeadersProcessor.process(exchange);
+
+        Assertions.assertEquals(reinjectionCount, exchange.getProperty(ExchangeProperty.KAFKA_REINJECTION_COUNT), "the reinjection count was not properly read from the Kafka header");
+    }
+}

--- a/connector-common/src/test/java/com/redhat/cloud/notifications/connector/KafkaReinjectionProcessorTest.java
+++ b/connector-common/src/test/java/com/redhat/cloud/notifications/connector/KafkaReinjectionProcessorTest.java
@@ -1,0 +1,63 @@
+package com.redhat.cloud.notifications.connector;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.apache.camel.Exchange;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.KAFKA_REINJECTION_COUNT;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.KAFKA_REINJECTION_DELAY;
+import static com.redhat.cloud.notifications.connector.IncomingCloudEventFilter.X_RH_NOTIFICATIONS_CONNECTOR_HEADER;
+
+@QuarkusTest
+public class KafkaReinjectionProcessorTest extends CamelQuarkusTestSupport {
+    @Inject
+    ConnectorConfig connectorConfig;
+
+    @Inject
+    KafkaReinjectionProcessor kafkaReinjectionProcessor;
+
+    /**
+     * Tests that the expected body and headers are set for the exchange
+     * message once we are in the message reinjection process.
+     */
+    @Test
+    void processReinjections() {
+        // Prepare a small set of test cases to make sure the logic is correct.
+        record TestCase(Integer reinjectedCount, long expectedDelay) { }
+
+        final List<TestCase> testCases = List.of(
+            new TestCase(null, TimeUnit.SECONDS.toMillis(10)),
+            new TestCase(0, TimeUnit.SECONDS.toMillis(10)),
+            new TestCase(1, TimeUnit.SECONDS.toMillis(30)),
+            new TestCase(2, TimeUnit.MINUTES.toMillis(1)),
+            new TestCase(5, this.connectorConfig.getIncomingKafkaMaxPollIntervalMs() / 2)
+        );
+
+        for (final TestCase t : testCases) {
+            // Prepare the exchange message.
+            final String originalCloudEvent = "original cloud event body";
+            final Exchange exchange = this.createExchangeWithBody("");
+            exchange.setProperty(ExchangeProperty.ORIGINAL_CLOUD_EVENT, originalCloudEvent);
+            exchange.setProperty(KAFKA_REINJECTION_COUNT, t.reinjectedCount());
+
+            // Call the processor under test.
+            this.kafkaReinjectionProcessor.process(exchange);
+
+            // Assert that the exchange contains the correct values.
+            Assertions.assertEquals(t.expectedDelay(), exchange.getProperty(KAFKA_REINJECTION_DELAY), String.format("the Kafka reinjection delay is incorrect for reinjection count value '%d'", 0));
+            Assertions.assertEquals(originalCloudEvent, exchange.getMessage().getBody(), "the body should be set to the original Cloud Event so that it gets published to Kafka");
+
+            final Map<String, Object> headers = exchange.getMessage().getHeaders();
+            Assertions.assertEquals(this.connectorConfig.getConnectorName(), headers.get(X_RH_NOTIFICATIONS_CONNECTOR_HEADER), "the connector's name should be set in the header so that when the message gets reinjected it doesn't get filtered by the incoming cloud event filter");
+            Assertions.assertEquals(Objects.requireNonNullElse(t.reinjectedCount(), 0) + 1, Integer.parseInt((String) headers.get(KafkaHeader.REINJECTION_COUNT)), "the reinjection was improperly incremented");
+        }
+    }
+}

--- a/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorRoutesTest.java
+++ b/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorRoutesTest.java
@@ -74,6 +74,9 @@ class DrawerConnectorRoutesTest extends ConnectorRoutesTest {
     @Disabled(value = "Not applicable on drawer use case")
     protected void testSuccessfulNotification() { }
 
+    @Disabled(value = "Not applicable on drawer use case")
+    protected void testSendReinjectionRoute() { }
+
     @Override
     protected Predicate checkOutgoingPayload(JsonObject incomingPayload) {
         // Not applicable on drawer use case


### PR DESCRIPTION
Another of the improvements for our fault tolerance is to reinject the notifications in the incoming Kafka queue again. By applying a non blocking delay, we ensure that also the connectors will not clog or stop processing more messages while the failed one is waiting to be reinjected.

## Jira ticket
[[RHCLOUD-28888]](https://issues.redhat.com/browse/RHCLOUD-28888)