### PR TITLE
 RHINENG-7841 | feature: "new system registered" template for Inventory

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -241,6 +241,11 @@ public class EmailTemplateMigrationService {
              * Former src/main/resources/templates/Inventory folder.
              */
             createInstantEmailTemplate(
+                warnings, "rhel", "inventory", List.of("new-system-registered"),
+                "Inventory/newSystemRegisteredEmailTitle", "txt", "New system registered instant email title",
+                "Inventory/newSystemRegisteredEmailBody", "html", "New system registered instant email body"
+            );
+            createInstantEmailTemplate(
                 warnings, "rhel", "inventory", List.of("validation-error"),
                 "Inventory/validationErrorEmailTitle", "txt", "Inventory instant email title",
                 "Inventory/validationErrorEmailBody", "html", "Inventory instant email body"

--- a/engine/src/main/resources/templates/Inventory/newSystemRegisteredEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Inventory/newSystemRegisteredEmailBodyV2.html
@@ -1,0 +1,18 @@
+{@boolean renderSection1=true}
+{@boolean renderButtonSection1=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Inventory - Red Hat Enterprise Linux
+{/content-title}
+{#content-title-section1}
+    New system registered
+{/content-title-section1}
+{#content-button-section1}
+    <a target="_blank" href="{environment.url}/insights/inventory/">Open Inventory in Insights</a>
+{/content-button-section1}
+{#content-body-section1}
+    <p>
+        <strong><a target="_blank" href="{environment.url}/insights/inventory/{action.context.inventory_id}">{action.context.display_name}</a></strong> was registered in Inventory.
+    </p>
+{/content-body-section1}
+{/include}

--- a/engine/src/main/resources/templates/Inventory/newSystemRegisteredEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/Inventory/newSystemRegisteredEmailTitleV2.txt
@@ -1,0 +1,1 @@
+Instant notification - New system registered - Inventory - Red Hat Enterprise Linux

--- a/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
@@ -7,9 +7,11 @@ import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
@@ -108,5 +110,65 @@ public class InventoryTestHelpers {
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         return emailActionMessage;
+    }
+
+    /**
+     * Creates an inventory action.
+     * @param bundle the bundle of the triggered event.
+     * @param application the application of the triggered event.
+     * @param eventType the type of the triggered event.
+     * @param inventoryId the inventory object that triggered the event.
+     * @param hostDisplayName the display name of the host that triggered the
+     *                        event.
+     * @return the build action.
+     */
+    public static Action createInventoryActionV2(
+        final String bundle,
+        final String application,
+        final String eventType,
+        final UUID inventoryId,
+        final String hostDisplayName
+    ) {
+        final Action emailActionMessage = new Action();
+        emailActionMessage.setBundle(bundle);
+        emailActionMessage.setApplication(application);
+        emailActionMessage.setTimestamp(LocalDateTime.now());
+        emailActionMessage.setEventType(eventType);
+
+        emailActionMessage.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("display_name", hostDisplayName)
+                .withAdditionalProperty("inventory_id", inventoryId)
+                .build()
+        );
+
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+
+        return emailActionMessage;
+    }
+
+    public static Event createNewSystemRegisteredEvent(
+        final UUID insightsId,
+        final UUID subscriptionManagerId,
+        final UUID satelliteId,
+        final UUID groupId,
+        final String groupName,
+        final String reporter,
+        final Instant systemCheckIn
+    ) {
+        return new Event.EventBuilder()
+            .withMetadata(null)
+            .withPayload(
+                new Payload.PayloadBuilder()
+                    .withAdditionalProperty("insights_id", insightsId)
+                    .withAdditionalProperty("subscription_manager_id", subscriptionManagerId)
+                    .withAdditionalProperty("satellite_id", satelliteId)
+                    .withAdditionalProperty("group_id", groupId)
+                    .withAdditionalProperty("group_name", groupName)
+                    .withAdditionalProperty("reporter", reporter)
+                    .withAdditionalProperty("system_check_in", systemCheckIn)
+                    .build()
+            )
+            .build();
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestInventoryTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestInventoryTemplate.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 public class TestInventoryTemplate extends EmailTemplatesInDbHelper {
 
-    private static final String EVENT_TYPE_NAME = "validation-error";
+    private static final String EVENT_TYPE_VALIDATION_ERROR = "validation-error";
 
     @Override
     protected String getApp() {
@@ -27,13 +27,13 @@ public class TestInventoryTemplate extends EmailTemplatesInDbHelper {
 
     @Override
     protected List<String> getUsedEventTypeNames() {
-        return List.of(EVENT_TYPE_NAME);
+        return List.of(EVENT_TYPE_VALIDATION_ERROR);
     }
 
     @Test
     public void testInstantEmailTitle() {
         Action action = InventoryTestHelpers.createInventoryAction("123456", "rhel", "inventory", "Host Validation Error");
-        String result = generateEmailSubject(EVENT_TYPE_NAME, action);
+        String result = generateEmailSubject(EVENT_TYPE_VALIDATION_ERROR, action);
         assertEquals("Instant notification - Validation error - Inventory - Red Hat Enterprise Linux", result);
     }
 
@@ -47,7 +47,7 @@ public class TestInventoryTemplate extends EmailTemplatesInDbHelper {
     @Test
     public void testInstantEmailBody() {
         Action action = InventoryTestHelpers.createInventoryAction("", "", "", "FooEvent");
-        String result = generateEmailBody(EVENT_TYPE_NAME, action);
+        String result = generateEmailBody(EVENT_TYPE_VALIDATION_ERROR, action);
         assertTrue(result.contains(InventoryTestHelpers.displayName1), "Body should contain host display name" + InventoryTestHelpers.displayName1);
         assertTrue(result.contains(InventoryTestHelpers.errorMessage1), "Body should contain error message" + InventoryTestHelpers.errorMessage1);
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));


### PR DESCRIPTION
Adds the "new system registered" instant email template for the
Inventory application.

![image](https://github.com/RedHatInsights/notifications-backend/assets/10974267/64f00f5f-6a1a-4923-89da-db8fcdd0b026)

## Jira ticket
[[RHINENG-7841]](https://issues.redhat.com/browse/RHINENG-7841)