### PR TITLE
[RHCLOUD-31436] Fix default email template loading on stage

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/TemplateRepository.java
@@ -114,12 +114,12 @@ public class TemplateRepository {
         final String instantEmailBodyPath = "templates/Default/instantEmailBody.html";
 
         String templateSubjectData = Files.readString(
-                Paths.get(this.getClass().getClassLoader().getResource(instantEmailSubjectPath).toURI()),
+                Paths.get(Thread.currentThread().getContextClassLoader().getResource(instantEmailSubjectPath).toURI()),
                 StandardCharsets.UTF_8
         );
 
         String templateBodyData = Files.readString(
-                Paths.get(this.getClass().getClassLoader().getResource(instantEmailBodyPath).toURI()),
+                Paths.get(Thread.currentThread().getContextClassLoader().getResource(instantEmailBodyPath).toURI()),
                 StandardCharsets.UTF_8
         );
 


### PR DESCRIPTION
We have a FileSystemNotFoundException - getFileSystem on stage.
This PR change the way we use the classLoader context according Quarkus recommendation : https://quarkus.io/guides/class-loading-reference