### PR TITLE
RHCLOUD-27431 | refactor: return credentials redacted

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -82,6 +82,7 @@ public class EndpointResource {
 
     public static final String EMPTY_SLACK_CHANNEL_ERROR = "The channel field is required";
     public static final String UNSUPPORTED_ENDPOINT_TYPE = "Unsupported endpoint type";
+    public static final String REDACTED_CREDENTIAL = "*****";
 
     @Inject
     EndpointRepository endpointRepository;
@@ -575,18 +576,18 @@ public class EndpointResource {
         if (endpoint.getProperties() instanceof SourcesSecretable sourcesSecretable) {
             final BasicAuthentication basicAuthentication = sourcesSecretable.getBasicAuthentication();
             if (basicAuthentication != null) {
-                basicAuthentication.setPassword("[REDACTED CREDENTIAL]");
-                basicAuthentication.setUsername("[REDACTED CREDENTIAL]");
+                basicAuthentication.setPassword(REDACTED_CREDENTIAL);
+                basicAuthentication.setUsername(REDACTED_CREDENTIAL);
             }
 
             final String bearerToken = sourcesSecretable.getBearerAuthentication();
             if (bearerToken != null) {
-                sourcesSecretable.setBearerAuthentication("[REDACTED CREDENTIAL]");
+                sourcesSecretable.setBearerAuthentication(REDACTED_CREDENTIAL);
             }
 
             final String secretToken = sourcesSecretable.getSecretToken();
             if (secretToken != null) {
-                sourcesSecretable.setSecretToken("[REDACTED CREDENTIAL]");
+                sourcesSecretable.setSecretToken(REDACTED_CREDENTIAL);
             }
         }
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -569,10 +569,7 @@ public class EndpointResource {
     @Deprecated(forRemoval = true)
     protected void redactSecretsForEndpoint(final SecurityContext securityContext, final Endpoint endpoint) {
         // Only redact the secrets for those users who have read only permissions.
-        if (securityContext.isUserInRole(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
-            || securityContext.isUserInRole(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-            || securityContext.isUserInRole(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS)
-        ) {
+        if (!securityContext.isUserInRole(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)) {
             if (endpoint.getProperties() instanceof SourcesSecretable sourcesSecretable) {
                 final BasicAuthentication basicAuthentication = sourcesSecretable.getBasicAuthentication();
                 if (basicAuthentication != null) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -550,7 +550,7 @@ public class LifecycleITest extends DbIsolatedTest {
         assertEquals(properties.getMethod().name(), jsonWebhookProperties.getString("method"));
         assertEquals(properties.getDisableSslVerification(), jsonWebhookProperties.getBoolean("disable_ssl_verification"));
         if (properties.getSecretToken() != null) {
-            assertEquals(properties.getSecretToken(), jsonWebhookProperties.getString("secret_token"));
+            assertEquals("[REDACTED CREDENTIAL]", jsonWebhookProperties.getString("secret_token"));
         }
         assertEquals(properties.getUrl(), jsonWebhookProperties.getString("url"));
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -17,7 +17,6 @@ import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.NotificationStatus;
 import com.redhat.cloud.notifications.models.WebhookProperties;
-import com.redhat.cloud.notifications.routers.EndpointResource;
 import com.redhat.cloud.notifications.routers.internal.models.AddApplicationRequest;
 import com.redhat.cloud.notifications.routers.internal.models.RequestDefaultBehaviorGroupPropertyList;
 import com.redhat.cloud.notifications.routers.models.RequestSystemSubscriptionProperties;
@@ -551,7 +550,7 @@ public class LifecycleITest extends DbIsolatedTest {
         assertEquals(properties.getMethod().name(), jsonWebhookProperties.getString("method"));
         assertEquals(properties.getDisableSslVerification(), jsonWebhookProperties.getBoolean("disable_ssl_verification"));
         if (properties.getSecretToken() != null) {
-            assertEquals(EndpointResource.REDACTED_CREDENTIAL, jsonWebhookProperties.getString("secret_token"));
+            assertEquals(properties.getSecretToken(), jsonWebhookProperties.getString("secret_token"));
         }
         assertEquals(properties.getUrl(), jsonWebhookProperties.getString("url"));
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -17,6 +17,7 @@ import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.NotificationStatus;
 import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.routers.EndpointResource;
 import com.redhat.cloud.notifications.routers.internal.models.AddApplicationRequest;
 import com.redhat.cloud.notifications.routers.internal.models.RequestDefaultBehaviorGroupPropertyList;
 import com.redhat.cloud.notifications.routers.models.RequestSystemSubscriptionProperties;
@@ -550,7 +551,7 @@ public class LifecycleITest extends DbIsolatedTest {
         assertEquals(properties.getMethod().name(), jsonWebhookProperties.getString("method"));
         assertEquals(properties.getDisableSslVerification(), jsonWebhookProperties.getBoolean("disable_ssl_verification"));
         if (properties.getSecretToken() != null) {
-            assertEquals("[REDACTED CREDENTIAL]", jsonWebhookProperties.getString("secret_token"));
+            assertEquals(EndpointResource.REDACTED_CREDENTIAL, jsonWebhookProperties.getString("secret_token"));
         }
         assertEquals(properties.getUrl(), jsonWebhookProperties.getString("url"));
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -836,7 +836,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         JsonObject attrSingleUpdated = updatedEndpoint.getJsonObject("properties");
         attrSingleUpdated.mapTo(WebhookProperties.class);
         assertEquals("endpoint found", updatedEndpoint.getString("name"));
-        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attrSingleUpdated.getString("secret_token"));
+        assertEquals("not-so-secret-anymore", attrSingleUpdated.getString("secret_token"));
         assertEquals(0, updatedEndpoint.getInteger("server_errors"));
     }
 
@@ -1125,10 +1125,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         JsonObject attr = responsePointSingle.getJsonObject("properties");
         attr.mapTo(WebhookProperties.class);
         assertNotNull(attr.getJsonObject("basic_authentication"));
-        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attr.getJsonObject("basic_authentication").getString("username"));
-        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attr.getJsonObject("basic_authentication").getString("password"));
-        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attr.getString("bearer_authentication"));
-        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attr.getString("secret_token"));
+        assertEquals("mypassword", attr.getJsonObject("basic_authentication").getString("password"));
+        assertEquals(properties.getBearerAuthentication(), attr.getString("bearer_authentication"));
     }
 
     @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -479,6 +479,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         cAttr.setDisableSslVerification(false);
         cAttr.setUrl(getMockServerUrl());
         cAttr.setBasicAuthentication(new BasicAuthentication("testuser", "secret"));
+        cAttr.setSecretToken("secret-token");
         Map<String, String> extras = new HashMap<>();
         extras.put("template", "11");
         cAttr.setExtras(extras);
@@ -522,9 +523,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
             assertNotNull(basicAuth);
             String user = basicAuth.getString("username");
             String pass = basicAuth.getString("password");
-            assertEquals("testuser", user);
-            assertEquals("secret", pass);
+            assertEquals("[REDACTED CREDENTIAL]", user);
+            assertEquals("[REDACTED CREDENTIAL]", pass);
 
+            assertEquals("[REDACTED CREDENTIAL]", properties.getString("secret_token"));
         } finally {
 
             given()
@@ -834,7 +836,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         JsonObject attrSingleUpdated = updatedEndpoint.getJsonObject("properties");
         attrSingleUpdated.mapTo(WebhookProperties.class);
         assertEquals("endpoint found", updatedEndpoint.getString("name"));
-        assertEquals("not-so-secret-anymore", attrSingleUpdated.getString("secret_token"));
+        assertEquals("[REDACTED CREDENTIAL]", attrSingleUpdated.getString("secret_token"));
         assertEquals(0, updatedEndpoint.getInteger("server_errors"));
     }
 
@@ -1123,8 +1125,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
         JsonObject attr = responsePointSingle.getJsonObject("properties");
         attr.mapTo(WebhookProperties.class);
         assertNotNull(attr.getJsonObject("basic_authentication"));
-        assertEquals("mypassword", attr.getJsonObject("basic_authentication").getString("password"));
-        assertEquals(properties.getBearerAuthentication(), attr.getString("bearer_authentication"));
+        assertEquals("[REDACTED CREDENTIAL]", attr.getJsonObject("basic_authentication").getString("username"));
+        assertEquals("[REDACTED CREDENTIAL]", attr.getJsonObject("basic_authentication").getString("password"));
+        assertEquals("[REDACTED CREDENTIAL]", attr.getString("bearer_authentication"));
+        assertEquals("[REDACTED CREDENTIAL]", attr.getString("secret_token"));
     }
 
     @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -523,10 +523,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
             assertNotNull(basicAuth);
             String user = basicAuth.getString("username");
             String pass = basicAuth.getString("password");
-            assertEquals("[REDACTED CREDENTIAL]", user);
-            assertEquals("[REDACTED CREDENTIAL]", pass);
+            assertEquals(EndpointResource.REDACTED_CREDENTIAL, user);
+            assertEquals(EndpointResource.REDACTED_CREDENTIAL, pass);
 
-            assertEquals("[REDACTED CREDENTIAL]", properties.getString("secret_token"));
+            assertEquals(EndpointResource.REDACTED_CREDENTIAL, properties.getString("secret_token"));
         } finally {
 
             given()
@@ -836,7 +836,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         JsonObject attrSingleUpdated = updatedEndpoint.getJsonObject("properties");
         attrSingleUpdated.mapTo(WebhookProperties.class);
         assertEquals("endpoint found", updatedEndpoint.getString("name"));
-        assertEquals("[REDACTED CREDENTIAL]", attrSingleUpdated.getString("secret_token"));
+        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attrSingleUpdated.getString("secret_token"));
         assertEquals(0, updatedEndpoint.getInteger("server_errors"));
     }
 
@@ -1125,10 +1125,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
         JsonObject attr = responsePointSingle.getJsonObject("properties");
         attr.mapTo(WebhookProperties.class);
         assertNotNull(attr.getJsonObject("basic_authentication"));
-        assertEquals("[REDACTED CREDENTIAL]", attr.getJsonObject("basic_authentication").getString("username"));
-        assertEquals("[REDACTED CREDENTIAL]", attr.getJsonObject("basic_authentication").getString("password"));
-        assertEquals("[REDACTED CREDENTIAL]", attr.getString("bearer_authentication"));
-        assertEquals("[REDACTED CREDENTIAL]", attr.getString("secret_token"));
+        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attr.getJsonObject("basic_authentication").getString("username"));
+        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attr.getJsonObject("basic_authentication").getString("password"));
+        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attr.getString("bearer_authentication"));
+        assertEquals(EndpointResource.REDACTED_CREDENTIAL, attr.getString("secret_token"));
     }
 
     @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -523,10 +523,10 @@ public class EndpointResourceTest extends DbIsolatedTest {
             assertNotNull(basicAuth);
             String user = basicAuth.getString("username");
             String pass = basicAuth.getString("password");
-            assertEquals(EndpointResource.REDACTED_CREDENTIAL, user);
-            assertEquals(EndpointResource.REDACTED_CREDENTIAL, pass);
+            assertEquals("testuser", user);
+            assertEquals("secret", pass);
 
-            assertEquals(EndpointResource.REDACTED_CREDENTIAL, properties.getString("secret_token"));
+            assertEquals("secret-token", properties.getString("secret_token"));
         } finally {
 
             given()

--- a/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthentication.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/BasicAuthentication.java
@@ -17,6 +17,10 @@ public class BasicAuthentication {
         return username;
     }
 
+    public void setUsername(final String username) {
+        this.username = username;
+    }
+
     public String getPassword() {
         return password;
     }


### PR DESCRIPTION
We are moving towards not returning the credentials to the users, and the first step we want to make is to simply remove them from the payloads we return when listing the endpoints.

## Jira ticket
RHCLOUD-27431