### PR TITLE
Update Postgres GPG keys for sonar integration

### DIFF
--- a/.rhcicd/sonarqube/Dockerfile
+++ b/.rhcicd/sonarqube/Dockerfile
@@ -13,7 +13,7 @@ ARG rh_it_root_ca_cert_secondary_url
 # install postgresql 15
 RUN microdnf install -y dnf
 RUN dnf install -y 'dnf-command(config-manager)'
-RUN dnf install -y  https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+RUN dnf --disablerepo=* -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 RUN dnf install -y postgresql15-server
 RUN dnf install -y postgresql15-contrib
 


### PR DESCRIPTION
PostgreSQL RPM repository GPG key update - 3 January 2024
Check [this](https://yum.postgresql.org/news/pgdg-rpm-repo-gpg-key-update/) for more details