### PR TITLE
Introduce email connector metrics

### DIFF
--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.connector.email;
 import com.redhat.cloud.notifications.connector.EngineToConnectorRouteBuilder;
 import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
 import com.redhat.cloud.notifications.connector.email.constants.Routes;
+import com.redhat.cloud.notifications.connector.email.metrics.EmailMetricsProcessor;
 import com.redhat.cloud.notifications.connector.email.processors.bop.BOPRequestPreparer;
 import com.redhat.cloud.notifications.connector.email.processors.recipients.RecipientsResolverRequestPreparer;
 import com.redhat.cloud.notifications.connector.email.processors.recipients.RecipientsResolverResponseProcessor;
@@ -44,6 +45,9 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
     @Inject
     RecipientsResolverResponseProcessor recipientsResolverResponseProcessor;
 
+    @Inject
+    EmailMetricsProcessor emailMetricsProcessor;
+
     /**
      * Configures the flow for this connector.
      */
@@ -75,6 +79,7 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
                     .process(this.BOPRequestPreparer)
                     .to(bopEndpoint)
                     .log(INFO, getClass().getName(), "Sent Email notification [orgId=${exchangeProperty." + ORG_ID + "}, historyId=${exchangeProperty." + ID + "}]")
+                    .process(emailMetricsProcessor)
             .end()
             .to(direct(SUCCESS));
     }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/constants/ExchangeProperty.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/constants/ExchangeProperty.java
@@ -44,4 +44,6 @@ public class ExchangeProperty {
      * Holds the rendered subject contents, ready to be sent in an email.
      */
     public static final String RENDERED_SUBJECT = "rendered_subject";
+
+    public static final String RECIPIENTS_SIZE = "recipientsSize";
 }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/metrics/EmailMetricsProcessor.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/metrics/EmailMetricsProcessor.java
@@ -1,0 +1,34 @@
+package com.redhat.cloud.notifications.connector.email.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+import static com.redhat.cloud.notifications.connector.email.constants.ExchangeProperty.RECIPIENTS_SIZE;
+
+@ApplicationScoped
+public class EmailMetricsProcessor implements Processor {
+
+    @Inject
+    MeterRegistry meterRegistry;
+
+    private Counter requestsCounter;
+    private Counter recipientsCounter;
+
+    @PostConstruct
+    void postConstruct() {
+        requestsCounter = meterRegistry.counter("notifications.connector.email.requests");
+        recipientsCounter = meterRegistry.counter("notifications.connector.email.recipients");
+    }
+
+    @Override
+    public void process(Exchange exchange) {
+        requestsCounter.increment();
+        int recipientsSize = exchange.getProperty(RECIPIENTS_SIZE, 0, int.class);
+        recipientsCounter.increment(recipientsSize);
+    }
+}

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparer.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/processors/bop/BOPRequestPreparer.java
@@ -36,6 +36,7 @@ public class BOPRequestPreparer implements Processor {
         recipients = users.stream().map(User::getEmail).collect(toSet());
         Set<String> emails = exchange.getProperty(ExchangeProperty.EMAIL_RECIPIENTS, Set.class);
         recipients.addAll(emails);
+        exchange.setProperty(ExchangeProperty.RECIPIENTS_SIZE, recipients.size());
 
         // Prepare the email to be sent.
         final Email email = new Email(


### PR DESCRIPTION
This PR introduces metrics which will give us a better vision of how many email requests we send to the email service and how email messages we send to the end users.