### PR TITLE
feature: remove the secrets' columns from the database

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
@@ -62,6 +62,7 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
     private Long bearerAuthenticationSourcesId;
 
     @JsonProperty("bearer_authentication")
+    @Transient
     private String bearerAuthentication;
 
     public String getUrl() {

--- a/database/src/main/resources/db/migration/V1.94.0__RHCLOUD-29443_remove_secrets_columns.sql
+++ b/database/src/main/resources/db/migration/V1.94.0__RHCLOUD-29443_remove_secrets_columns.sql
@@ -1,0 +1,13 @@
+ALTER TABLE
+    "camel_properties"
+DROP COLUMN
+    "basic_authentication",
+DROP COLUMN
+    "secret_token";
+
+ALTER TABLE
+    "endpoint_webhooks"
+DROP COLUMN
+    "basic_authentication",
+DROP COLUMN
+    "secret_token";


### PR DESCRIPTION
After migrating all the secrets to sources, we decided that it was time to remove both the database columns for the secrets and the feature flag, since storing secrets in Sources is going to be enabled by default.

## Depends on
* https://github.com/RedHatInsights/notifications-backend/pull/2350 

## Jira ticket
[[RHCLOUD-29443]](https://issues.redhat.com/browse/RHCLOIUD-29443)