### PR TITLE
RHCLOUD-27431 | refactor: don't return secrets on responses | Endpoints and service implementation

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -213,10 +213,10 @@ public class EndpointRepository {
         String endpointQuery = "UPDATE Endpoint SET name = :name, description = :description, enabled = :enabled, serverErrors = 0 " +
                 "WHERE orgId = :orgId AND id = :id";
         String webhookQuery = "UPDATE WebhookProperties SET url = :url, method = :method, " +
-                "disableSslVerification = :disableSslVerification, secretToken = :secretToken, basicAuthentication = :basicAuthentication WHERE endpoint.id = :endpointId";
+                "disableSslVerification = :disableSslVerification, secretTokenLegacy = :secretToken, basicAuthenticationLegacy = :basicAuthentication WHERE endpoint.id = :endpointId";
         String camelQuery = "UPDATE CamelProperties SET url = :url, extras = :extras, " +
-                "basicAuthentication = :basicAuthentication, " +
-                "disableSslVerification = :disableSslVerification, secretToken = :secretToken WHERE endpoint.id = :endpointId";
+                "basicAuthenticationLegacy = :basicAuthentication, " +
+                "disableSslVerification = :disableSslVerification, secretTokenLegacy = :secretToken WHERE endpoint.id = :endpointId";
 
         if (endpoint.getType() != null && endpoint.getType().isSystemEndpointType) {
             throw new RuntimeException("Unable to update a system endpoint of type " + endpoint.getType());
@@ -243,8 +243,8 @@ public class EndpointRepository {
                             .setParameter("url", properties.getUrl())
                             .setParameter("method", properties.getMethod())
                             .setParameter("disableSslVerification", properties.getDisableSslVerification())
-                            .setParameter("secretToken", properties.getSecretToken())
-                            .setParameter("basicAuthentication", properties.getBasicAuthentication())
+                            .setParameter("secretToken", properties.getSecretTokenLegacy())
+                            .setParameter("basicAuthentication", properties.getBasicAuthenticationLegacy())
                             .setParameter("endpointId", endpoint.getId())
                             .executeUpdate() > 0;
                 case CAMEL:
@@ -252,10 +252,10 @@ public class EndpointRepository {
                     return entityManager.createQuery(camelQuery)
                             .setParameter("url", cAttr.getUrl())
                             .setParameter("disableSslVerification", cAttr.getDisableSslVerification())
-                            .setParameter("secretToken", cAttr.getSecretToken())
+                            .setParameter("secretToken", cAttr.getSecretTokenLegacy())
                             .setParameter("endpointId", endpoint.getId())
                             .setParameter("extras", cAttr.getExtras())
-                            .setParameter("basicAuthentication", cAttr.getBasicAuthentication())
+                            .setParameter("basicAuthentication", cAttr.getBasicAuthenticationLegacy())
                             .executeUpdate() > 0;
                 default:
                     return true;
@@ -384,11 +384,11 @@ public class EndpointRepository {
                 "WHERE EXISTS ( " +
                     "SELECT cp FROM CamelProperties cp " +
                     "WHERE cp.id = e.id AND cp.basicAuthenticationSourcesId IS NULL AND cp.secretTokenSourcesId IS NULL " +
-                "AND (cp.basicAuthentication IS NOT NULL OR cp.secretToken IS NOT NULL) " +
+                "AND (cp.basicAuthenticationLegacy IS NOT NULL OR cp.secretTokenLegacy IS NOT NULL) " +
                 ") OR EXISTS ( " +
                     "SELECT wp FROM WebhookProperties wp " +
                     "WHERE wp.id = e.id AND wp.basicAuthenticationSourcesId IS NULL AND wp.secretTokenSourcesId IS NULL " +
-                    "AND (wp.basicAuthentication IS NOT NULL OR wp.secretToken IS NOT NULL) " +
+                    "AND (wp.basicAuthenticationLegacy IS NOT NULL OR wp.secretTokenLegacy IS NOT NULL) " +
                 ")";
 
         final List<Endpoint> endpoints =  this.entityManager

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -473,9 +473,9 @@ public class EndpointResource {
                 var incomingEndpointProps = (SourcesSecretable) endpointProperties;
                 var databaseEndpointProps = (SourcesSecretable) databaseEndpointProperties;
 
-                databaseEndpointProps.setBasicAuthentication(incomingEndpointProps.getBasicAuthentication());
-                databaseEndpointProps.setSecretToken(incomingEndpointProps.getSecretToken());
-                databaseEndpointProps.setBearerAuthentication(incomingEndpointProps.getBearerAuthentication());
+                databaseEndpointProps.setBasicAuthenticationLegacy(incomingEndpointProps.getBasicAuthenticationLegacy());
+                databaseEndpointProps.setSecretTokenLegacy(incomingEndpointProps.getSecretTokenLegacy());
+                databaseEndpointProps.setBearerAuthenticationLegacy(incomingEndpointProps.getBearerAuthenticationLegacy());
                 this.secretUtils.updateSecretsForEndpoint(dbEndpoint);
             }
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -16,6 +16,9 @@ import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.SourcesSecretable;
 import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
+import com.redhat.cloud.notifications.models.secrets.BasicAuthentication;
+import com.redhat.cloud.notifications.models.secrets.BearerToken;
+import com.redhat.cloud.notifications.models.secrets.SecretToken;
 import com.redhat.cloud.notifications.routers.endpoints.EndpointTestRequest;
 import com.redhat.cloud.notifications.routers.endpoints.InternalEndpointTestRequest;
 import com.redhat.cloud.notifications.routers.engine.EndpointTestService;
@@ -550,5 +553,183 @@ public class EndpointResource {
 
     private boolean isEndpointTypeAllowed(EndpointType endpointType) {
         return !featureFlipper.isEmailsOnlyMode() || endpointType.isSystemEndpointType;
+    }
+
+    @APIResponse(responseCode = "204", description = "The basic authentication secret was created or updated for the given integration")
+    @APIResponse(responseCode = "400", description = "The integration does not support the basic authentication secrets or the basic authentication object is invalid")
+    @APIResponse(responseCode = "404", description = "The specified integration could not be found")
+    @Consumes(APPLICATION_JSON)
+    @Operation(summary = "Create or update the basic authentication secret for the integration", description = "Creates a basic authentication secret for the integration if it wasn't created already. If the integration already had a basic authentication secret, it will update it.")
+    @Parameters(
+        {
+            @Parameter(
+                name = "uuid",
+                in = ParameterIn.PATH,
+                description = "The UUID of the endpoint to create or update the secret for.",
+                schema = @Schema(type = SchemaType.STRING)
+            )
+        }
+    )
+    @Path("/{integrationUuid}/secrets/basic-authentication")
+    @PUT
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    @Transactional
+    public void createUpdateEndpointSecretsBasicAuthentication(@Context SecurityContext securityContext, @RestPath UUID integrationUuid, @RequestBody final BasicAuthentication basicAuthentication) {
+        final String orgId = SecurityContextUtil.getOrgId(securityContext);
+
+        final Endpoint endpoint = this.endpointRepository.getEndpoint(orgId, integrationUuid);
+        if (endpoint == null) {
+            throw new NotFoundException("integration not found");
+        }
+
+        this.secretUtils.createUpdateBasicAuthenticationSecret(endpoint, basicAuthentication);
+    }
+
+    @APIResponse(responseCode = "204", description = "The bearer token secret was created or updated for the given integration")
+    @APIResponse(responseCode = "400", description = "The integration does not support the bearer token secrets or the bearer token object is invalid")
+    @APIResponse(responseCode = "404", description = "The specified integration could not be found")
+    @Consumes(APPLICATION_JSON)
+    @Operation(summary = "Create or update the bearer token secret for the integration", description = "Creates a bearer token secret for the integration if it wasn't created already. If the integration already had a bearer token secret, it will update it.")
+    @Parameters(
+        {
+            @Parameter(
+                name = "uuid",
+                in = ParameterIn.PATH,
+                description = "The UUID of the endpoint to create or update the secret for.",
+                schema = @Schema(type = SchemaType.STRING)
+            )
+        }
+    )
+    @Path("/{integrationUuid}/secrets/bearer-token")
+    @PUT
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    @Transactional
+    public void createUpdateEndpointSecretsBearerToken(@Context SecurityContext securityContext, @RestPath UUID integrationUuid, @RequestBody final BearerToken bearerToken) {
+        final String orgId = SecurityContextUtil.getOrgId(securityContext);
+
+        final Endpoint endpoint = this.endpointRepository.getEndpoint(orgId, integrationUuid);
+        if (endpoint == null) {
+            throw new NotFoundException("integration not found");
+        }
+
+        this.secretUtils.createUpdateBearerTokenSecret(endpoint, bearerToken);
+    }
+
+    @APIResponse(responseCode = "204", description = "The secret token secret was created or updated for the given integration")
+    @APIResponse(responseCode = "400", description = "The integration does not support the secret token secrets or the secret token object is invalid")
+    @APIResponse(responseCode = "404", description = "The specified integration could not be found")
+    @Consumes(APPLICATION_JSON)
+    @Operation(summary = "Create or update the secret token secret for the integration", description = "Creates a secret token secret for the integration if it wasn't created already. If the integration already had a secret token secret, it will update it.")
+    @Parameters(
+        {
+            @Parameter(
+                name = "uuid",
+                in = ParameterIn.PATH,
+                description = "The UUID of the endpoint to create or update the secret for.",
+                schema = @Schema(type = SchemaType.STRING)
+            )
+        }
+    )
+    @Path("/{integrationUuid}/secrets/secret-token")
+    @PUT
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    @Transactional
+    public void createUpdateEndpointSecretsSecretToken(@Context SecurityContext securityContext, @RestPath UUID integrationUuid, @RequestBody final SecretToken secretToken) {
+        final String orgId = SecurityContextUtil.getOrgId(securityContext);
+
+        final Endpoint endpoint = this.endpointRepository.getEndpoint(orgId, integrationUuid);
+        if (endpoint == null) {
+            throw new NotFoundException("integration not found");
+        }
+
+        this.secretUtils.createUpdateSecretTokenSecret(endpoint, secretToken);
+    }
+
+    @APIResponse(responseCode = "204", description = "The basic authentication secret was deleted for the given integration")
+    @APIResponse(responseCode = "400", description = "The integration does not support basic authentication secrets")
+    @APIResponse(responseCode = "404", description = "The specified integration could not be found")
+    @DELETE
+    @Operation(summary = "Delete the basic authentication secret for the integration.", description = "Deletes the basic authentication secret for the integration.")
+    @Parameters(
+        {
+            @Parameter(
+                name = "uuid",
+                in = ParameterIn.PATH,
+                description = "The UUID of the endpoint to delete the secret for.",
+                schema = @Schema(type = SchemaType.STRING)
+            )
+        }
+    )
+    @Path("/{integrationUuid}/secrets/basic-authentication")
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    @Transactional
+    public void deleteBasicAuthenticationSecret(@Context SecurityContext securityContext, @RestPath UUID integrationUuid) {
+        final String orgId = SecurityContextUtil.getOrgId(securityContext);
+
+        final Endpoint endpoint = this.endpointRepository.getEndpoint(orgId, integrationUuid);
+        if (endpoint == null) {
+            throw new NotFoundException("integration not found");
+        }
+
+        this.secretUtils.deleteBasicAuthenticationSecret(endpoint);
+    }
+
+    @APIResponse(responseCode = "204", description = "The bearer token secret was deleted for the given integration")
+    @APIResponse(responseCode = "400", description = "The integration does not support the bearer token secrets")
+    @APIResponse(responseCode = "404", description = "The specified integration could not be found")
+    @DELETE
+    @Operation(summary = "Delete the bearer token secret for the integration.", description = "Deletes the bearer token secret for the integration.")
+    @Parameters(
+        {
+            @Parameter(
+                name = "uuid",
+                in = ParameterIn.PATH,
+                description = "The UUID of the endpoint to delete the secret for.",
+                schema = @Schema(type = SchemaType.STRING)
+            )
+        }
+    )
+    @Path("/{integrationUuid}/secrets/bearer-token")
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    @Transactional
+    public void deleteBearerTokenSecret(@Context SecurityContext securityContext, @RestPath UUID integrationUuid) {
+        final String orgId = SecurityContextUtil.getOrgId(securityContext);
+
+        final Endpoint endpoint = this.endpointRepository.getEndpoint(orgId, integrationUuid);
+        if (endpoint == null) {
+            throw new NotFoundException("integration not found");
+        }
+
+        this.secretUtils.deleteBearerTokenSecret(endpoint);
+    }
+
+    @APIResponse(responseCode = "204", description = "The secret token secret was deleted for the given integration")
+    @APIResponse(responseCode = "400", description = "The integration does not support the secret token secrets")
+    @APIResponse(responseCode = "404", description = "The specified integration could not be found")
+    @DELETE
+    @Consumes(APPLICATION_JSON)
+    @Operation(summary = "Delete the secret token secret for the integration.", description = "Deletes the secret token secret for the integration.")
+    @Parameters(
+        {
+            @Parameter(
+                name = "uuid",
+                in = ParameterIn.PATH,
+                description = "The UUID of the endpoint to delete the secret for.",
+                schema = @Schema(type = SchemaType.STRING)
+            )
+        }
+    )
+    @Path("/{integrationUuid}/secrets/secret-token")
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    @Transactional
+    public void deleteSecretTokenSecret(@Context SecurityContext securityContext, @RestPath UUID integrationUuid) {
+        final String orgId = SecurityContextUtil.getOrgId(securityContext);
+
+        final Endpoint endpoint = this.endpointRepository.getEndpoint(orgId, integrationUuid);
+        if (endpoint == null) {
+            throw new NotFoundException("integration not found");
+        }
+
+        this.secretUtils.deleteSecretTokenSecret(endpoint);
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/SourcesSecretsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/SourcesSecretsMigrationService.java
@@ -121,7 +121,7 @@ public class SourcesSecretsMigrationService {
         }
 
         // Pick up errors to delete the secrets
-        this.secretUtils.createSecretsForEndpoint(endpoint);
+        this.secretUtils.createSecretsForEndpointLegacy(endpoint);
 
         this.processedEndpoints.put(endpoint.getId(), endpoint);
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -6,7 +6,7 @@ import com.redhat.cloud.notifications.db.repositories.BundleRepository;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
 import com.redhat.cloud.notifications.models.Application;
-import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.CamelProperties;
@@ -358,8 +358,8 @@ public class ResourceHelpers {
 
                 // Maybe set a basic authentication, maybe not...
                 if (i % 3 == 0) {
-                    camelProperties.setBasicAuthentication(
-                        new BasicAuthentication(
+                    camelProperties.setBasicAuthenticationLegacy(
+                        new BasicAuthenticationLegacy(
                             UUID.randomUUID().toString(),
                             UUID.randomUUID().toString()
                         )
@@ -368,7 +368,7 @@ public class ResourceHelpers {
 
                 // Maybe set a secret token, maybe not...
                 if (i % 3 == 0) {
-                    camelProperties.setSecretToken(UUID.randomUUID().toString());
+                    camelProperties.setSecretTokenLegacy(UUID.randomUUID().toString());
                 }
 
                 camelProperties.setBasicAuthenticationSourcesId(random.nextLong());
@@ -385,8 +385,8 @@ public class ResourceHelpers {
 
                 // Maybe set a basic authentication, maybe not...
                 if (i % 3 == 0) {
-                    webhookProperties.setBasicAuthentication(
-                        new BasicAuthentication(
+                    webhookProperties.setBasicAuthenticationLegacy(
+                        new BasicAuthenticationLegacy(
                             UUID.randomUUID().toString(),
                             UUID.randomUUID().toString()
                         )
@@ -395,7 +395,7 @@ public class ResourceHelpers {
 
                 // Maybe set a secret token, maybe not...
                 if (i % 3 == 0) {
-                    webhookProperties.setSecretToken(UUID.randomUUID().toString());
+                    webhookProperties.setSecretTokenLegacy(UUID.randomUUID().toString());
                 }
 
                 webhookProperties.setBasicAuthenticationSourcesId(random.nextLong());
@@ -431,10 +431,10 @@ public class ResourceHelpers {
             camelProperties.setDisableSslVerification(random.nextBoolean());
             camelProperties.setUrl("https://example.org");
 
-            camelProperties.setBasicAuthentication(
-                new BasicAuthentication(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+            camelProperties.setBasicAuthenticationLegacy(
+                new BasicAuthenticationLegacy(UUID.randomUUID().toString(), UUID.randomUUID().toString())
             );
-            camelProperties.setSecretToken(UUID.randomUUID().toString());
+            camelProperties.setSecretTokenLegacy(UUID.randomUUID().toString());
 
             final Endpoint endpoint = new Endpoint();
             endpoint.setDescription(UUID.randomUUID().toString());
@@ -456,10 +456,10 @@ public class ResourceHelpers {
             webhookProperties.setMethod(HttpType.GET);
             webhookProperties.setUrl("https://example.org");
 
-            webhookProperties.setBasicAuthentication(
-                new BasicAuthentication(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+            webhookProperties.setBasicAuthenticationLegacy(
+                new BasicAuthenticationLegacy(UUID.randomUUID().toString(), UUID.randomUUID().toString())
             );
-            webhookProperties.setSecretToken(UUID.randomUUID().toString());
+            webhookProperties.setSecretTokenLegacy(UUID.randomUUID().toString());
 
             final Endpoint endpoint = new Endpoint();
             endpoint.setDescription(UUID.randomUUID().toString());
@@ -479,7 +479,7 @@ public class ResourceHelpers {
     /**
      * Generates five endpoints which contain either {@link CamelProperties} or
      * {@link WebhookProperties} properties, but that have either a null
-     * or empty {@link BasicAuthentication}, mimicking what current basic
+     * or empty {@link BasicAuthenticationLegacy}, mimicking what current basic
      * authentications look like right now in the database. The properties
      * always contain a secret token. They should be fetchable by
      * {@link EndpointRepository#findEndpointWithPropertiesWithStoredSecrets()}
@@ -496,11 +496,11 @@ public class ResourceHelpers {
 
         // Generates an empty basic authentication or a null one, replicating
         // what we currently have in the database.
-        final Supplier<BasicAuthentication> getRandomBasicAuth = () -> {
+        final Supplier<BasicAuthenticationLegacy> getRandomBasicAuth = () -> {
             if (random.nextBoolean()) {
-                return new BasicAuthentication("", "");
+                return new BasicAuthenticationLegacy("", "");
             } else {
-                return new BasicAuthentication(null, null);
+                return new BasicAuthenticationLegacy(null, null);
             }
         };
 
@@ -516,9 +516,9 @@ public class ResourceHelpers {
                 endpoint.setSubType("dromedary");
 
                 final CamelProperties camelProperties = new CamelProperties();
-                camelProperties.setBasicAuthentication(getRandomBasicAuth.get());
+                camelProperties.setBasicAuthenticationLegacy(getRandomBasicAuth.get());
                 camelProperties.setDisableSslVerification(random.nextBoolean());
-                camelProperties.setSecretToken(UUID.randomUUID().toString());
+                camelProperties.setSecretTokenLegacy(UUID.randomUUID().toString());
                 camelProperties.setUrl("https://example.org");
 
                 endpoint.setProperties(camelProperties);
@@ -526,10 +526,10 @@ public class ResourceHelpers {
                 endpoint.setType(EndpointType.WEBHOOK);
 
                 final WebhookProperties webhookProperties = new WebhookProperties();
-                webhookProperties.setBasicAuthentication(getRandomBasicAuth.get());
+                webhookProperties.setBasicAuthenticationLegacy(getRandomBasicAuth.get());
                 webhookProperties.setDisableSslVerification(random.nextBoolean());
                 webhookProperties.setMethod(HttpType.GET);
-                webhookProperties.setSecretToken(UUID.randomUUID().toString());
+                webhookProperties.setSecretTokenLegacy(UUID.randomUUID().toString());
                 webhookProperties.setUrl("https://example.org");
 
                 endpoint.setProperties(webhookProperties);

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.db.repositories;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
-import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.Endpoint;
@@ -249,10 +249,10 @@ public class EndpointRepositoryTest {
     @Deprecated(forRemoval = true)
     private Endpoint createCamelEndpointWithCamelProperties() {
         final CamelProperties camelProperties = new CamelProperties();
-        camelProperties.setBasicAuthentication(new BasicAuthentication("a", "b"));
+        camelProperties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("a", "b"));
         camelProperties.setDisableSslVerification(true);
         camelProperties.setExtras(Map.of("a", "b"));
-        camelProperties.setSecretToken("secret token!");
+        camelProperties.setSecretTokenLegacy("secret token!");
         camelProperties.setUrl("https://example.com");
 
         final Endpoint camelEndpoint = new Endpoint();
@@ -277,10 +277,10 @@ public class EndpointRepositoryTest {
     @Deprecated(forRemoval = true)
     private Endpoint createWebhookEndpointWithWebhookProperties() {
         final WebhookProperties webhookProperties = new WebhookProperties();
-        webhookProperties.setBasicAuthentication(new BasicAuthentication("a", "b"));
+        webhookProperties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("a", "b"));
         webhookProperties.setDisableSslVerification(true);
         webhookProperties.setMethod(HttpType.GET);
-        webhookProperties.setSecretToken("secret token!");
+        webhookProperties.setSecretTokenLegacy("secret token!");
         webhookProperties.setUrl("https://example.com");
 
         final Endpoint webhookEndpoint = new Endpoint();

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -513,7 +513,7 @@ public class LifecycleITest extends DbIsolatedTest {
         WebhookProperties properties = new WebhookProperties();
         properties.setMethod(HttpType.POST);
         properties.setDisableSslVerification(true);
-        properties.setSecretToken(secretToken);
+        properties.setSecretTokenLegacy(secretToken);
         properties.setUrl(getMockServerUrl() + WEBHOOK_MOCK_PATH);
 
         Endpoint endpoint = new Endpoint();
@@ -549,8 +549,8 @@ public class LifecycleITest extends DbIsolatedTest {
         jsonWebhookProperties.mapTo(WebhookProperties.class);
         assertEquals(properties.getMethod().name(), jsonWebhookProperties.getString("method"));
         assertEquals(properties.getDisableSslVerification(), jsonWebhookProperties.getBoolean("disable_ssl_verification"));
-        if (properties.getSecretToken() != null) {
-            assertEquals(properties.getSecretToken(), jsonWebhookProperties.getString("secret_token"));
+        if (properties.getSecretTokenLegacy() != null) {
+            assertEquals(properties.getSecretTokenLegacy(), jsonWebhookProperties.getString("secret_token"));
         }
         assertEquals(properties.getUrl(), jsonWebhookProperties.getString("url"));
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -9,7 +9,7 @@ import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
-import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointStatus;
@@ -163,7 +163,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         WebhookProperties properties = new WebhookProperties();
         properties.setMethod(POST);
         properties.setDisableSslVerification(false);
-        properties.setSecretToken("my-super-secret-token");
+        properties.setSecretTokenLegacy("my-super-secret-token");
         properties.setUrl(getMockServerUrl());
 
         Endpoint ep = new Endpoint();
@@ -283,7 +283,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             WebhookProperties properties = new WebhookProperties();
             properties.setMethod(POST);
             properties.setDisableSslVerification(false);
-            properties.setSecretToken("my-super-secret-token");
+            properties.setSecretTokenLegacy("my-super-secret-token");
             properties.setUrl(getMockServerUrl());
 
             Endpoint endpoint1 = new Endpoint();
@@ -337,9 +337,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
             // Different endpoint type with same name
             CamelProperties camelProperties = new CamelProperties();
-            camelProperties.setBasicAuthentication(new BasicAuthentication());
+            camelProperties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy());
             camelProperties.setExtras(Map.of());
-            camelProperties.setSecretToken("secret");
+            camelProperties.setSecretTokenLegacy("secret");
             camelProperties.setUrl("http://nowhere");
 
             ep = new Endpoint();
@@ -424,7 +424,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         WebhookProperties properties = new WebhookProperties();
         properties.setMethod(POST);
         properties.setDisableSslVerification(false);
-        properties.setSecretToken("my-super-secret-token");
+        properties.setSecretTokenLegacy("my-super-secret-token");
         properties.setUrl(getMockServerUrl());
 
         // Test with properties, but without endpoint type
@@ -478,7 +478,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         CamelProperties cAttr = new CamelProperties();
         cAttr.setDisableSslVerification(false);
         cAttr.setUrl(getMockServerUrl());
-        cAttr.setBasicAuthentication(new BasicAuthentication("testuser", "secret"));
+        cAttr.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("testuser", "secret"));
         Map<String, String> extras = new HashMap<>();
         extras.put("template", "11");
         cAttr.setExtras(extras);
@@ -550,7 +550,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         CamelProperties cAttr = new CamelProperties();
         cAttr.setDisableSslVerification(false);
         cAttr.setUrl(getMockServerUrl());
-        cAttr.setBasicAuthentication(new BasicAuthentication("testuser", "secret"));
+        cAttr.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("testuser", "secret"));
         Map<String, String> extras = new HashMap<>();
         extras.put("template", "11");
         cAttr.setExtras(extras);
@@ -757,7 +757,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         WebhookProperties properties = new WebhookProperties();
         properties.setMethod(POST);
         properties.setDisableSslVerification(false);
-        properties.setSecretToken("my-super-secret-token");
+        properties.setSecretTokenLegacy("my-super-secret-token");
         properties.setUrl(getMockServerUrl());
 
         Endpoint ep = new Endpoint();
@@ -861,7 +861,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         WebhookProperties properties = new WebhookProperties();
         properties.setMethod(POST);
         properties.setDisableSslVerification(false);
-        properties.setSecretToken("my-super-secret-token");
+        properties.setSecretTokenLegacy("my-super-secret-token");
         properties.setUrl(getMockServerUrl());
 
         Endpoint ep = new Endpoint();
@@ -889,7 +889,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         // Add Camel
         CamelProperties camelProperties = new CamelProperties();
         camelProperties.setDisableSslVerification(false);
-        camelProperties.setSecretToken("my-super-secret-token");
+        camelProperties.setSecretTokenLegacy("my-super-secret-token");
         camelProperties.setUrl(getMockServerUrl());
         camelProperties.setExtras(new HashMap<>());
 
@@ -1085,9 +1085,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
         WebhookProperties properties = new WebhookProperties();
         properties.setMethod(POST);
         properties.setDisableSslVerification(false);
-        properties.setSecretToken("my-super-secret-token");
-        properties.setBasicAuthentication(new BasicAuthentication("myuser", "mypassword"));
-        properties.setBearerAuthentication("my-test-bearer-token");
+        properties.setSecretTokenLegacy("my-super-secret-token");
+        properties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("myuser", "mypassword"));
+        properties.setBearerAuthenticationLegacy("my-test-bearer-token");
         properties.setUrl(getMockServerUrl());
 
         Endpoint ep = new Endpoint();
@@ -1124,7 +1124,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         attr.mapTo(WebhookProperties.class);
         assertNotNull(attr.getJsonObject("basic_authentication"));
         assertEquals("mypassword", attr.getJsonObject("basic_authentication").getString("password"));
-        assertEquals(properties.getBearerAuthentication(), attr.getString("bearer_authentication"));
+        assertEquals(properties.getBearerAuthenticationLegacy(), attr.getString("bearer_authentication"));
     }
 
     @Test
@@ -1278,7 +1278,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         WebhookProperties webhookProperties = new WebhookProperties();
         webhookProperties.setMethod(POST);
         webhookProperties.setDisableSslVerification(false);
-        webhookProperties.setSecretToken("my-super-secret-token");
+        webhookProperties.setSecretTokenLegacy("my-super-secret-token");
         webhookProperties.setUrl(getMockServerUrl());
         ep.setProperties(webhookProperties);
 
@@ -1444,7 +1444,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         WebhookProperties webhookProperties = new WebhookProperties();
         webhookProperties.setMethod(POST);
         webhookProperties.setDisableSslVerification(false);
-        webhookProperties.setSecretToken("my-super-secret-token");
+        webhookProperties.setSecretTokenLegacy("my-super-secret-token");
         webhookProperties.setUrl(getMockServerUrl());
         ep.setProperties(webhookProperties);
 
@@ -1587,7 +1587,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             WebhookProperties properties = new WebhookProperties();
             properties.setMethod(POST);
             properties.setDisableSslVerification(false);
-            properties.setSecretToken("my-super-secret-token");
+            properties.setSecretTokenLegacy("my-super-secret-token");
             properties.setUrl(getMockServerUrl());
 
             Endpoint ep = new Endpoint();
@@ -1787,15 +1787,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         // Create the properties for the endpoint. Leave the URL so that we can set it afterwards.
         final var camelProperties = new CamelProperties();
-        camelProperties.setBasicAuthentication(new BasicAuthentication("endpoint-invalid-urls-basic-authentication-username", "endpoint-invalid-urls-basic-authentication-password"));
+        camelProperties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("endpoint-invalid-urls-basic-authentication-username", "endpoint-invalid-urls-basic-authentication-password"));
         camelProperties.setDisableSslVerification(false);
-        camelProperties.setSecretToken("endpoint-invalid-urls-secret-token");
+        camelProperties.setSecretTokenLegacy("endpoint-invalid-urls-secret-token");
 
         final var webhookProperties = new WebhookProperties();
-        webhookProperties.setBasicAuthentication(new BasicAuthentication("endpoint-invalid-urls-basic-authentication-username", "endpoint-invalid-urls-basic-authentication-password"));
+        webhookProperties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("endpoint-invalid-urls-basic-authentication-username", "endpoint-invalid-urls-basic-authentication-password"));
         webhookProperties.setDisableSslVerification(false);
         webhookProperties.setMethod(POST);
-        webhookProperties.setSecretToken("endpoint-invalid-urls-secret-token");
+        webhookProperties.setSecretTokenLegacy("endpoint-invalid-urls-secret-token");
 
         // Create an endpoint without the type and the properties set.
         final var endpoint = new Endpoint();
@@ -1923,15 +1923,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         // Create the properties for the endpoint. Leave the URL so that we can set it afterwards.
         final var camelProperties = new CamelProperties();
-        camelProperties.setBasicAuthentication(new BasicAuthentication(username, password));
+        camelProperties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy(username, password));
         camelProperties.setDisableSslVerification(disableSslVerification);
-        camelProperties.setSecretToken(secretToken);
+        camelProperties.setSecretTokenLegacy(secretToken);
 
         final var webhookProperties = new WebhookProperties();
-        webhookProperties.setBasicAuthentication(new BasicAuthentication(username, password));
+        webhookProperties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy(username, password));
         webhookProperties.setDisableSslVerification(disableSslVerification);
         webhookProperties.setMethod(method);
-        webhookProperties.setSecretToken(secretToken);
+        webhookProperties.setSecretTokenLegacy(secretToken);
 
         // Create an endpoint without the type and the properties set.
         final var name = "endpoint-invalid-urls-name";
@@ -1996,7 +1996,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         WebhookProperties properties = new WebhookProperties();
         properties.setMethod(POST);
         properties.setDisableSslVerification(false);
-        properties.setSecretToken("my-super-secret-token");
+        properties.setSecretTokenLegacy("my-super-secret-token");
         properties.setUrl(getMockServerUrl());
 
         Endpoint ep = new Endpoint();
@@ -2020,7 +2020,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         CamelProperties cAttr = new CamelProperties();
         cAttr.setDisableSslVerification(false);
         cAttr.setUrl(getMockServerUrl());
-        cAttr.setBasicAuthentication(new BasicAuthentication("testuser", "secret"));
+        cAttr.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("testuser", "secret"));
         Map<String, String> extras = new HashMap<>();
         extras.put("template", "11");
         cAttr.setExtras(extras);
@@ -2249,9 +2249,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
             // Now update the endpoint by setting the "basic authentication"
             // and the "secret token".
-            properties.setBasicAuthentication(new BasicAuthentication("basic-auth-user", "basic-auth-password"));
-            properties.setSecretToken("my-super-secret-token");
-            properties.setBearerAuthentication("my-super-bearer-token");
+            properties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("basic-auth-user", "basic-auth-password"));
+            properties.setSecretTokenLegacy("my-super-secret-token");
+            properties.setBearerAuthenticationLegacy("my-super-bearer-token");
 
             // The below two secrets will be returned when we simulate that
             // we have called sources to create these secrets.
@@ -2326,9 +2326,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
             // Create the endpoint that we will attempt to modify.
             final WebhookProperties properties = new WebhookProperties();
             properties.setDisableSslVerification(false);
-            properties.setBasicAuthentication(new BasicAuthentication("basic-auth-user", "basic-auth-password"));
+            properties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("basic-auth-user", "basic-auth-password"));
             properties.setMethod(HttpType.GET);
-            properties.setSecretToken("my-super-secret-token");
+            properties.setSecretTokenLegacy("my-super-secret-token");
             properties.setUrl(getMockServerUrl());
 
             final Endpoint endpoint = new Endpoint();
@@ -2379,8 +2379,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
             // Now update the endpoint by setting its "basic authentication" to
             // null, which triggers the secret deletion in Sources.
-            properties.setBasicAuthentication(null);
-            properties.setSecretToken(null);
+            properties.setBasicAuthenticationLegacy(null);
+            properties.setSecretTokenLegacy(null);
 
             given()
                 .header(identityHeader)
@@ -2437,10 +2437,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
             // Create the endpoint that we will attempt to modify.
             final WebhookProperties properties = new WebhookProperties();
-            properties.setBasicAuthentication(new BasicAuthentication("basic-auth-user", "basic-auth-password"));
+            properties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("basic-auth-user", "basic-auth-password"));
             properties.setDisableSslVerification(false);
             properties.setMethod(HttpType.GET);
-            properties.setSecretToken("my-super-secret-token ");
+            properties.setSecretTokenLegacy("my-super-secret-token ");
             properties.setUrl(getMockServerUrl());
 
             final Endpoint endpoint = new Endpoint();
@@ -2498,8 +2498,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
             // Now update the endpoint by updating its "basic authentication"
             // and "secret token".
-            properties.setBasicAuthentication(new BasicAuthentication("basic-auth-user", "basic-auth-password"));
-            properties.setSecretToken("my-super-secret-token");
+            properties.setBasicAuthenticationLegacy(new BasicAuthenticationLegacy("basic-auth-user", "basic-auth-password"));
+            properties.setSecretTokenLegacy("my-super-secret-token");
 
             // The below two secrets will be returned when we simulate that
             // we have called sources to update these secrets. This should
@@ -2644,7 +2644,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             WebhookProperties properties = new WebhookProperties();
             properties.setMethod(POST);
             properties.setDisableSslVerification(false);
-            properties.setSecretToken("my-super-secret-token");
+            properties.setSecretTokenLegacy("my-super-secret-token");
             properties.setUrl(getMockServerUrl() + "/" + i);
 
             Endpoint ep = new Endpoint();

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/SourcesSecretsMigrationServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/SourcesSecretsMigrationServiceTest.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.routers.internal;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
-import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointProperties;
@@ -118,14 +118,14 @@ public class SourcesSecretsMigrationServiceTest {
             final Endpoint endpoint = entry.getValue();
 
             if (endpoint.getProperties() instanceof SourcesSecretable properties) {
-                final BasicAuthentication basicAuthentication = properties.getBasicAuthentication();
+                final BasicAuthenticationLegacy basicAuthenticationLegacy = properties.getBasicAuthenticationLegacy();
 
-                if (!this.isBasicAuthNullOrBlank(basicAuthentication)) {
+                if (!this.isBasicAuthNullOrBlank(basicAuthenticationLegacy)) {
                     final Secret stubbedBasicAuthSecret = new Secret();
                     stubbedBasicAuthSecret.id = random.nextLong(1, Long.MAX_VALUE);
                     stubbedBasicAuthSecret.authenticationType = Secret.TYPE_BASIC_AUTH;
-                    stubbedBasicAuthSecret.password = properties.getBasicAuthentication().getPassword();
-                    stubbedBasicAuthSecret.username = properties.getBasicAuthentication().getUsername();
+                    stubbedBasicAuthSecret.password = properties.getBasicAuthenticationLegacy().getPassword();
+                    stubbedBasicAuthSecret.username = properties.getBasicAuthenticationLegacy().getUsername();
 
                     // Store the generated stub for later checks.
                     generatedSecrets.put(stubbedBasicAuthSecret.id, stubbedBasicAuthSecret);
@@ -139,7 +139,7 @@ public class SourcesSecretsMigrationServiceTest {
                 final Secret stubbedSecretTokenSecret = new Secret();
                 stubbedSecretTokenSecret.id = random.nextLong(1, Long.MAX_VALUE);
                 stubbedSecretTokenSecret.authenticationType = Secret.TYPE_SECRET_TOKEN;
-                stubbedSecretTokenSecret.password = properties.getSecretToken();
+                stubbedSecretTokenSecret.password = properties.getSecretTokenLegacy();
 
                 // Store the generated stub for later checks.
                 generatedSecrets.put(stubbedSecretTokenSecret.id, stubbedSecretTokenSecret);
@@ -199,17 +199,17 @@ public class SourcesSecretsMigrationServiceTest {
 
             if (entry.getValue().getProperties() instanceof SourcesSecretable properties) {
                 final Long basicAuthSourcesId = properties.getBasicAuthenticationSourcesId();
-                final BasicAuthentication basicAuthentication = properties.getBasicAuthentication();
+                final BasicAuthenticationLegacy basicAuthenticationLegacy = properties.getBasicAuthenticationLegacy();
 
                 // There might be null or blank basic authentications. In these
                 // cases, just check the secret tokens...
-                if (!this.isBasicAuthNullOrBlank(basicAuthentication)) {
+                if (!this.isBasicAuthNullOrBlank(basicAuthenticationLegacy)) {
                     final Secret basicAuthSecret = generatedSecrets.get(basicAuthSourcesId);
                     Assertions.assertNotNull(basicAuthSecret, "the stubbed basic authentication secret specified by the Sources reference was not found");
 
                     Assertions.assertEquals(basicAuthSecret.authenticationType, Secret.TYPE_BASIC_AUTH);
-                    Assertions.assertEquals(basicAuthentication.getUsername(), basicAuthSecret.username);
-                    Assertions.assertEquals(basicAuthentication.getPassword(), basicAuthSecret.password);
+                    Assertions.assertEquals(basicAuthenticationLegacy.getUsername(), basicAuthSecret.username);
+                    Assertions.assertEquals(basicAuthenticationLegacy.getPassword(), basicAuthSecret.password);
 
                     updatedSecretReferencesInDatabase++;
                 }
@@ -218,7 +218,7 @@ public class SourcesSecretsMigrationServiceTest {
                 // not blank, at least in this test case.
                 final long secretTokenSourcesId = properties.getSecretTokenSourcesId();
 
-                final String secretToken = properties.getSecretToken();
+                final String secretToken = properties.getSecretTokenLegacy();
                 final Secret secretTokenSecret = generatedSecrets.get(secretTokenSourcesId);
 
                 Assertions.assertNotNull(secretTokenSecret, "the stubbed secret token secret specified by the Sources reference was not found");
@@ -342,15 +342,15 @@ public class SourcesSecretsMigrationServiceTest {
     /**
      * Checks if the provided basic authentication is null or if its elements
      * are blank.
-     * @param basicAuthentication the basic authentication to check.
+     * @param basicAuthenticationLegacy the basic authentication to check.
      * @return true if the basic authentication is null or its elements are
      * blank.
      */
     @Deprecated(forRemoval = true)
-    private boolean isBasicAuthNullOrBlank(final BasicAuthentication basicAuthentication) {
-        return basicAuthentication == null
-            || (basicAuthentication.getPassword() == null || basicAuthentication.getPassword().isBlank())
-            || (basicAuthentication.getUsername() == null || basicAuthentication.getUsername().isBlank());
+    private boolean isBasicAuthNullOrBlank(final BasicAuthenticationLegacy basicAuthenticationLegacy) {
+        return basicAuthenticationLegacy == null
+            || (basicAuthenticationLegacy.getPassword() == null || basicAuthenticationLegacy.getPassword().isBlank())
+            || (basicAuthenticationLegacy.getUsername() == null || basicAuthenticationLegacy.getUsername().isBlank());
     }
 
     /**

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SecretUtilsTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SecretUtilsTest.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.routers.sources;
 
-import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.SourcesSecretable;
 import com.redhat.cloud.notifications.models.WebhookProperties;
@@ -89,14 +89,14 @@ public class SecretUtilsTest {
         final var props = (SourcesSecretable) endpoint.getProperties();
 
         // Assert the results.
-        final BasicAuthentication basicAuth = props.getBasicAuthentication();
+        final BasicAuthenticationLegacy basicAuth = props.getBasicAuthenticationLegacy();
         Assertions.assertEquals(BASIC_AUTH_PASSWORD, basicAuth.getPassword(), "the basic authentication's password field doesn't match");
         Assertions.assertEquals(BASIC_AUTH_USERNAME, basicAuth.getUsername(), "the basic authentication's username field doesn't match");
 
-        final String secretToken = props.getSecretToken();
+        final String secretToken = props.getSecretTokenLegacy();
         Assertions.assertEquals(SECRET_TOKEN, secretToken, "the secret token doesn't match");
 
-        final String secretBearer = props.getBearerAuthentication();
+        final String secretBearer = props.getBearerAuthenticationLegacy();
         Assertions.assertEquals(BEARER_AUTHENTICATION, secretBearer, "the secret bearer doesn't match");
 
         // Assert that the underlying function was called exactly three times,
@@ -147,11 +147,11 @@ public class SecretUtilsTest {
 
         Endpoint endpoint = new Endpoint();
         WebhookProperties webhookProperties = new WebhookProperties();
-        BasicAuthentication basicAuth = new BasicAuthentication(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
+        BasicAuthenticationLegacy basicAuth = new BasicAuthenticationLegacy(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
 
-        webhookProperties.setBasicAuthentication(basicAuth);
-        webhookProperties.setSecretToken(SECRET_TOKEN);
-        webhookProperties.setBearerAuthentication(BEARER_AUTHENTICATION);
+        webhookProperties.setBasicAuthenticationLegacy(basicAuth);
+        webhookProperties.setSecretTokenLegacy(SECRET_TOKEN);
+        webhookProperties.setBearerAuthenticationLegacy(BEARER_AUTHENTICATION);
 
         endpoint.setProperties(webhookProperties);
         endpoint.setOrgId(orgId);
@@ -205,8 +205,8 @@ public class SecretUtilsTest {
 
         Endpoint endpoint = new Endpoint();
         WebhookProperties webhookProperties = new WebhookProperties();
-        webhookProperties.setSecretToken(SECRET_TOKEN);
-        webhookProperties.setBearerAuthentication(BEARER_AUTHENTICATION);
+        webhookProperties.setSecretTokenLegacy(SECRET_TOKEN);
+        webhookProperties.setBearerAuthenticationLegacy(BEARER_AUTHENTICATION);
 
         endpoint.setProperties(webhookProperties);
         endpoint.setOrgId(orgId);
@@ -254,14 +254,14 @@ public class SecretUtilsTest {
 
         Endpoint endpoint = new Endpoint();
         WebhookProperties webhookProperties = new WebhookProperties();
-        webhookProperties.setSecretToken(SECRET_TOKEN);
+        webhookProperties.setSecretTokenLegacy(SECRET_TOKEN);
 
         endpoint.setProperties(webhookProperties);
         endpoint.setOrgId(orgId);
 
         // Create a basic authentication with blank fields.
-        BasicAuthentication basicAuthentication = new BasicAuthentication("     ", "     ");
-        webhookProperties.setBasicAuthentication(basicAuthentication);
+        BasicAuthenticationLegacy basicAuthenticationLegacy = new BasicAuthenticationLegacy("     ", "     ");
+        webhookProperties.setBasicAuthenticationLegacy(basicAuthenticationLegacy);
 
         // Set up the mock call for the "create" call from the REST Client. In this case, since the basic
         // authentication is null, only the secret token should be created.
@@ -303,9 +303,9 @@ public class SecretUtilsTest {
 
         Endpoint endpoint = new Endpoint();
         WebhookProperties webhookProperties = new WebhookProperties();
-        BasicAuthentication basicAuth = new BasicAuthentication(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
+        BasicAuthenticationLegacy basicAuth = new BasicAuthenticationLegacy(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
 
-        webhookProperties.setBasicAuthentication(basicAuth);
+        webhookProperties.setBasicAuthenticationLegacy(basicAuth);
 
         endpoint.setProperties(webhookProperties);
         endpoint.setOrgId(orgId);
@@ -350,15 +350,15 @@ public class SecretUtilsTest {
 
         Endpoint endpoint = new Endpoint();
         WebhookProperties webhookProperties = new WebhookProperties();
-        BasicAuthentication basicAuth = new BasicAuthentication(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
+        BasicAuthenticationLegacy basicAuth = new BasicAuthenticationLegacy(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
 
-        webhookProperties.setBasicAuthentication(basicAuth);
+        webhookProperties.setBasicAuthenticationLegacy(basicAuth);
 
         endpoint.setProperties(webhookProperties);
         endpoint.setOrgId(orgId);
 
         // Set the secret token to blank.
-        webhookProperties.setSecretToken("     ");
+        webhookProperties.setSecretTokenLegacy("     ");
 
         // Set up the mock call for the "create" call from the REST Client. Since only the "basic authentication"
         // secret is supposed to be created, that's the one we are expecting to get from the mocked service.
@@ -416,14 +416,14 @@ public class SecretUtilsTest {
         final String updatedSecretToken = String.format("%s-updated", SECRET_TOKEN);
         final String updatedBearer = String.format("%s-updated", BEARER_AUTHENTICATION);
 
-        BasicAuthentication basicAuth = new BasicAuthentication(updatedUsername, updatedPassword);
-        webhookProperties.setBasicAuthentication(basicAuth);
+        BasicAuthenticationLegacy basicAuth = new BasicAuthenticationLegacy(updatedUsername, updatedPassword);
+        webhookProperties.setBasicAuthenticationLegacy(basicAuth);
         webhookProperties.setBasicAuthenticationSourcesId(BASIC_AUTH_SOURCES_ID);
 
-        webhookProperties.setSecretToken(updatedSecretToken);
+        webhookProperties.setSecretTokenLegacy(updatedSecretToken);
         webhookProperties.setSecretTokenSourcesId(SECRET_TOKEN_SOURCES_ID);
 
-        webhookProperties.setBearerAuthentication(updatedBearer);
+        webhookProperties.setBearerAuthenticationLegacy(updatedBearer);
         webhookProperties.setBearerAuthenticationSourcesId(BEARER_TOKEN_SOURCES_ID);
 
         endpoint.setProperties(webhookProperties);
@@ -447,14 +447,14 @@ public class SecretUtilsTest {
         final var props = (SourcesSecretable) endpoint.getProperties();
 
         // Assert the results.
-        final BasicAuthentication basicAuthResult = props.getBasicAuthentication();
+        final BasicAuthenticationLegacy basicAuthResult = props.getBasicAuthenticationLegacy();
         Assertions.assertEquals(updatedPassword, basicAuthResult.getPassword(), "the updated basic authentication's password doesn't match");
         Assertions.assertEquals(updatedUsername, basicAuthResult.getUsername(), "the updated basic authentication's username doesn't match");
 
-        final String secretToken = props.getSecretToken();
+        final String secretToken = props.getSecretTokenLegacy();
         Assertions.assertEquals(updatedSecretToken, secretToken, "the updated secret token doesn't match");
 
-        final String bearerToken = props.getBearerAuthentication();
+        final String bearerToken = props.getBearerAuthenticationLegacy();
         Assertions.assertEquals(updatedBearer, bearerToken, "the updated bearer doesn't match");
 
         // Assert that the underlying "update" function was called exactly two times, since we are expecting that both
@@ -518,14 +518,14 @@ public class SecretUtilsTest {
         Mockito.verifyNoInteractions(this.sourcesServiceMock);
 
         // Set the basic authentication as having blank values. It should also be a NOOP.
-        final BasicAuthentication basicAuthentication = new BasicAuthentication("     ", "     ");
-        webhookProperties.setBasicAuthentication(basicAuthentication);
+        final BasicAuthenticationLegacy basicAuthenticationLegacy = new BasicAuthenticationLegacy("     ", "     ");
+        webhookProperties.setBasicAuthenticationLegacy(basicAuthenticationLegacy);
         this.secretUtils.updateSecretsForEndpoint(endpoint);
 
         Mockito.verifyNoInteractions(this.sourcesServiceMock);
 
         // Set the secret token as a blank value. It should also be a NOOP.
-        webhookProperties.setSecretToken("     ");
+        webhookProperties.setSecretTokenLegacy("     ");
         this.secretUtils.updateSecretsForEndpoint(endpoint);
 
         Mockito.verifyNoInteractions(this.sourcesServiceMock);
@@ -550,11 +550,11 @@ public class SecretUtilsTest {
 
         Endpoint endpoint = new Endpoint();
         WebhookProperties webhookProperties = new WebhookProperties();
-        BasicAuthentication basicAuth = new BasicAuthentication(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
+        BasicAuthenticationLegacy basicAuth = new BasicAuthenticationLegacy(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
 
-        webhookProperties.setBasicAuthentication(basicAuth);
-        webhookProperties.setSecretToken(SECRET_TOKEN);
-        webhookProperties.setBearerAuthentication(BEARER_AUTHENTICATION);
+        webhookProperties.setBasicAuthenticationLegacy(basicAuth);
+        webhookProperties.setSecretTokenLegacy(SECRET_TOKEN);
+        webhookProperties.setBearerAuthenticationLegacy(BEARER_AUTHENTICATION);
 
         endpoint.setProperties(webhookProperties);
         endpoint.setOrgId(orgId);
@@ -642,7 +642,7 @@ public class SecretUtilsTest {
      */
     @Test
     void isBasicAuthNullOrBlankTest() {
-        final var basicAuth = new BasicAuthentication("username", "password");
+        final var basicAuth = new BasicAuthenticationLegacy("username", "password");
 
         Assertions.assertFalse(this.secretUtils.isBasicAuthNullOrBlank(basicAuth), "the basic authentication should have not been considered as blank");
     }
@@ -653,16 +653,16 @@ public class SecretUtilsTest {
      */
     @Test
     void itIsBasicAuthNullOrBlankTest() {
-        final var blankBasicAuths = new ArrayList<BasicAuthentication>();
+        final var blankBasicAuths = new ArrayList<BasicAuthenticationLegacy>();
 
-        blankBasicAuths.add(new BasicAuthentication());
-        blankBasicAuths.add(new BasicAuthentication(null, null));
-        blankBasicAuths.add(new BasicAuthentication(null, ""));
-        blankBasicAuths.add(new BasicAuthentication("", null));
-        blankBasicAuths.add(new BasicAuthentication("", ""));
-        blankBasicAuths.add(new BasicAuthentication(null, "     "));
-        blankBasicAuths.add(new BasicAuthentication("     ", null));
-        blankBasicAuths.add(new BasicAuthentication("     ", "     "));
+        blankBasicAuths.add(new BasicAuthenticationLegacy());
+        blankBasicAuths.add(new BasicAuthenticationLegacy(null, null));
+        blankBasicAuths.add(new BasicAuthenticationLegacy(null, ""));
+        blankBasicAuths.add(new BasicAuthenticationLegacy("", null));
+        blankBasicAuths.add(new BasicAuthenticationLegacy("", ""));
+        blankBasicAuths.add(new BasicAuthenticationLegacy(null, "     "));
+        blankBasicAuths.add(new BasicAuthenticationLegacy("     ", null));
+        blankBasicAuths.add(new BasicAuthenticationLegacy("     ", "     "));
 
         for (final var basicAuth : blankBasicAuths) {
             Assertions.assertTrue(this.secretUtils.isBasicAuthNullOrBlank(basicAuth), "the basic authentication should have been considered as blank");

--- a/common/src/main/java/com/redhat/cloud/notifications/db/converters/BasicAuthenticationConverter.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/db/converters/BasicAuthenticationConverter.java
@@ -1,30 +1,30 @@
 package com.redhat.cloud.notifications.db.converters;
 
 import com.redhat.cloud.notifications.Base64Utils;
-import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
 import io.vertx.core.json.Json;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 @Converter
-public class BasicAuthenticationConverter implements AttributeConverter<BasicAuthentication, String> {
+public class BasicAuthenticationConverter implements AttributeConverter<BasicAuthenticationLegacy, String> {
 
     @Override
-    public String convertToDatabaseColumn(BasicAuthentication auth) {
+    public String convertToDatabaseColumn(BasicAuthenticationLegacy auth) {
         if (auth == null) {
             return null;
         } else {
-            BasicAuthentication encodedAuth = new BasicAuthentication(auth.getUsername(), Base64Utils.encode(auth.getPassword()));
+            BasicAuthenticationLegacy encodedAuth = new BasicAuthenticationLegacy(auth.getUsername(), Base64Utils.encode(auth.getPassword()));
             return Json.encode(encodedAuth);
         }
     }
 
     @Override
-    public BasicAuthentication convertToEntityAttribute(String json) {
+    public BasicAuthenticationLegacy convertToEntityAttribute(String json) {
         if (json == null) {
             return null;
         } else {
-            BasicAuthentication auth = Json.decodeValue(json, BasicAuthentication.class);
+            BasicAuthenticationLegacy auth = Json.decodeValue(json, BasicAuthenticationLegacy.class);
             auth.setPassword(Base64Utils.decode(auth.getPassword()));
             return auth;
         }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthenticationLegacy.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthenticationLegacy.java
@@ -2,13 +2,13 @@ package com.redhat.cloud.notifications.models;
 
 import java.util.Objects;
 
-public class BasicAuthentication {
+public class BasicAuthenticationLegacy {
     private String username;
     private String password;
 
-    public BasicAuthentication() { }
+    public BasicAuthenticationLegacy() { }
 
-    public BasicAuthentication(String username, String password) {
+    public BasicAuthenticationLegacy(String username, String password) {
         this.username = username;
         this.password = password;
     }
@@ -30,8 +30,8 @@ public class BasicAuthentication {
         if (this == o) {
             return true;
         }
-        if (o instanceof BasicAuthentication) {
-            BasicAuthentication other = (BasicAuthentication) o;
+        if (o instanceof BasicAuthenticationLegacy) {
+            BasicAuthenticationLegacy other = (BasicAuthenticationLegacy) o;
             return Objects.equals(username, other.username) &&
                     Objects.equals(password, other.password);
         }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthenticationLegacy.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthenticationLegacy.java
@@ -17,6 +17,10 @@ public class BasicAuthenticationLegacy {
         return username;
     }
 
+    public void setUsername(final String username) {
+        this.username = username;
+    }
+
     public String getPassword() {
         return password;
     }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
@@ -1,16 +1,22 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.db.converters.BasicAuthenticationConverter;
 import com.redhat.cloud.notifications.db.converters.MapConverter;
+import com.redhat.cloud.notifications.models.secrets.BasicAuthentication;
+import com.redhat.cloud.notifications.models.secrets.BearerToken;
+import com.redhat.cloud.notifications.models.secrets.SecretToken;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -28,6 +34,9 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
 
     @NotNull
     private Boolean disableSslVerification = Boolean.FALSE;
+
+    @Transient
+    Secrets secrets = new Secrets();
 
     @Column(name = "secret_token")
     @Deprecated
@@ -75,11 +84,13 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
     }
 
     @Deprecated(forRemoval = true)
+    @JsonGetter("secret_token")
     public void setSecretTokenLegacy(String secretToken) {
         this.secretTokenLegacy = secretToken;
     }
 
     @Deprecated(forRemoval = true)
+    @JsonSetter("secret_token")
     public String getSecretTokenLegacy() {
         return secretTokenLegacy;
     }
@@ -93,11 +104,13 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
     }
 
     @Deprecated(forRemoval = true)
+    @JsonGetter("basic_authentication")
     public BasicAuthenticationLegacy getBasicAuthenticationLegacy() {
         return basicAuthenticationLegacy;
     }
 
     @Deprecated(forRemoval = true)
+    @JsonSetter("basic_authentication")
     public void setBasicAuthenticationLegacy(BasicAuthenticationLegacy basicAuthenticationLegacy) {
         this.basicAuthenticationLegacy = basicAuthenticationLegacy;
     }
@@ -119,13 +132,51 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
     }
 
     @Deprecated(forRemoval = true)
+    @JsonGetter("bearer_token")
     public String getBearerAuthenticationLegacy() {
         return null;
     }
 
     @Deprecated(forRemoval = true)
+    @JsonSetter("bearer_token")
     public void setBearerAuthenticationLegacy(String bearerAuthentication) {
         // do nothing here
+    }
+
+    @Override
+    public Secrets getSecrets() {
+        return this.secrets;
+    }
+
+    @Override
+    public BasicAuthentication getBasicAuthentication() {
+        return this.secrets.getBasicAuthentication();
+    }
+
+    @Override
+    public void setBasicAuthentication(final BasicAuthentication basicAuthentication) {
+        this.secrets.setBasicAuthentication(basicAuthentication);
+    }
+
+    @Override
+    public BearerToken getBearerToken() {
+        // Not supported for Camel endpoints.
+        return null;
+    }
+
+    @Override
+    public void setBearerToken(final BearerToken bearerToken) {
+        // Not supported for Camel endpoints.
+    }
+
+    @Override
+    public SecretToken getSecretToken() {
+        return this.secrets.getSecretToken();
+    }
+
+    @Override
+    public void setSecretToken(final SecretToken secretToken) {
+        this.secrets.setSecretToken(secretToken);
     }
 
     @Override

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.db.converters.BasicAuthenticationConverter;
@@ -28,8 +29,10 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
     @NotNull
     private Boolean disableSslVerification = Boolean.FALSE;
 
+    @Column(name = "secret_token")
+    @Deprecated
     @Size(max = 255)
-    private String secretToken; // TODO Should be optional
+    private String secretTokenLegacy; // TODO Should be optional
 
     /**
      * The ID of the "secret token" secret in the Sources backend.
@@ -38,9 +41,12 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
     @JsonIgnore
     private Long secretTokenSourcesId;
 
+    @Column(name = "basic_authentication")
     @Convert(converter = BasicAuthenticationConverter.class)
+    @Deprecated(forRemoval = true)
+    @JsonProperty("basic_authentication")
     @Valid
-    private BasicAuthentication basicAuthentication;
+    private BasicAuthenticationLegacy basicAuthenticationLegacy;
 
     /**
      * The ID of the "basic authentication" secret in the Sources backend.
@@ -68,12 +74,14 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
         this.url = url;
     }
 
-    public void setSecretToken(String secretToken) {
-        this.secretToken = secretToken;
+    @Deprecated(forRemoval = true)
+    public void setSecretTokenLegacy(String secretToken) {
+        this.secretTokenLegacy = secretToken;
     }
 
-    public String getSecretToken() {
-        return secretToken;
+    @Deprecated(forRemoval = true)
+    public String getSecretTokenLegacy() {
+        return secretTokenLegacy;
     }
 
     public Long getSecretTokenSourcesId() {
@@ -84,12 +92,14 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
         this.secretTokenSourcesId = secretTokenSourcesId;
     }
 
-    public BasicAuthentication getBasicAuthentication() {
-        return basicAuthentication;
+    @Deprecated(forRemoval = true)
+    public BasicAuthenticationLegacy getBasicAuthenticationLegacy() {
+        return basicAuthenticationLegacy;
     }
 
-    public void setBasicAuthentication(BasicAuthentication basicAuthentication) {
-        this.basicAuthentication = basicAuthentication;
+    @Deprecated(forRemoval = true)
+    public void setBasicAuthenticationLegacy(BasicAuthenticationLegacy basicAuthenticationLegacy) {
+        this.basicAuthenticationLegacy = basicAuthenticationLegacy;
     }
 
     public Long getBasicAuthenticationSourcesId() {
@@ -108,11 +118,13 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
         // do nothing here
     }
 
-    public String getBearerAuthentication() {
+    @Deprecated(forRemoval = true)
+    public String getBearerAuthenticationLegacy() {
         return null;
     }
 
-    public void setBearerAuthentication(String bearerAuthentication) {
+    @Deprecated(forRemoval = true)
+    public void setBearerAuthenticationLegacy(String bearerAuthentication) {
         // do nothing here
     }
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Secrets.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Secrets.java
@@ -1,0 +1,49 @@
+package com.redhat.cloud.notifications.models;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.redhat.cloud.notifications.models.secrets.BasicAuthentication;
+import com.redhat.cloud.notifications.models.secrets.BearerToken;
+import com.redhat.cloud.notifications.models.secrets.SecretToken;
+
+/**
+ * Represents the secrets that the properties of the endpoints can support.
+ */
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Secrets {
+    private BasicAuthentication basicAuthentication;
+    private BearerToken bearerToken;
+    private SecretToken secretToken;
+
+    public Secrets() { }
+
+    public Secrets(final BasicAuthentication basicAuthentication, final BearerToken bearerToken, final SecretToken secretToken) {
+        this.basicAuthentication = basicAuthentication;
+        this.bearerToken = bearerToken;
+        this.secretToken = secretToken;
+    }
+
+    public BasicAuthentication getBasicAuthentication() {
+        return basicAuthentication;
+    }
+
+    public void setBasicAuthentication(final BasicAuthentication basicAuthenticationLegacy) {
+        this.basicAuthentication = basicAuthenticationLegacy;
+    }
+
+    public BearerToken getBearerToken() {
+        return bearerToken;
+    }
+
+    public void setBearerToken(final BearerToken bearerToken) {
+        this.bearerToken = bearerToken;
+    }
+
+    public SecretToken getSecretToken() {
+        return secretToken;
+    }
+
+    public void setSecretToken(final SecretToken secretToken) {
+        this.secretToken = secretToken;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/SourcesSecretable.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/SourcesSecretable.java
@@ -9,13 +9,15 @@ public interface SourcesSecretable {
      * Get the contents of the secret token.
      * @return the contents of the secret token.
      */
-    String getSecretToken();
+    @Deprecated(forRemoval = true)
+    String getSecretTokenLegacy();
 
     /**
      * Set the contents of the secret token.
      * @param secretToken the contents of the secret token.
      */
-    void setSecretToken(String secretToken);
+    @Deprecated(forRemoval = true)
+    void setSecretTokenLegacy(String secretToken);
 
     /**
      * Get the ID of the "secret token" secret stored in Sources.
@@ -33,13 +35,15 @@ public interface SourcesSecretable {
      * Get the basic authentication object.
      * @return the basic authentication object.
      */
-    BasicAuthentication getBasicAuthentication();
+    @Deprecated(forRemoval = true)
+    BasicAuthenticationLegacy getBasicAuthenticationLegacy();
 
     /**
      * Set the basic authentication object.
-     * @param basicAuthentication the basic authentication object to be set.
+     * @param basicAuthenticationLegacy the basic authentication object to be set.
      */
-    void setBasicAuthentication(BasicAuthentication basicAuthentication);
+    @Deprecated(forRemoval = true)
+    void setBasicAuthenticationLegacy(BasicAuthenticationLegacy basicAuthenticationLegacy);
 
 
     /**
@@ -58,7 +62,9 @@ public interface SourcesSecretable {
 
     void setBearerAuthenticationSourcesId(Long bearerAuthenticationSourcesId);
 
-    String getBearerAuthentication();
+    @Deprecated(forRemoval = true)
+    String getBearerAuthenticationLegacy();
 
-    void setBearerAuthentication(String bearerAuthentication);
+    @Deprecated(forRemoval = true)
+    void setBearerAuthenticationLegacy(String bearerAuthentication);
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/SourcesSecretable.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/SourcesSecretable.java
@@ -1,10 +1,28 @@
 package com.redhat.cloud.notifications.models;
 
+import com.redhat.cloud.notifications.models.secrets.BasicAuthentication;
+import com.redhat.cloud.notifications.models.secrets.BearerToken;
+import com.redhat.cloud.notifications.models.secrets.SecretToken;
+
 /**
  * The goal of this interface is to declare the required getters and setters the target class needs to implement. This
  * will enable the class to be able to store the secrets in Sources, and to pull the secrets from it.
  */
 public interface SourcesSecretable {
+    Secrets getSecrets();
+
+    BasicAuthentication getBasicAuthentication();
+
+    void setBasicAuthentication(BasicAuthentication basicAuthenticationLegacy);
+
+    BearerToken getBearerToken();
+
+    void setBearerToken(BearerToken bearerToken);
+
+    SecretToken getSecretToken();
+
+    void setSecretToken(SecretToken secretToken);
+
     /**
      * Get the contents of the secret token.
      * @return the contents of the secret token.

--- a/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
@@ -1,15 +1,21 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.db.converters.BasicAuthenticationConverter;
 import com.redhat.cloud.notifications.db.converters.HttpTypeConverter;
+import com.redhat.cloud.notifications.models.secrets.BasicAuthentication;
+import com.redhat.cloud.notifications.models.secrets.BearerToken;
+import com.redhat.cloud.notifications.models.secrets.SecretToken;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -32,6 +38,9 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
     @NotNull
     @JsonProperty("disable_ssl_verification")
     private Boolean disableSslVerification = Boolean.FALSE;
+
+    @Transient
+    Secrets secrets = new Secrets();
 
     @Column(name = "secret_token")
     @Deprecated(forRemoval = true)
@@ -94,11 +103,13 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
     }
 
     @Deprecated(forRemoval = true)
+    @JsonGetter("secret_token")
     public String getSecretTokenLegacy() {
         return secretTokenLegacy;
     }
 
     @Deprecated(forRemoval = true)
+    @JsonSetter("secret_token")
     public void setSecretTokenLegacy(String secretToken) {
         this.secretTokenLegacy = secretToken;
     }
@@ -112,11 +123,13 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
     }
 
     @Deprecated(forRemoval = true)
+    @JsonGetter("basic_authentication")
     public BasicAuthenticationLegacy getBasicAuthenticationLegacy() {
         return basicAuthenticationLegacy;
     }
 
     @Deprecated(forRemoval = true)
+    @JsonSetter("basic_authentication")
     public void setBasicAuthenticationLegacy(BasicAuthenticationLegacy basicAuthenticationLegacy) {
         this.basicAuthenticationLegacy = basicAuthenticationLegacy;
     }
@@ -138,12 +151,50 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
     }
 
     @Deprecated(forRemoval = true)
+    @JsonGetter("bearer_token")
     public String getBearerAuthenticationLegacy() {
         return bearerAuthenticationLegacy;
     }
 
     @Deprecated(forRemoval = true)
+
+    @JsonSetter("bearer_token")
     public void setBearerAuthenticationLegacy(String bearerAuthentication) {
         this.bearerAuthenticationLegacy = bearerAuthentication;
+    }
+
+    @Override
+    public Secrets getSecrets() {
+        return this.secrets;
+    }
+
+    @Override
+    public BasicAuthentication getBasicAuthentication() {
+        return this.secrets.getBasicAuthentication();
+    }
+
+    @Override
+    public void setBasicAuthentication(final BasicAuthentication basicAuthentication) {
+        this.secrets.setBasicAuthentication(basicAuthentication);
+    }
+
+    @Override
+    public BearerToken getBearerToken() {
+        return this.secrets.getBearerToken();
+    }
+
+    @Override
+    public void setBearerToken(final BearerToken bearerToken) {
+        this.secrets.setBearerToken(bearerToken);
+    }
+
+    @Override
+    public SecretToken getSecretToken() {
+        return this.secrets.getSecretToken();
+    }
+
+    @Override
+    public void setSecretToken(final SecretToken secretToken) {
+        this.secrets.setSecretToken(secretToken);
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
@@ -33,9 +33,11 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
     @JsonProperty("disable_ssl_verification")
     private Boolean disableSslVerification = Boolean.FALSE;
 
+    @Column(name = "secret_token")
+    @Deprecated(forRemoval = true)
     @Size(max = 255)
     @JsonProperty("secret_token")
-    private String secretToken; // TODO Should be optional
+    private String secretTokenLegacy; // TODO Should be optional
 
     /**
      * The ID of the "secret token" secret in the Sources backend.
@@ -44,10 +46,12 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
     @JsonIgnore
     private Long secretTokenSourcesId;
 
+    @Column(name = "basic_authentication")
     @Convert(converter = BasicAuthenticationConverter.class)
+    @Deprecated(forRemoval = true)
     @JsonProperty("basic_authentication")
     @Valid
-    private BasicAuthentication basicAuthentication;
+    private BasicAuthenticationLegacy basicAuthenticationLegacy;
 
     /**
      * The ID of the "basic authentication" secret in the Sources backend.
@@ -60,8 +64,10 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
     @JsonIgnore
     private Long bearerAuthenticationSourcesId;
 
+    @Column(name = "bearer_authentication")
+    @Deprecated(forRemoval = true)
     @JsonProperty("bearer_authentication")
-    private String bearerAuthentication;
+    private String bearerAuthenticationLegacy;
 
     public String getUrl() {
         return url;
@@ -87,12 +93,14 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
         this.disableSslVerification = disableSslVerification;
     }
 
-    public String getSecretToken() {
-        return secretToken;
+    @Deprecated(forRemoval = true)
+    public String getSecretTokenLegacy() {
+        return secretTokenLegacy;
     }
 
-    public void setSecretToken(String secretToken) {
-        this.secretToken = secretToken;
+    @Deprecated(forRemoval = true)
+    public void setSecretTokenLegacy(String secretToken) {
+        this.secretTokenLegacy = secretToken;
     }
 
     public Long getSecretTokenSourcesId() {
@@ -103,12 +111,14 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
         this.secretTokenSourcesId = secretTokenSourcesId;
     }
 
-    public BasicAuthentication getBasicAuthentication() {
-        return basicAuthentication;
+    @Deprecated(forRemoval = true)
+    public BasicAuthenticationLegacy getBasicAuthenticationLegacy() {
+        return basicAuthenticationLegacy;
     }
 
-    public void setBasicAuthentication(BasicAuthentication basicAuthentication) {
-        this.basicAuthentication = basicAuthentication;
+    @Deprecated(forRemoval = true)
+    public void setBasicAuthenticationLegacy(BasicAuthenticationLegacy basicAuthenticationLegacy) {
+        this.basicAuthenticationLegacy = basicAuthenticationLegacy;
     }
 
     public Long getBasicAuthenticationSourcesId() {
@@ -127,11 +137,13 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
         this.bearerAuthenticationSourcesId = bearerAuthenticationSourcesId;
     }
 
-    public String getBearerAuthentication() {
-        return bearerAuthentication;
+    @Deprecated(forRemoval = true)
+    public String getBearerAuthenticationLegacy() {
+        return bearerAuthenticationLegacy;
     }
 
-    public void setBearerAuthentication(String bearerAuthentication) {
-        this.bearerAuthentication = bearerAuthentication;
+    @Deprecated(forRemoval = true)
+    public void setBearerAuthenticationLegacy(String bearerAuthentication) {
+        this.bearerAuthenticationLegacy = bearerAuthentication;
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/secrets/BasicAuthentication.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/secrets/BasicAuthentication.java
@@ -1,0 +1,65 @@
+package com.redhat.cloud.notifications.models.secrets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public final class BasicAuthentication extends Secret {
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String username;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String password;
+
+    public BasicAuthentication() { }
+
+    public BasicAuthentication(final String username, final String password) {
+        this.present = true;
+
+        this.username = username;
+        this.password = password;
+    }
+
+    public boolean isBlank() {
+        return this.username == null || this.username.isBlank()
+            && this.password == null || this.password.isBlank();
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(final String username) {
+        this.present = true;
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(final String password) {
+        this.present = true;
+        this.password = password;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o instanceof BasicAuthentication that) {
+            return Objects.equals(this.username, that.username)
+                && Objects.equals(this.password, that.password);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.username, this.password);
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/secrets/BearerToken.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/secrets/BearerToken.java
@@ -1,0 +1,49 @@
+package com.redhat.cloud.notifications.models.secrets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public final class BearerToken extends Secret {
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String token;
+
+    public BearerToken() { }
+
+    public BearerToken(final String token) {
+        this.present = true;
+        this.token = token;
+    }
+
+    public boolean isBlank() {
+        return this.token == null || this.token.isBlank();
+    }
+
+    public String getToken() {
+        return this.token;
+    }
+
+    public void setToken(final String token) {
+        this.present = true;
+        this.token = token;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o instanceof BearerToken that) {
+            return this.token.equals(that.token);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.token);
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/secrets/Secret.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/secrets/Secret.java
@@ -1,0 +1,25 @@
+package com.redhat.cloud.notifications.models.secrets;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public abstract class Secret {
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY, value = "is_present")
+    protected boolean present;
+
+    /**
+     * Is the secret present in Sources?
+     * @return {@code true} if the secret is present in Sources.
+     */
+    @JsonIgnore
+    public boolean isPresent() {
+        return this.present;
+    }
+
+    @JsonIgnore
+    public abstract boolean isBlank();
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/secrets/SecretToken.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/secrets/SecretToken.java
@@ -1,0 +1,49 @@
+package com.redhat.cloud.notifications.models.secrets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public final class SecretToken extends Secret {
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String token;
+
+    public SecretToken() { }
+
+    public SecretToken(final String token) {
+        this.present = true;
+        this.token = token;
+    }
+
+    public boolean isBlank() {
+        return this.token == null || this.token.isBlank();
+    }
+
+    public String getToken() {
+        return this.token;
+    }
+
+    public void setToken(final String token) {
+        this.present = true;
+        this.token = token;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o instanceof SecretToken that) {
+            return this.token.equals(that.token);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.token);
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.routers.sources;
 
-import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.SourcesSecretable;
@@ -48,8 +48,8 @@ public class SecretUtils {
             if (basicAuthSourcesId != null) {
                 Secret secret = loadSecretFromSources(endpoint, basicAuthSourcesId);
 
-                props.setBasicAuthentication(
-                    new BasicAuthentication(
+                props.setBasicAuthenticationLegacy(
+                    new BasicAuthenticationLegacy(
                         secret.username,
                         secret.password
                     )
@@ -59,13 +59,13 @@ public class SecretUtils {
             final Long secretTokenSourcesId = props.getSecretTokenSourcesId();
             if (secretTokenSourcesId != null) {
                 Secret secret = loadSecretFromSources(endpoint, secretTokenSourcesId);
-                props.setSecretToken(secret.password);
+                props.setSecretTokenLegacy(secret.password);
             }
 
             final Long bearerSourcesId = props.getBearerAuthenticationSourcesId();
             if (bearerSourcesId != null) {
                 Secret secret = loadSecretFromSources(endpoint, bearerSourcesId);
-                props.setBearerAuthentication(secret.password);
+                props.setBearerAuthenticationLegacy(secret.password);
             }
         }
     }
@@ -94,7 +94,7 @@ public class SecretUtils {
         if (endpointProperties instanceof SourcesSecretable) {
             var props = (SourcesSecretable) endpointProperties;
 
-            final BasicAuthentication basicAuth = props.getBasicAuthentication();
+            final BasicAuthenticationLegacy basicAuth = props.getBasicAuthenticationLegacy();
             if (!this.isBasicAuthNullOrBlank(basicAuth)) {
                 final long id = this.createBasicAuthentication(basicAuth, endpoint.getOrgId());
 
@@ -103,7 +103,7 @@ public class SecretUtils {
                 props.setBasicAuthenticationSourcesId(id);
             }
 
-            final String secretToken = props.getSecretToken();
+            final String secretToken = props.getSecretTokenLegacy();
             if (secretToken != null && !secretToken.isBlank()) {
                 final long id = this.createSecretTokenSecret(secretToken, Secret.TYPE_SECRET_TOKEN, endpoint.getOrgId());
 
@@ -112,7 +112,7 @@ public class SecretUtils {
                 props.setSecretTokenSourcesId(id);
             }
 
-            final String bearerToken = props.getBearerAuthentication();
+            final String bearerToken = props.getBearerAuthenticationLegacy();
             if (bearerToken != null && !bearerToken.isBlank()) {
                 final long id = this.createSecretTokenSecret(secretToken, Secret.TYPE_BEARER_AUTHENTICATION, endpoint.getOrgId());
                 Log.infof("[secret_id: %s] Secret bearer token created in Sources", id);
@@ -141,7 +141,7 @@ public class SecretUtils {
         if (endpointProperties instanceof SourcesSecretable) {
             var props = (SourcesSecretable) endpointProperties;
 
-            final BasicAuthentication basicAuth = props.getBasicAuthentication();
+            final BasicAuthenticationLegacy basicAuth = props.getBasicAuthenticationLegacy();
             final Long basicAuthId = props.getBasicAuthenticationSourcesId();
             if (basicAuthId != null) {
                 if (this.isBasicAuthNullOrBlank(basicAuth)) {
@@ -173,11 +173,11 @@ public class SecretUtils {
                 }
             }
 
-            final String secretToken = props.getSecretToken();
+            final String secretToken = props.getSecretTokenLegacy();
             final Long secretTokenId = props.getSecretTokenSourcesId();
             props.setSecretTokenSourcesId(updateSecretToken(endpoint, secretToken, secretTokenId, Secret.TYPE_SECRET_TOKEN, "Secret token secret"));
 
-            final String bearerToken = props.getBearerAuthentication();
+            final String bearerToken = props.getBearerAuthenticationLegacy();
             final Long bearerTokenId = props.getBearerAuthenticationSourcesId();
             props.setBearerAuthenticationSourcesId(updateSecretToken(endpoint, bearerToken, bearerTokenId, Secret.TYPE_BEARER_AUTHENTICATION, "Bearer token"));
         }
@@ -257,16 +257,16 @@ public class SecretUtils {
 
     /**
      * Creates a "basic authentication" secret in Sources.
-     * @param basicAuthentication the contents of the "basic authentication" secret.
+     * @param basicAuthenticationLegacy the contents of the "basic authentication" secret.
      * @param orgId the organization id related to this operation for the tenant identification.
      * @return the id of the created secret.
      */
-    private long createBasicAuthentication(final BasicAuthentication basicAuthentication, final String orgId) {
+    private long createBasicAuthentication(final BasicAuthenticationLegacy basicAuthenticationLegacy, final String orgId) {
         Secret secret = new Secret();
 
         secret.authenticationType = Secret.TYPE_BASIC_AUTH;
-        secret.password = basicAuthentication.getPassword();
-        secret.username = basicAuthentication.getUsername();
+        secret.password = basicAuthenticationLegacy.getPassword();
+        secret.username = basicAuthenticationLegacy.getUsername();
 
         return createSecret(orgId, secret);
     }
@@ -297,18 +297,18 @@ public class SecretUtils {
     }
 
     /**
-     * Checks whether the provided {@link BasicAuthentication} object is null, or if its inner password and username
+     * Checks whether the provided {@link BasicAuthenticationLegacy} object is null, or if its inner password and username
      * fields are blank. If any of the username or password fields contain a non-blank string, then it is assumed that
      * the object is not blank.
-     * @param basicAuthentication the object to check.
+     * @param basicAuthenticationLegacy the object to check.
      * @return {@code true} if the object is null, or if the password and the username are blank.
      */
-    protected boolean isBasicAuthNullOrBlank(final BasicAuthentication basicAuthentication) {
-        if (basicAuthentication == null) {
+    protected boolean isBasicAuthNullOrBlank(final BasicAuthenticationLegacy basicAuthenticationLegacy) {
+        if (basicAuthenticationLegacy == null) {
             return true;
         }
 
-        return (basicAuthentication.getPassword() == null || basicAuthentication.getPassword().isBlank()) &&
-                (basicAuthentication.getUsername() == null || basicAuthentication.getUsername().isBlank());
+        return (basicAuthenticationLegacy.getPassword() == null || basicAuthenticationLegacy.getPassword().isBlank()) &&
+                (basicAuthenticationLegacy.getUsername() == null || basicAuthenticationLegacy.getUsername().isBlank());
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
@@ -1,9 +1,14 @@
 package com.redhat.cloud.notifications.routers.sources;
 
 import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
+import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointProperties;
 import com.redhat.cloud.notifications.models.SourcesSecretable;
+import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.models.secrets.BasicAuthentication;
+import com.redhat.cloud.notifications.models.secrets.BearerToken;
+import com.redhat.cloud.notifications.models.secrets.SecretToken;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.quarkus.logging.Log;
@@ -11,6 +16,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.Optional;
 
 @ApplicationScoped
 public class SecretUtils {
@@ -39,43 +46,56 @@ public class SecretUtils {
      * @param endpoint the endpoint to get the secrets from.
      */
     public void loadSecretsForEndpoint(Endpoint endpoint) {
-        EndpointProperties endpointProperties = endpoint.getProperties();
+        final EndpointProperties endpointProperties = endpoint.getProperties();
 
-        if (endpointProperties instanceof SourcesSecretable) {
-            var props = (SourcesSecretable) endpointProperties;
+        if (endpointProperties instanceof SourcesSecretable properties) {
 
-            final Long basicAuthSourcesId = props.getBasicAuthenticationSourcesId();
+            final Long basicAuthSourcesId = properties.getBasicAuthenticationSourcesId();
             if (basicAuthSourcesId != null) {
-                Secret secret = loadSecretFromSources(endpoint, basicAuthSourcesId);
+                final Secret secret = this.loadSecretFromSources(endpoint.getOrgId(), basicAuthSourcesId);
 
-                props.setBasicAuthenticationLegacy(
-                    new BasicAuthenticationLegacy(
+                properties.setBasicAuthenticationLegacy(
+                    new com.redhat.cloud.notifications.models.BasicAuthenticationLegacy(
+                        secret.username,
+                        secret.password
+                    )
+                );
+
+                properties.setBasicAuthentication(
+                    new BasicAuthentication(
                         secret.username,
                         secret.password
                     )
                 );
             }
 
-            final Long secretTokenSourcesId = props.getSecretTokenSourcesId();
+            final Long secretTokenSourcesId = properties.getSecretTokenSourcesId();
             if (secretTokenSourcesId != null) {
-                Secret secret = loadSecretFromSources(endpoint, secretTokenSourcesId);
-                props.setSecretTokenLegacy(secret.password);
+                final Secret secret = this.loadSecretFromSources(endpoint.getOrgId(), secretTokenSourcesId);
+                properties.setSecretTokenLegacy(secret.password);
+                properties.setSecretToken(new SecretToken(secret.password));
             }
 
-            final Long bearerSourcesId = props.getBearerAuthenticationSourcesId();
+            final Long bearerSourcesId = properties.getBearerAuthenticationSourcesId();
             if (bearerSourcesId != null) {
-                Secret secret = loadSecretFromSources(endpoint, bearerSourcesId);
-                props.setBearerAuthenticationLegacy(secret.password);
+                final Secret secret = this.loadSecretFromSources(endpoint.getOrgId(), bearerSourcesId);
+                properties.setBearerAuthenticationLegacy(secret.password);
+                properties.setBearerToken(new BearerToken(secret.password));
             }
         }
     }
 
-    private Secret loadSecretFromSources(Endpoint endpoint, Long secretId) {
-
+    /**
+     * Loads a secret from Sources.
+     * @param orgId the organization ID the secret is associated to.
+     * @param secretId the secret's Sources ID.
+     * @return the stored secret in Sources.
+     */
+    private Secret loadSecretFromSources(final String orgId, final Long secretId) {
         final Timer.Sample getSecretTimer = Timer.start(this.meterRegistry);
 
         final Secret secret = this.sourcesService.getById(
-            endpoint.getOrgId(),
+            orgId,
             this.sourcesPsk,
             secretId
         );
@@ -87,8 +107,11 @@ public class SecretUtils {
     /**
      * Creates the endpoint's secrets in Sources.
      * @param endpoint the endpoint to create the secrets from.
+     * @deprecated since it will be deleted once the Sources migration service
+     * is deleted.
      */
-    public void createSecretsForEndpoint(Endpoint endpoint) {
+    @Deprecated(forRemoval = true)
+    public void createSecretsForEndpointLegacy(Endpoint endpoint) {
         EndpointProperties endpointProperties = endpoint.getProperties();
 
         if (endpointProperties instanceof SourcesSecretable) {
@@ -105,7 +128,7 @@ public class SecretUtils {
 
             final String secretToken = props.getSecretTokenLegacy();
             if (secretToken != null && !secretToken.isBlank()) {
-                final long id = this.createSecretTokenSecret(secretToken, Secret.TYPE_SECRET_TOKEN, endpoint.getOrgId());
+                final long id = this.createSecretTokenSecretLegacy(secretToken, Secret.TYPE_SECRET_TOKEN, endpoint.getOrgId());
 
                 Log.infof("[secret_id: %s] Secret token secret created in Sources", id);
 
@@ -114,10 +137,170 @@ public class SecretUtils {
 
             final String bearerToken = props.getBearerAuthenticationLegacy();
             if (bearerToken != null && !bearerToken.isBlank()) {
-                final long id = this.createSecretTokenSecret(secretToken, Secret.TYPE_BEARER_AUTHENTICATION, endpoint.getOrgId());
+                final long id = this.createSecretTokenSecretLegacy(secretToken, Secret.TYPE_BEARER_AUTHENTICATION, endpoint.getOrgId());
                 Log.infof("[secret_id: %s] Secret bearer token created in Sources", id);
                 props.setBearerAuthenticationSourcesId(id);
             }
+        }
+    }
+
+    /**
+     * Creates the endpoint's secrets in Sources.
+     * @param endpoint the endpoint to create the secrets from.
+     */
+    public void createSecretsForEndpoint(Endpoint endpoint) {
+        final EndpointProperties endpointProperties = endpoint.getProperties();
+        // Synchronize the legacy and the new properties, since we are going to
+        // work with just the new ones.
+        this.legacySyncProperties(endpointProperties);
+
+        if (endpointProperties instanceof SourcesSecretable properties) {
+
+            final BasicAuthentication basicAuth = properties.getBasicAuthentication();
+            if (!this.isBasicAuthenticationNullOrBlank(basicAuth)) {
+                final long id = this.createBasicAuthenticationSecret(endpoint.getOrgId(), basicAuth);
+
+                Log.infof("[secret_id: %s] Basic authentication secret created in Sources", id);
+
+                properties.setBasicAuthenticationSourcesId(id);
+            }
+
+            final SecretToken secretToken = properties.getSecretToken();
+            if (secretToken != null && !secretToken.isBlank()) {
+                final long id = this.createSecretTokenSecret(endpoint.getOrgId(), secretToken);
+
+                Log.infof("[secret_id: %s] Secret token secret created in Sources", id);
+
+                properties.setSecretTokenSourcesId(id);
+            }
+
+            final BearerToken bearerToken = properties.getBearerToken();
+            if (bearerToken != null && !bearerToken.isBlank()) {
+                final long id = this.createBearerTokenSecret(endpoint.getOrgId(), bearerToken);
+
+                Log.infof("[secret_id: %s] Secret bearer token created in Sources", id);
+
+                properties.setBearerAuthenticationSourcesId(id);
+            }
+        }
+    }
+
+    /**
+     * Creates a basic authentication secret for the given endpoint. If the
+     * endpoint already had one associated, it updates it instead.
+     * @param endpoint the endpoint to create or update the basic
+     *                 authentication secret for.
+     * @param basicAuthentication the basic authentication to be created or
+     *                            updated.
+     */
+    public void createUpdateBasicAuthenticationSecret(final Endpoint endpoint, final BasicAuthentication basicAuthentication) {
+        final SourcesSecretable properties = (SourcesSecretable) endpoint.getProperties();
+
+        final Long basicAuthenticationSourcesReference = properties.getBasicAuthenticationSourcesId();
+        if (basicAuthenticationSourcesReference == null) {
+            final long secretId = this.createBasicAuthenticationSecret(endpoint.getOrgId(), basicAuthentication);
+
+            Log.infof("[secret_id: %s] Basic authentication secret created in Sources", secretId);
+
+            properties.setBasicAuthenticationSourcesId(secretId);
+        } else {
+            this.updateBasicAuthenticationSecret(endpoint.getOrgId(), basicAuthenticationSourcesReference, basicAuthentication);
+
+            Log.infof("[endpoint_id: %s][secret_id: %s] Basic authentication secret updated in Sources", endpoint.getId(), basicAuthenticationSourcesReference);
+        }
+    }
+
+    /**
+     * Deletes the basic authentication secret from Sources for the given
+     * endpoint.
+     * @param endpoint the endpoint to delete the secret for.
+     */
+    public void deleteBasicAuthenticationSecret(final Endpoint endpoint) {
+        final SourcesSecretable properties = (SourcesSecretable) endpoint.getProperties();
+
+        final Long basicAuthenticationSourcesReference = properties.getBasicAuthenticationSourcesId();
+        if (basicAuthenticationSourcesReference != null) {
+            this.deleteSecret(endpoint, basicAuthenticationSourcesReference, "[endpoint_id: %s][secret_id: %s] Basic authentication secret deleted in Sources");
+
+            properties.setBasicAuthenticationSourcesId(null);
+        }
+    }
+
+    /**
+     * Creates a bearer token secret for the given endpoint. If the endpoint
+     * already had one associated, it updates it instead.
+     * @param endpoint the endpoint to create or update the bearer token secret
+     *                 for.
+     * @param bearerToken the bearer token to be created or updated.
+     */
+    public void createUpdateBearerTokenSecret(final Endpoint endpoint, final BearerToken bearerToken) {
+        final SourcesSecretable properties = (SourcesSecretable) endpoint.getProperties();
+
+        final Long bearerTokenSourcesReference = properties.getBearerAuthenticationSourcesId();
+        if (bearerTokenSourcesReference == null) {
+            final long secretId = this.createBearerTokenSecret(endpoint.getOrgId(), bearerToken);
+
+            Log.infof("[secret_id: %s] Bearer token secret created in Sources", secretId);
+
+            properties.setBearerAuthenticationSourcesId(secretId);
+        } else {
+            this.updateBearerTokenSecret(endpoint.getOrgId(), bearerTokenSourcesReference, bearerToken);
+
+            Log.infof("[endpoint_id: %s][secret_id: %s] Bearer token secret updated in Sources", endpoint.getId(), bearerTokenSourcesReference);
+        }
+    }
+
+    /**
+     * Deletes the bearer token secret from Sources for the given endpoint.
+     * @param endpoint the endpoint to delete the secret for.
+     */
+    public void deleteBearerTokenSecret(final Endpoint endpoint) {
+        final SourcesSecretable properties = (SourcesSecretable) endpoint.getProperties();
+
+        final Long bearerTokenSourcesReference = properties.getBearerAuthenticationSourcesId();
+        if (bearerTokenSourcesReference != null) {
+            this.deleteSecret(endpoint, bearerTokenSourcesReference, "[endpoint_id: %s][secret_id: %s] Bearer token secret deleted in Sources");
+
+            properties.setBearerAuthenticationSourcesId(null);
+        }
+    }
+
+    /**
+     * Creates a secret token secret for the given endpoint. If the endpoint
+     * already had one associated, it updates it instead.
+     * @param endpoint the endpoint to create or update the secret token secret
+     *                 for.
+     * @param secretToken the bearer token to be created or updated.
+     */
+    public void createUpdateSecretTokenSecret(final Endpoint endpoint, final SecretToken secretToken) {
+        final SourcesSecretable properties = (SourcesSecretable) endpoint.getProperties();
+
+        final Long secretTokenSourcesReference = properties.getSecretTokenSourcesId();
+        if (secretTokenSourcesReference == null) {
+            final long secretId = this.createSecretTokenSecret(endpoint.getOrgId(), secretToken);
+
+            Log.infof("[secret_id: %s] Secret token secret created in Sources", secretId);
+
+            properties.setSecretTokenSourcesId(secretId);
+        } else {
+            this.updateSecretTokenSecret(endpoint.getOrgId(), secretTokenSourcesReference, secretToken);
+
+            Log.infof("[endpoint_id: %s][secret_id: %s] Secret token secret updated in Sources", endpoint.getId(), secretTokenSourcesReference);
+        }
+    }
+
+    /**
+     * Deletes the secret token secret from Sources for the given endpoint.
+     * @param endpoint the endpoint to delete the secret for.
+     */
+    public void deleteSecretTokenSecret(final Endpoint endpoint) {
+        final SourcesSecretable properties = (SourcesSecretable) endpoint.getProperties();
+
+        final Long secretTokenSourcesId = properties.getSecretTokenSourcesId();
+        if (secretTokenSourcesId != null) {
+            this.deleteSecret(endpoint, secretTokenSourcesId, "[endpoint_id: %s][secret_id: %s] Secret token secret deleted in Sources");
+
+            properties.setSecretTokenSourcesId(null);
         }
     }
 
@@ -134,7 +317,12 @@ public class SecretUtils {
      *  assumed that the user wants the secret to be created.</li>
      * </ul>
      * @param endpoint the endpoint to update the secrets from.
+     * @deprecated this is the legacy way of doing things. From now on, the
+     * secrets will be updated with dedicated endpoints which define the clear
+     * intent of what needs to be done, instead of us having to interpret what
+     * we should do in each case.
      */
+    @Deprecated(forRemoval = true)
     public void updateSecretsForEndpoint(Endpoint endpoint) {
         EndpointProperties endpointProperties = endpoint.getProperties();
 
@@ -183,6 +371,13 @@ public class SecretUtils {
         }
     }
 
+    /**
+     * @deprecated this is the legacy way of doing things. From now on, the
+     * secrets will be updated with dedicated endpoints which define the clear
+     * intent of what needs to be done, instead of us having to interpret what
+     * we should do in each case.
+     */
+    @Deprecated(forRemoval = true)
     private Long updateSecretToken(Endpoint endpoint, String password, Long secretId, String secretType, String logDisplaySecretType) {
         if (secretId != null) {
             if (password == null || password.isBlank()) {
@@ -210,7 +405,7 @@ public class SecretUtils {
             if (password == null || password.isBlank()) {
                 Log.debugf("[endpoint_id: %s] %s not created in Sources: the secret token object is null or blank", endpoint.getId(), logDisplaySecretType);
             } else {
-                final long id = this.createSecretTokenSecret(password, secretType, endpoint.getOrgId());
+                final long id = this.createSecretTokenSecretLegacy(password, secretType, endpoint.getOrgId());
                 Log.infof("[endpoint_id: %s][secret_id: %s] %s created in Sources during an endpoint update operation", endpoint.getId(), id, logDisplaySecretType);
                 return id;
             }
@@ -223,25 +418,24 @@ public class SecretUtils {
      * token" ID on the database.
      * @param endpoint the endpoint to delete the secrets from.
      */
-    public void deleteSecretsForEndpoint(Endpoint endpoint) {
-        EndpointProperties endpointProperties = endpoint.getProperties();
+    public void deleteSecretsForEndpoint(final Endpoint endpoint) {
+        final EndpointProperties endpointProperties = endpoint.getProperties();
 
-        if (endpointProperties instanceof SourcesSecretable) {
-            var props = (SourcesSecretable) endpointProperties;
+        if (endpointProperties instanceof SourcesSecretable properties) {
 
-            final Long basicAuthId = props.getBasicAuthenticationSourcesId();
+            final Long basicAuthId = properties.getBasicAuthenticationSourcesId();
             if (basicAuthId != null) {
-                deleteSecret(endpoint, basicAuthId, "[endpoint_id: %s][secret_id: %s] Basic authentication secret updated in Sources");
+                this.deleteSecret(endpoint, basicAuthId, "[endpoint_id: %s][secret_id: %s] Basic authentication secret updated in Sources");
             }
 
-            final Long secretTokenId = props.getSecretTokenSourcesId();
+            final Long secretTokenId = properties.getSecretTokenSourcesId();
             if (secretTokenId != null) {
-                deleteSecret(endpoint, secretTokenId, "[endpoint_id: %s][secret_id: %s] Secret token secret deleted in Sources");
+                this.deleteSecret(endpoint, secretTokenId, "[endpoint_id: %s][secret_id: %s] Secret token secret deleted in Sources");
             }
 
-            final Long bearerSourcesId = props.getBearerAuthenticationSourcesId();
+            final Long bearerSourcesId = properties.getBearerAuthenticationSourcesId();
             if (bearerSourcesId != null) {
-                deleteSecret(endpoint, bearerSourcesId, "[endpoint_id: %s][secret_id: %s] Bearer token deleted in Sources");
+                this.deleteSecret(endpoint, bearerSourcesId, "[endpoint_id: %s][secret_id: %s] Bearer token deleted in Sources");
             }
         }
     }
@@ -260,7 +454,11 @@ public class SecretUtils {
      * @param basicAuthenticationLegacy the contents of the "basic authentication" secret.
      * @param orgId the organization id related to this operation for the tenant identification.
      * @return the id of the created secret.
+     * @deprecated for removal since it works with the legacy version of the
+     * basic authentication. Used in the {@link SecretUtils#updateSecretsForEndpoint(Endpoint)}
+     * function.
      */
+    @Deprecated(forRemoval = true)
     private long createBasicAuthentication(final BasicAuthenticationLegacy basicAuthenticationLegacy, final String orgId) {
         Secret secret = new Secret();
 
@@ -272,12 +470,77 @@ public class SecretUtils {
     }
 
     /**
+     * Creates a "basic authentication" secret in Sources.
+     * @param orgId the organization the secret is associated with.
+     * @param basicAuthentication the contents of the secret to create.
+     * @return the id of the created secret.
+     */
+    private long createBasicAuthenticationSecret(final String orgId, final BasicAuthentication basicAuthentication) {
+        final Secret secret = new Secret();
+
+        secret.authenticationType = Secret.TYPE_BASIC_AUTH;
+        secret.password = basicAuthentication.getPassword();
+        secret.username = basicAuthentication.getUsername();
+
+        return this.createSecret(orgId, secret);
+    }
+
+    /**
+     * Updates a "basic authentication" secret in Sources.
+     * @param orgId the organization the secret is associated with.
+     * @param secretId the ID of the secret to update.
+     * @param basicAuthentication the contents of the secret to update.
+     */
+    private void updateBasicAuthenticationSecret(final String orgId, final long secretId, final BasicAuthentication basicAuthentication) {
+        final Secret secret = new Secret();
+
+        secret.authenticationType = Secret.TYPE_BASIC_AUTH;
+        secret.password = basicAuthentication.getPassword();
+        secret.username = basicAuthentication.getUsername();
+
+        this.updateSecret(orgId, secretId, secret);
+    }
+
+    /**
+     * Creates a "bearer token" secret in Sources.
+     * @param orgId the organization the secret is associated with.
+     * @param bearerToken the contents of the secret to create.
+     * @return the Sources ID reference of the created secret.
+     */
+    private long createBearerTokenSecret(final String orgId, final BearerToken bearerToken) {
+        final Secret secret = new Secret();
+
+        secret.authenticationType = Secret.TYPE_BEARER_AUTHENTICATION;
+        secret.password = bearerToken.getToken();
+
+        return this.createSecret(orgId, secret);
+    }
+
+    /**
+     * Updates a "bearer token" secret in Sources.
+     * @param orgId the organization the secret is associated with.
+     * @param secretId the ID of the secret to update.
+     * @param bearerToken the contents of the secret to update.
+     */
+    private void updateBearerTokenSecret(final String orgId, final long secretId, final BearerToken bearerToken) {
+        final Secret secret = new Secret();
+
+        secret.authenticationType = Secret.TYPE_BEARER_AUTHENTICATION;
+        secret.password = bearerToken.getToken();
+
+        this.updateSecret(orgId, secretId, secret);
+    }
+
+    /**
      * Creates a "secret token" secret in Sources.
      * @param secretToken the "secret token"'s contents.
      * @param orgId the organization id related to this operation for the tenant identification.
      * @return the id of the created secret.
+     * @deprecated for removal since it is only used in the legacy {@link SecretUtils#updateSecretsForEndpoint(Endpoint)}
+     * function.
      */
-    private long createSecretTokenSecret(final String secretToken, final String tokenType, final String orgId) {
+    @Deprecated(forRemoval = true)
+    private long createSecretTokenSecretLegacy(final String secretToken, final String tokenType, final String orgId) {
         Secret secret = new Secret();
 
         secret.authenticationType = tokenType;
@@ -286,7 +549,43 @@ public class SecretUtils {
         return createSecret(orgId, secret);
     }
 
-    private Long createSecret(String orgId, Secret secret) {
+    /**
+     * Creates a "secret token" secret in Sources.
+     * @param orgId the organization the secret is associated with.
+     * @param secretToken the contents of the secret to create.
+     * @return the Sources ID reference of the created secret.
+     */
+    private long createSecretTokenSecret(final String orgId, final SecretToken secretToken) {
+        final Secret secret = new Secret();
+
+        secret.authenticationType = Secret.TYPE_SECRET_TOKEN;
+        secret.password = secretToken.getToken();
+
+        return this.createSecret(orgId, secret);
+    }
+
+    /**
+     * Updates a "secret token" secret in Sources.
+     * @param orgId the organization the secret is associated with.
+     * @param secretId the ID of the secret to update.
+     * @param secretToken the contents of the secret to update.
+     */
+    private void updateSecretTokenSecret(final String orgId, final long secretId, final SecretToken secretToken) {
+        final Secret secret = new Secret();
+
+        secret.authenticationType = Secret.TYPE_SECRET_TOKEN;
+        secret.password = secretToken.getToken();
+
+        this.updateSecret(orgId, secretId, secret);
+    }
+
+    /**
+     * Creates a Secret in sources.
+     * @param orgId the organization to associate the secret with.
+     * @param secret the secret to be created.
+     * @return the reference ID for the Sources secret.
+     */
+    private Long createSecret(final String orgId, final Secret secret) {
         final Secret createdSecret = this.sourcesService.create(
             orgId,
             this.sourcesPsk,
@@ -294,6 +593,34 @@ public class SecretUtils {
         );
 
         return createdSecret.id;
+    }
+
+    /**
+     * Updates a Secret in sources.
+     * @param orgId the organization the secret belongs to.
+     * @param secretId the ID of the secret to be updated.
+     * @param secret the secret's contents to update.
+     */
+    private void updateSecret(final String orgId, final long secretId, final Secret secret) {
+        this.sourcesService.update(
+            orgId,
+            this.sourcesPsk,
+            secretId,
+            secret
+        );
+    }
+
+    /**
+     * Checks whether the provide basic authentication object is null or blank.
+     * @param basicAuthenticationLegacy the basic authentication object to check.
+     * @return {@code true} if the basic authentication object is null or blank.
+     */
+    protected boolean isBasicAuthenticationNullOrBlank(final BasicAuthentication basicAuthenticationLegacy) {
+        if (basicAuthenticationLegacy == null) {
+            return true;
+        } else {
+            return basicAuthenticationLegacy.isBlank();
+        }
     }
 
     /**
@@ -309,6 +636,163 @@ public class SecretUtils {
         }
 
         return (basicAuthenticationLegacy.getPassword() == null || basicAuthenticationLegacy.getPassword().isBlank()) &&
-                (basicAuthenticationLegacy.getUsername() == null || basicAuthenticationLegacy.getUsername().isBlank());
+            (basicAuthenticationLegacy.getUsername() == null || basicAuthenticationLegacy.getUsername().isBlank());
+    }
+
+    /**
+     * Synchronizes the legacy properties and the new ones for the secrets. The
+     * new properties take precedence in the event of both the legacy and new
+     * properties are specified, and therefore the old ones get overridden.
+     *
+     * Basically, for all the secrets from an endpoint's properties:
+     *
+     * - If both the legacy and the new secrets are present, override the
+     * legacy ones with the new ones.
+     * - If only the legacy secrets are present, create the new secrets.
+     * - If only the new secrets are present, create the legacy secrets.
+     * @param endpointProperties the endpoint properties to update.
+     * @deprecated since this function will only exist as long as we support
+     * the old legacy properties.
+     */
+    @Deprecated(forRemoval = true)
+    public void legacySyncProperties(final EndpointProperties endpointProperties) {
+        final SourcesSecretable ss = (SourcesSecretable) endpointProperties;
+
+        // Sync the basic authentication properties.
+        final BasicAuthenticationLegacy basicAuthenticationLegacy = ss.getBasicAuthenticationLegacy();
+        final Optional<BasicAuthentication> basicAuthenticationOptional = this.getBasicAuthentication(endpointProperties);
+
+        if (basicAuthenticationLegacy != null && basicAuthenticationOptional.isPresent()) {
+            final BasicAuthentication basicAuthentication = basicAuthenticationOptional.get();
+
+            basicAuthenticationLegacy.setPassword(basicAuthentication.getPassword());
+            basicAuthenticationLegacy.setUsername(basicAuthentication.getUsername());
+
+            ss.setBasicAuthenticationLegacy(basicAuthenticationLegacy);
+        }
+
+        if (basicAuthenticationLegacy != null && basicAuthenticationOptional.isEmpty()) {
+            final BasicAuthentication basicAuthentication = new BasicAuthentication(
+                basicAuthenticationLegacy.getUsername(),
+                basicAuthenticationLegacy.getPassword()
+            );
+
+            ss.setBasicAuthentication(basicAuthentication);
+        }
+
+        if (basicAuthenticationLegacy == null && basicAuthenticationOptional.isPresent()) {
+            final BasicAuthentication basicAuthentication = basicAuthenticationOptional.get();
+
+            final BasicAuthenticationLegacy bal = new BasicAuthenticationLegacy(
+                basicAuthentication.getUsername(),
+                basicAuthentication.getPassword()
+            );
+
+            ss.setBasicAuthenticationLegacy(bal);
+        }
+
+        // Sync the bearer token properties
+        final String bearerTokenLegacy = ss.getBearerAuthenticationLegacy();
+        final Optional<BearerToken> bearerTokenOptional = this.getBearerToken(endpointProperties);
+
+        if (bearerTokenLegacy != null && bearerTokenOptional.isPresent()) {
+            ss.setBearerAuthenticationLegacy(bearerTokenOptional.get().getToken());
+        }
+
+        if (bearerTokenLegacy != null && bearerTokenOptional.isEmpty()) {
+            final BearerToken bearerToken = new BearerToken(
+                bearerTokenLegacy
+            );
+
+            ss.setBearerToken(bearerToken);
+        }
+
+        if (bearerTokenLegacy == null && bearerTokenOptional.isPresent()) {
+            final BearerToken bearerToken = bearerTokenOptional.get();
+
+            ss.setBearerAuthenticationLegacy(bearerToken.getToken());
+        }
+
+        // Sync the secret token properties.
+        final String secretTokenLegacy = ss.getSecretTokenLegacy();
+        final Optional<SecretToken> secretTokenOptional = this.getSecretToken(endpointProperties);
+
+        if (secretTokenLegacy != null && secretTokenOptional.isPresent()) {
+            ss.setSecretTokenLegacy(secretTokenOptional.get().getToken());
+        }
+
+        if (secretTokenLegacy != null && secretTokenOptional.isEmpty()) {
+            final SecretToken secretToken = new SecretToken(
+                secretTokenLegacy
+            );
+
+            ss.setSecretToken(secretToken);
+        }
+
+        if (secretTokenLegacy == null && secretTokenOptional.isPresent()) {
+            final SecretToken secretToken = secretTokenOptional.get();
+
+            ss.setSecretTokenLegacy(secretToken.getToken());
+        }
+    }
+
+    /**
+     * Check if the given endpoint has properties that are of the type that
+     * support Sources secrets.
+     * @param endpoint the endpoint to check.
+     * @return {@code true} if the endpoint's properties are from a class type
+     * that supports Sources secrets.
+     */
+    public static boolean isSourcesSecretable(final Endpoint endpoint) {
+        return endpoint.getProperties() instanceof CamelProperties
+            || endpoint.getProperties() instanceof WebhookProperties;
+    }
+
+    /**
+     * Gets the basic authentication object from the given endpoint properties.
+     * @param endpointProperties the endpoint properties to get the basic
+     *                           authentication from.
+     * @return an optional basic authentication object.
+     */
+    private Optional<BasicAuthentication> getBasicAuthentication(final EndpointProperties endpointProperties) {
+        if (endpointProperties instanceof CamelProperties cp) {
+            return Optional.ofNullable(cp.getBasicAuthentication());
+        } else if (endpointProperties instanceof WebhookProperties wp) {
+            return Optional.ofNullable(wp.getBasicAuthentication());
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the bearer token object from the given endpoint properties.
+     * @param endpointProperties the endpoint properties to get the bearer
+     *                           token from.
+     * @return an optional bearer token object.
+     */
+    private Optional<BearerToken> getBearerToken(final EndpointProperties endpointProperties) {
+        if (endpointProperties instanceof CamelProperties cp) {
+            return Optional.ofNullable(cp.getBearerToken());
+        } else if (endpointProperties instanceof WebhookProperties wp) {
+            return Optional.ofNullable(wp.getBearerToken());
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the secret token object from the given endpoint properties.
+     * @param endpointProperties the endpoint properties to get the secret
+     *                           token from.
+     * @return an optional secret token object.
+     */
+    private Optional<SecretToken> getSecretToken(final EndpointProperties endpointProperties) {
+        if (endpointProperties instanceof CamelProperties cp) {
+            return Optional.ofNullable(cp.getSecretToken());
+        } else if (endpointProperties instanceof WebhookProperties wp) {
+            return Optional.ofNullable(wp.getSecretToken());
+        }
+
+        return Optional.empty();
     }
 }

--- a/connector-webhook/src/test/java/com/redhat/cloud/notifications/connector/webhook/authentication/BasicAuthenticationLegacyTest.java
+++ b/connector-webhook/src/test/java/com/redhat/cloud/notifications/connector/webhook/authentication/BasicAuthenticationLegacyTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class BasicAuthenticationTest {
+class BasicAuthenticationLegacyTest {
     BasicAuthenticationProcessor testee = new BasicAuthenticationProcessor();
 
     @Test

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.processors.eventing;
 import com.redhat.cloud.notifications.Base64Utils;
 import com.redhat.cloud.notifications.DelayedThrower;
 import com.redhat.cloud.notifications.config.FeatureFlipper;
-import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.Event;
@@ -91,19 +91,19 @@ public class EventingProcessor extends EndpointTypeProcessor {
     }
 
     private static Optional<String> getSecretToken(CamelProperties properties) {
-        if (properties.getSecretToken() == null || properties.getSecretToken().isBlank()) {
+        if (properties.getSecretTokenLegacy() == null || properties.getSecretTokenLegacy().isBlank()) {
             return Optional.empty();
         } else {
-            return Optional.of(properties.getSecretToken());
+            return Optional.of(properties.getSecretTokenLegacy());
         }
     }
 
     private static Optional<String> getBasicAuth(CamelProperties properties) {
-        BasicAuthentication basicAuthentication = properties.getBasicAuthentication();
-        if (basicAuthentication == null || basicAuthentication.getUsername() == null || basicAuthentication.getPassword() == null) {
+        BasicAuthenticationLegacy basicAuthenticationLegacy = properties.getBasicAuthenticationLegacy();
+        if (basicAuthenticationLegacy == null || basicAuthenticationLegacy.getUsername() == null || basicAuthenticationLegacy.getPassword() == null) {
             return Optional.empty();
         } else {
-            String credentials = basicAuthentication.getUsername() + ":" + basicAuthentication.getPassword();
+            String credentials = basicAuthenticationLegacy.getUsername() + ":" + basicAuthenticationLegacy.getPassword();
             return Optional.of(Base64Utils.encode(credentials));
         }
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -249,7 +249,7 @@ public class LifecycleITest {
         WebhookProperties properties = new WebhookProperties();
         properties.setMethod(HttpType.POST);
         properties.setDisableSslVerification(true);
-        properties.setSecretToken(secretToken);
+        properties.setSecretTokenLegacy(secretToken);
         properties.setUrl(getMockServerUrl() + WEBHOOK_MOCK_PATH);
         return createEndpoint(accountId, WEBHOOK, "endpoint", "Endpoint", properties);
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/eventing/EventingTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/eventing/EventingTypeProcessorTest.java
@@ -12,7 +12,7 @@ import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.ingress.Recipient;
-import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.BasicAuthenticationLegacy;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.Event;
@@ -177,8 +177,8 @@ class EventingTypeProcessorTest {
         assertEquals(properties1.getUrl(), notifMetadata.getString("url"));
         assertEquals(endpoint1.getSubType(), notifMetadata.getString("type"));
 
-        assertEquals(properties1.getSecretToken(), notifMetadata.getString(TOKEN_HEADER));
-        checkBasicAuthentication(notifMetadata, properties1.getBasicAuthentication());
+        assertEquals(properties1.getSecretTokenLegacy(), notifMetadata.getString(TOKEN_HEADER));
+        checkBasicAuthentication(notifMetadata, properties1.getBasicAuthenticationLegacy());
 
         // Finally, we need to check the Kafka message metadata.
         UUID historyId = result.get(0).getId();
@@ -241,13 +241,13 @@ class EventingTypeProcessorTest {
     }
 
     private static Endpoint buildCamelEndpoint(String accountId) {
-        BasicAuthentication basicAuth = new BasicAuthentication(FIXTURE_CAMEL_BASIC_AUTH_USERNAME, FIXTURE_CAMEL_BASIC_AUTH_PASSWORD);
+        BasicAuthenticationLegacy basicAuth = new BasicAuthenticationLegacy(FIXTURE_CAMEL_BASIC_AUTH_USERNAME, FIXTURE_CAMEL_BASIC_AUTH_PASSWORD);
 
         CamelProperties properties = new CamelProperties();
         properties.setUrl(FIXTURE_CAMEL_URL);
         properties.setDisableSslVerification(FIXTURE_CAMEL_SSL_VERIFICATION);
-        properties.setSecretToken(FIXTURE_CAMEL_SECRET_TOKEN);
-        properties.setBasicAuthentication(basicAuth);
+        properties.setSecretTokenLegacy(FIXTURE_CAMEL_SECRET_TOKEN);
+        properties.setBasicAuthenticationLegacy(basicAuth);
 
         Endpoint endpoint = new Endpoint();
         endpoint.setAccountId(accountId);
@@ -258,7 +258,7 @@ class EventingTypeProcessorTest {
         return endpoint;
     }
 
-    private void checkBasicAuthentication(JsonObject notifMetadata, BasicAuthentication expectedBasicAuth) {
+    private void checkBasicAuthentication(JsonObject notifMetadata, BasicAuthenticationLegacy expectedBasicAuth) {
         String credentials = expectedBasicAuth.getUsername() + ":" + expectedBasicAuth.getPassword();
         String expectedBase64Credentials = Base64Utils.encode(credentials);
         assertEquals(expectedBase64Credentials, notifMetadata.getString("basicAuth"));


### PR DESCRIPTION
## Summary
This second part focuses on implementing the changes in order to support the new endpoints for the secrets' management, and the required functions in the `SecretUtils` class.

## Depends on

* https://github.com/RedHatInsights/notifications-backend/pull/2448

## Description
We are making an effort to stop returning secrets in responses, and at
the same time, signal if they are present or not, so that the UI can
effectively show feedback about that.
    
Since we need a transition period until the UI moves to the new way of
managing secrets, we still support both ways of managing them.

## Jira ticket
[[RHCLOUD-27431]](https://issues.redhat.com/browse/RHCLOUD-27431)