### PR TITLE
RHCLOUD-30424 | refactor: specify the components that need resources in an env var

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -33,7 +33,16 @@ export COMPONENT_NAME="notifications-backend"
 export REF_ENV="insights-stage"
 export IMAGE="quay.io/cloudservices/notifications-backend"
 export DEPLOY_TIMEOUT="1200"
-export EXTRA_DEPLOY_ARGS="--set-parameter notifications-engine/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-email/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-google-chat/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-microsoft-teams/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-servicenow/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-slack/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-splunk/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-webhook/IMAGE_TAG=${IMAGE_TAG}"
+export EXTRA_DEPLOY_ARGS="""
+--set-image-tag notifications-engine=${IMAGE_TAG}
+--set-image-tag notifications-connector-email=${IMAGE_TAG}
+--set-image-tag notifications-connector-google-chat=${IMAGE_TAG}
+--set-image-tag notifications-connector-microsoft-teams=${IMAGE_TAG}
+--set-image-tag notifications-connector-servicenow=${IMAGE_TAG}
+--set-image-tag notifications-connector-slack=${IMAGE_TAG}
+--set-image-tag notifications-connector-splunk=${IMAGE_TAG}
+--set-image-tag notifications-connector-webhook=${IMAGE_TAG}
+"""
 # The following components need to be deployed with the proper amount of resources in the Ephemeral environment, as
 # otherwise the deployments fail because of a lack of resources.
 export COMPONENTS_W_RESOURCES="historical-system-profiles system-baseline"

--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -33,7 +33,10 @@ export COMPONENT_NAME="notifications-backend"
 export REF_ENV="insights-stage"
 export IMAGE="quay.io/cloudservices/notifications-backend"
 export DEPLOY_TIMEOUT="1200"
-export EXTRA_DEPLOY_ARGS="--set-parameter notifications-engine/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-email/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-google-chat/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-microsoft-teams/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-servicenow/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-slack/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-splunk/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-webhook/IMAGE_TAG=${IMAGE_TAG} --no-remove-resources historical-system-profiles --no-remove-resources system-baseline"
+export EXTRA_DEPLOY_ARGS="--set-parameter notifications-engine/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-email/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-google-chat/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-microsoft-teams/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-servicenow/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-slack/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-splunk/IMAGE_TAG=${IMAGE_TAG} --set-parameter notifications-connector-webhook/IMAGE_TAG=${IMAGE_TAG}"
+# The following components need to be deployed with the proper amount of resources in the Ephemeral environment, as
+# otherwise the deployments fail because of a lack of resources.
+export COMPONENTS_W_RESOURCES="historical-system-profiles system-baseline"
 source $CICD_ROOT/deploy_ephemeral_env.sh
 
 # Run IQE tests


### PR DESCRIPTION
Instead of adding the components in the "extra deploy arguments", we can specify them in a dedicated environment variable instead, which makes the script easier to read.

## Jira ticket.
[[RHCLOUD-30424]](https://issues.redhat.com/browse/RHCLOUD-30424)