### PR TITLE
Fix cache config

### DIFF
--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -196,4 +196,4 @@ quarkus.cache.caffeine.is-email-aggregation-supported.expire-after-write=PT5M
 quarkus.cache.caffeine.rbac-recipient-users-provider-get-users.expire-after-write=PT10M
 quarkus.cache.caffeine.rbac-recipient-users-provider-get-group-users.expire-after-write=PT10M
 quarkus.cache.caffeine.recipients-resolver-results.expire-after-write=PT1M
-quarkus.cache.caffeine.bundle.by.id.expire-after-write=PT15M
+quarkus.cache.caffeine."bundle.by.id".expire-after-write=PT15M


### PR DESCRIPTION
Fixes
```
18:38:33 #10 37.45 [WARNING] [io.quarkus.config] Unrecognized configuration key "quarkus.cache.caffeine.bundle.by.id.expire-after-write" was provided; it will be ignored; verify that the dependency extension for this configuration is set or that you did not make a typo
```