### PR TITLE
RHCLOUD-28460 Move engine feature flags to Unleash

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -236,6 +236,10 @@ objects:
           value: ${NOTIFICATIONS_DRAWER_CONNECTOR_ENABLED}
         - name: NOTIFICATIONS_ASYNC_AGGREGATION_ENABLED
           value: ${NOTIFICATIONS_ASYNC_AGGREGATION_ENABLED}
+        - name: NOTIFICATIONS_UNLEASH_ENABLED
+          value: ${NOTIFICATIONS_UNLEASH_ENABLED}
+        - name: QUARKUS_UNLEASH_ACTIVE
+          value: ${NOTIFICATIONS_UNLEASH_ENABLED}
 parameters:
 - name: BACKOFFICE_CLIENT_ENV
   description: Back-office client environment
@@ -314,6 +318,8 @@ parameters:
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
   value: INFO
+- name: NOTIFICATIONS_UNLEASH_ENABLED
+  value: "false"
 - name: QUARKUS_HIBERNATE_ORM_LOG_SQL
   value: "false"
 - name: QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT
@@ -399,6 +405,4 @@ parameters:
 - name: NOTIFICATIONS_ASYNC_AGGREGATION_ENABLED
   value: "false"
 - name: PROCESSOR_EMAIL_AGGREGATION_USE_RECIPIENTS_RESOLVER_CLOWDAPP_ENABLED
-  value: "false"
-- name: UNLEASH_ENABLED
   value: "false"

--- a/engine/src/main/java/com/redhat/cloud/notifications/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/EngineConfig.java
@@ -2,27 +2,133 @@ package com.redhat.cloud.notifications;
 
 import com.redhat.cloud.notifications.config.FeatureFlipper;
 import io.getunleash.Unleash;
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Startup;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.Map;
+import java.util.function.Supplier;
 
 @ApplicationScoped
 public class EngineConfig {
 
+    // TODO Remove this when we're fully migrated to Unleash in all environments.
     @ConfigProperty(name = "notifications.unleash.enabled", defaultValue = "false")
     boolean unleashEnabled;
 
     @Inject
     Unleash unleash;
 
+    // TODO Remove this when we're fully migrated to Unleash in all environments.
     @Inject
     FeatureFlipper featureFlipper;
 
-    public boolean isEmailsOnlyMode() {
+    private static String toggleName(String feature) {
+        return String.format("notifications-engine.%s.enabled", feature);
+    }
+
+    // Unleash toggles names.
+    private static final String AGGREGATION_WITH_RECIPIENTS_RESOLVER_ENABLED = toggleName("aggregation-with-recipients-resolver");
+    private static final String ASYNC_AGGREGATION_ENABLED = toggleName("async-aggregation");
+    private static final String DEFAULT_TEMPLATE_ENABLED = toggleName("default-template");
+    private static final String DRAWER_ENABLED = toggleName("drawer");
+    private static final String DRAWER_CONNECTOR_ENABLED = toggleName("drawer-connector");
+    private static final String EMAILS_ONLY_MODE_ENABLED = toggleName("emails-only-mode");
+    private static final String HCC_EMAIL_SENDER_NAME_ENABLED = toggleName("hcc-email-sender-name");
+    private static final String KAFKA_CONSUMED_TOTAL_CHECKER_ENABLED = toggleName("kafka-consumed-total-checker");
+    private static final String SECURED_EMAIL_TEMPLATES_ENABLED = toggleName("secured-email-templates");
+
+    private final Map<String, Supplier<Boolean>> loggedToggles = Map.of(
+        AGGREGATION_WITH_RECIPIENTS_RESOLVER_ENABLED, this::isAggregationWithRecipientsResolverEnabled,
+        ASYNC_AGGREGATION_ENABLED, this::isAsyncAggregationEnabled,
+        DEFAULT_TEMPLATE_ENABLED, this::isDefaultTemplateEnabled,
+        DRAWER_ENABLED, this::isDrawerEnabled,
+        DRAWER_CONNECTOR_ENABLED, this::isDrawerConnectorEnabled,
+        EMAILS_ONLY_MODE_ENABLED, this::isEmailsOnlyModeEnabled,
+        HCC_EMAIL_SENDER_NAME_ENABLED, this::isHccEmailSenderNameEnabled,
+        KAFKA_CONSUMED_TOTAL_CHECKER_ENABLED, this::isKafkaConsumedTotalCheckerEnabled,
+        SECURED_EMAIL_TEMPLATES_ENABLED, this::isSecuredEmailTemplatesEnabled
+    );
+
+    void logFeatureTogglesAtStartup(@Observes Startup event) {
+        Log.info("=== Feature toggles startup status ===");
+        loggedToggles.forEach((name, value) -> {
+            Log.infof("%s=%s", name, value.get());
+        });
+    }
+
+    public boolean isAggregationWithRecipientsResolverEnabled() {
         if (unleashEnabled) {
-            return unleash.isEnabled("notifications-engine.emails-only-mode.enabled", false);
+            return unleash.isEnabled(AGGREGATION_WITH_RECIPIENTS_RESOLVER_ENABLED, false);
+        } else {
+            return featureFlipper.isUseRecipientsResolverClowdappForDailyDigestEnabled();
+        }
+    }
+
+    public boolean isAsyncAggregationEnabled() {
+        if (unleashEnabled) {
+            return unleash.isEnabled(ASYNC_AGGREGATION_ENABLED, false);
+        } else {
+            return featureFlipper.isAsyncAggregation();
+        }
+    }
+
+    public boolean isDefaultTemplateEnabled() {
+        if (unleashEnabled) {
+            return unleash.isEnabled(DEFAULT_TEMPLATE_ENABLED, false);
+        } else {
+            return featureFlipper.isUseDefaultTemplate();
+        }
+    }
+
+    public boolean isDrawerEnabled() {
+        if (unleashEnabled) {
+            return unleash.isEnabled(DRAWER_ENABLED, false);
+        } else {
+            return featureFlipper.isDrawerEnabled();
+        }
+    }
+
+    public boolean isDrawerConnectorEnabled() {
+        if (unleashEnabled) {
+            return unleash.isEnabled(DRAWER_CONNECTOR_ENABLED, false);
+        } else {
+            return featureFlipper.isDrawerConnectorEnabled();
+        }
+    }
+
+    public boolean isEmailsOnlyModeEnabled() {
+        if (unleashEnabled) {
+            return unleash.isEnabled(EMAILS_ONLY_MODE_ENABLED, true);
         } else {
             return featureFlipper.isEmailsOnlyMode();
+        }
+    }
+
+    public boolean isHccEmailSenderNameEnabled() {
+        if (unleashEnabled) {
+            return unleash.isEnabled(HCC_EMAIL_SENDER_NAME_ENABLED, false);
+        } else {
+            return featureFlipper.isHccEmailSenderNameEnabled();
+        }
+    }
+
+    public boolean isKafkaConsumedTotalCheckerEnabled() {
+        if (unleashEnabled) {
+            return unleash.isEnabled(KAFKA_CONSUMED_TOTAL_CHECKER_ENABLED, false);
+        } else {
+            return featureFlipper.isKafkaConsumedTotalCheckerEnabled();
+        }
+    }
+
+    public boolean isSecuredEmailTemplatesEnabled() {
+        if (unleashEnabled) {
+            return unleash.isEnabled(SECURED_EMAIL_TEMPLATES_ENABLED, true);
+        } else {
+            return featureFlipper.isUseSecuredEmailTemplates();
         }
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.db.repositories;
 
-import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
 import com.redhat.cloud.notifications.models.InstantEmailTemplate;
 import com.redhat.cloud.notifications.models.IntegrationTemplate;
@@ -34,7 +34,7 @@ public class TemplateRepository {
     EntityManager entityManager;
 
     @Inject
-    FeatureFlipper featureFlipper;
+    EngineConfig engineConfig;
 
     private Optional<InstantEmailTemplate> defaultEmailTemplate = null;
 
@@ -58,7 +58,7 @@ public class TemplateRepository {
                     .getSingleResult();
             return Optional.of(emailTemplate);
         } catch (NoResultException e) {
-            if (featureFlipper.isUseDefaultTemplate()) {
+            if (engineConfig.isDefaultTemplateEnabled()) {
                 return getDefaultEmailTemplate();
             }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ConnectorReceiver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ConnectorReceiver.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.events;
 
-import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.processors.drawer.DrawerProcessor;
@@ -53,7 +53,7 @@ public class ConnectorReceiver {
     }
 
     @Inject
-    FeatureFlipper featureFlipper;
+    EngineConfig engineConfig;
 
     @Inject
     DrawerProcessor drawerProcessor;
@@ -70,7 +70,7 @@ public class ConnectorReceiver {
             String historyId = (String) decodedPayload.get("historyId");
             final Endpoint endpoint = notificationHistoryRepository.getEndpointForHistoryId(historyId);
 
-            if (featureFlipper.isDrawerConnectorEnabled()) {
+            if (engineConfig.isDrawerConnectorEnabled()) {
                 drawerProcessor.manageConnectorDrawerReturnsIfNeeded(decodedPayload, UUID.fromString(historyId));
             }
             boolean updated = camelHistoryFillerHelper.updateHistoryItem(decodedPayload);

--- a/engine/src/main/java/com/redhat/cloud/notifications/health/KafkaConsumedTotalChecker.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/health/KafkaConsumedTotalChecker.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.health;
 
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.config.FeatureFlipper;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -17,6 +18,9 @@ public class KafkaConsumedTotalChecker {
 
     @Inject
     FeatureFlipper featureFlipper;
+
+    @Inject
+    EngineConfig engineConfig;
 
     @Inject
     MeterRegistry meterRegistry;
@@ -39,7 +43,7 @@ public class KafkaConsumedTotalChecker {
 
     @Scheduled(every = "${notifications.kafka-consumed-total-checker.period:5m}", delayed = "${notifications.kafka-consumed-total-checker.initial-delay:5m}")
     public void periodicCheck() {
-        if (featureFlipper.isKafkaConsumedTotalCheckerEnabled()) {
+        if (engineConfig.isKafkaConsumedTotalCheckerEnabled()) {
             double currentTotal = consumedTotalCounter.count();
             if (currentTotal == previousTotal) {
                 Log.debugf("Kafka records consumed total check failed for topic '%s'", INGRESS_TOPIC);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.processors.camel;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.DelayedThrower;
-import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
@@ -28,7 +28,7 @@ import static com.redhat.cloud.notifications.models.IntegrationTemplate.Template
 public abstract class CamelProcessor extends EndpointTypeProcessor {
 
     @Inject
-    FeatureFlipper featureFlipper;
+    EngineConfig engineConfig;
 
     @Inject
     BaseTransformer baseTransformer;
@@ -50,7 +50,7 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
 
     @Override
     public void process(Event event, List<Endpoint> endpoints) {
-        if (featureFlipper.isEmailsOnlyMode()) {
+        if (engineConfig.isEmailsOnlyModeEnabled()) {
             Log.warn("Skipping event processing because Notifications is running in emails only mode");
             return;
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
@@ -3,7 +3,7 @@ package com.redhat.cloud.notifications.processors.drawer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.DelayedThrower;
-import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.db.repositories.BundleRepository;
 import com.redhat.cloud.notifications.db.repositories.DrawerNotificationRepository;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
@@ -81,7 +81,7 @@ public class DrawerProcessor extends SystemEndpointTypeProcessor {
     EventRepository eventRepository;
 
     @Inject
-    FeatureFlipper featureFlipper;
+    EngineConfig engineConfig;
 
     @Inject
     @Channel(DRAWER_CHANNEL)
@@ -106,7 +106,7 @@ public class DrawerProcessor extends SystemEndpointTypeProcessor {
 
     @Override
     public void process(Event event, List<Endpoint> endpoints) {
-        if (!featureFlipper.isDrawerEnabled()) {
+        if (!engineConfig.isDrawerEnabled()) {
             return;
         }
         if (endpoints == null || endpoints.isEmpty()) {
@@ -123,7 +123,7 @@ public class DrawerProcessor extends SystemEndpointTypeProcessor {
         // get default endpoint
         Endpoint endpoint = endpointRepository.getOrCreateDefaultSystemSubscription(event.getAccountId(), event.getOrgId(), EndpointType.DRAWER);
 
-        if (featureFlipper.isDrawerConnectorEnabled()) {
+        if (engineConfig.isDrawerConnectorEnabled()) {
             DrawerEntryPayload drawerEntryPayload = buildJsonPayloadFromEvent(event);
 
             final Set<String> unsubscribers =

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolver.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.processors.email;
 
-import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.models.Event;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -20,7 +20,7 @@ public class EmailActorsResolver {
     private static final String STAGE_ENVIRONMENT = "stage";
 
     @Inject
-    FeatureFlipper featureFlipper;
+    EngineConfig engineConfig;
 
     /**
      * Determines which sender should be set in the email from the given event.
@@ -51,7 +51,7 @@ public class EmailActorsResolver {
     }
 
     private String getDefaultEmailSender() {
-        if (featureFlipper.isHccEmailSenderNameEnabled()) {
+        if (engineConfig.isHccEmailSenderNameEnabled()) {
             return RH_HCC_SENDER;
         } else {
             return RH_INSIGHTS_SENDER;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -1,6 +1,6 @@
 package com.redhat.cloud.notifications.processors.email;
 
-import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.db.repositories.EventTypeRepository;
@@ -58,7 +58,7 @@ public class EmailAggregator {
     SubscriptionRepository subscriptionRepository;
 
     @Inject
-    FeatureFlipper featureFlipper;
+    EngineConfig engineConfig;
 
     @Inject
     EventTypeRepository eventTypeRepository;
@@ -115,7 +115,7 @@ public class EmailAggregator {
                 Set<String> unsubscribers = unsubscribersByEventType.getOrDefault(eventType.getName(), Collections.emptySet());
 
                 Set<User> recipients;
-                if (featureFlipper.isUseRecipientsResolverClowdappForDailyDigestEnabled()) {
+                if (engineConfig.isAggregationWithRecipientsResolverEnabled()) {
                     try {
                         Log.info("Start calling external resolver service ");
                         recipients = externalRecipientsResolver.recipientUsers(

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailSubscriptionTypeProcessor.java
@@ -1,7 +1,7 @@
 package com.redhat.cloud.notifications.processors.email;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.db.repositories.BundleRepository;
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
@@ -101,7 +101,7 @@ public class EmailSubscriptionTypeProcessor extends SystemEndpointTypeProcessor 
     TemplateService templateService;
 
     @Inject
-    FeatureFlipper featureFlipper;
+    EngineConfig engineConfig;
 
     @Inject
     ActionParser actionParser;
@@ -175,7 +175,7 @@ public class EmailSubscriptionTypeProcessor extends SystemEndpointTypeProcessor 
     }
 
     public void processAggregation(Event event) {
-        if (featureFlipper.isAsyncAggregation()) {
+        if (engineConfig.isAsyncAggregationEnabled()) {
             /*
              * The aggregation process is long-running task. To avoid blocking the thread used to consume
              * Kafka messages from the ingress topic, we're performing the aggregation from a worker thread.

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
@@ -26,7 +26,7 @@ public class EventingProcessor extends EndpointTypeProcessor {
     public static final String NOTIF_METADATA_KEY = "notif-metadata";
 
     @Inject
-    EngineConfig configuration;
+    EngineConfig engineConfig;
 
     @Inject
     BaseTransformer baseTransformer;
@@ -39,7 +39,7 @@ public class EventingProcessor extends EndpointTypeProcessor {
 
     @Override
     public void process(Event event, List<Endpoint> endpoints) {
-        if (configuration.isEmailsOnlyMode()) {
+        if (engineConfig.isEmailsOnlyModeEnabled()) {
             Log.warn("Skipping event processing because Notifications is running in emails only mode");
             return;
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -1,7 +1,7 @@
 package com.redhat.cloud.notifications.processors.webhooks;
 
 import com.redhat.cloud.notifications.DelayedThrower;
-import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.WebhookProperties;
@@ -33,7 +33,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
     BaseTransformer transformer;
 
     @Inject
-    FeatureFlipper featureFlipper;
+    EngineConfig engineConfig;
 
     @Inject
     MeterRegistry registry;
@@ -50,7 +50,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
 
     @Override
     public void process(Event event, List<Endpoint> endpoints) {
-        if (featureFlipper.isEmailsOnlyMode()) {
+        if (engineConfig.isEmailsOnlyModeEnabled()) {
             Log.warn("Skipping event processing because Notifications is running in emails only mode");
             return;
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -1,7 +1,7 @@
 package com.redhat.cloud.notifications.templates;
 
 import com.cronutils.utils.StringUtils;
-import com.redhat.cloud.notifications.config.FeatureFlipper;
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.EventType;
@@ -41,7 +41,7 @@ public class EmailTemplateMigrationService {
     EntityManager entityManager;
 
     @Inject
-    FeatureFlipper featureFlipper;
+    EngineConfig engineConfig;
 
     /*
      * Templates from resources may evolve after the first migration to DB templates, before we enable DB templates
@@ -63,7 +63,7 @@ public class EmailTemplateMigrationService {
         List<String> warnings = new ArrayList<>();
 
         Log.debug("Migration starting");
-        if (featureFlipper.isUseSecuredEmailTemplates()) {
+        if (engineConfig.isSecuredEmailTemplatesEnabled()) {
             getOrCreateTemplate("Secure/Common/insightsEmailBody", "html", "Common Insights email body");
             createDailyEmailTemplate(
                 warnings, "rhel", "advisor",
@@ -590,7 +590,7 @@ public class EmailTemplateMigrationService {
             String subjectTemplateName, String subjectTemplateExtension, String subjectTemplateDescription,
             String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription) {
 
-        if (!featureFlipper.isUseSecuredEmailTemplates()) {
+        if (!engineConfig.isSecuredEmailTemplatesEnabled()) {
             subjectTemplateName += "V2";
             bodyTemplateName += "V2";
         }
@@ -649,7 +649,7 @@ public class EmailTemplateMigrationService {
     private void createDailyEmailTemplate(List<String> warnings, String bundleName, String appName,
                                           String subjectTemplateName, String subjectTemplateExtension, String subjectTemplateDescription,
                                           String bodyTemplateName, String bodyTemplateExtension, String bodyTemplateDescription) {
-        if (!featureFlipper.isUseSecuredEmailTemplates()) {
+        if (!engineConfig.isSecuredEmailTemplatesEnabled()) {
             subjectTemplateName += "V2";
             bodyTemplateName += "V2";
         }

--- a/engine/src/test/java/com/redhat/cloud/notifications/EmailTemplatesInDbHelper.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/EmailTemplatesInDbHelper.java
@@ -57,6 +57,9 @@ public abstract class EmailTemplatesInDbHelper {
     FeatureFlipper featureFlipper;
 
     @Inject
+    EngineConfig engineConfig;
+
+    @Inject
     EmailTemplateMigrationService emailTemplateMigrationService;
 
     protected final Map<String, UUID> eventTypes = new HashMap<>();
@@ -86,7 +89,7 @@ public abstract class EmailTemplatesInDbHelper {
             eventTypes.put(eventTypeToCreate, eventType.getId());
         }
         featureFlipper.setUseSecuredEmailTemplates(useSecuredTemplates());
-        if (featureFlipper.isUseSecuredEmailTemplates()) {
+        if (engineConfig.isSecuredEmailTemplatesEnabled()) {
             emailTemplateMigrationService.deleteAllTemplates();
         }
         migrate();

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.processors.email;
 
+import com.redhat.cloud.notifications.EngineConfig;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
@@ -67,6 +68,9 @@ class EmailAggregatorTest {
     @Inject
     FeatureFlipper featureFlipper;
 
+    @Inject
+    EngineConfig engineConfig;
+
     @InjectSpy
     EmailAggregator emailAggregator;
 
@@ -114,7 +118,7 @@ class EmailAggregatorTest {
 
         when(endpointRepository.getTargetEmailSubscriptionEndpoints(anyString(), any(UUID.class))).thenReturn(List.of(endpoint));
 
-        if (featureFlipper.isUseRecipientsResolverClowdappForDailyDigestEnabled()) {
+        if (engineConfig.isAggregationWithRecipientsResolverEnabled()) {
             when(recipientsResolverService.getRecipients(any(RecipientsQuery.class))).then(parameters -> {
                 RecipientsQuery query = parameters.getArgument(0);
                 Set<String> users = query.subscribers;
@@ -198,7 +202,7 @@ class EmailAggregatorTest {
     }
 
     private void verifyRecipientsResolverInteractions(int legacyRecipientResolverInvocations) {
-        if (featureFlipper.isUseRecipientsResolverClowdappForDailyDigestEnabled()) {
+        if (engineConfig.isAggregationWithRecipientsResolverEnabled()) {
             verify(recipientsResolverService, times(1)).getRecipients(any());
             verifyNoInteractions(recipientResolver);
         } else {

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/DbQuteEngineTest.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.templates;
 
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Event;
@@ -39,9 +38,6 @@ public class DbQuteEngineTest {
 
     @Inject
     TemplateService templateService;
-
-    @Inject
-    FeatureFlipper featureFlipper;
 
     @Test
     void testIncludeExistingTemplate() {

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationServiceTest.java
@@ -1,7 +1,6 @@
 package com.redhat.cloud.notifications.templates;
 
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
 import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
@@ -44,9 +43,6 @@ public class EmailTemplateMigrationServiceTest {
 
     @Inject
     TemplateService templateService;
-
-    @Inject
-    FeatureFlipper featureFlipper;
 
     @Test
     void testMigration() {

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorOpenShiftTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorOpenShiftTemplate.java
@@ -2,11 +2,8 @@ package com.redhat.cloud.notifications.templates;
 
 import com.redhat.cloud.notifications.EmailTemplatesInDbHelper;
 import com.redhat.cloud.notifications.TestHelpers;
-import com.redhat.cloud.notifications.config.FeatureFlipper;
 import com.redhat.cloud.notifications.ingress.Action;
 import io.quarkus.test.junit.QuarkusTest;
-import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -19,12 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestAdvisorOpenShiftTemplate extends EmailTemplatesInDbHelper {
 
     static final String NEW_RECOMMENDATION = "new-recommendation";
-
-    @Inject
-    FeatureFlipper featureFlipper;
-
-    @Inject
-    EntityManager entityManager;
 
     @Override
     protected String getApp() {


### PR DESCRIPTION
This PR moves most of the `engine` feature flags to Unleash. Some flags are not moved because they're no longer used in any environment.

We'll transition from env vars to Unleash in several steps because some special environments may not support Unleash yet. That's why `FeatureFlipper` is still present and, for now, enabled by default.

Unleash is not integrated in the unit tests yet. This will come in a subsequent PR.