### PR TITLE
RHCLOUD-31375 Test an Unleash activation strategy based on orgId

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/EngineConfig.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications;
 
 import com.redhat.cloud.notifications.config.FeatureFlipper;
 import io.getunleash.Unleash;
+import io.getunleash.UnleashContext;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -46,7 +47,6 @@ public class EngineConfig {
         DEFAULT_TEMPLATE_ENABLED, this::isDefaultTemplateEnabled,
         DRAWER_ENABLED, this::isDrawerEnabled,
         EMAILS_ONLY_MODE_ENABLED, this::isEmailsOnlyModeEnabled,
-        HCC_EMAIL_SENDER_NAME_ENABLED, this::isHccEmailSenderNameEnabled,
         KAFKA_CONSUMED_TOTAL_CHECKER_ENABLED, this::isKafkaConsumedTotalCheckerEnabled,
         SECURED_EMAIL_TEMPLATES_ENABLED, this::isSecuredEmailTemplatesEnabled
     );
@@ -98,9 +98,10 @@ public class EngineConfig {
         }
     }
 
-    public boolean isHccEmailSenderNameEnabled() {
+    public boolean isHccEmailSenderNameEnabled(String orgId) {
         if (unleashEnabled) {
-            return unleash.isEnabled(HCC_EMAIL_SENDER_NAME_ENABLED, false);
+            UnleashContext unleashContext = UnleashContext.builder().addProperty("orgId", orgId).build();
+            return unleash.isEnabled(HCC_EMAIL_SENDER_NAME_ENABLED, unleashContext, false);
         } else {
             return featureFlipper.isHccEmailSenderNameEnabled();
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolver.java
@@ -51,10 +51,10 @@ public class EmailActorsResolver {
                     return OPENSHIFT_SENDER_PROD;
                 }
             } else {
-                return getDefaultEmailSender();
+                return getDefaultEmailSender(event.getOrgId());
             }
         } catch (Exception e) {
-            String emailSender = getDefaultEmailSender();
+            String emailSender = getDefaultEmailSender(event.getOrgId());
             Log.warnf(e, "Something went wrong while determining the email sender, falling back to default value: %s", emailSender);
             return emailSender;
         }
@@ -85,8 +85,8 @@ public class EmailActorsResolver {
         return "openshift".equals(bundle) && "cluster-manager".equals(application);
     }
 
-    private String getDefaultEmailSender() {
-        if (engineConfig.isHccEmailSenderNameEnabled()) {
+    private String getDefaultEmailSender(String orgId) {
+        if (engineConfig.isHccEmailSenderNameEnabled(orgId)) {
             return RH_HCC_SENDER;
         } else {
             return RH_INSIGHTS_SENDER;


### PR DESCRIPTION
This should allow us to enable the HCC email sender name for selected orgs only.