### PR TITLE
RHCLOUD-31337 | fix: the template name is clashing with the backend's one

### DIFF
--- a/.rhcicd/floorist/floorplan.yaml
+++ b/.rhcicd/floorist/floorplan.yaml
@@ -2,7 +2,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: notifications-backend
+  name: notifications-floorist
 objects:
 - apiVersion: metrics.console.redhat.com/v1alpha1
   kind: FloorPlan


### PR DESCRIPTION
The template name for Floorist should be different than the one for the back end. I forgot to change it.

## Jira tickets
[[RHCLOUD-31337]](https://issues.redhat.com/browse/RHCLOUD-31337)