### PR TITLE
RHCLOUD-31165 | feature: use DTOs for the Endpoint model

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -147,19 +147,6 @@
             <version>${quarkus-logging-cloudwatch.version}</version>
         </dependency>
 
-        <!-- MapStruct -->
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct</artifactId>
-            <version>${mapstruct.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
-            <version>${mapstruct.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>json-schema-validator</artifactId>
@@ -272,6 +259,20 @@
                         <includeOnlyProperty>git.commit.id.abbrev</includeOnlyProperty>
                     </includeOnlyProperties>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -217,6 +217,15 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -262,20 +271,6 @@
                         <includeOnlyProperty>git.commit.id.abbrev</includeOnlyProperty>
                     </includeOnlyProperties>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler-plugin.version}</version>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.mapstruct</groupId>
-                            <artifactId>mapstruct-processor</artifactId>
-                            <version>${mapstruct.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -13,6 +13,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <json-schema-validator-tests.version>3.3.0</json-schema-validator-tests.version>
+    </properties>
+
     <dependencies>
 
         <!-- notifications modules -->
@@ -147,19 +151,18 @@
             <version>${quarkus-logging-cloudwatch.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>3.3.0</version>
-            <scope>test</scope>
-        </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.redhat.cloud.notifications</groupId>
             <artifactId>notifications-common</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>${json-schema-validator-tests.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -147,6 +147,26 @@
             <version>${quarkus-logging-cloudwatch.version}</version>
         </dependency>
 
+        <!-- MapStruct -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.redhat.cloud.notifications</groupId>

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EndpointPage.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/EndpointPage.java
@@ -1,17 +1,17 @@
 package com.redhat.cloud.notifications.routers.models;
 
-import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointDTO;
 
 import java.util.List;
 import java.util.Map;
 
-public class EndpointPage extends Page<Endpoint> {
+public class EndpointPage extends Page<EndpointDTO> {
 
     public EndpointPage() {
         super();
     }
 
-    public EndpointPage(List<Endpoint> data, Map<String, String> links, Meta meta) {
+    public EndpointPage(List<EndpointDTO> data, Map<String, String> links, Meta meta) {
         super(data, links, meta);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.db;
 
+import com.redhat.cloud.notifications.db.model.Stats;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.db.repositories.BehaviorGroupRepository;
 import com.redhat.cloud.notifications.db.repositories.BundleRepository;
@@ -176,9 +177,9 @@ public class ResourceHelpers {
         return endpointRepository.createEndpoint(endpoint);
     }
 
-    public int[] createTestEndpoints(String accountId, String orgId, int count) {
-        int[] statsValues = new int[3];
-        statsValues[0] = count;
+    public Stats createTestEndpoints(String accountId, String orgId, int count) {
+        final Stats stats = new Stats(count);
+
         for (int i = 0; i < count; i++) {
             // Add new endpoints
             WebhookProperties properties = new WebhookProperties();
@@ -191,11 +192,11 @@ public class ResourceHelpers {
             ep.setDescription("Automatically generated");
             boolean enabled = (i % (count / 5)) != 0;
             if (!enabled) {
-                statsValues[1]++;
+                stats.increaseDisabledCount();
             }
             ep.setEnabled(enabled);
             if (i > 0) {
-                statsValues[2]++;
+                stats.increaseWebhookCount();
                 ep.setProperties(properties);
             }
 
@@ -203,7 +204,7 @@ public class ResourceHelpers {
             ep.setOrgId(orgId);
             endpointRepository.createEndpoint(ep);
         }
-        return statsValues;
+        return stats;
     }
 
     public NotificationHistory createNotificationHistory(Event event, Endpoint endpoint, NotificationStatus status) {
@@ -354,7 +355,7 @@ public class ResourceHelpers {
 
                 final CamelProperties camelProperties = new CamelProperties();
                 camelProperties.setDisableSslVerification(random.nextBoolean());
-                camelProperties.setUrl("https://example.org");
+                camelProperties.setUrl("https://redhat.com");
 
                 // Maybe set a basic authentication, maybe not...
                 if (i % 3 == 0) {
@@ -381,7 +382,7 @@ public class ResourceHelpers {
                 final WebhookProperties webhookProperties = new WebhookProperties();
                 webhookProperties.setDisableSslVerification(random.nextBoolean());
                 webhookProperties.setMethod(HttpType.GET);
-                webhookProperties.setUrl("https://example.org");
+                webhookProperties.setUrl("https://redhat.com");
 
                 // Maybe set a basic authentication, maybe not...
                 if (i % 3 == 0) {
@@ -429,7 +430,7 @@ public class ResourceHelpers {
         for (int i = 0; i < 5; i++) {
             final CamelProperties camelProperties = new CamelProperties();
             camelProperties.setDisableSslVerification(random.nextBoolean());
-            camelProperties.setUrl("https://example.org");
+            camelProperties.setUrl("https://redhat.com");
 
             camelProperties.setBasicAuthentication(
                 new BasicAuthentication(UUID.randomUUID().toString(), UUID.randomUUID().toString())
@@ -454,7 +455,7 @@ public class ResourceHelpers {
             final WebhookProperties webhookProperties = new WebhookProperties();
             webhookProperties.setDisableSslVerification(random.nextBoolean());
             webhookProperties.setMethod(HttpType.GET);
-            webhookProperties.setUrl("https://example.org");
+            webhookProperties.setUrl("https://redhat.com");
 
             webhookProperties.setBasicAuthentication(
                 new BasicAuthentication(UUID.randomUUID().toString(), UUID.randomUUID().toString())
@@ -519,7 +520,7 @@ public class ResourceHelpers {
                 camelProperties.setBasicAuthentication(getRandomBasicAuth.get());
                 camelProperties.setDisableSslVerification(random.nextBoolean());
                 camelProperties.setSecretToken(UUID.randomUUID().toString());
-                camelProperties.setUrl("https://example.org");
+                camelProperties.setUrl("https://redhat.com");
 
                 endpoint.setProperties(camelProperties);
             } else {
@@ -530,7 +531,7 @@ public class ResourceHelpers {
                 webhookProperties.setDisableSslVerification(random.nextBoolean());
                 webhookProperties.setMethod(HttpType.GET);
                 webhookProperties.setSecretToken(UUID.randomUUID().toString());
-                webhookProperties.setUrl("https://example.org");
+                webhookProperties.setUrl("https://redhat.com");
 
                 endpoint.setProperties(webhookProperties);
             }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/model/Stats.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/model/Stats.java
@@ -1,0 +1,38 @@
+package com.redhat.cloud.notifications.db.model;
+
+import com.redhat.cloud.notifications.routers.EndpointResourceTest;
+
+/**
+ * A helper class for the {@link com.redhat.cloud.notifications.db.ResourceHelpers#createTestEndpoints(String, String, int)}
+ * function. It then gets used in {@link EndpointResourceTest#testSortingOrder()} and {@link EndpointResourceTest#testActive()}.
+ */
+public final class Stats {
+    private final int createdEndpointsCount;
+    private int disabledCount;
+    private int webhookCount;
+
+    public Stats(final int createdEndpointsCount) {
+        this.createdEndpointsCount = createdEndpointsCount;
+        this.disabledCount = 0;
+    }
+
+    public int getCreatedEndpointsCount() {
+        return this.createdEndpointsCount;
+    }
+
+    public void increaseDisabledCount() {
+        this.disabledCount++;
+    }
+
+    public int getDisabledCount() {
+        return this.disabledCount;
+    }
+
+    public int getWebhookCount() {
+        return this.webhookCount;
+    }
+
+    public void increaseWebhookCount() {
+        this.webhookCount++;
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/model/Stats.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/model/Stats.java
@@ -13,7 +13,6 @@ public final class Stats {
 
     public Stats(final int createdEndpointsCount) {
         this.createdEndpointsCount = createdEndpointsCount;
-        this.disabledCount = 0;
     }
 
     public int getCreatedEndpointsCount() {

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -17,6 +17,9 @@ import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.NotificationStatus;
 import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.WebhookPropertiesDTO;
+import com.redhat.cloud.notifications.models.mappers.v1.endpoint.EndpointMapper;
 import com.redhat.cloud.notifications.routers.internal.models.AddApplicationRequest;
 import com.redhat.cloud.notifications.routers.internal.models.RequestDefaultBehaviorGroupPropertyList;
 import com.redhat.cloud.notifications.routers.models.RequestSystemSubscriptionProperties;
@@ -85,6 +88,9 @@ public class LifecycleITest extends DbIsolatedTest {
     private static final String EVENT_TYPE_NAME = "all";
     private static final String WEBHOOK_MOCK_PATH = "/test/lifecycle";
     private static final String SECRET_TOKEN = "super-secret-token";
+
+    @Inject
+    EndpointMapper endpointMapper;
 
     @Inject
     EntityManager entityManager;
@@ -555,7 +561,7 @@ public class LifecycleITest extends DbIsolatedTest {
                 .basePath(API_INTEGRATIONS_V_1_0)
                 .header(identityHeader)
                 .contentType(JSON)
-                .body(Json.encode(endpoint))
+                .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
                 .when()
                 .post("/endpoints")
                 .then()
@@ -564,7 +570,7 @@ public class LifecycleITest extends DbIsolatedTest {
                 .extract().body().asString();
 
         JsonObject jsonEndpoint = new JsonObject(responseBody);
-        jsonEndpoint.mapTo(Endpoint.class);
+        jsonEndpoint.mapTo(EndpointDTO.class);
         assertNotNull(jsonEndpoint.getString("id"));
         assertNull(jsonEndpoint.getString("accountId"));
         assertNull(jsonEndpoint.getString("orgId"));
@@ -598,8 +604,8 @@ public class LifecycleITest extends DbIsolatedTest {
 
         JsonArray jsonEndpoints = new JsonObject(responseBody).getJsonArray("data");
         assertEquals(expectedEndpointIds.length, jsonEndpoints.size());
-        jsonEndpoints.getJsonObject(0).mapTo(Endpoint.class);
-        jsonEndpoints.getJsonObject(0).getJsonObject("properties").mapTo(WebhookProperties.class);
+        jsonEndpoints.getJsonObject(0).mapTo(EndpointDTO.class);
+        jsonEndpoints.getJsonObject(0).getJsonObject("properties").mapTo(WebhookPropertiesDTO.class);
 
         for (String endpointId : expectedEndpointIds) {
             if (!responseBody.contains(endpointId)) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
@@ -1,0 +1,298 @@
+package com.redhat.cloud.notifications.models.mappers.v1.endpoint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import com.redhat.cloud.notifications.models.BasicAuthentication;
+import com.redhat.cloud.notifications.models.CamelProperties;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointProperties;
+import com.redhat.cloud.notifications.models.EndpointStatus;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.HttpType;
+import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
+import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointStatusDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointTypeDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.CamelPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.WebhookPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets.BasicAuthenticationDTO;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@QuarkusTest
+public class EndpointMapperTest {
+    private static final String ENDPOINT_CAMEL_CREATE_JSON = "json-schemas/v1/endpoint/implementations/create/endpoint-camel.json";
+    private static final String ENDPOINT_WEBHOOK_CREATE_JSON = "json-schemas/v1/endpoint/implementations/create/endpoint-webhook.json";
+    private static final String SCHEMA_PATH_ENDPOINT_CREATE = "json-schemas/v1/endpoint/endpoint-schema-create.json";
+    private static final String SCHEMA_PATH_ENDPOINT_READ = "json-schemas/v1/endpoint/endpoint-schema-read.json";
+
+    final EndpointMapper endpointMapper;
+    /**
+     * Schema to use when we want to validate the "endpoint create" payloads.
+     */
+    final JsonSchema schemaEndpointCreate;
+    /**
+     * Schema to use when we want to validate the "endpoint read" payloads.
+     */
+    final JsonSchema schemaEndpointRead;
+    final ObjectMapper objectMapper;
+
+    /**
+     * Create the EndpointMapperTest class.
+     * @param endpointMapper the endpoint mapper to be injected.
+     * @param objectMapper the object mapper to be injected.
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    public EndpointMapperTest(
+        EndpointMapper endpointMapper,
+        ObjectMapper objectMapper
+    ) throws IOException, URISyntaxException {
+        this.endpointMapper = endpointMapper;
+        this.objectMapper = objectMapper;
+
+        // Load the JSON Schema.
+        final JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+
+        // Create the corresponding schemas.
+        final String schemaContentsEndpointCreate = this.readStringFromClasspathResource(SCHEMA_PATH_ENDPOINT_CREATE);
+        this.schemaEndpointCreate = jsonSchemaFactory.getSchema(schemaContentsEndpointCreate);
+
+        final String schemaContentsEndpointRead = this.readStringFromClasspathResource(SCHEMA_PATH_ENDPOINT_READ);
+        this.schemaEndpointRead = jsonSchemaFactory.getSchema(schemaContentsEndpointRead);
+    }
+
+    /**
+     * Prior to the introduction of MapStruct and DTOs into the project, the {@link Endpoint}
+     * class was being used as the exposed model to clients. This tests ensures that the introduction of DTOs and
+     * mappers did not change the model exposed to the clients.
+     * @throws IOException if the JSON schema's contents could not be read.
+     * @throws URISyntaxException if the JSON schema's path is wrong.
+     */
+    @Test
+    void testEndpointMapperToDTO() throws IOException, URISyntaxException {
+        // Prepare the endpoint we will convert to DTO to.
+        final Endpoint endpoint = new Endpoint();
+
+        endpoint.setId(UUID.randomUUID());
+        endpoint.setName("endpoint name");
+        endpoint.setDescription("endpoint description");
+        endpoint.setEnabled(true);
+        endpoint.setServerErrors(12);
+        endpoint.setType(EndpointType.CAMEL);
+        endpoint.setSubType("slack");
+        endpoint.setCreated(LocalDateTime.now());
+
+        final CamelProperties camelProperties = new CamelProperties();
+        camelProperties.setDisableSslVerification(false);
+        camelProperties.setUrl("https://redhat.com");
+        camelProperties.setBasicAuthentication(new BasicAuthentication("username", "password"));
+        camelProperties.setSecretToken("secret-token");
+
+        final SystemSubscriptionProperties systemSubscriptionProperties = new SystemSubscriptionProperties();
+        systemSubscriptionProperties.setGroupId(UUID.randomUUID());
+        systemSubscriptionProperties.setIgnorePreferences(false);
+        systemSubscriptionProperties.setOnlyAdmins(false);
+
+        final WebhookProperties webhookProperties = new WebhookProperties();
+        webhookProperties.setDisableSslVerification(false);
+        webhookProperties.setMethod(HttpType.POST);
+        webhookProperties.setUrl("https://redhat.com");
+        webhookProperties.setBasicAuthentication(new BasicAuthentication("username", "password"));
+        webhookProperties.setBearerAuthentication("bearer authentication");
+        webhookProperties.setSecretToken("secret token");
+
+        // Loop through the properties and generate the JSON for the DTO.
+        for (final EndpointProperties properties : List.of(camelProperties, systemSubscriptionProperties, webhookProperties)) {
+            endpoint.setProperties(properties);
+
+            // Generate the DTO.
+            final EndpointDTO endpointDTO = this.endpointMapper.toDTO(endpoint);
+
+            // Turn it into JSON and validate it against the schema.
+            final Set<ValidationMessage> validationMessages = this.schemaEndpointRead.validate(this.objectMapper.valueToTree(endpointDTO));
+
+            // Any errors are unexpected since the resulting JSON should be conforming to the defined schema.
+            this.assertNoSchemaValidationErrors(validationMessages);
+        }
+    }
+
+    /**
+     * Test that a payload which conforms to the endpoint schema is properly
+     * deserialized into a DTO, and that then that DTO gets properly mapped to
+     * an internal entity.
+     * @throws IOException if the JSON file cannot be read.
+     * @throws URISyntaxException if the path to the JSON file is incorrect.
+     */
+    @Test
+    void testEndpointMapperCamelToDTOToEntity() throws IOException, URISyntaxException {
+        final String endpointCamelJSON = this.readStringFromClasspathResource(ENDPOINT_CAMEL_CREATE_JSON);
+
+        // Assert that the JSON file complies with the defined schema.
+        final Set<ValidationMessage> validationMessages = this.schemaEndpointCreate.validate(this.objectMapper.readTree(endpointCamelJSON));
+        this.assertNoSchemaValidationErrors(validationMessages);
+
+        // Attempt reading the JSON into a DTO, which should succeed.
+        final EndpointDTO dto = this.objectMapper.readValue(endpointCamelJSON, EndpointDTO.class);
+
+        // Assert that the DTO was properly built.
+        Assertions.assertEquals("Camel endpoint", dto.getName(), "the name of the endpoint was not properly deserialized");
+        Assertions.assertEquals("A JSON structure which represents a camel endpoint", dto.getDescription(), "the description of the endpoint was not properly deserialized");
+        Assertions.assertTrue(dto.getEnabled(), "the \"enabled\" status of the endpoint was not properly deserialized");
+        Assertions.assertEquals(EndpointStatusDTO.READY, dto.getStatus(), "the status of the endpoint was not properly deserialized");
+        Assertions.assertEquals(23, dto.getServerErrors(), "the number of server errors of the endpoint were not properly deserialized");
+        Assertions.assertEquals("slack", dto.getSubType(), "the subtype of the endpoint was not properly deserialized");
+        Assertions.assertEquals(EndpointTypeDTO.CAMEL, dto.getType(), "the type of the endpoint was not properly deserialized");
+
+        // Assert that the endpoint's properties were correctly deserialized.
+        Assertions.assertInstanceOf(CamelPropertiesDTO.class, dto.getProperties(), "the properties of the camel endpoint were not properly deserialized as camel properties");
+        final CamelPropertiesDTO camelPropertiesDTO = (CamelPropertiesDTO) dto.getProperties();
+
+        Assertions.assertTrue(camelPropertiesDTO.getDisableSslVerification(), "the \"disable SSL verification\" flag was not properly deserialized");
+        Assertions.assertEquals("my-slack-channel", camelPropertiesDTO.getExtras().get("channel"), "the \"channel\" property from the \"extras\" was not properly deserialized");
+        Assertions.assertEquals("https://redhat.com", camelPropertiesDTO.getUrl(), "the url was not properly deserialized");
+
+        final BasicAuthenticationDTO basicAuthenticationDTO = camelPropertiesDTO.getBasicAuthentication();
+        Assertions.assertNotNull(basicAuthenticationDTO, "the basic authentication object was not properly deserialized");
+        Assertions.assertEquals("camel-user", basicAuthenticationDTO.getUsername(), "the username of the basic authentication object was not properly deserialized");
+        Assertions.assertEquals("camel-pass", basicAuthenticationDTO.getPassword(), "the password of the basic authentication object was not properly deserialized");
+
+        Assertions.assertEquals("c4m3l-up3r-s3cr3t-t0k3n", camelPropertiesDTO.getSecretToken(), "the secret token was not properly deserialized");
+
+        final Endpoint entity = this.endpointMapper.toEntity(dto);
+
+        // Assert that the entity was properly mapped.
+        Assertions.assertEquals("Camel endpoint", entity.getName(), "the name of the endpoint was not properly mapped");
+        Assertions.assertEquals("A JSON structure which represents a camel endpoint", entity.getDescription(), "the description of the endpoint was not properly mapped");
+        Assertions.assertTrue(entity.isEnabled(), "the \"enabled\" status of the endpoint was not properly mapped");
+        Assertions.assertEquals(EndpointStatus.READY, entity.getStatus(), "the status of the endpoint was not properly mapped");
+        Assertions.assertEquals(23, entity.getServerErrors(), "the number of server errors of the endpoint were not properly mapped");
+        Assertions.assertEquals("slack", entity.getSubType(), "the subtype of the endpoint was not properly mapped");
+        Assertions.assertEquals(EndpointType.CAMEL, entity.getType(), "the type of the endpoint was not properly mapped");
+
+        // Assert that the endpoint's properties were correctly mapped.
+        Assertions.assertInstanceOf(CamelProperties.class, entity.getProperties(), "the properties of the camel endpoint were not properly mapped as camel properties");
+        final CamelProperties camelProperties = (CamelProperties) entity.getProperties();
+
+        Assertions.assertTrue(camelProperties.getDisableSslVerification(), "the \"disable SSL verification\" flag was not properly mapped");
+        Assertions.assertEquals("my-slack-channel", camelProperties.getExtras().get("channel"), "the \"channel\" property from the \"extras\" was not properly mapped");
+        Assertions.assertEquals("https://redhat.com", camelProperties.getUrl(), "the url was not properly mapped");
+
+        final BasicAuthentication basicAuthentication = camelProperties.getBasicAuthentication();
+        Assertions.assertNotNull(basicAuthentication, "the basic authentication object was not properly mapped");
+        Assertions.assertEquals("camel-user", basicAuthentication.getUsername(), "the username of the basic authentication object was not properly mapped");
+        Assertions.assertEquals("camel-pass", basicAuthentication.getPassword(), "the password of the basic authentication object was not properly mapped");
+
+        Assertions.assertEquals("c4m3l-up3r-s3cr3t-t0k3n", camelProperties.getSecretToken(), "the secret token was not properly mapped");
+    }
+
+    /**
+     * Test that a payload which conforms to the endpoint schema is properly
+     * deserialized into a DTO, and that then that DTO gets properly mapped to
+     * an internal entity.
+     * @throws IOException if the JSON file cannot be read.
+     * @throws URISyntaxException if the path to the JSON file is incorrect.
+     */
+    @Test
+    void testEndpointMapperWebhookToDTOToEntity() throws IOException, URISyntaxException {
+        final String endpointWebhookJson = this.readStringFromClasspathResource(ENDPOINT_WEBHOOK_CREATE_JSON);
+
+        // Assert that the JSON file complies with the defined schema.
+        final Set<ValidationMessage> validationMessages = this.schemaEndpointCreate.validate(this.objectMapper.readTree(endpointWebhookJson));
+        this.assertNoSchemaValidationErrors(validationMessages);
+
+        // Attempt reading the JSON into a DTO, which should succeed.
+        final EndpointDTO dto = this.objectMapper.readValue(endpointWebhookJson, EndpointDTO.class);
+
+        // Assert that the DTO was properly built.
+        Assertions.assertEquals("Webhook endpoint", dto.getName(), "the name of the endpoint was not properly deserialized");
+        Assertions.assertEquals("A JSON structure which represents a webhook endpoint", dto.getDescription(), "the description of the endpoint was not properly deserialized");
+        Assertions.assertTrue(dto.getEnabled(), "the \"enabled\" status of the endpoint was not properly deserialized");
+        Assertions.assertEquals(EndpointStatusDTO.READY, dto.getStatus(), "the status of the endpoint was not properly deserialized");
+        Assertions.assertEquals(12, dto.getServerErrors(), "the number of server errors of the endpoint were not properly deserialized");
+        Assertions.assertNull(dto.getSubType(), "the subtype of the endpoint was not properly deserialized");
+        Assertions.assertEquals(EndpointTypeDTO.WEBHOOK, dto.getType(), "the type of the endpoint was not properly deserialized");
+
+        // Assert that the endpoint's properties were correctly deserialized.
+        Assertions.assertInstanceOf(WebhookPropertiesDTO.class, dto.getProperties(), "the properties of the webhook endpoint were not properly deserialized as webhook properties");
+        final WebhookPropertiesDTO webhookPropertiesDTO = (WebhookPropertiesDTO) dto.getProperties();
+
+        Assertions.assertTrue(webhookPropertiesDTO.getDisableSslVerification(), "the \"disable SSL verification\" flag was not properly deserialized");
+        Assertions.assertEquals(HttpType.POST, webhookPropertiesDTO.getMethod(), "the method property was not properly deserialized");
+        Assertions.assertEquals("https://redhat.com", webhookPropertiesDTO.getUrl(), "the url was not properly deserialized");
+
+        final BasicAuthenticationDTO basicAuthenticationDTO = webhookPropertiesDTO.getBasicAuthentication();
+        Assertions.assertNotNull(basicAuthenticationDTO, "the basic authentication object was not properly deserialized");
+        Assertions.assertEquals("webhook-user", basicAuthenticationDTO.getUsername(), "the username of the basic authentication object was not properly deserialized");
+        Assertions.assertEquals("webhook-pass", basicAuthenticationDTO.getPassword(), "the password of the basic authentication object was not properly deserialized");
+
+        Assertions.assertEquals("w3bh00k-bearer-t0k3n", webhookPropertiesDTO.getBearerAuthentication(), "the bearer authentication was not properly deserialized");
+        Assertions.assertEquals("w3bh00k-sup3r-s3cr3t-t0k3n", webhookPropertiesDTO.getSecretToken(), "the secret token was not properly deserialized");
+
+        final Endpoint entity = this.endpointMapper.toEntity(dto);
+
+        // Assert that the entity was properly mapped.
+        Assertions.assertEquals("Webhook endpoint", entity.getName(), "the name of the endpoint was not properly mapped");
+        Assertions.assertEquals("A JSON structure which represents a webhook endpoint", entity.getDescription(), "the description of the endpoint was not properly mapped");
+        Assertions.assertTrue(entity.isEnabled(), "the \"enabled\" status of the endpoint was not properly mapped");
+        Assertions.assertEquals(EndpointStatus.READY, entity.getStatus(), "the status of the endpoint was not properly mapped");
+        Assertions.assertEquals(12, entity.getServerErrors(), "the number of server errors of the endpoint were not properly mapped");
+        Assertions.assertNull(entity.getSubType(), "the subtype of the endpoint was not properly mapped");
+        Assertions.assertEquals(EndpointType.WEBHOOK, entity.getType(), "the type of the endpoint was not properly mapped");
+
+        // Assert that the endpoint's properties were correctly mapped.
+        Assertions.assertInstanceOf(WebhookProperties.class, entity.getProperties(), "the properties of the webhook endpoint were not properly mapped as webhook properties");
+        final WebhookProperties webhookProperties = (WebhookProperties) entity.getProperties();
+
+        Assertions.assertTrue(webhookProperties.getDisableSslVerification(), "the \"disable SSL verification\" flag was not properly mapped");
+        Assertions.assertEquals(HttpType.POST, webhookPropertiesDTO.getMethod(), "the method property was not properly mapped");
+        Assertions.assertEquals("https://redhat.com", webhookProperties.getUrl(), "the url was not properly mapped");
+
+        final BasicAuthentication basicAuthentication = webhookProperties.getBasicAuthentication();
+        Assertions.assertNotNull(basicAuthentication, "the basic authentication object was not properly mapped");
+        Assertions.assertEquals("webhook-user", basicAuthentication.getUsername(), "the username of the basic authentication object was not properly mapped");
+        Assertions.assertEquals("webhook-pass", basicAuthentication.getPassword(), "the password of the basic authentication object was not properly mapped");
+
+        Assertions.assertEquals("w3bh00k-bearer-t0k3n", webhookProperties.getBearerAuthentication(), "the bearer authentication was not properly mapped");
+        Assertions.assertEquals("w3bh00k-sup3r-s3cr3t-t0k3n", webhookProperties.getSecretToken(), "the secret token was not properly mapped");
+    }
+
+    private void assertNoSchemaValidationErrors(final Set<ValidationMessage> validationMessages) {
+        // Any errors are unexpected since the resulting JSON should be conforming to the defined schema.
+        for (final ValidationMessage validationMessage : validationMessages) {
+            Assertions.fail(String.format("unexpected validation failure \"%s\"", validationMessage));
+        }
+    }
+
+    /**
+     * Reads the contents of a classpath resource as a string.
+     * @param resourcePath the path of the resource.
+     * @return the string contents of the resource.
+     * @throws IOException if the contents could not be read.
+     * @throws URISyntaxException if the resource's path is wrong.
+     */
+    private String readStringFromClasspathResource(final String resourcePath) throws IOException, URISyntaxException {
+        return Files.readString(
+            Paths.get(
+                Thread.currentThread()
+                    .getContextClassLoader()
+                    .getResource(resourcePath)
+                    .toURI()
+            )
+        );
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -38,7 +38,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
-import io.restassured.module.jsv.JsonSchemaValidator;
 import io.restassured.response.Response;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -552,9 +551,6 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .then()
                 .statusCode(200)
                 .contentType(JSON)
-                .and()
-                .assertThat()
-                .body(JsonSchemaValidator.matchesJsonSchemaInClasspath("json-schemas/v1/endpoint/endpoint-schema-read.json"))
                 .extract().asString();
 
         JsonObject responsePoint = new JsonObject(responseBody);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -8,6 +8,7 @@ import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.model.Stats;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.models.BasicAuthentication;
 import com.redhat.cloud.notifications.models.CamelProperties;
@@ -18,6 +19,8 @@ import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.SourcesSecretable;
 import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
 import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointDTO;
+import com.redhat.cloud.notifications.models.mappers.v1.endpoint.EndpointMapper;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidator;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrlValidatorTest;
 import com.redhat.cloud.notifications.routers.endpoints.EndpointTestRequest;
@@ -35,6 +38,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
+import io.restassured.module.jsv.JsonSchemaValidator;
 import io.restassured.response.Response;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -112,6 +116,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @InjectMock
     BackendConfig backendConfig;
+
+    @Inject
+    EndpointMapper endpointMapper;
 
     @InjectSpy
     EndpointRepository endpointRepository;
@@ -202,7 +209,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(ep))
+                .body(Json.encode(this.endpointMapper.toDTO(ep)))
                 .post("/endpoints")
                 .then()
                 .statusCode(200)
@@ -210,7 +217,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         JsonObject responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertNotNull(responsePoint.getString("id"));
         assertEquals(3, responsePoint.getInteger("server_errors"));
         assertEquals(READY.toString(), responsePoint.getString("status"));
@@ -226,7 +233,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        List<Endpoint> endpoints = endpointPage.getData();
+        List<EndpointDTO> endpointDTOS = endpointPage.getData();
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
+
         assertEquals(1, endpoints.size());
 
         // Fetch single endpoint also and verify
@@ -420,7 +435,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         JsonObject endpoint = new JsonObject(response.getBody().asString());
-        endpoint.mapTo(Endpoint.class);
+        endpoint.mapTo(EndpointDTO.class);
         return endpoint;
     }
 
@@ -532,15 +547,18 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(ep))
+                .body(Json.encode(this.endpointMapper.toDTO(ep)))
                 .post("/endpoints")
                 .then()
                 .statusCode(200)
                 .contentType(JSON)
+                .and()
+                .assertThat()
+                .body(JsonSchemaValidator.matchesJsonSchemaInClasspath("json-schemas/v1/endpoint/endpoint-schema-read.json"))
                 .extract().asString();
 
         JsonObject responsePoint = new JsonObject(responseBody);
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         String id = responsePoint.getString("id");
         assertNotNull(id);
 
@@ -643,7 +661,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(endpoint))
+                .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
                 .post("/endpoints")
                 .then()
                 .statusCode(400)
@@ -657,7 +675,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(endpoint))
+                .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
                 .post("/endpoints")
                 .then()
                 .statusCode(400)
@@ -671,7 +689,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(endpoint))
+                .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
                 .post("/endpoints")
                 .then()
                 .statusCode(400)
@@ -704,7 +722,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .header(identityHeader)
             .when()
             .contentType(JSON)
-            .body(Json.encode(endpoint))
+            .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
             .post("/endpoints")
             .then()
             .statusCode(400)
@@ -718,7 +736,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .header(identityHeader)
             .when()
             .contentType(JSON)
-            .body(Json.encode(endpoint))
+            .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
             .post("/endpoints")
             .then()
             .statusCode(200)
@@ -732,7 +750,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .header(identityHeader)
             .contentType(JSON)
             .pathParam("id", endpointUuidRaw)
-            .body(Json.encode(endpoint))
+            .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
             .when()
             .put("/endpoints/{id}")
             .then()
@@ -782,7 +800,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(ep))
+                .body(Json.encode(this.endpointMapper.toDTO(ep)))
                 .post("/endpoints")
                 .then()
                 .statusCode(200)
@@ -790,7 +808,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().asString();
 
         JsonObject responsePoint = new JsonObject(responseBody);
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         String id = responsePoint.getString("id");
         assertNotNull(id);
         assertEquals(READY.toString(), responsePoint.getString("status"));
@@ -813,7 +831,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             responseBody = given()
                     .header(identityHeader)
                     .contentType(JSON)
-                    .body(Json.encode(ep))
+                    .body(Json.encode(this.endpointMapper.toDTO(ep)))
                     .when()
                     .put("/endpoints/" + id)
                     .then()
@@ -883,7 +901,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(ep))
+                .body(Json.encode(this.endpointMapper.toDTO(ep)))
                 .post("/endpoints")
                 .then()
                 .statusCode(200)
@@ -891,7 +909,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         JsonObject responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertNotNull(responsePoint.getString("id"));
         assertEquals(7, responsePoint.getInteger("server_errors"));
 
@@ -907,7 +925,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        List<Endpoint> endpoints = endpointPage.getData();
+        List<EndpointDTO> endpointDTOS = endpointPage.getData();
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
+
         assertEquals(1, endpoints.size());
 
         // Fetch single endpoint also and verify
@@ -1003,7 +1029,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(ep))
+                .body(Json.encode(this.endpointMapper.toDTO(ep)))
                 .post("/endpoints")
                 .then()
                 .statusCode(200)
@@ -1011,7 +1037,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         JsonObject responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertNotNull(responsePoint.getString("id"));
 
         // Add Camel
@@ -1033,7 +1059,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(camelEp))
+                .body(Json.encode(this.endpointMapper.toDTO(camelEp)))
                 .post("/endpoints")
                 .then()
                 .statusCode(200)
@@ -1041,7 +1067,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertNotNull(responsePoint.getString("id"));
 
         // Fetch the list to ensure everything was inserted correctly.
@@ -1055,7 +1081,14 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        List<Endpoint> endpoints = endpointPage.getData();
+        List<EndpointDTO> endpointDTOS = endpointPage.getData();
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
         assertEquals(2, endpoints.size());
 
         // Fetch the list with types
@@ -1070,7 +1103,14 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        endpoints = endpointPage.getData();
+        endpointDTOS = endpointPage.getData();
+
+        endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
 
         // Ensure there is only the requested types
         assertEquals(
@@ -1103,7 +1143,14 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        List<Endpoint> endpoints = endpointPage.getData();
+        List<EndpointDTO> endpointDTOS = endpointPage.getData();
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
         assertEquals(10, endpoints.size());
         assertEquals(29, endpointPage.getMeta().getCount());
 
@@ -1120,7 +1167,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        endpoints = endpointPage.getData();
+        endpointDTOS = endpointPage.getData();
+
+        endpoints = new ArrayList<>(endpointDTOS.size());
+        for (final EndpointDTO endpointDTO : endpointDTOS) {
+            endpoints.add(
+                    this.endpointMapper.toEntity(endpointDTO)
+            );
+        }
+
         assertEquals(9, endpoints.size());
         assertEquals(29, endpointPage.getMeta().getCount());
     }
@@ -1136,9 +1191,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
         // Create 50 test-ones with sanely sortable name & enabled & disabled & type
-        int[] stats = helpers.createTestEndpoints(accountId, orgId, 50);
-        int disableCount = stats[1];
-        int webhookCount = stats[2];
+        final Stats stats = helpers.createTestEndpoints(accountId, orgId, 50);
 
         Response response = given()
                 .header(identityHeader)
@@ -1150,8 +1203,13 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        Endpoint[] endpoints = endpointPage.getData().toArray(new Endpoint[0]);
-        assertEquals(stats[0], endpoints.length);
+
+        List<Endpoint> endpoints = new ArrayList<>(endpointPage.getData().size());
+        for (final EndpointDTO endpointDTO : endpointPage.getData()) {
+            endpoints.add(this.endpointMapper.toEntity(endpointDTO));
+        }
+
+        assertEquals(stats.getCreatedEndpointsCount(), endpoints.size());
 
         response = given()
                 .header(identityHeader)
@@ -1164,17 +1222,22 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        endpoints = endpointPage.getData().toArray(new Endpoint[0]);
-        assertFalse(endpoints[0].isEnabled());
-        assertFalse(endpoints[disableCount - 1].isEnabled());
-        assertTrue(endpoints[disableCount].isEnabled());
-        assertTrue(endpoints[stats[0] - 1].isEnabled());
+
+        endpoints = new ArrayList<>(endpointPage.getData().size());
+        for (final EndpointDTO endpointDTO : endpointPage.getData()) {
+            endpoints.add(this.endpointMapper.toEntity(endpointDTO));
+        }
+
+        assertFalse(endpoints.get(0).isEnabled());
+        assertFalse(endpoints.get(stats.getDisabledCount() - 1).isEnabled());
+        assertTrue(endpoints.get(stats.getDisabledCount()).isEnabled());
+        assertTrue(endpoints.get(stats.getCreatedEndpointsCount() - 1).isEnabled());
 
         response = given()
                 .header(identityHeader)
                 .queryParam("sort_by", "name:desc")
                 .queryParam("limit", "50")
-                .queryParam("offset", stats[0] - 20)
+                .queryParam("offset", stats.getCreatedEndpointsCount() - 20)
                 .when()
                 .get("/endpoints?limit=100")
                 .then()
@@ -1183,11 +1246,16 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        endpoints = endpointPage.getData().toArray(new Endpoint[0]);
-        assertEquals(20, endpoints.length);
-        assertEquals("Endpoint 1", endpoints[endpoints.length - 1].getName());
-        assertEquals("Endpoint 10", endpoints[endpoints.length - 2].getName());
-        assertEquals("Endpoint 27", endpoints[0].getName());
+
+        endpoints = new ArrayList<>(endpointPage.getData().size());
+        for (final EndpointDTO endpointDTO : endpointPage.getData()) {
+            endpoints.add(this.endpointMapper.toEntity(endpointDTO));
+        }
+
+        assertEquals(20, endpoints.size());
+        assertEquals("Endpoint 1", endpoints.get(endpoints.size() - 1).getName());
+        assertEquals("Endpoint 10", endpoints.get(endpoints.size() - 2).getName());
+        assertEquals("Endpoint 27", endpoints.get(0).getName());
 
         given()
                 .header(identityHeader)
@@ -1256,7 +1324,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(ep))
+                .body(Json.encode(this.endpointMapper.toDTO(ep)))
                 .post("/endpoints")
                 .then()
                 .statusCode(200)
@@ -1264,7 +1332,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         JsonObject responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertNotNull(responsePoint.getString("id"));
 
         // Fetch single endpoint also and verify
@@ -1306,7 +1374,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(ep))
+                .body(Json.encode(this.endpointMapper.toDTO(ep)))
                 .post("/endpoints")
                 .then()
                 .statusCode(400)
@@ -1329,7 +1397,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         JsonObject responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertNotNull(responsePoint.getString("id"));
 
         // It is always enabled
@@ -1350,7 +1418,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertEquals(defaultEndpointId, responsePoint.getString("id"));
 
         // Different properties are different endpoints
@@ -1371,7 +1439,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertFalse(endpointIds.contains(responsePoint.getString("id")));
         endpointIds.add(responsePoint.getString("id"));
 
@@ -1387,7 +1455,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertTrue(endpointIds.contains(responsePoint.getString("id")));
 
         // It is not possible to delete it
@@ -1495,7 +1563,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .extract().response();
 
         JsonObject responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertNotNull(responsePoint.getString("id"));
 
         // It is always enabled
@@ -1516,7 +1584,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .extract().response();
 
         responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertEquals(defaultEndpointId, responsePoint.getString("id"));
 
         // Different properties are different endpoints
@@ -1537,7 +1605,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .extract().response();
 
         responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertFalse(endpointIds.contains(responsePoint.getString("id")));
         endpointIds.add(responsePoint.getString("id"));
 
@@ -1553,7 +1621,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .extract().response();
 
         responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertTrue(endpointIds.contains(responsePoint.getString("id")));
 
         // It is not possible to delete it
@@ -1645,7 +1713,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         JsonObject responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         String endpointId = responsePoint.getString("id");
         assertNotNull(endpointId);
 
@@ -1662,7 +1730,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         responsePoint = new JsonObject(response.getBody().asString());
-        responsePoint.mapTo(Endpoint.class);
+        responsePoint.mapTo(EndpointDTO.class);
         assertEquals(endpointId, responsePoint.getString("id"));
 
         // Invalid group is a bad request (i.e. group does not exist)
@@ -1766,7 +1834,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                     .extract().response();
 
             JsonObject responsePoint = new JsonObject(response.getBody().asString());
-            responsePoint.mapTo(Endpoint.class);
+            responsePoint.mapTo(EndpointDTO.class);
             assertNotNull(responsePoint.getString("id"));
 
             // Fetch the list
@@ -1789,9 +1857,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
-        // stats[0] is the count
-        // stats[1] are the inactive ones
-        int[] stats = resourceHelpers.createTestEndpoints(TestConstants.DEFAULT_ACCOUNT_ID, orgId, 11);
+        final Stats stats = resourceHelpers.createTestEndpoints(TestConstants.DEFAULT_ACCOUNT_ID, orgId, 11);
 
         // Get all endpoints
         Response response = given()
@@ -1804,8 +1870,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         EndpointPage endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        assertEquals(stats[0], endpointPage.getMeta().getCount());
-        assertEquals(stats[0], endpointPage.getData().size());
+        assertEquals(stats.getCreatedEndpointsCount(), endpointPage.getMeta().getCount());
+        assertEquals(stats.getCreatedEndpointsCount(), endpointPage.getData().size());
 
         // Only active
         response = given()
@@ -1819,8 +1885,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        assertEquals(stats[0] - stats[1], endpointPage.getMeta().getCount());
-        assertEquals(stats[0] - stats[1], endpointPage.getData().size());
+        assertEquals(stats.getCreatedEndpointsCount() - stats.getDisabledCount(), endpointPage.getMeta().getCount());
+        assertEquals(stats.getCreatedEndpointsCount() - stats.getDisabledCount(), endpointPage.getData().size());
 
         // Only inactive
         response = given()
@@ -1834,8 +1900,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .extract().response();
 
         endpointPage = Json.decodeValue(response.getBody().asString(), EndpointPage.class);
-        assertEquals(stats[1], endpointPage.getMeta().getCount());
-        assertEquals(stats[1], endpointPage.getData().size());
+        assertEquals(stats.getDisabledCount(), endpointPage.getMeta().getCount());
+        assertEquals(stats.getDisabledCount(), endpointPage.getData().size());
 
     }
 
@@ -2016,7 +2082,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                             .header(identityHeader)
                             .when()
                             .contentType(JSON)
-                            .body(Json.encode(endpoint))
+                            .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
                             .post("/endpoints")
                             .then()
                             .statusCode(400)
@@ -2122,11 +2188,13 @@ public class EndpointResourceTest extends DbIsolatedTest {
             endpoint.setProperties(camelProperties);
             endpoint.setSubType(subType);
 
+            EndpointDTO dto = this.endpointMapper.toDTO(endpoint);
+
             given()
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(endpoint))
+                .body(Json.encode(dto))
                 .post("/endpoints")
                 .then()
                 .statusCode(200);
@@ -2137,11 +2205,13 @@ public class EndpointResourceTest extends DbIsolatedTest {
             endpoint.setSubType(null);
             endpoint.setProperties(webhookProperties);
 
+            dto = this.endpointMapper.toDTO(endpoint);
+
             given()
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(endpoint))
+                .body(Json.encode(dto))
                 .post("/endpoints")
                 .then()
                 .statusCode(200);
@@ -2180,7 +2250,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .header(identityHeader)
                 .when()
                 .contentType(JSON)
-                .body(Json.encode(ep))
+                .body(Json.encode(this.endpointMapper.toDTO(ep)))
                 .post("/endpoints")
                 .then()
                 .statusCode(400);
@@ -2395,7 +2465,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .header(identityHeader)
             .when()
             .contentType(JSON)
-            .body(Json.encode(endpoint))
+            .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
             .post("/endpoints")
             .then()
             .statusCode(200)
@@ -2441,7 +2511,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .header(identityHeader)
             .when()
             .contentType(JSON)
-            .body(Json.encode(endpoint))
+            .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
             .put(String.format("/endpoints/%s", endpointUuid))
             .then()
             .statusCode(200);
@@ -2514,7 +2584,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .header(identityHeader)
             .when()
             .contentType(JSON)
-            .body(Json.encode(endpoint))
+            .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
             .post("/endpoints")
             .then()
             .statusCode(200)
@@ -2616,7 +2686,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .header(identityHeader)
             .when()
             .contentType(JSON)
-            .body(Json.encode(endpoint))
+            .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
             .post("/endpoints")
             .then()
             .statusCode(200)
@@ -2667,7 +2737,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .header(identityHeader)
             .when()
             .contentType(JSON)
-            .body(Json.encode(endpoint))
+            .body(Json.encode(this.endpointMapper.toDTO(endpoint)))
             .put(String.format("/endpoints/%s", endpointUuid))
             .then()
             .statusCode(200);
@@ -2724,7 +2794,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         // Check the POST response.
         JsonObject jsonEndpoint = new JsonObject(responseBody);
-        jsonEndpoint.mapTo(Endpoint.class);
+        jsonEndpoint.mapTo(EndpointDTO.class);
         assertNotNull(jsonEndpoint.getString("id"));
         assertEquals(READY.toString(), jsonEndpoint.getString("status"));
         assertEquals(properties.getUrl(), jsonEndpoint.getJsonObject("properties").getString("url"));
@@ -2824,7 +2894,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .header(identityHeader)
             .when()
             .contentType(JSON)
-            .body(Json.encode(webhookEndpoint))
+            .body(Json.encode(this.endpointMapper.toDTO(webhookEndpoint)))
             .post("/endpoints")
             .then()
             .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
@@ -2896,7 +2966,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                     .extract().response();
 
             JsonObject responsePoint = new JsonObject(response.getBody().asString());
-            responsePoint.mapTo(Endpoint.class);
+            responsePoint.mapTo(EndpointDTO.class);
             assertNotNull(responsePoint.getString("id"));
         }
     }

--- a/backend/src/test/resources/json-schemas/v1/endpoint/endpoint-schema-create.json
+++ b/backend/src/test/resources/json-schemas/v1/endpoint/endpoint-schema-create.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schema for the expected payload to receive when an endpoint wants to be created in Notifications",
+  "type": "object",
+  "required": [
+    "name",
+    "description",
+    "enabled",
+    "status",
+    "server_errors",
+    "type",
+    "properties"
+  ],
+  "properties": {
+    "name": {
+      "maxLength": 255,
+      "minLength": 1,
+      "title": "Name of the endpoint",
+      "type": "string"
+    },
+    "description": {
+      "minLength": 1,
+      "title": "Description of the endpoint",
+      "type": "string"
+    },
+    "enabled": {
+      "title": "Is the endpoint enabled?",
+      "type": "boolean"
+    },
+    "status": {
+      "enum": [
+        "DELETING",
+        "FAILED",
+        "NEW",
+        "PROVISIONING",
+        "READY",
+        "UNKNOWN"
+      ],
+      "title": "Status of the endpoint"
+    },
+    "server_errors": {
+      "minimum": 0,
+      "title": "Number of server errors that the endpoint suffered from when contacting the remote servers",
+      "type": "integer"
+    },
+    "type": {
+      "enum": [
+        "ansible",
+        "camel",
+        "drawer",
+        "email_subscription",
+        "webhook"
+      ],
+      "title": "Type of the endpoint",
+      "type": "string"
+    },
+    "sub_type": {
+      "enum": [
+        "ansible",
+        "google_chat",
+        "slack",
+        "teams"
+      ],
+      "title": "Subtype of the endpoint",
+      "type": "string"
+    },
+    "properties": {
+      "title": "Properties of the endpoint",
+      "type": "object",
+      "oneOf": [
+        {
+          "title": "Camel properties",
+          "type": "object",
+          "required": [
+            "disable_ssl_verification",
+            "url"
+          ],
+          "properties": {
+            "disable_ssl_verification": {
+              "$ref": "#/definitions/disable_ssl_verification"
+            },
+            "url": {
+              "$ref": "#/definitions/url"
+            },
+            "basic_authentication": {
+              "$ref": "#/definitions/basic-authentication"
+            },
+            "secret_token": {
+              "$ref": "#/definitions/secret-token"
+            }
+          }
+        },
+        {
+          "title": "System subscription properties",
+          "type": "object",
+          "required": [
+            "ignore_preferences",
+            "only_admins"
+          ],
+          "properties": {
+            "ignore_preferences": {
+              "title": "Ignore the user preferences?",
+              "type": "boolean"
+            },
+            "only_admins": {
+              "title": "Is the email only for administrators",
+              "type": "boolean"
+            },
+            "group_id": {
+              "format": "uuid",
+              "title": "The identifier of the group to send the email to",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "title": "Webhook properties",
+          "type": "object",
+          "required": [
+            "disable_ssl_verification",
+            "method",
+            "url"
+          ],
+          "properties": {
+            "disable_ssl_verification": {
+              "$ref": "#/definitions/disable_ssl_verification"
+            },
+            "method": {
+              "$ref": "#/definitions/http-method"
+            },
+            "url": {
+              "$ref": "#/definitions/url"
+            },
+            "basic_authentication": {
+              "$ref": "#/definitions/basic-authentication"
+            },
+            "bearer_authentication": {
+              "$ref": "#/definitions/bearer-authentication"
+            },
+            "secret_token": {
+              "$ref": "#/definitions/secret-token"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "disable_ssl_verification": {
+      "title": "Definition of the endpoint properties' disable ssl verification object",
+      "type": "boolean"
+    },
+    "http-method": {
+      "enum": [
+        "get",
+        "post",
+        "put"
+      ],
+      "title": "Definition of the endpoint properties' HTTP method object",
+      "type": "string"
+    },
+    "url": {
+      "format": "url",
+      "title": "Definition of the endpoint properties' URL object",
+      "type": "string"
+    },
+    "basic-authentication": {
+      "title": "Definition of the endpoint properties' basic authentication object",
+      "type": "object",
+      "required": [
+        "username",
+        "password"
+      ],
+      "properties": {
+        "username": {
+          "minLength": 1,
+          "title": "Username of the basic authentication object",
+          "type": "string"
+        },
+        "password": {
+          "minLength": 1,
+          "title": "Password of the basic authentication object",
+          "type": "string"
+        }
+      }
+    },
+    "bearer-authentication": {
+      "minLength": 1,
+      "title": "Definition of the endpoint properties' bearer token object",
+      "type": "string"
+    },
+    "secret-token": {
+      "minLength": 1,
+      "title": "Definition of the endpoint properties' secret token object",
+      "type": "string"
+    }
+  }
+}

--- a/backend/src/test/resources/json-schemas/v1/endpoint/endpoint-schema-read.json
+++ b/backend/src/test/resources/json-schemas/v1/endpoint/endpoint-schema-read.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schema for the expected payload to receive when fetching an endpoint from Notifications",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "description",
+    "created",
+    "enabled",
+    "status",
+    "server_errors",
+    "type",
+    "properties"
+  ],
+  "properties": {
+    "id": {
+      "format": "uuid",
+      "title": "Endpoint's identifier",
+      "type": "string"
+    },
+    "name": {
+      "maxLength": 255,
+      "minLength": 1,
+      "title": "Name of the endpoint",
+      "type": "string"
+    },
+    "description": {
+      "minLength": 1,
+      "title": "Description of the endpoint",
+      "type": "string"
+    },
+    "enabled": {
+      "title": "Is the endpoint enabled?",
+      "type": "boolean"
+    },
+    "status": {
+      "enum": [
+        "DELETING",
+        "FAILED",
+        "NEW",
+        "PROVISIONING",
+        "READY",
+        "UNKNOWN"
+      ],
+      "title": "Status of the endpoint"
+    },
+    "server_errors": {
+      "minimum": 0,
+      "title": "Number of server errors that the endpoint suffered from when contacting the remote servers",
+      "type": "integer"
+    },
+    "type": {
+      "enum": [
+        "ansible",
+        "camel",
+        "drawer",
+        "email_subscription",
+        "webhook"
+      ],
+      "title": "Type of the endpoint",
+      "type": "string"
+    },
+    "sub_type": {
+      "enum": [
+        "ansible",
+        "google_chat",
+        "slack",
+        "teams"
+      ],
+      "title": "Subtype of the endpoint",
+      "type": "string"
+    },
+    "created": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{1,12}$",
+      "title": "Creation timestamp of the endpoint",
+      "type": "string"
+    },
+    "properties": {
+      "title": "Properties of the endpoint",
+      "type": "object",
+      "oneOf": [
+        {
+          "title": "Camel properties",
+          "type": "object",
+          "required": [
+            "disable_ssl_verification",
+            "url"
+          ],
+          "properties": {
+            "disable_ssl_verification": {
+              "$ref": "#/definitions/disable_ssl_verification"
+            },
+            "url": {
+              "$ref": "#/definitions/url"
+            },
+            "basic_authentication": {
+              "$ref": "#/definitions/basic-authentication"
+            },
+            "secret_token": {
+              "$ref": "#/definitions/secret-token"
+            }
+          }
+        },
+        {
+          "title": "System subscription properties",
+          "type": "object",
+          "required": [
+            "ignore_preferences",
+            "only_admins"
+          ],
+          "properties": {
+            "ignore_preferences": {
+              "title": "Ignore the user preferences?",
+              "type": "boolean"
+            },
+            "only_admins": {
+              "title": "Is the email only for administrators",
+              "type": "boolean"
+            },
+            "group_id": {
+              "format": "uuid",
+              "title": "The identifier of the group to send the email to",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "title": "Webhook properties",
+          "type": "object",
+          "required": [
+            "disable_ssl_verification",
+            "method",
+            "url"
+          ],
+          "properties": {
+            "disable_ssl_verification": {
+              "$ref": "#/definitions/disable_ssl_verification"
+            },
+            "method": {
+              "$ref": "#/definitions/http-method"
+            },
+            "url": {
+              "$ref": "#/definitions/url"
+            },
+            "basic_authentication": {
+              "$ref": "#/definitions/basic-authentication"
+            },
+            "bearer_authentication": {
+              "$ref": "#/definitions/bearer-authentication"
+            },
+            "secret_token": {
+              "$ref": "#/definitions/secret-token"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "disable_ssl_verification": {
+      "title": "Definition of the endpoint properties' disable ssl verification object",
+      "type": "boolean"
+    },
+    "http-method": {
+      "enum": [
+        "get",
+        "post",
+        "put"
+      ],
+      "title": "Definition of the endpoint properties' HTTP method object",
+      "type": "string"
+    },
+    "url": {
+      "format": "url",
+      "title": "Definition of the endpoint properties' URL object",
+      "type": "string"
+    },
+    "basic-authentication": {
+      "title": "Definition of the endpoint properties' basic authentication object",
+      "type": "object",
+      "required": [
+        "username",
+        "password"
+      ],
+      "properties": {
+        "username": {
+          "minLength": 1,
+          "title": "Username of the basic authentication object",
+          "type": "string"
+        },
+        "password": {
+          "minLength": 1,
+          "title": "Password of the basic authentication object",
+          "type": "string"
+        }
+      }
+    },
+    "bearer-authentication": {
+      "minLength": 1,
+      "title": "Definition of the endpoint properties' bearer token object",
+      "type": "string"
+    },
+    "secret-token": {
+      "minLength": 1,
+      "title": "Definition of the endpoint properties' secret token object",
+      "type": "string"
+    }
+  }
+}

--- a/backend/src/test/resources/json-schemas/v1/endpoint/implementations/create/endpoint-camel.json
+++ b/backend/src/test/resources/json-schemas/v1/endpoint/implementations/create/endpoint-camel.json
@@ -1,0 +1,21 @@
+{
+  "name": "Camel endpoint",
+  "description": "A JSON structure which represents a camel endpoint",
+  "enabled": true,
+  "status": "READY",
+  "server_errors": 23,
+  "sub_type": "slack",
+  "type": "camel",
+  "properties": {
+    "disable_ssl_verification": true,
+    "extras": {
+      "channel": "my-slack-channel"
+    },
+    "url": "https://redhat.com",
+    "basic_authentication": {
+      "username": "camel-user",
+      "password": "camel-pass"
+    },
+    "secret_token": "c4m3l-up3r-s3cr3t-t0k3n"
+  }
+}

--- a/backend/src/test/resources/json-schemas/v1/endpoint/implementations/create/endpoint-webhook.json
+++ b/backend/src/test/resources/json-schemas/v1/endpoint/implementations/create/endpoint-webhook.json
@@ -1,0 +1,20 @@
+{
+  "name": "Webhook endpoint",
+  "description": "A JSON structure which represents a webhook endpoint",
+  "enabled": true,
+  "status": "READY",
+  "server_errors": 12,
+  "subtype": null,
+  "type": "webhook",
+  "properties": {
+    "disable_ssl_verification": true,
+    "method": "POST",
+    "url": "https://redhat.com",
+    "basic_authentication": {
+      "username": "webhook-user",
+      "password": "webhook-pass"
+    },
+    "bearer_authentication": "w3bh00k-bearer-t0k3n",
+    "secret_token": "w3bh00k-sup3r-s3cr3t-t0k3n"
+  }
+}

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -59,6 +59,19 @@
             <version>${redhat.event-schemas.version}</version>
         </dependency>
 
+        <!-- MapStruct -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -65,12 +65,6 @@
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
-            <version>${mapstruct.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Test -->
         <dependency>
@@ -107,6 +101,20 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -101,11 +101,6 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler-plugin.version}</version>
                 <configuration>
                     <annotationProcessorPaths>
                         <path>

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
@@ -1,53 +1,38 @@
 package com.redhat.cloud.notifications.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.db.converters.MapConverter;
-import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 import java.util.Map;
 
 @Entity
 @Table(name = "camel_properties")
-@JsonNaming(SnakeCaseStrategy.class)
 public class CamelProperties extends EndpointProperties implements SourcesSecretable {
 
-    @NotNull
-    @ValidNonPrivateUrl
     private String url;
 
-    @NotNull
     private Boolean disableSslVerification = Boolean.FALSE;
 
     @Transient
-    @Size(max = 255)
     private String secretToken;
 
     /**
      * The ID of the "secret token" secret in the Sources backend.
      */
     @Column(name = "secret_token_id")
-    @JsonIgnore
     private Long secretTokenSourcesId;
 
     @Transient
-    @Valid
     private BasicAuthentication basicAuthentication;
 
     /**
      * The ID of the "basic authentication" secret in the Sources backend.
      */
     @Column(name = "basic_authentication_id")
-    @JsonIgnore
     private Long basicAuthenticationSourcesId;
 
     @Convert(converter = MapConverter.class)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
@@ -1,11 +1,15 @@
 package com.redhat.cloud.notifications.models;
 
 import com.redhat.cloud.notifications.db.converters.MapConverter;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.Map;
 
@@ -13,11 +17,15 @@ import java.util.Map;
 @Table(name = "camel_properties")
 public class CamelProperties extends EndpointProperties implements SourcesSecretable {
 
+    @NotNull
+    @ValidNonPrivateUrl
     private String url;
 
+    @NotNull
     private Boolean disableSslVerification = Boolean.FALSE;
 
     @Transient
+    @Size(max = 255)
     private String secretToken;
 
     /**
@@ -27,6 +35,7 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
     private Long secretTokenSourcesId;
 
     @Transient
+    @Valid
     private BasicAuthentication basicAuthentication;
 
     /**

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CompositeEndpointType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CompositeEndpointType.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications.models;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.redhat.cloud.notifications.db.converters.EndpointTypeConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -19,7 +18,6 @@ public class CompositeEndpointType {
     private EndpointType type;
 
     @Column(name = "endpoint_sub_type")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Size(max = 20)
     private String subType;
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CreationTimestamped.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CreationTimestamped.java
@@ -1,23 +1,16 @@
 package com.redhat.cloud.notifications.models;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
-import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
-import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
-
 @MappedSuperclass
 public abstract class CreationTimestamped {
 
     protected static final ZoneId UTC = ZoneId.of("UTC");
 
-    @JsonProperty(access = READ_ONLY)
-    @JsonFormat(shape = STRING)
     private LocalDateTime created;
 
     public LocalDateTime getCreated() {

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CreationTimestamped.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CreationTimestamped.java
@@ -1,16 +1,23 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
+import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
+
 @MappedSuperclass
 public abstract class CreationTimestamped {
 
     protected static final ZoneId UTC = ZoneId.of("UTC");
 
+    @JsonProperty(access = READ_ONLY)
+    @JsonFormat(shape = STRING)
     private LocalDateTime created;
 
     public LocalDateTime getCreated() {

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -1,10 +1,6 @@
 package com.redhat.cloud.notifications.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -14,12 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -27,12 +17,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-
 @Entity
 @Table(name = "endpoints")
-@JsonNaming(SnakeCaseStrategy.class)
 public class Endpoint extends CreationUpdateTimestamped {
 
     public static final Map<String, String> SORT_FIELDS = Map.of(
@@ -45,22 +31,14 @@ public class Endpoint extends CreationUpdateTimestamped {
 
     // This field is generated (when needed) from the additionalPrePersist method.
     @Id
-    @JsonProperty(access = READ_ONLY)
     private UUID id;
 
-    @Size(max = 50)
-    @JsonIgnore
     private String accountId;
 
-    @Size(max = 50)
-    @JsonIgnore
     private String orgId;
 
-    @NotNull
-    @Size(max = 255)
     private String name;
 
-    @NotNull
     private String description;
 
     private Boolean enabled = Boolean.FALSE;
@@ -68,53 +46,22 @@ public class Endpoint extends CreationUpdateTimestamped {
     @Enumerated(EnumType.STRING)
     private EndpointStatus status = EndpointStatus.UNKNOWN;
 
-    @Valid
-    @NotNull
     @Embedded
-    @JsonIgnore
     private final CompositeEndpointType compositeType = new CompositeEndpointType();
 
-    @Min(0)
     private int serverErrors;
 
-    @Schema(oneOf = { WebhookProperties.class, SystemSubscriptionProperties.class, CamelProperties.class })
-    @JsonTypeInfo(
-            use = JsonTypeInfo.Id.NAME,
-            property = "type",
-            include = JsonTypeInfo.As.EXTERNAL_PROPERTY)
-    @JsonSubTypes({
-        @JsonSubTypes.Type(value = WebhookProperties.class, name = "webhook"),
-        @JsonSubTypes.Type(value = WebhookProperties.class, name = "ansible"),
-        @JsonSubTypes.Type(value = SystemSubscriptionProperties.class, name = "email_subscription"),
-        @JsonSubTypes.Type(value = SystemSubscriptionProperties.class, name = "drawer"),
-        @JsonSubTypes.Type(value = CamelProperties.class, name = "camel")
-    })
-    @Valid
     @Transient
     private EndpointProperties properties;
 
     @OneToMany(mappedBy = "endpoint", cascade = CascadeType.REMOVE)
-    @JsonIgnore
     private Set<BehaviorGroupAction> behaviorGroupActions;
 
     @JsonIgnore
     private LocalDateTime serverErrorsSince;
 
     @OneToMany(mappedBy = "endpoint")
-    @JsonIgnore
     private Set<NotificationHistory> notificationHistories;
-
-    @JsonIgnore
-    @AssertTrue(message = "This type requires a sub_type")
-    private boolean isSubTypePresentWhenRequired() {
-        return !compositeType.getType().requiresSubType || compositeType.getSubType() != null;
-    }
-
-    @JsonIgnore
-    @AssertTrue(message = "This type does not support sub_type")
-    private boolean isSubTypeNotPresentWhenNotRequired() {
-        return compositeType.getType().requiresSubType || compositeType.getSubType() == null;
-    }
 
     @Override
     protected void additionalPrePersist() {
@@ -175,7 +122,6 @@ public class Endpoint extends CreationUpdateTimestamped {
         this.enabled = enabled;
     }
 
-    @JsonProperty(required = true)
     public EndpointType getType() {
         return compositeType.getType();
     }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -57,7 +56,6 @@ public class Endpoint extends CreationUpdateTimestamped {
     @OneToMany(mappedBy = "endpoint", cascade = CascadeType.REMOVE)
     private Set<BehaviorGroupAction> behaviorGroupActions;
 
-    @JsonIgnore
     private LocalDateTime serverErrorsSince;
 
     @OneToMany(mappedBy = "endpoint")

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -1,5 +1,8 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -22,6 +25,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Entity
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class) // TODO remove them once the transition to DTOs have been completed.
 @Table(name = "endpoints")
 public class Endpoint extends CreationUpdateTimestamped {
 
@@ -37,9 +41,11 @@ public class Endpoint extends CreationUpdateTimestamped {
     @Id
     private UUID id;
 
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     @Size(max = 50)
     private String accountId;
 
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     @Size(max = 50)
     private String orgId;
 
@@ -56,6 +62,7 @@ public class Endpoint extends CreationUpdateTimestamped {
     private EndpointStatus status = EndpointStatus.UNKNOWN;
 
     @Embedded
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     @NotNull
     @Valid
     private final CompositeEndpointType compositeType = new CompositeEndpointType();
@@ -67,19 +74,24 @@ public class Endpoint extends CreationUpdateTimestamped {
     @Valid
     private EndpointProperties properties;
 
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     @OneToMany(mappedBy = "endpoint", cascade = CascadeType.REMOVE)
     private Set<BehaviorGroupAction> behaviorGroupActions;
 
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     private LocalDateTime serverErrorsSince;
 
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     @OneToMany(mappedBy = "endpoint")
     private Set<NotificationHistory> notificationHistories;
 
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     @AssertTrue(message = "This type requires a sub_type")
     private boolean isSubTypePresentWhenRequired() {
         return !compositeType.getType().requiresSubType || compositeType.getSubType() != null;
     }
 
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     @AssertTrue(message = "This type does not support sub_type")
     private boolean isSubTypeNotPresentWhenNotRequired() {
         return compositeType.getType().requiresSubType || compositeType.getSubType() == null;

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Endpoint.java
@@ -9,6 +9,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -32,12 +37,17 @@ public class Endpoint extends CreationUpdateTimestamped {
     @Id
     private UUID id;
 
+    @Size(max = 50)
     private String accountId;
 
+    @Size(max = 50)
     private String orgId;
 
+    @NotNull
+    @Size(max = 255)
     private String name;
 
+    @NotNull
     private String description;
 
     private Boolean enabled = Boolean.FALSE;
@@ -46,11 +56,15 @@ public class Endpoint extends CreationUpdateTimestamped {
     private EndpointStatus status = EndpointStatus.UNKNOWN;
 
     @Embedded
+    @NotNull
+    @Valid
     private final CompositeEndpointType compositeType = new CompositeEndpointType();
 
+    @Min(0)
     private int serverErrors;
 
     @Transient
+    @Valid
     private EndpointProperties properties;
 
     @OneToMany(mappedBy = "endpoint", cascade = CascadeType.REMOVE)
@@ -60,6 +74,16 @@ public class Endpoint extends CreationUpdateTimestamped {
 
     @OneToMany(mappedBy = "endpoint")
     private Set<NotificationHistory> notificationHistories;
+
+    @AssertTrue(message = "This type requires a sub_type")
+    private boolean isSubTypePresentWhenRequired() {
+        return !compositeType.getType().requiresSubType || compositeType.getSubType() != null;
+    }
+
+    @AssertTrue(message = "This type does not support sub_type")
+    private boolean isSubTypeNotPresentWhenNotRequired() {
+        return compositeType.getType().requiresSubType || compositeType.getSubType() == null;
+    }
 
     @Override
     protected void additionalPrePersist() {

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum EndpointType {
     WEBHOOK(false, false),
     EMAIL_SUBSCRIPTION(false, true),
@@ -15,4 +17,27 @@ public enum EndpointType {
         this.isSystemEndpointType = isSystemEndpointType;
     }
 
+    /**
+     * Transforms the enum values to lowercase. It is required for the
+     * following tests to work:
+     * <ul>
+     *     <li>
+     *         {@link EndpointResourceTest#testAddEndpointDrawerSubscription}
+     *         {@link EndpointResourceTest#testAddEndpointEmailSubscription}
+     *         {@link EndpointResourceTest#testAnsibleEndpointCRUD}
+     *     </li>
+     * </ul>
+     *
+     * The reason for this is that we use the entities to build the payloads
+     * that we send to the endpoints, and since the enum values get written in
+     * uppercase letters by default, the target endpoints were not recognizing
+     * the type of the endpoints being managed, since they expect the lowercase
+     * values.
+     *
+     * @return the enum value in lowercase.
+     */
+    @JsonValue
+    public String toLowerCase() {
+        return this.toString().toLowerCase();
+    }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
@@ -1,19 +1,10 @@
 package com.redhat.cloud.notifications.models;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
-
-@Schema(enumeration = { "webhook", "email_subscription", "camel", "ansible", "drawer" })
 public enum EndpointType {
-    @JsonProperty("webhook")
     WEBHOOK(false, false),
-    @JsonProperty("email_subscription")
     EMAIL_SUBSCRIPTION(false, true),
-    @JsonProperty("camel")
     CAMEL(true, false),
-    @JsonProperty("ansible")
     ANSIBLE(false, false),
-    @JsonProperty("drawer")
     DRAWER(false, true);
 
     public final boolean requiresSubType;

--- a/common/src/main/java/com/redhat/cloud/notifications/models/SystemSubscriptionProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/SystemSubscriptionProperties.java
@@ -1,23 +1,17 @@
 package com.redhat.cloud.notifications.models;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 
 import java.util.Objects;
 import java.util.UUID;
 
 @Entity
 @Table(name = "email_properties")
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SystemSubscriptionProperties extends EndpointProperties {
 
-    @NotNull
     private boolean onlyAdmins;
 
-    @NotNull
     private boolean ignorePreferences;
 
     private UUID groupId;

--- a/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
@@ -1,40 +1,24 @@
 package com.redhat.cloud.notifications.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.db.converters.HttpTypeConverter;
-import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 
 @Entity
 @Table(name = "endpoint_webhooks")
-@JsonNaming(SnakeCaseStrategy.class)
 public class WebhookProperties extends EndpointProperties implements SourcesSecretable {
 
-    @NotNull
-    @ValidNonPrivateUrl
     private String url;
 
-    @NotNull
     @Convert(converter = HttpTypeConverter.class)
     private HttpType method;
 
-    @NotNull
-    @JsonProperty("disable_ssl_verification")
     private Boolean disableSslVerification = Boolean.FALSE;
 
-    @Size(max = 255)
-    @JsonProperty("secret_token")
     @Transient
     private String secretToken;
 
@@ -42,10 +26,8 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
      * The ID of the "secret token" secret in the Sources backend.
      */
     @Column(name = "secret_token_id")
-    @JsonIgnore
     private Long secretTokenSourcesId;
 
-    @JsonProperty("basic_authentication")
     @Transient
     @Valid
     private BasicAuthentication basicAuthentication;
@@ -54,14 +36,11 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
      * The ID of the "basic authentication" secret in the Sources backend.
      */
     @Column(name = "basic_authentication_id")
-    @JsonIgnore
     private Long basicAuthenticationSourcesId;
 
     @Column(name = "bearer_authentication_id")
-    @JsonIgnore
     private Long bearerAuthenticationSourcesId;
 
-    @JsonProperty("bearer_authentication")
     @Transient
     private String bearerAuthentication;
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
@@ -1,24 +1,32 @@
 package com.redhat.cloud.notifications.models;
 
 import com.redhat.cloud.notifications.db.converters.HttpTypeConverter;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "endpoint_webhooks")
 public class WebhookProperties extends EndpointProperties implements SourcesSecretable {
 
+    @NotNull
+    @ValidNonPrivateUrl
     private String url;
 
     @Convert(converter = HttpTypeConverter.class)
+    @NotNull
     private HttpType method;
 
+    @NotNull
     private Boolean disableSslVerification = Boolean.FALSE;
 
+    @Size(max = 255)
     @Transient
     private String secretToken;
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -47,6 +48,7 @@ public final class EndpointDTO {
     @Size(max = 20)
     private String subType;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime created;
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -26,12 +26,10 @@ public final class EndpointDTO {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private UUID id;
 
-    @JsonProperty(required = true)
     @NotNull
     @Size(max = 255)
     private String name;
 
-    @JsonProperty(required = true)
     @NotNull
     private String description;
 
@@ -39,23 +37,19 @@ public final class EndpointDTO {
 
     private EndpointStatusDTO status = EndpointStatusDTO.UNKNOWN;
 
-    @JsonProperty(required = true)
     @Min(0)
     private int serverErrors;
 
-    @JsonProperty(required = true)
     @NotNull
     private EndpointTypeDTO type;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty(required = true)
     @Size(max = 20)
     private String subType;
 
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime created;
 
-    @JsonProperty(required = true)
     @JsonSubTypes({
         @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "camel"),
         @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "CAMEl"),

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -71,8 +71,6 @@ public final class EndpointDTO {
     @Valid
     private EndpointPropertiesDTO properties;
 
-    public EndpointDTO() { }
-
     @JsonIgnore
     @AssertTrue(message = "This type requires a sub_type")
     private boolean isSubTypePresentWhenRequired() {

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -52,7 +52,7 @@ public final class EndpointDTO {
 
     @JsonSubTypes({
         @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "camel"),
-        @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "CAMEl"),
+        @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "CAMEL"),
         @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "drawer"),
         @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "DRAWER"),
         @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "email_subscription"),

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -58,10 +58,15 @@ public final class EndpointDTO {
     @JsonProperty(required = true)
     @JsonSubTypes({
         @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "camel"),
+        @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "CAMEl"),
         @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "drawer"),
+        @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "DRAWER"),
         @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "email_subscription"),
+        @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "EMAIL_SUBSCRIPTION"),
         @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "ansible"),
-        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "webhook")
+        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "ANSIBLE"),
+        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "webhook"),
+        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "WEBHOOK")
     })
     @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -52,15 +52,10 @@ public final class EndpointDTO {
 
     @JsonSubTypes({
         @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "camel"),
-        @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "CAMEL"),
         @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "drawer"),
-        @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "DRAWER"),
         @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "email_subscription"),
-        @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "EMAIL_SUBSCRIPTION"),
         @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "ansible"),
-        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "ANSIBLE"),
         @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "webhook"),
-        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "WEBHOOK")
     })
     @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -1,0 +1,167 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.CamelPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.EndpointPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.SystemSubscriptionPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.WebhookPropertiesDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public final class EndpointDTO {
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private UUID id;
+
+    @JsonProperty(required = true)
+    @NotNull
+    @Size(max = 255)
+    private String name;
+
+    @JsonProperty(required = true)
+    @NotNull
+    private String description;
+
+    private Boolean enabled = Boolean.FALSE;
+
+    private EndpointStatusDTO status = EndpointStatusDTO.UNKNOWN;
+
+    @JsonProperty(required = true)
+    @Min(0)
+    private int serverErrors;
+
+    @JsonProperty(required = true)
+    @NotNull
+    private EndpointTypeDTO type;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(required = true)
+    @Size(max = 20)
+    private String subType;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private LocalDateTime created;
+
+    @JsonProperty(required = true)
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "camel"),
+        @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "drawer"),
+        @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "email_subscription"),
+        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "ansible"),
+        @JsonSubTypes.Type(value = WebhookPropertiesDTO.class, name = "webhook")
+    })
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type",
+        include = JsonTypeInfo.As.EXTERNAL_PROPERTY)
+    @Schema(oneOf = { CamelPropertiesDTO.class, SystemSubscriptionPropertiesDTO.class, WebhookPropertiesDTO.class })
+    @Valid
+    private EndpointPropertiesDTO properties;
+
+    public EndpointDTO() { }
+
+    @JsonIgnore
+    @AssertTrue(message = "This type requires a sub_type")
+    private boolean isSubTypePresentWhenRequired() {
+        return !this.type.requiresSubType || this.subType != null;
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "This type does not support sub_type")
+    private boolean isSubTypeNotPresentWhenNotRequired() {
+        return this.type.requiresSubType || this.subType == null;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(final String description) {
+        this.description = description;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(final Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public EndpointStatusDTO getStatus() {
+        return status;
+    }
+
+    public void setStatus(final EndpointStatusDTO status) {
+        this.status = status;
+    }
+
+    public int getServerErrors() {
+        return serverErrors;
+    }
+
+    public void setServerErrors(final int serverErrors) {
+        this.serverErrors = serverErrors;
+    }
+
+    public EndpointTypeDTO getType() {
+        return type;
+    }
+
+    public void setType(final EndpointTypeDTO type) {
+        this.type = type;
+    }
+
+    public String getSubType() {
+        return subType;
+    }
+
+    public void setSubType(final String subType) {
+        this.subType = subType;
+    }
+
+    public LocalDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(final LocalDateTime created) {
+        this.created = created;
+    }
+
+    public EndpointPropertiesDTO getProperties() {
+        return properties;
+    }
+
+    public void setProperties(final EndpointPropertiesDTO properties) {
+        this.properties = properties;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointStatusDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointStatusDTO.java
@@ -1,0 +1,10 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint;
+
+public enum EndpointStatusDTO {
+    DELETING,
+    FAILED,
+    NEW,
+    PROVISIONING,
+    READY, // 0, default for existing ones
+    UNKNOWN
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
@@ -1,0 +1,24 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum EndpointTypeDTO {
+    ANSIBLE(false, false),
+    CAMEL(true, false),
+    DRAWER(false, true),
+    EMAIL_SUBSCRIPTION(false, true),
+    WEBHOOK(false, false);
+
+    public final boolean requiresSubType;
+    public final boolean isSystemEndpointType;
+
+    EndpointTypeDTO(boolean requiresSubType, boolean isSystemEndpointType) {
+        this.requiresSubType = requiresSubType;
+        this.isSystemEndpointType = isSystemEndpointType;
+    }
+
+    @JsonValue
+    public String toLowerCase() {
+        return this.toString().toLowerCase();
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
@@ -1,12 +1,20 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(enumeration = { "webhook", "email_subscription", "camel", "ansible", "drawer" })
 public enum EndpointTypeDTO {
+    @JsonProperty("ansible")
     ANSIBLE(false, false),
+    @JsonProperty("camel")
     CAMEL(true, false),
+    @JsonProperty("drawer")
     DRAWER(false, true),
+    @JsonProperty("email_subscription")
     EMAIL_SUBSCRIPTION(false, true),
+    @JsonProperty("webhook")
     WEBHOOK(false, false);
 
     public final boolean requiresSubType;

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
@@ -1,20 +1,14 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(enumeration = { "webhook", "email_subscription", "camel", "ansible", "drawer" })
 public enum EndpointTypeDTO {
-    @JsonProperty("ansible")
     ANSIBLE(false, false),
-    @JsonProperty("camel")
     CAMEL(true, false),
-    @JsonProperty("drawer")
     DRAWER(false, true),
-    @JsonProperty("email_subscription")
     EMAIL_SUBSCRIPTION(false, true),
-    @JsonProperty("webhook")
     WEBHOOK(false, false);
 
     public final boolean requiresSubType;
@@ -25,6 +19,10 @@ public enum EndpointTypeDTO {
         this.isSystemEndpointType = isSystemEndpointType;
     }
 
+    /**
+     * Transforms the enum values to lowercase.
+     * @return the enum value in lowercase.
+     */
     @JsonValue
     public String toLowerCase() {
         return this.toString().toLowerCase();

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
@@ -1,0 +1,73 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets.BasicAuthenticationDTO;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.Map;
+
+public final class CamelPropertiesDTO extends EndpointPropertiesDTO {
+    @NotNull
+    @JsonProperty(required = true)
+    private Boolean disableSslVerification = Boolean.FALSE;
+
+    private Map<String, String> extras;
+
+    @NotNull
+    @JsonProperty(required = true)
+    @ValidNonPrivateUrl
+    private String url;
+
+    @JsonProperty(required = true)
+    @Valid
+    private BasicAuthenticationDTO basicAuthentication;
+
+    @JsonProperty(required = true)
+    @Size(max = 255)
+    private String secretToken;
+
+    public CamelPropertiesDTO() { }
+
+    public Boolean getDisableSslVerification() {
+        return disableSslVerification;
+    }
+
+    public void setDisableSslVerification(final Boolean disableSslVerification) {
+        this.disableSslVerification = disableSslVerification;
+    }
+
+    public Map<String, String> getExtras() {
+        return extras;
+    }
+
+    public void setExtras(final Map<String, String> extras) {
+        this.extras = extras;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    public BasicAuthenticationDTO getBasicAuthentication() {
+        return basicAuthentication;
+    }
+
+    public void setBasicAuthentication(final BasicAuthenticationDTO basicAuthentication) {
+        this.basicAuthentication = basicAuthentication;
+    }
+
+    public String getSecretToken() {
+        return secretToken;
+    }
+
+    public void setSecretToken(final String secretToken) {
+        this.secretToken = secretToken;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
@@ -24,8 +24,6 @@ public final class CamelPropertiesDTO extends EndpointPropertiesDTO {
     @Size(max = 255)
     private String secretToken;
 
-    public CamelPropertiesDTO() { }
-
     public Boolean getDisableSslVerification() {
         return disableSslVerification;
     }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
@@ -10,8 +10,6 @@ import jakarta.validation.constraints.Size;
 import java.util.Map;
 
 public final class CamelPropertiesDTO extends EndpointPropertiesDTO {
-    @NotNull
-    @JsonProperty(required = true)
     private Boolean disableSslVerification = Boolean.FALSE;
 
     private Map<String, String> extras;

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Size;
 import java.util.Map;
 
 public final class CamelPropertiesDTO extends EndpointPropertiesDTO {
+    @NotNull
     private Boolean disableSslVerification = Boolean.FALSE;
 
     private Map<String, String> extras;

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/CamelPropertiesDTO.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets.BasicAuthenticationDTO;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.validation.Valid;
@@ -15,15 +14,12 @@ public final class CamelPropertiesDTO extends EndpointPropertiesDTO {
     private Map<String, String> extras;
 
     @NotNull
-    @JsonProperty(required = true)
     @ValidNonPrivateUrl
     private String url;
 
-    @JsonProperty(required = true)
     @Valid
     private BasicAuthenticationDTO basicAuthentication;
 
-    @JsonProperty(required = true)
     @Size(max = 255)
     private String secretToken;
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/EndpointPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/EndpointPropertiesDTO.java
@@ -1,0 +1,8 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public abstract class EndpointPropertiesDTO {
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
@@ -9,11 +8,9 @@ public final class SystemSubscriptionPropertiesDTO extends EndpointPropertiesDTO
     private UUID groupId;
 
     @NotNull
-    @JsonProperty(required = true)
     private boolean ignorePreferences;
 
     @NotNull
-    @JsonProperty(required = true)
     private boolean onlyAdmins;
 
     public SystemSubscriptionPropertiesDTO() { }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
@@ -1,0 +1,44 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public final class SystemSubscriptionPropertiesDTO extends EndpointPropertiesDTO {
+    private UUID groupId;
+
+    @NotNull
+    @JsonProperty(required = true)
+    private boolean ignorePreferences;
+
+    @NotNull
+    @JsonProperty(required = true)
+    private boolean onlyAdmins;
+
+    public SystemSubscriptionPropertiesDTO() { }
+
+    public UUID getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(final UUID groupId) {
+        this.groupId = groupId;
+    }
+
+    public boolean isIgnorePreferences() {
+        return ignorePreferences;
+    }
+
+    public void setIgnorePreferences(final boolean ignorePreferences) {
+        this.ignorePreferences = ignorePreferences;
+    }
+
+    public boolean isOnlyAdmins() {
+        return onlyAdmins;
+    }
+
+    public void setOnlyAdmins(final boolean onlyAdmins) {
+        this.onlyAdmins = onlyAdmins;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
@@ -13,8 +13,6 @@ public final class SystemSubscriptionPropertiesDTO extends EndpointPropertiesDTO
     @NotNull
     private boolean onlyAdmins;
 
-    public SystemSubscriptionPropertiesDTO() { }
-
     public UUID getGroupId() {
         return groupId;
     }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/SystemSubscriptionPropertiesDTO.java
@@ -1,16 +1,12 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
 
-import jakarta.validation.constraints.NotNull;
-
 import java.util.UUID;
 
 public final class SystemSubscriptionPropertiesDTO extends EndpointPropertiesDTO {
     private UUID groupId;
 
-    @NotNull
     private boolean ignorePreferences;
 
-    @NotNull
     private boolean onlyAdmins;
 
     public UUID getGroupId() {
@@ -21,7 +17,7 @@ public final class SystemSubscriptionPropertiesDTO extends EndpointPropertiesDTO
         this.groupId = groupId;
     }
 
-    public boolean isIgnorePreferences() {
+    public Boolean isIgnorePreferences() {
         return ignorePreferences;
     }
 
@@ -29,7 +25,7 @@ public final class SystemSubscriptionPropertiesDTO extends EndpointPropertiesDTO
         this.ignorePreferences = ignorePreferences;
     }
 
-    public boolean isOnlyAdmins() {
+    public Boolean isOnlyAdmins() {
         return onlyAdmins;
     }
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
@@ -1,0 +1,85 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.redhat.cloud.notifications.models.HttpType;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets.BasicAuthenticationDTO;
+import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public final class WebhookPropertiesDTO extends EndpointPropertiesDTO {
+    @NotNull
+    @JsonProperty(value = "disable_ssl_verification", required = true)
+    private Boolean disableSslVerification = Boolean.FALSE;
+
+    @NotNull
+    @JsonProperty(required = true)
+    private HttpType method;
+
+    @NotNull
+    @JsonProperty(required = true)
+    @ValidNonPrivateUrl
+    private String url;
+
+    @JsonProperty("basic_authentication")
+    @Valid
+    private BasicAuthenticationDTO basicAuthentication;
+
+    @JsonProperty("bearer_authentication")
+    private String bearerAuthentication;
+
+    @Size(max = 255)
+    @JsonProperty("secret_token")
+    private String secretToken;
+
+    public WebhookPropertiesDTO() { }
+
+    public Boolean getDisableSslVerification() {
+        return disableSslVerification;
+    }
+
+    public void setDisableSslVerification(final Boolean disableSslVerification) {
+        this.disableSslVerification = disableSslVerification;
+    }
+
+    public HttpType getMethod() {
+        return method;
+    }
+
+    public void setMethod(final HttpType method) {
+        this.method = method;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    public BasicAuthenticationDTO getBasicAuthentication() {
+        return basicAuthentication;
+    }
+
+    public void setBasicAuthentication(final BasicAuthenticationDTO basicAuthentication) {
+        this.basicAuthentication = basicAuthentication;
+    }
+
+    public String getBearerAuthentication() {
+        return bearerAuthentication;
+    }
+
+    public void setBearerAuthentication(final String bearerAuthentication) {
+        this.bearerAuthentication = bearerAuthentication;
+    }
+
+    public String getSecretToken() {
+        return secretToken;
+    }
+
+    public void setSecretToken(final String secretToken) {
+        this.secretToken = secretToken;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
@@ -26,8 +26,6 @@ public final class WebhookPropertiesDTO extends EndpointPropertiesDTO {
     @Size(max = 255)
     private String secretToken;
 
-    public WebhookPropertiesDTO() { }
-
     public Boolean getDisableSslVerification() {
         return disableSslVerification;
     }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets.BasicAuthenticationDTO;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
@@ -10,27 +9,21 @@ import jakarta.validation.constraints.Size;
 
 public final class WebhookPropertiesDTO extends EndpointPropertiesDTO {
     @NotNull
-    @JsonProperty(value = "disable_ssl_verification", required = true)
     private Boolean disableSslVerification = Boolean.FALSE;
 
     @NotNull
-    @JsonProperty(required = true)
     private HttpType method;
 
     @NotNull
-    @JsonProperty(required = true)
     @ValidNonPrivateUrl
     private String url;
 
-    @JsonProperty("basic_authentication")
     @Valid
     private BasicAuthenticationDTO basicAuthentication;
 
-    @JsonProperty("bearer_authentication")
     private String bearerAuthentication;
 
     @Size(max = 255)
-    @JsonProperty("secret_token")
     private String secretToken;
 
     public WebhookPropertiesDTO() { }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/secrets/BasicAuthenticationDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/secrets/BasicAuthenticationDTO.java
@@ -4,11 +4,6 @@ public final class BasicAuthenticationDTO {
     private String username;
     private String password;
 
-    public BasicAuthenticationDTO(String username, String password) {
-        this.username = username;
-        this.password = password;
-    }
-
     public String getUsername() {
         return username;
     }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/secrets/BasicAuthenticationDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/secrets/BasicAuthenticationDTO.java
@@ -1,0 +1,27 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets;
+
+public final class BasicAuthenticationDTO {
+    private String username;
+    private String password;
+
+    public BasicAuthenticationDTO(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(final String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapper.java
@@ -36,6 +36,7 @@ public interface EndpointMapper {
     @Mapping(target = "notificationHistories", ignore = true)
     @Mapping(target = "orgId", ignore = true)
     @Mapping(target = "updated", ignore = true)
+    @Mapping(target = "serverErrorsSince", ignore = true)
     Endpoint toEntity(EndpointDTO endpoint);
 
     /**

--- a/common/src/main/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapper.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapper.java
@@ -1,0 +1,135 @@
+package com.redhat.cloud.notifications.models.mappers.v1.endpoint;
+
+import com.redhat.cloud.notifications.models.CamelProperties;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointProperties;
+import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
+import com.redhat.cloud.notifications.models.WebhookProperties;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.CamelPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.EndpointPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.SystemSubscriptionPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.WebhookPropertiesDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.Named;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.CDI)
+public interface EndpointMapper {
+    /**
+     * Maps an internal endpoint's entity into a DTO.
+     * @param endpoint the internal entity to map.
+     * @return the mapped DTO.
+     */
+    @Mapping(source = "properties", target = "properties", qualifiedByName = "mapEntityProperties")
+    EndpointDTO toDTO(Endpoint endpoint);
+
+    /**
+     * Maps an endpoint's DTO to an internal entity.
+     * @param endpoint the DTO to map.
+     * @return the mapped internal entity.
+     */
+    @Mapping(source = "properties", target = "properties", qualifiedByName = "mapDTOProperties")
+    @Mapping(target = "accountId", ignore = true)
+    @Mapping(target = "behaviorGroupActions", ignore = true)
+    @Mapping(target = "notificationHistories", ignore = true)
+    @Mapping(target = "orgId", ignore = true)
+    @Mapping(target = "updated", ignore = true)
+    Endpoint toEntity(EndpointDTO endpoint);
+
+    /**
+     * Maps a camel properties' internal entity to a DTO.
+     * @param camelProperties the internal entity to map.
+     * @return the mapped DTO.
+     */
+    CamelPropertiesDTO camelToDTO(CamelProperties camelProperties);
+
+    /**
+     * Maps a camel properties' DTO into an internal entity.
+     * @param camelPropertiesDTO the DTO to map.
+     * @return the mapped internal entity.
+     */
+    @Mapping(target = "basicAuthenticationSourcesId", ignore = true)
+    @Mapping(target = "bearerAuthentication", ignore = true)
+    @Mapping(target = "bearerAuthenticationSourcesId", ignore = true)
+    @Mapping(target = "endpoint", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "secretTokenSourcesId", ignore = true)
+    CamelProperties camelToEntity(CamelPropertiesDTO camelPropertiesDTO);
+
+    /**
+     * Maps a system subscription properties' internal entity into a DTO.
+     * @param systemSubscriptionProperties the internal entity to map.
+     * @return the mapped DTO.
+     */
+    SystemSubscriptionPropertiesDTO systemToDTO(SystemSubscriptionProperties systemSubscriptionProperties);
+
+    /**
+     * Maps a system subscription properties' DTO into an internal entity.
+     * @param systemSubscriptionPropertiesDTO the DTO to map.
+     * @return thue mapped internal entity.
+     */
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "endpoint", ignore = true)
+    SystemSubscriptionProperties systemToEntity(SystemSubscriptionPropertiesDTO systemSubscriptionPropertiesDTO);
+
+    /**
+     * Maps a webhook properties' internal entity into a DTO.
+     * @param webhookProperties the internal entity to map.
+     * @return the mapped DTO.
+     */
+    WebhookPropertiesDTO webhookToDTO(WebhookProperties webhookProperties);
+
+    /**
+     * Maps a webhook properties DTO into an internal entity.
+     * @param webhookPropertiesDTO the DTO to map.
+     * @return the mapped internal entity.
+     */
+    @Mapping(target = "basicAuthenticationSourcesId", ignore = true)
+    @Mapping(target = "bearerAuthenticationSourcesId", ignore = true)
+    @Mapping(target = "endpoint", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "secretTokenSourcesId", ignore = true)
+    WebhookProperties webhookToEntity(WebhookPropertiesDTO webhookPropertiesDTO);
+
+    /**
+     * Maps the internal endpoint properties' entity into one of the more specific classes that extend it, and then
+     * maps them into an endpoint properties' DTO.
+     * @param endpointProperties the internal entity to map.
+     * @return the mapped DTO.
+     */
+    @Named("mapEntityProperties")
+    default EndpointPropertiesDTO mapEntityProperties(final EndpointProperties endpointProperties) {
+        if (endpointProperties == null) {
+            return null;
+        }
+
+        return switch (endpointProperties) {
+            case CamelProperties properties -> this.camelToDTO(properties);
+            case SystemSubscriptionProperties properties -> this.systemToDTO(properties);
+            case WebhookProperties properties -> this.webhookToDTO(properties);
+            default -> throw new IllegalStateException("Invalid endpoint properties mapped to class");
+        };
+    }
+
+    /**
+     * Maps the generic endpoint properties' DTO into one of the more specific classes that extend it, and then maps
+     * them into an endpoint properties entity.
+     * @param endpointPropertiesDTO the DTO to map.
+     * @return the mapped internal entity.
+     */
+    @Named("mapDTOProperties")
+    default EndpointProperties mapDTOProperties(final EndpointPropertiesDTO endpointPropertiesDTO) {
+        if (endpointPropertiesDTO == null) {
+            return null;
+        }
+
+        return switch (endpointPropertiesDTO) {
+            case CamelPropertiesDTO properties -> this.camelToEntity(properties);
+            case SystemSubscriptionPropertiesDTO properties -> this.systemToEntity(properties);
+            case WebhookPropertiesDTO properties -> this.webhookToEntity(properties);
+            default -> throw new IllegalStateException("Invalid endpoint properties mapped to class");
+        };
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
 
     <properties>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
-        <json-schema-validator.version>1.3.3</json-schema-validator.version>
 
         <enforcer-plugin.version>3.4.1</enforcer-plugin.version>
         <maven-minimum-version>3.8.4</maven-minimum-version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,9 @@
     </profiles>
 
     <properties>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <json-schema-validator.version>1.3.3</json-schema-validator.version>
+
         <enforcer-plugin.version>3.4.1</enforcer-plugin.version>
         <maven-minimum-version>3.8.4</maven-minimum-version>
         <java-version>21</java-version>


### PR DESCRIPTION
Using DTOs will help us decouple the internal model from the model exposed to the clients, which will give us freedom to perform internal changes without fear of affecting anyone who is integrated with us.

## Jira ticket
[[RHCLOUD-31165]](https://issues.redhat.com/browse/RHCLOUD-31165)