### PR TITLE
RHINENG-7838 | feature: Inventory system deleted

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -246,6 +246,11 @@ public class EmailTemplateMigrationService {
                 "Inventory/newSystemRegisteredEmailBody", "html", "New system registered instant email body"
             );
             createInstantEmailTemplate(
+                warnings, "rhel", "inventory", List.of("system-deleted"),
+                "Inventory/systemDeletedEmailTitle", "txt", "System deleted instant email title",
+                "Inventory/systemDeletedEmailBody", "html", "System deleted instant email body"
+            );
+            createInstantEmailTemplate(
                 warnings, "rhel", "inventory", List.of("validation-error"),
                 "Inventory/validationErrorEmailTitle", "txt", "Inventory instant email title",
                 "Inventory/validationErrorEmailBody", "html", "Inventory instant email body"

--- a/engine/src/main/resources/templates/Inventory/systemDeletedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Inventory/systemDeletedEmailBodyV2.html
@@ -1,0 +1,18 @@
+{@boolean renderSection1=true}
+{@boolean renderButtonSection1=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Inventory - Red Hat Enterprise Linux
+{/content-title}
+{#content-title-section1}
+    System deleted
+{/content-title-section1}
+{#content-button-section1}
+    <a target="_blank" href="{environment.url}/insights/inventory/">Open Inventory in Insights</a>
+{/content-button-section1}
+{#content-body-section1}
+    <p>
+        <strong>{action.context.display_name}</strong> was deleted from Inventory.
+    </p>
+{/content-body-section1}
+{/include}

--- a/engine/src/main/resources/templates/Inventory/systemDeletedEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/Inventory/systemDeletedEmailTitleV2.txt
@@ -1,0 +1,1 @@
+Instant notification - System deleted - Inventory - Red Hat Enterprise Linux

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestInventoryTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestInventoryTemplate.java
@@ -25,9 +25,11 @@ public class TestInventoryTemplate extends EmailTemplatesInDbHelper {
     Environment environment;
 
     private static final String EVENT_TYPE_NEW_SYSTEM_REGISTERED = "new-system-registered";
+    private static final String EVENT_TYPE_SYSTEM_DELETED = "system-deleted";
     private static final String EVENT_TYPE_VALIDATION_ERROR = "validation-error";
 
     private static final String EMAIL_SUBJECT_NEW_SYSTEM_REGISTERED = "Instant notification - New system registered - Inventory - Red Hat Enterprise Linux";
+    private static final String EMAIL_SUBJECT_SYSTEM_DELETED = "Instant notification - System deleted - Inventory - Red Hat Enterprise Linux";
 
     @Override
     protected String getApp() {
@@ -36,7 +38,11 @@ public class TestInventoryTemplate extends EmailTemplatesInDbHelper {
 
     @Override
     protected List<String> getUsedEventTypeNames() {
-        return List.of(EVENT_TYPE_NEW_SYSTEM_REGISTERED, EVENT_TYPE_VALIDATION_ERROR);
+        return List.of(
+            EVENT_TYPE_SYSTEM_DELETED,
+            EVENT_TYPE_NEW_SYSTEM_REGISTERED,
+            EVENT_TYPE_VALIDATION_ERROR
+        );
     }
 
     @Test
@@ -105,6 +111,39 @@ public class TestInventoryTemplate extends EmailTemplatesInDbHelper {
 
         Assertions.assertTrue(result.contains(hostDisplayName), "the message body should contain the host's display name");
         Assertions.assertTrue(result.contains("was registered in Inventory."), "the message body should indicate that the system was registered");
+
+        this.assertOpenInventoryInsightsButtonPresent(result);
+    }
+
+    /**
+     * Tests that the subject template for the "system deleted" event is
+     * correctly rendered and contains the expected text.
+     */
+    @Test
+    void testInstantSystemDeletedSubject() {
+        final String hostDisplayName = "deleted-host";
+        final UUID inventoryId = UUID.randomUUID();
+
+        final Action action = InventoryTestHelpers.createInventoryActionV2("rhel", "inventory", "new-system-registered", inventoryId, hostDisplayName);
+        final String result = this.generateEmailSubject(EVENT_TYPE_SYSTEM_DELETED, action);
+
+        Assertions.assertEquals(EMAIL_SUBJECT_SYSTEM_DELETED, result);
+    }
+
+    /**
+     * Tests that the body template for the "system deleted" event is correctly
+     * rendered and contains the expected text.
+     */
+    @Test
+    void testInstantSystemDeletedBody() {
+        final String hostDisplayName = "deleted-host";
+        final UUID inventoryId = UUID.randomUUID();
+
+        final Action action = InventoryTestHelpers.createInventoryActionV2("rhel", "inventory", "new-system-registered", inventoryId, hostDisplayName);
+        final String result = this.generateEmailBody(EVENT_TYPE_SYSTEM_DELETED, action);
+
+        Assertions.assertTrue(result.contains(hostDisplayName), "the message body should contain the host's display name");
+        Assertions.assertTrue(result.contains("was deleted from Inventory."), "the message body should indicate that the system was deleted");
 
         this.assertOpenInventoryInsightsButtonPresent(result);
     }


### PR DESCRIPTION
Adds the "inventory system deleted" template.

![image](https://github.com/RedHatInsights/notifications-backend/assets/10974267/d71d4fdc-86a6-4586-bb72-9a7a36e7adf8)

## Dependencies

* https://github.com/RedHatInsights/notifications-backend/pull/2529

## Jira ticket
[[RHINENG-7838]](https://issues.redhat.com/browse/RHINENG-7838)