### PR TITLE
Remove whitespace from OCM templates footer

### DIFF
--- a/engine/src/main/resources/templates/OCM/clusterUpdateInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterUpdateInstantEmailBodyV2.html
@@ -41,6 +41,6 @@ More info
 {#content-body-section2}
 If you have any questions, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">contact us</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
 <br/><br/>
-Thank you for choosing Red Hat OpenShift {#switch action.events[0].payload.global_vars.subscription_plan}{#case 'OSD'}Dedicated{#case 'OSDTrial'}Dedicated Trial{#case 'MOA'}Service on AWS{/switch}.
+Thank you for choosing Red Hat OpenShift{#switch action.events[0].payload.global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
 {/content-body-section2}
 {/include}

--- a/engine/src/main/resources/templates/OCM/genericInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/genericInstantEmailBodyV2.html
@@ -53,7 +53,7 @@ More info
 {/switch}
 
 <p>
-    Thank you for choosing Red Hat OpenShift {#switch action.events[0].payload.global_vars.subscription_plan}{#case 'OSD'}Dedicated{#case 'OSDTrial'}Dedicated Trial{#case 'MOA'}Service on AWS{/switch}.
+    Thank you for choosing Red Hat OpenShift{#switch action.events[0].payload.global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
 </p>
 {/let}
 {/content-body-section2}


### PR DESCRIPTION
This PR changes
```
Thank you for choosing Red Hat OpenShift .
```
to
```
Thank you for choosing Red Hat OpenShift.
```
when the OCM payload doesn't contain a `subscription_plan` value.