### PR TITLE
Add email template for TAM event type

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/DrawerTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/DrawerTemplateMigrationService.java
@@ -229,6 +229,10 @@ public class DrawerTemplateMigrationService {
                 warnings, "console", "rbac", List.of("request-access"),
                 "Rbac/requestAccess", "html", "Rbac platform group to custom drawer body"
         );
+        createDrawerIntegrationTemplate(
+                warnings, "console", "rbac", List.of("rh-new-tam-request-created"),
+                "Rbac/tamAccessRequest", "html", "Rbac tam access request drawer body"
+        );
 
         // Sources
         createDrawerIntegrationTemplate(

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -445,6 +445,11 @@ public class EmailTemplateMigrationService {
                     "Rbac/requestAccessEmailTitle", "txt", "Rbac request access email title",
                     "Rbac/requestAccessEmailBody", "html", "Rbac request access email body"
             );
+            createInstantEmailTemplate(
+                    warnings, "console", "rbac", List.of("rh-new-tam-request-created"),
+                    "Rbac/tamAccessRequestEmailTitle", "txt", "Rbac tam access request email title",
+                    "Rbac/tamAccessRequestEmailBody", "html", "Rbac tam access request email body"
+            );
 
             /*
              * Former src/main/resources/templates/ResourceOptimization folder.

--- a/engine/src/main/resources/templates/Rbac/requestAccessEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/requestAccessEmailBodyV2.html
@@ -29,6 +29,6 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/iam/user-access/groups/}">Review your user access groups in the console</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/groups/">Review your user access groups in the console</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/tamAccessRequestEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/tamAccessRequestEmailBodyV2.html
@@ -1,0 +1,18 @@
+{@boolean renderSection1=true}
+{@boolean renderButtonSection1=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    User Access - Console
+{/content-title}
+{#content-title-section1}
+    New TAM Access Request
+{/content-title-section1}
+{#content-body-section1}
+    <p>
+        A technical account manager requested to access your account.
+    </p>
+{/content-body-section1}
+{#content-button-section1}
+    <a target="_blank" href="{environment.url}/iam/user-access/access-requests/{action.events[0].payload.request_id}">Check the request in Insights</a>
+{/content-button-section1}
+{/include}

--- a/engine/src/main/resources/templates/Rbac/tamAccessRequestEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/Rbac/tamAccessRequestEmailTitleV2.txt
@@ -1,0 +1,1 @@
+Instant notification - New TAM access request created - User Access - Console

--- a/engine/src/main/resources/templates/drawer/Rbac/tamAccessRequest.html
+++ b/engine/src/main/resources/templates/drawer/Rbac/tamAccessRequest.html
@@ -1,0 +1,1 @@
+A Technical Account Manager <b>{data.events[0].payload.username}</b> requested to access your account.

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestRbacTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestRbacTemplate.java
@@ -30,12 +30,13 @@ public class TestRbacTemplate extends EmailTemplatesInDbHelper {
     static final String GROUP_DELETED = "group-deleted";
     static final String PLATFORM_DEFAULT_GROUP_TURNED_INTO_CUSTOM = "platform-default-group-turned-into-custom";
     static final String REQUEST_ACCESS = "request-access";
+    static final String RH_TAM_ACCESS_REQUESTED = "rh-new-tam-request-created";
 
     static String[] RBAC_EVENT_TYPE_NAMES() {
         return new String[]{RH_NEW_ROLE_AVAILABLE, RH_PLATFORM_DEFAULT_ROLE_UPDATED, RH_NON_PLATFORM_DEFAULT_ROLE_UPDATED, CUSTOM_ROLE_CREATED,
             CUSTOM_ROLE_UPDATED, CUSTOM_ROLE_DELETED, RH_NEW_ROLE_ADDED_TO_DEFAULT_ACCESS, RH_ROLE_REMOVED_FROM_DEFAULT_ACCESS,
             CUSTOM_DEFAULT_ACCESS_UPDATED, GROUP_CREATED, GROUP_UPDATED, GROUP_DELETED, PLATFORM_DEFAULT_GROUP_TURNED_INTO_CUSTOM,
-            REQUEST_ACCESS};
+            REQUEST_ACCESS, RH_TAM_ACCESS_REQUESTED};
     }
 
     @Override
@@ -115,6 +116,9 @@ public class TestRbacTemplate extends EmailTemplatesInDbHelper {
             case REQUEST_ACCESS:
                 assertEquals("Instant notification - Request access - User Access - Console", result);
                 break;
+            case RH_TAM_ACCESS_REQUESTED:
+                assertEquals("Instant notification - New TAM access request created - User Access - Console", result);
+                break;
             default:
                 break;
         }
@@ -193,6 +197,12 @@ public class TestRbacTemplate extends EmailTemplatesInDbHelper {
                 assertTrue(result.contains("https://console.redhat.com/stuff"));
                 assertTrue(result.contains("I want access to stuff"));
                 assertTrue(result.contains("testUser AT somewhere"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case RH_TAM_ACCESS_REQUESTED:
+                assertTrue(result.contains("New TAM Access Request"));
+                assertTrue(result.contains("A technical account manager requested to access your account."));
+                assertTrue(result.contains("Check the request in Insights"));
                 assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
                 break;
             default:


### PR DESCRIPTION
Adding email templates for new event type: rh-new-tam-request-created.

https://issues.redhat.com/browse/RHCLOUD-25247