### PR TITLE
RHCLOUD-29443 | feature: remove the bearer authentication column from the database

### DIFF
--- a/database/src/main/resources/db/migration/V1.96.0__RHCLOUD-29443_remove_secrets_columns.sql
+++ b/database/src/main/resources/db/migration/V1.96.0__RHCLOUD-29443_remove_secrets_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    "endpoint_webhooks"
+DROP COLUMN
+    "bearer_authentication";


### PR DESCRIPTION
After marking the "bearer token" property as "@Transient", and deploying that change, it is time to remove the column from the database.

## Jira ticket
[[RHCLOUD-29443]](https://issues.redhat.com/browse/RHCLOUD-29443)