### PR TITLE
RHCLOUD-31165 | feature: use DTOs for the Endpoint model

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -142,6 +142,26 @@
             <version>${quarkus-logging-cloudwatch.version}</version>
         </dependency>
 
+        <!-- MapStruct -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.redhat.cloud.notifications</groupId>

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EndpointPage.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EndpointPage.java
@@ -1,17 +1,17 @@
 package com.redhat.cloud.notifications.routers.models;
 
-import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointDTO;
 
 import java.util.List;
 import java.util.Map;
 
-public class EndpointPage extends Page<Endpoint> {
+public class EndpointPage extends Page<EndpointDTO> {
 
     public EndpointPage() {
         super();
     }
 
-    public EndpointPage(List<Endpoint> data, Map<String, String> links, Meta meta) {
+    public EndpointPage(List<EndpointDTO> data, Map<String, String> links, Meta meta) {
         super(data, links, meta);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.db;
 
+import com.redhat.cloud.notifications.db.model.Stats;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.db.repositories.BehaviorGroupRepository;
 import com.redhat.cloud.notifications.db.repositories.BundleRepository;
@@ -176,9 +177,9 @@ public class ResourceHelpers {
         return endpointRepository.createEndpoint(endpoint);
     }
 
-    public int[] createTestEndpoints(String accountId, String orgId, int count) {
-        int[] statsValues = new int[3];
-        statsValues[0] = count;
+    public Stats createTestEndpoints(String accountId, String orgId, int count) {
+        final Stats stats = new Stats(count);
+
         for (int i = 0; i < count; i++) {
             // Add new endpoints
             WebhookProperties properties = new WebhookProperties();
@@ -191,11 +192,11 @@ public class ResourceHelpers {
             ep.setDescription("Automatically generated");
             boolean enabled = (i % (count / 5)) != 0;
             if (!enabled) {
-                statsValues[1]++;
+                stats.increaseDisabledCount();
             }
             ep.setEnabled(enabled);
             if (i > 0) {
-                statsValues[2]++;
+                stats.increaseWebhookCount();
                 ep.setProperties(properties);
             }
 
@@ -203,7 +204,7 @@ public class ResourceHelpers {
             ep.setOrgId(orgId);
             endpointRepository.createEndpoint(ep);
         }
-        return statsValues;
+        return stats;
     }
 
     public NotificationHistory createNotificationHistory(Event event, Endpoint endpoint, NotificationStatus status) {
@@ -354,7 +355,7 @@ public class ResourceHelpers {
 
                 final CamelProperties camelProperties = new CamelProperties();
                 camelProperties.setDisableSslVerification(random.nextBoolean());
-                camelProperties.setUrl("https://example.org");
+                camelProperties.setUrl("https://redhat.com");
 
                 // Maybe set a basic authentication, maybe not...
                 if (i % 3 == 0) {
@@ -381,7 +382,7 @@ public class ResourceHelpers {
                 final WebhookProperties webhookProperties = new WebhookProperties();
                 webhookProperties.setDisableSslVerification(random.nextBoolean());
                 webhookProperties.setMethod(HttpType.GET);
-                webhookProperties.setUrl("https://example.org");
+                webhookProperties.setUrl("https://redhat.com");
 
                 // Maybe set a basic authentication, maybe not...
                 if (i % 3 == 0) {
@@ -429,7 +430,7 @@ public class ResourceHelpers {
         for (int i = 0; i < 5; i++) {
             final CamelProperties camelProperties = new CamelProperties();
             camelProperties.setDisableSslVerification(random.nextBoolean());
-            camelProperties.setUrl("https://example.org");
+            camelProperties.setUrl("https://redhat.com");
 
             camelProperties.setBasicAuthentication(
                 new BasicAuthentication(UUID.randomUUID().toString(), UUID.randomUUID().toString())
@@ -454,7 +455,7 @@ public class ResourceHelpers {
             final WebhookProperties webhookProperties = new WebhookProperties();
             webhookProperties.setDisableSslVerification(random.nextBoolean());
             webhookProperties.setMethod(HttpType.GET);
-            webhookProperties.setUrl("https://example.org");
+            webhookProperties.setUrl("https://redhat.com");
 
             webhookProperties.setBasicAuthentication(
                 new BasicAuthentication(UUID.randomUUID().toString(), UUID.randomUUID().toString())
@@ -519,7 +520,7 @@ public class ResourceHelpers {
                 camelProperties.setBasicAuthentication(getRandomBasicAuth.get());
                 camelProperties.setDisableSslVerification(random.nextBoolean());
                 camelProperties.setSecretToken(UUID.randomUUID().toString());
-                camelProperties.setUrl("https://example.org");
+                camelProperties.setUrl("https://redhat.com");
 
                 endpoint.setProperties(camelProperties);
             } else {
@@ -530,7 +531,7 @@ public class ResourceHelpers {
                 webhookProperties.setDisableSslVerification(random.nextBoolean());
                 webhookProperties.setMethod(HttpType.GET);
                 webhookProperties.setSecretToken(UUID.randomUUID().toString());
-                webhookProperties.setUrl("https://example.org");
+                webhookProperties.setUrl("https://redhat.com");
 
                 endpoint.setProperties(webhookProperties);
             }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/model/Stats.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/model/Stats.java
@@ -1,0 +1,38 @@
+package com.redhat.cloud.notifications.db.model;
+
+import com.redhat.cloud.notifications.routers.EndpointResourceTest;
+
+/**
+ * A helper class for the {@link com.redhat.cloud.notifications.db.ResourceHelpers#createTestEndpoints(String, String, int)}
+ * function. It then gets used in {@link EndpointResourceTest#testSortingOrder()} and {@link EndpointResourceTest#testActive()}.
+ */
+public final class Stats {
+    private final int createdEndpointsCount;
+    private int disabledCount;
+    private int webhookCount;
+
+    public Stats(final int createdEndpointsCount) {
+        this.createdEndpointsCount = createdEndpointsCount;
+        this.disabledCount = 0;
+    }
+
+    public int getCreatedEndpointsCount() {
+        return this.createdEndpointsCount;
+    }
+
+    public void increaseDisabledCount() {
+        this.disabledCount++;
+    }
+
+    public int getDisabledCount() {
+        return this.disabledCount;
+    }
+
+    public int getWebhookCount() {
+        return this.webhookCount;
+    }
+
+    public void increaseWebhookCount() {
+        this.webhookCount++;
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
@@ -1,0 +1,101 @@
+package com.redhat.cloud.notifications.models.mappers.v1.endpoint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.CamelProperties;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointProperties;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.HttpType;
+import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
+import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointDTO;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@QuarkusTest
+public class EndpointMapperTest {
+    @Inject
+    EndpointMapper endpointMapper;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    final JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+
+    /**
+     * Prior to the introduction of MapStruct and DTOs into the project, the {@link Endpoint}
+     * class was being used as the exposed model to clients. This tests ensures that the introduction of DTOs and
+     * mappers did not change the model exposed to the clients.
+     *
+     * @throws IOException if the JSON schema could not be loaded.
+     */
+    @Test
+    void testEndpointMapper() throws IOException, URISyntaxException {
+        // Prepare the endpoint we will convert to DTO to.
+        final Endpoint endpoint = new Endpoint();
+
+        endpoint.setId(UUID.randomUUID());
+        endpoint.setName("endpoint name");
+        endpoint.setDescription("endpoint description");
+        endpoint.setEnabled(true);
+        endpoint.setServerErrors(12);
+        endpoint.setType(EndpointType.CAMEL);
+        endpoint.setSubType("slack");
+        endpoint.setCreated(LocalDateTime.now());
+
+        final CamelProperties camelProperties = new CamelProperties();
+        camelProperties.setDisableSslVerification(false);
+        camelProperties.setUrl("https://redhat.com");
+        camelProperties.setBasicAuthentication(new BasicAuthentication("username", "password"));
+        camelProperties.setSecretToken("secret-token");
+
+        final SystemSubscriptionProperties systemSubscriptionProperties = new SystemSubscriptionProperties();
+        systemSubscriptionProperties.setGroupId(UUID.randomUUID());
+        systemSubscriptionProperties.setIgnorePreferences(false);
+        systemSubscriptionProperties.setOnlyAdmins(false);
+
+        final WebhookProperties webhookProperties = new WebhookProperties();
+        webhookProperties.setDisableSslVerification(false);
+        webhookProperties.setMethod(HttpType.POST);
+        webhookProperties.setUrl("https://redhat.com");
+        webhookProperties.setBasicAuthentication(new BasicAuthentication("username", "password"));
+        webhookProperties.setBearerAuthentication("bearer authentication");
+        webhookProperties.setSecretToken("secret token");
+
+        // Load the JSON Schema.
+        final String schemaContents = Files.readString(Paths.get(Thread.currentThread().getContextClassLoader().getResource("json-schemas/v1/endpoint/endpoint-schema.json").toURI()));
+        final JsonSchema endpointSchema = this.jsonSchemaFactory.getSchema(schemaContents);
+
+        // Loop through the properties and generate the JSON for the DTO.
+        for (final EndpointProperties properties : List.of(camelProperties, systemSubscriptionProperties, webhookProperties)) {
+            endpoint.setProperties(properties);
+
+            // Generate the DTO.
+            final EndpointDTO endpointDTO = this.endpointMapper.toDTO(endpoint);
+
+            // Turn it into JSON and validate it against the schema.
+            final Set<ValidationMessage> validationMessages = endpointSchema.validate(this.objectMapper.valueToTree(endpointDTO));
+
+            // Any errors are unexpected since the resulting JSON should be conforming to the defined schema.
+            for (final ValidationMessage validationMessage : validationMessages) {
+                Assertions.fail(String.format("unexpected validation failure \"%s\" with payload: %s", validationMessage, this.objectMapper.valueToTree(endpointDTO)));
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -8,6 +8,7 @@ import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.model.Stats;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.models.BasicAuthentication;
 import com.redhat.cloud.notifications.models.CamelProperties;
@@ -17,6 +18,8 @@ import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
 import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointDTO;
+import com.redhat.cloud.notifications.models.mappers.v1.endpoint.EndpointMapper;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidator;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidatorTest;
 import com.redhat.cloud.notifications.routers.endpoints.EndpointTestRequest;
@@ -33,6 +36,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
+import io.restassured.module.jsv.JsonSchemaValidator;
 import io.restassured.response.Response;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -109,6 +113,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @Inject
     FeatureFlipper featureFlipper;
+
+    @Inject
+    EndpointMapper endpointMapper;
 
     @Inject
     EndpointRepository endpointRepository;
@@ -202,7 +209,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        List<Endpoint> endpoints = endpointPage.getData();
+        List<EndpointDTO> endpointDTOS = endpointPage.getData();
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
+
         assertEquals(1, endpoints.size());
 
         // Fetch single endpoint also and verify
@@ -501,6 +516,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .then()
                 .statusCode(200)
                 .contentType(JSON)
+                .and()
+                .assertThat()
+                .body(JsonSchemaValidator.matchesJsonSchemaInClasspath("json-schemas/v1/endpoint/endpoint-schema.json"))
                 .extract().asString();
 
         JsonObject responsePoint = new JsonObject(responseBody);
@@ -798,7 +816,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        List<Endpoint> endpoints = endpointPage.getData();
+        List<EndpointDTO> endpointDTOS = endpointPage.getData();
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
+
         assertEquals(1, endpoints.size());
 
         // Fetch single endpoint also and verify
@@ -929,7 +955,14 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        List<Endpoint> endpoints = endpointPage.getData();
+        List<EndpointDTO> endpointDTOS = endpointPage.getData();
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
         assertEquals(2, endpoints.size());
 
         // Fetch the list with types
@@ -944,7 +977,14 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        endpoints = endpointPage.getData();
+        endpointDTOS = endpointPage.getData();
+
+        endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
 
         // Ensure there is only the requested types
         assertEquals(
@@ -977,7 +1017,14 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        List<Endpoint> endpoints = endpointPage.getData();
+        List<EndpointDTO> endpointDTOS = endpointPage.getData();
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
         assertEquals(10, endpoints.size());
         assertEquals(29, endpointPage.getMeta().getCount());
 
@@ -994,7 +1041,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        endpoints = endpointPage.getData();
+        endpointDTOS = endpointPage.getData();
+
+        endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
+
         assertEquals(9, endpoints.size());
         assertEquals(29, endpointPage.getMeta().getCount());
     }
@@ -1010,9 +1065,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
         // Create 50 test-ones with sanely sortable name & enabled & disabled & type
-        int[] stats = helpers.createTestEndpoints(accountId, orgId, 50);
-        int disableCount = stats[1];
-        int webhookCount = stats[2];
+        final Stats stats = helpers.createTestEndpoints(accountId, orgId, 50);
 
         Response response = given()
                 .header(identityHeader)
@@ -1024,8 +1077,13 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        Endpoint[] endpoints = endpointPage.getData().toArray(new Endpoint[0]);
-        assertEquals(stats[0], endpoints.length);
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointPage.getData().size());
+        for (final EndpointDTO endpointDTO : endpointPage.getData()) {
+            endpoints.add(this.endpointMapper.toEntity(endpointDTO));
+        }
+
+        assertEquals(stats.getCreatedEndpointsCount(), endpoints.size());
 
         response = given()
                 .header(identityHeader)
@@ -1038,17 +1096,22 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        endpoints = endpointPage.getData().toArray(new Endpoint[0]);
-        assertFalse(endpoints[0].isEnabled());
-        assertFalse(endpoints[disableCount - 1].isEnabled());
-        assertTrue(endpoints[disableCount].isEnabled());
-        assertTrue(endpoints[stats[0] - 1].isEnabled());
+
+        endpoints = new ArrayList<>(endpointPage.getData().size());
+        for (final EndpointDTO endpointDTO : endpointPage.getData()) {
+            endpoints.add(this.endpointMapper.toEntity(endpointDTO));
+        }
+
+        assertFalse(endpoints.get(0).isEnabled());
+        assertFalse(endpoints.get(stats.getDisabledCount() - 1).isEnabled());
+        assertTrue(endpoints.get(stats.getDisabledCount()).isEnabled());
+        assertTrue(endpoints.get(stats.getCreatedEndpointsCount() - 1).isEnabled());
 
         response = given()
                 .header(identityHeader)
                 .queryParam("sort_by", "name:desc")
                 .queryParam("limit", "50")
-                .queryParam("offset", stats[0] - 20)
+                .queryParam("offset", stats.getCreatedEndpointsCount() - 20)
                 .when()
                 .get("/endpoints?limit=100")
                 .then()
@@ -1057,11 +1120,16 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        endpoints = endpointPage.getData().toArray(new Endpoint[0]);
-        assertEquals(20, endpoints.length);
-        assertEquals("Endpoint 1", endpoints[endpoints.length - 1].getName());
-        assertEquals("Endpoint 10", endpoints[endpoints.length - 2].getName());
-        assertEquals("Endpoint 27", endpoints[0].getName());
+
+        endpoints = new ArrayList<>(endpointPage.getData().size());
+        for (final EndpointDTO endpointDTO : endpointPage.getData()) {
+            endpoints.add(this.endpointMapper.toEntity(endpointDTO));
+        }
+
+        assertEquals(20, endpoints.size());
+        assertEquals("Endpoint 1", endpoints.get(endpoints.size() - 1).getName());
+        assertEquals("Endpoint 10", endpoints.get(endpoints.size() - 2).getName());
+        assertEquals("Endpoint 27", endpoints.get(0).getName());
 
         given()
                 .header(identityHeader)
@@ -1634,9 +1702,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
-        // stats[0] is the count
-        // stats[1] are the inactive ones
-        int[] stats = resourceHelpers.createTestEndpoints(TestConstants.DEFAULT_ACCOUNT_ID, orgId, 11);
+        final Stats stats = resourceHelpers.createTestEndpoints(TestConstants.DEFAULT_ACCOUNT_ID, orgId, 11);
 
         // Get all endpoints
         Response response = given()
@@ -1649,8 +1715,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        assertEquals(stats[0], endpointPage.getMeta().getCount());
-        assertEquals(stats[0], endpointPage.getData().size());
+        assertEquals(stats.getCreatedEndpointsCount(), endpointPage.getMeta().getCount());
+        assertEquals(stats.getCreatedEndpointsCount(), endpointPage.getData().size());
 
         // Only active
         response = given()
@@ -1664,8 +1730,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        assertEquals(stats[0] - stats[1], endpointPage.getMeta().getCount());
-        assertEquals(stats[0] - stats[1], endpointPage.getData().size());
+        assertEquals(stats.getCreatedEndpointsCount() - stats.getDisabledCount(), endpointPage.getMeta().getCount());
+        assertEquals(stats.getCreatedEndpointsCount() - stats.getDisabledCount(), endpointPage.getData().size());
 
         // Only inactive
         response = given()
@@ -1679,8 +1745,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        assertEquals(stats[1], endpointPage.getMeta().getCount());
-        assertEquals(stats[1], endpointPage.getData().size());
+        assertEquals(stats.getDisabledCount(), endpointPage.getMeta().getCount());
+        assertEquals(stats.getDisabledCount(), endpointPage.getData().size());
 
     }
 

--- a/backend/src/test/resources/json-schemas/v1/endpoint/endpoint-schema.json
+++ b/backend/src/test/resources/json-schemas/v1/endpoint/endpoint-schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Root",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "description",
+    "created",
+    "enabled",
+    "status",
+    "server_errors",
+    "type",
+    "sub_type",
+    "properties"
+  ],
+  "properties": {
+    "id": {
+      "format": "uuid",
+      "title": "Endpoint's identifier",
+      "type": "string"
+    },
+    "name": {
+      "maxLength": 255,
+      "minLength": 1,
+      "title": "Name of the endpoint",
+      "type": "string"
+    },
+    "description": {
+      "minLength": 1,
+      "title": "Description of the endpoint",
+      "type": "string"
+    },
+    "enabled": {
+      "title": "Is the endpoint enabled?",
+      "type": "boolean"
+    },
+    "status": {
+      "enum": [
+        "DELETING",
+        "FAILED",
+        "NEW",
+        "PROVISIONING",
+        "READY",
+        "UNKNOWN"
+      ],
+      "title": "Status of the endpoint"
+    },
+    "server_errors": {
+      "minimum": 0,
+      "title": "Number of server errors that the endpoint suffered from when contacting the remote servers",
+      "type": "integer"
+    },
+    "type": {
+      "enum": [
+        "ansible",
+        "camel",
+        "drawer",
+        "email_subscription",
+        "webhook"
+      ],
+      "title": "Type of the endpoint",
+      "type": "string"
+    },
+    "sub_type": {
+      "enum": [
+        "ansible",
+        "google_chat",
+        "slack",
+        "teams"
+      ],
+      "title": "Subtype of the endpoint",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{1,12}$",
+      "title": "Creation timestamp of the endpoint",
+      "type": "string"
+    },
+    "properties": {
+      "title": "Properties of the endpoint",
+      "type": "object",
+      "oneOf": [
+        {
+          "title": "Camel properties",
+          "type": "object",
+          "required": [
+            "disable_ssl_verification",
+            "url"
+          ],
+          "properties": {
+            "disable_ssl_verification": {
+              "$ref": "#/definitions/disable_ssl_verification"
+            },
+            "url": {
+              "$ref": "#/definitions/url"
+            },
+            "basic_authentication": {
+              "$ref": "#/definitions/basic-authentication"
+            },
+            "bearer_authentication": {
+              "$ref": "#/definitions/bearer-authentication"
+            },
+            "secret_token": {
+              "$ref": "#/definitions/secret-token"
+            }
+          }
+        },
+        {
+          "title": "System subscription properties",
+          "type": "object",
+          "required": [
+            "ignore_preferences",
+            "only_admins"
+          ],
+          "properties": {
+            "ignore_preferences": {
+              "title": "Ignore the user preferences?",
+              "type": "boolean"
+            },
+            "only_admins": {
+              "title": "Is the email only for administrators",
+              "type": "boolean"
+            },
+            "group_id": {
+              "format": "uuid",
+              "title": "The identifier of the group to send the email to",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "title": "Webhook properties",
+          "type": "object",
+          "required": [
+            "disable_ssl_verification",
+            "method",
+            "url"
+          ],
+          "properties": {
+            "disable_ssl_verification": {
+              "$ref": "#/definitions/disable_ssl_verification"
+            },
+            "method": {
+              "$ref": "#/definitions/http-method"
+            },
+            "url": {
+              "$ref": "#/definitions/url"
+            },
+            "basic_authentication": {
+              "$ref": "#/definitions/basic-authentication"
+            },
+            "bearer_authentication": {
+              "$ref": "#/definitions/bearer-authentication"
+            },
+            "secret_token": {
+              "$ref": "#/definitions/secret-token"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "disable_ssl_verification": {
+      "title": "Definition of the endpoint properties' disable ssl verification object",
+      "type": "boolean"
+    },
+    "http-method": {
+      "enum": [
+        "get",
+        "post",
+        "put"
+      ],
+      "title": "Definition of the endpoint properties' HTTP method object",
+      "type": "string"
+    },
+    "url": {
+      "format": "url",
+      "title": "Definition of the endpoint properties' URL object",
+      "type": "string"
+    },
+    "basic-authentication": {
+      "title": "Definition of the endpoint properties' basic authentication object",
+      "type": "object",
+      "required": [
+        "username",
+        "password"
+      ],
+      "properties": {
+        "username": {
+          "minLength": 1,
+          "title": "Username of the basic authentication object",
+          "type": "string"
+        },
+        "password": {
+          "minLength": 1,
+          "title": "Password of the basic authentication object",
+          "type": "string"
+        }
+      }
+    },
+    "bearer-authentication": {
+      "minLength": 1,
+      "title": "Definition of the endpoint properties' bearer token object",
+      "type": "string"
+    },
+    "secret-token": {
+      "minLength": 1,
+      "title": "Definition of the endpoint properties' secret token object",
+      "type": "string"
+    }
+  }
+}

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -58,6 +58,19 @@
             <version>${redhat.event-schemas.version}</version>
         </dependency>
 
+        <!-- MapStruct -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -1,0 +1,160 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.CamelPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.EndpointPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.SystemSubscriptionPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.WebhookPropertiesDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class EndpointDTO {
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private UUID id;
+
+    @NotNull
+    @Size(max = 255)
+    private String name;
+
+    @NotNull
+    private String description;
+
+    private Boolean enabled;
+
+    @NotNull
+    private EndpointStatusDTO status;
+
+    @Min(0)
+    private int serverErrors;
+
+    @NotNull
+    private EndpointTypeDTO type;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Size(max = 20)
+    private String subType;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private LocalDateTime created;
+
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "camel"),
+        @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "drawer"),
+        @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "email_subscription"),
+        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "ansible"),
+        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "webhook")
+    })
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type",
+        include = JsonTypeInfo.As.EXTERNAL_PROPERTY)
+    @Valid
+    private EndpointPropertiesDTO properties;
+
+    public EndpointDTO() { }
+
+    @JsonIgnore
+    @AssertTrue(message = "This type requires a sub_type")
+    private boolean isSubTypePresentWhenRequired() {
+        return !this.type.requiresSubType || this.subType != null;
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "This type does not support sub_type")
+    private boolean isSubTypeNotPresentWhenNotRequired() {
+        return this.type.requiresSubType || this.subType == null;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(final String description) {
+        this.description = description;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(final Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public EndpointStatusDTO getStatus() {
+        return status;
+    }
+
+    public void setStatus(final EndpointStatusDTO status) {
+        this.status = status;
+    }
+
+    public int getServerErrors() {
+        return serverErrors;
+    }
+
+    public void setServerErrors(final int serverErrors) {
+        this.serverErrors = serverErrors;
+    }
+
+    public EndpointTypeDTO getType() {
+        return type;
+    }
+
+    public void setType(final EndpointTypeDTO type) {
+        this.type = type;
+    }
+
+    public String getSubType() {
+        return subType;
+    }
+
+    public void setSubType(final String subType) {
+        this.subType = subType;
+    }
+
+    public LocalDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(final LocalDateTime created) {
+        this.created = created;
+    }
+
+    public EndpointPropertiesDTO getProperties() {
+        return properties;
+    }
+
+    public void setProperties(final EndpointPropertiesDTO properties) {
+        this.properties = properties;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointStatusDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointStatusDTO.java
@@ -1,0 +1,10 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint;
+
+public enum EndpointStatusDTO {
+    DELETING,
+    FAILED,
+    NEW,
+    PROVISIONING,
+    READY, // 0, default for existing ones
+    UNKNOWN
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
@@ -1,0 +1,24 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum EndpointTypeDTO {
+    ANSIBLE(false, false),
+    CAMEL(true, false),
+    DRAWER(false, true),
+    EMAIL_SUBSCRIPTION(false, true),
+    WEBHOOK(false, false);
+
+    public final boolean requiresSubType;
+    public final boolean isSystemEndpointType;
+
+    EndpointTypeDTO(boolean requiresSubType, boolean isSystemEndpointType) {
+        this.requiresSubType = requiresSubType;
+        this.isSystemEndpointType = isSystemEndpointType;
+    }
+
+    @JsonValue
+    public String toLowerCase() {
+        return this.toString().toLowerCase();
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
@@ -1,0 +1,66 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
+
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets.BasicAuthenticationDTO;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.Map;
+
+public final class CamelPropertiesDTO extends EndpointPropertiesDTO {
+    @NotNull
+    private Boolean disableSslVerification = Boolean.FALSE;
+
+    private Map<String, String> extras;
+
+    @NotNull
+    @ValidNonPrivateUrl
+    private String url;
+
+    private BasicAuthenticationDTO basicAuthentication;
+
+    @Size(max = 255)
+    private String secretToken;
+
+    public CamelPropertiesDTO() { }
+
+    public Boolean getDisableSslVerification() {
+        return disableSslVerification;
+    }
+
+    public void setDisableSslVerification(final Boolean disableSslVerification) {
+        this.disableSslVerification = disableSslVerification;
+    }
+
+    public Map<String, String> getExtras() {
+        return extras;
+    }
+
+    public void setExtras(final Map<String, String> extras) {
+        this.extras = extras;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    public BasicAuthenticationDTO getBasicAuthentication() {
+        return basicAuthentication;
+    }
+
+    public void setBasicAuthentication(final BasicAuthenticationDTO basicAuthentication) {
+        this.basicAuthentication = basicAuthentication;
+    }
+
+    public String getSecretToken() {
+        return secretToken;
+    }
+
+    public void setSecretToken(final String secretToken) {
+        this.secretToken = secretToken;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/EndpointPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/EndpointPropertiesDTO.java
@@ -1,0 +1,8 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public abstract class EndpointPropertiesDTO {
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
@@ -1,0 +1,41 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public final class SystemSubscriptionPropertiesDTO extends EndpointPropertiesDTO {
+    private UUID groupId;
+
+    @NotNull
+    private boolean ignorePreferences;
+
+    @NotNull
+    private boolean onlyAdmins;
+
+    public SystemSubscriptionPropertiesDTO() { }
+
+    public UUID getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(final UUID groupId) {
+        this.groupId = groupId;
+    }
+
+    public boolean isIgnorePreferences() {
+        return ignorePreferences;
+    }
+
+    public void setIgnorePreferences(final boolean ignorePreferences) {
+        this.ignorePreferences = ignorePreferences;
+    }
+
+    public boolean isOnlyAdmins() {
+        return onlyAdmins;
+    }
+
+    public void setOnlyAdmins(final boolean onlyAdmins) {
+        this.onlyAdmins = onlyAdmins;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
@@ -1,0 +1,84 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.redhat.cloud.notifications.models.HttpType;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets.BasicAuthenticationDTO;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public final class WebhookPropertiesDTO extends EndpointPropertiesDTO {
+    @NotNull
+    @JsonProperty("disable_ssl_verification")
+    private Boolean disableSslVerification = Boolean.FALSE;
+
+    @NotNull
+    private HttpType method;
+
+    @NotNull
+    @ValidNonPrivateUrl
+    private String url;
+
+    @JsonProperty("basic_authentication")
+    @Valid
+    private BasicAuthenticationDTO basicAuthentication;
+
+    @JsonProperty("bearer_authentication")
+    private String bearerAuthentication;
+
+
+    @Size(max = 255)
+    @JsonProperty("secret_token")
+    private String secretToken;
+
+    public WebhookPropertiesDTO() { }
+
+    public Boolean getDisableSslVerification() {
+        return disableSslVerification;
+    }
+
+    public void setDisableSslVerification(final Boolean disableSslVerification) {
+        this.disableSslVerification = disableSslVerification;
+    }
+
+    public HttpType getMethod() {
+        return method;
+    }
+
+    public void setMethod(final HttpType method) {
+        this.method = method;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    public BasicAuthenticationDTO getBasicAuthentication() {
+        return basicAuthentication;
+    }
+
+    public void setBasicAuthentication(final BasicAuthenticationDTO basicAuthentication) {
+        this.basicAuthentication = basicAuthentication;
+    }
+
+    public String getBearerAuthentication() {
+        return bearerAuthentication;
+    }
+
+    public void setBearerAuthentication(final String bearerAuthentication) {
+        this.bearerAuthentication = bearerAuthentication;
+    }
+
+    public String getSecretToken() {
+        return secretToken;
+    }
+
+    public void setSecretToken(final String secretToken) {
+        this.secretToken = secretToken;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/secrets/BasicAuthenticationDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/secrets/BasicAuthenticationDTO.java
@@ -1,0 +1,27 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets;
+
+public final class BasicAuthenticationDTO {
+    private String username;
+    private String password;
+
+    public BasicAuthenticationDTO(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(final String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapper.java
@@ -1,0 +1,141 @@
+package com.redhat.cloud.notifications.models.mappers.v1.endpoint;
+
+import com.redhat.cloud.notifications.models.CamelProperties;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointProperties;
+import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
+import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.CamelPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.EndpointPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.SystemSubscriptionPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.WebhookPropertiesDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.Named;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.CDI)
+public interface EndpointMapper {
+    /**
+     * Maps an internal endpoint's entity into a DTO.
+     * @param endpoint the internal entity to map.
+     * @return the mapped DTO.
+     */
+    @Mapping(source = "properties", target = "properties", qualifiedByName = "mapEntityProperties")
+    EndpointDTO toDTO(Endpoint endpoint);
+
+    /**
+     * Maps an endpoint's DTO to an internal entity.
+     * @param endpoint the DTO to map.
+     * @return the mapped internal entity.
+     */
+    @Mapping(source = "properties", target = "properties", qualifiedByName = "mapDTOProperties")
+    @Mapping(target = "accountId", ignore = true)
+    @Mapping(target = "behaviorGroupActions", ignore = true)
+    @Mapping(target = "notificationHistories", ignore = true)
+    @Mapping(target = "orgId", ignore = true)
+    @Mapping(target = "updated", ignore = true)
+    Endpoint toEntity(EndpointDTO endpoint);
+
+    /**
+     * Maps a camel properties' internal entity to a DTO.
+     * @param camelProperties the internal entity to map.
+     * @return the mapped DTO.
+     */
+    CamelPropertiesDTO camelToDTO(CamelProperties camelProperties);
+
+    /**
+     * Maps a camel properties' DTO into an internal entity.
+     * @param camelPropertiesDTO the DTO to map.
+     * @return the mapped internal entity.
+     */
+    @Mapping(target = "basicAuthenticationSourcesId", ignore = true)
+    @Mapping(target = "bearerAuthentication", ignore = true)
+    @Mapping(target = "bearerAuthenticationSourcesId", ignore = true)
+    @Mapping(target = "endpoint", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "secretTokenSourcesId", ignore = true)
+    CamelProperties camelToEntity(CamelPropertiesDTO camelPropertiesDTO);
+
+    /**
+     * Maps a system subscription properties' internal entity into a DTO.
+     * @param systemSubscriptionProperties the internal entity to map.
+     * @return the mapped DTO.
+     */
+    SystemSubscriptionPropertiesDTO systemToDTO(SystemSubscriptionProperties systemSubscriptionProperties);
+
+    /**
+     * Maps a system subscription properties' DTO into an internal entity.
+     * @param systemSubscriptionPropertiesDTO the DTO to map.
+     * @return thue mapped internal entity.
+     */
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "endpoint", ignore = true)
+    SystemSubscriptionProperties systemToEntity(SystemSubscriptionPropertiesDTO systemSubscriptionPropertiesDTO);
+
+    /**
+     * Maps a webhook properties' internal entity into a DTO.
+     * @param webhookProperties the internal entity to map.
+     * @return the mapped DTO.
+     */
+    WebhookPropertiesDTO webhookToDTO(WebhookProperties webhookProperties);
+
+    /**
+     * Maps a webhook properties DTO into an internal entity.
+     * @param webhookPropertiesDTO the DTO to map.
+     * @return the mapped internal entity.
+     */
+    @Mapping(target = "basicAuthenticationSourcesId", ignore = true)
+    @Mapping(target = "bearerAuthenticationSourcesId", ignore = true)
+    @Mapping(target = "endpoint", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "secretTokenSourcesId", ignore = true)
+    WebhookProperties webhookToEntity(WebhookPropertiesDTO webhookPropertiesDTO);
+
+    /**
+     * Maps the internal endpoint properties' entity into one of the more specific classes that extend it, and then
+     * maps them into an endpoint properties' DTO.
+     * @param endpointProperties the internal entity to map.
+     * @return the mapped DTO.
+     */
+    @Named("mapEntityProperties")
+    default EndpointPropertiesDTO mapEntityProperties(final EndpointProperties endpointProperties) {
+        if (endpointProperties == null) {
+            return null;
+        }
+
+        if (endpointProperties instanceof CamelProperties properties) {
+            return this.camelToDTO(properties);
+        } else if (endpointProperties instanceof SystemSubscriptionProperties properties) {
+            return this.systemToDTO(properties);
+        } else if (endpointProperties instanceof WebhookProperties properties) {
+            return this.webhookToDTO(properties);
+        } else {
+            throw new IllegalStateException("Invalid endpoint properties mapped to class");
+        }
+    }
+
+    /**
+     * Maps the generic endpoint properties' DTO into one of the more specific classes that extend it, and then maps
+     * them into an endpoint properties entity.
+     * @param endpointPropertiesDTO the DTO to map.
+     * @return the mapped internal entity.
+     */
+    @Named("mapDTOProperties")
+    default EndpointProperties mapDTOProperties(final EndpointPropertiesDTO endpointPropertiesDTO) {
+        if (endpointPropertiesDTO == null) {
+            return null;
+        }
+
+        if (endpointPropertiesDTO instanceof CamelPropertiesDTO properties) {
+            return this.camelToEntity(properties);
+        } else if (endpointPropertiesDTO instanceof SystemSubscriptionPropertiesDTO properties) {
+            return this.systemToEntity(properties);
+        } else if (endpointPropertiesDTO instanceof WebhookPropertiesDTO properties) {
+            return this.webhookToEntity(properties);
+        } else {
+            throw new IllegalStateException("Invalid endpoint properties mapped to class");
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,9 @@
     </profiles>
 
     <properties>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <json-schema-validator.version>1.3.3</json-schema-validator.version>
+
         <enforcer-plugin.version>3.4.1</enforcer-plugin.version>
         <maven-minimum-version>3.8.4</maven-minimum-version>
         <java-version>17</java-version>


### PR DESCRIPTION
Using DTOs will help us decouple the internal model from the model exposed to the clients, which will give us freedom to perform internal changes without fear of affecting anyone who is integrated with us.

## Jira ticket
[[RHCLOUD-31165]](https://issues.redhat.com/browse/RHCLOUD-31165)