### PR TITLE
RHCLOUD-31525 | feature: Daily digest inventory emails

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregator.java
@@ -11,21 +11,44 @@ public class InventoryEmailAggregator extends AbstractEmailPayloadAggregator {
 
     private static final String EVENT_TYPE = "event_type";
     private static final String VALIDATION_ERROR = "validation-error";
+    public static final String DELETED_SYSTEMS = "deleted_systems";
+    public static final String NEW_SYSTEMS = "new_systems";
+    public static final String STALE_SYSTEMS = "stale_systems";
     private static final String ERRORS = "errors";
+
+    public static final String EVENT_TYPE_NEW_SYSTEM_REGISTERED = "new-system-registered";
+    public static final String EVENT_TYPE_SYSTEM_BECAME_STALE = "system-became-stale";
+    public static final String EVENT_TYPE_SYSTEM_DELETED = "system-deleted";
 
     private static final List<String> EVENT_TYPES = Arrays.asList(VALIDATION_ERROR);
 
+    /**
+     * Represents the list of new event types with a new payload object that
+     * is sent by Inventory.
+     */
+    private static final List<String> NEW_EVENT_TYPES = List.of(
+        EVENT_TYPE_NEW_SYSTEM_REGISTERED,
+        EVENT_TYPE_SYSTEM_BECAME_STALE,
+        EVENT_TYPE_SYSTEM_DELETED
+    );
+
+    private static final String CONTEXT_KEY = "context";
     private static final String INVENTORY_KEY = "inventory";
     private static final String EVENTS_KEY = "events";
     private static final String PAYLOAD_KEY = "payload";
     private static final String ERROR_KEY = "error";
     private static final String MESSAGE_KEY = "message";
-    private static final String DISPLAY_NAME_KEY = "display_name";
+    public static final String DISPLAY_NAME_KEY = "display_name";
+
+    public static final String INVENTORY_ID_KEY = "inventory_id";
 
     public InventoryEmailAggregator() {
         JsonObject inventory = new JsonObject();
 
+        inventory.put(DELETED_SYSTEMS, new JsonArray());
         inventory.put(ERRORS, new JsonArray());
+        inventory.put(NEW_SYSTEMS, new JsonArray());
+        inventory.put(STALE_SYSTEMS, new JsonArray());
 
         context.put(INVENTORY_KEY, inventory);
     }
@@ -36,23 +59,38 @@ public class InventoryEmailAggregator extends AbstractEmailPayloadAggregator {
         JsonObject notificationJson = notification.getPayload();
         String eventType = notificationJson.getString(EVENT_TYPE);
 
-        if (!EVENT_TYPES.contains(eventType)) {
-            return;
+        if (VALIDATION_ERROR.equals(eventType)) {
+            notificationJson.getJsonArray(EVENTS_KEY).stream().forEach(eventObject -> {
+                JsonObject event = (JsonObject) eventObject;
+                JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
+                JsonObject receivedErrorObject = payload.getJsonObject(ERROR_KEY);
+                String errorMessage = receivedErrorObject.getString(MESSAGE_KEY);
+                String displayName = payload.getString(DISPLAY_NAME_KEY);
+
+                JsonObject error = new JsonObject();
+
+                error.put("message", errorMessage);
+                error.put("display_name", displayName);
+
+                inventory.getJsonArray(ERRORS).add(error);
+            });
+        } else if (NEW_EVENT_TYPES.contains(eventType)) {
+            final JsonArray systemsList;
+            if (EVENT_TYPE_NEW_SYSTEM_REGISTERED.equals(eventType)) {
+                systemsList = inventory.getJsonArray(NEW_SYSTEMS);
+            } else if (EVENT_TYPE_SYSTEM_BECAME_STALE.equals(eventType)) {
+                systemsList = inventory.getJsonArray(STALE_SYSTEMS);
+            } else {
+                systemsList = inventory.getJsonArray(DELETED_SYSTEMS);
+            }
+
+            final JsonObject context = notificationJson.getJsonObject(CONTEXT_KEY);
+
+            final JsonObject system = new JsonObject();
+            system.put(INVENTORY_ID_KEY, context.getString(INVENTORY_ID_KEY));
+            system.put(DISPLAY_NAME_KEY, context.getString(DISPLAY_NAME_KEY));
+
+            systemsList.add(system);
         }
-
-        notificationJson.getJsonArray(EVENTS_KEY).stream().forEach(eventObject -> {
-            JsonObject event = (JsonObject) eventObject;
-            JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
-            JsonObject receivedErrorObject = payload.getJsonObject(ERROR_KEY);
-            String errorMessage = receivedErrorObject.getString(MESSAGE_KEY);
-            String displayName = payload.getString(DISPLAY_NAME_KEY);
-
-            JsonObject error = new JsonObject();
-
-            error.put("message", errorMessage);
-            error.put("display_name", displayName);
-
-            inventory.getJsonArray(ERRORS).add(error);
-        });
     }
 }

--- a/engine/src/main/resources/templates/Inventory/dailyEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Inventory/dailyEmailBodyV2.html
@@ -1,18 +1,19 @@
 {@boolean renderSection1=true}
-{@boolean renderButtonSection1=true}
+{@boolean renderSection2=true}
+{@boolean renderSection3=true}
+{@boolean renderButtonSection3=true}
 {#include Common/insightsEmailBody}
+
 {#content-title}
     Daily digest - Inventory - Red Hat Enterprise Linux
 {/content-title}
+
 {#content-title-section1}
     Host{#if action.context.inventory.errors.size() > 1}s{/if} with validation error
 {/content-title-section1}
 {#content-title-right-part-section1}
     <a target="_blank" href="{environment.url}/insights/inventory/">{action.context.inventory.errors.size()}</a>
 {/content-title-right-part-section1}
-{#content-button-section1}
-    <a target="_blank" href="{environment.url}/insights/inventory/">Open Inventory in Insights</a>
-{/content-button-section1}
 {#content-body-section1}
     <p>
         Red Hat Insights has identified {action.context.inventory.errors.size()} host{#if action.context.inventory.errors.size() > 1}s{/if} that presented a validation error.
@@ -30,7 +31,7 @@
             </tr>
         </thead>
         <tbody>
-            {#each action.context.inventory.errors.take(action.context.inventory.errors.size() > 10 ? 10 : action.context.inventory.errors.size())}
+            {#each action.context.inventory.errors}
             <tr>
                 <td>{#if it.display_name}{it.display_name}{#else}Not available{/if}</td>
                 <td>{it.message}</td>
@@ -40,4 +41,80 @@
     </table>
 
 {/content-body-section1}
+
+{#content-title-section2}
+    Systems
+{/content-title-section2}
+{#content-subtitle-section2}
+    {#let total_systems_state_change=(action.context.inventory.new_systems.size() + action.context.inventory.stale_systems.size() + action.context.inventory.deleted_systems.size())}
+        {total_systems_state_change} system{#if total_systems_state_change > 1}s{/if} changed of state
+    {/let}
+{/content-subtitle-section2}
+{#content-title-right-part-section2}
+    <a target="_blank" href="{environment.url}/insights/inventory/">{action.context.inventory.new_systems.size() + action.context.inventory.stale_systems.size() + action.context.inventory.deleted_systems.size()}</a>
+{/content-title-right-part-section2}
+{#content-body-section2}
+{#if action.context.inventory.new_systems.size() > 0}
+    <table class="rh-data-table-bordered">
+        <thead>
+            <tr>
+                <th>New system registered</th>
+            </tr>
+        </thead>
+        <tbody>
+            {#each action.context.inventory.new_systems}
+            <tr>
+                <td><a target="_blank" href="{environment.url}/insights/inventory/{it.inventory_id}">{it.display_name}</a></td>
+            </tr>
+            {/each}
+        </tbody>
+    </table>
+    {#if action.context.inventory.stale_systems.orEmpty.size() > 0 || action.context.inventory.deleted_systems.orEmpty.size > 0}
+        <div style="height: 24px">&nbsp;</div>
+    {/if}
+{/if}
+{#if action.context.inventory.stale_systems.size() > 0}
+    <table class="rh-data-table-bordered">
+        <thead>
+        <tr>
+            <th>Stale system</th>
+        </tr>
+        </thead>
+        <tbody>
+        {#each action.context.inventory.stale_systems}
+        <tr>
+            <td><a target="_blank" href="{environment.url}/insights/inventory/{it.inventory_id}">{it.display_name}</a></td>
+        </tr>
+        {/each}
+        </tbody>
+    </table>
+    {#if action.context.inventory.deleted_systems.orEmpty.size > 0}
+        <div style="height: 24px">&nbsp;</div>
+    {/if}
+{/if}
+{#if action.context.inventory.deleted_systems.size() > 0}
+    <table class="rh-data-table-bordered">
+        <thead>
+        <tr>
+            <th>System deleted</th>
+        </tr>
+        </thead>
+        <tbody>
+        {#each action.context.inventory.deleted_systems}
+            <tr>
+                <td>{it.display_name}</td>
+            </tr>
+        {/each}
+        </tbody>
+    </table>
+{/if}
+{/content-body-section2}
+{#content-body-section3}
+    <p>
+    If you want to see more details, go to Insights Inventory for Red Hat Enterprise Linux.
+    </p>
+{/content-body-section3}
+{#content-button-section3}
+    <a target="_blank" href="{environment.url}/insights/inventory/">Open Inventory in Insights</a>
+{/content-button-section3}
 {/include}

--- a/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
@@ -6,16 +6,13 @@ import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
-import com.redhat.cloud.notifications.processors.email.aggregators.InventoryEmailAggregator;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
@@ -101,76 +98,22 @@ public class InventoryTestHelpers {
         UUID inventoryId,
         String displayName
     ) {
-        return createEmailAggregationV2(
-            "rhel",
-            "inventory",
-            eventType,
-            inventoryId,
-            String.format("hostname-%s", inventoryId),
-            displayName,
-            String.format("rhel-version-%s", inventoryId),
-            "https://redhat.com",
-            Map.of("inventory-id", inventoryId.toString()),
-            inventoryId,
-            inventoryId,
-            inventoryId,
-            inventoryId,
-            String.format("group-name-%s", inventoryId),
-            String.format("reporter-%s", inventoryId)
-        );
-    }
-
-    /**
-     * Creates an email aggregation for the new event types and the new payload
-     * structure that Inventory is going to send.
-     * @param bundle the bundle of the event.
-     * @param application the application of the event.
-     * @param eventType the type of the event.
-     * @param inventoryId the ID of the inventory that originated the event.
-     * @param hostname the affected host's hostname.
-     * @param displayName the affected host's display name.
-     * @param rhelVersion the affected host's RHEL version.
-     * @param hostURL the affected host's URL.
-     * @param tags any custom tags specified by Inventory.
-     * @param insightsId the associated insights ID of the event.
-     * @param subscriptionManagerId the associated subscription manager ID of the event.
-     * @param satelliteId the associated satellite's ID.
-     * @param groupId the associated group's ID.
-     * @param groupName the associated group's name.
-     * @param reporter the reporter of the event.
-     * @return the generated email aggregation.
-     */
-    public static EmailAggregation createEmailAggregationV2(
-        String bundle,
-        String application,
-        String eventType,
-        UUID inventoryId,
-        String hostname,
-        String displayName,
-        String rhelVersion,
-        String hostURL,
-        Map<String, String> tags,
-        UUID insightsId,
-        UUID subscriptionManagerId,
-        UUID satelliteId,
-        UUID groupId,
-        String groupName,
-        String reporter
-    ) {
         final EmailAggregation aggregation = new EmailAggregation();
-        aggregation.setBundleName(bundle);
-        aggregation.setApplicationName(application);
+        aggregation.setBundleName("rhel");
+        aggregation.setApplicationName("inventory");
         aggregation.setOrgId(DEFAULT_ORG_ID);
 
         final Action emailActionMessage = new Action();
-        emailActionMessage.setBundle(bundle);
-        emailActionMessage.setApplication(application);
+        emailActionMessage.setBundle("rhel");
+        emailActionMessage.setApplication("inventory");
         emailActionMessage.setTimestamp(LocalDateTime.now());
         emailActionMessage.setEventType(eventType);
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         // Transform the tags to the expected format.
         record Tag(String value, String key) { }
+
+        final Map<String, String> tags = Map.of("inventory-id", inventoryId.toString());
 
         final List<Tag> convertedTags = new ArrayList<>();
         for (Map.Entry<String, String> entry : tags.entrySet()) {
@@ -182,10 +125,10 @@ public class InventoryTestHelpers {
         emailActionMessage.setContext(
             new Context.ContextBuilder()
                 .withAdditionalProperty("inventory_id", inventoryId)
-                .withAdditionalProperty("hostname", hostname)
+                .withAdditionalProperty("hostname", String.format("hostname-%s", inventoryId))
                 .withAdditionalProperty("display_name", displayName)
-                .withAdditionalProperty("rhel_version", rhelVersion)
-                .withAdditionalProperty("host_url", hostURL)
+                .withAdditionalProperty("rhel_version", String.format("rhel-version-%s", inventoryId))
+                .withAdditionalProperty("host_url", "https://redhat.com")
                 .withAdditionalProperty("tags", convertedTags)
                 .build()
         );
@@ -196,12 +139,12 @@ public class InventoryTestHelpers {
                     .withMetadata(new Metadata.MetadataBuilder().build())
                     .withPayload(
                         new Payload.PayloadBuilder()
-                            .withAdditionalProperty("insights_id", insightsId)
-                            .withAdditionalProperty("subscription_manager_id", subscriptionManagerId)
-                            .withAdditionalProperty("satellite_id", satelliteId)
-                            .withAdditionalProperty("group_id", groupId)
-                            .withAdditionalProperty("group_name", groupName)
-                            .withAdditionalProperty("reporter", reporter)
+                            .withAdditionalProperty("insights_id", inventoryId)
+                            .withAdditionalProperty("subscription_manager_id", inventoryId)
+                            .withAdditionalProperty("satellite_id", inventoryId)
+                            .withAdditionalProperty("group_id", inventoryId)
+                            .withAdditionalProperty("group_name", String.format("group-name-%s", inventoryId))
+                            .withAdditionalProperty("reporter", String.format("reporter-%s", inventoryId))
                             .withAdditionalProperty("system_check_in", Instant.now(Clock.systemUTC()))
                             .build()
                     )
@@ -244,8 +187,6 @@ public class InventoryTestHelpers {
         return emailActionMessage;
     }
 
-
-
     /**
      * Creates an inventory action.
      * @param bundle the bundle of the triggered event.
@@ -279,58 +220,5 @@ public class InventoryTestHelpers {
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 
         return emailActionMessage;
-    }
-
-    public static Event createNewSystemRegisteredEvent(
-        final UUID insightsId,
-        final UUID subscriptionManagerId,
-        final UUID satelliteId,
-        final UUID groupId,
-        final String groupName,
-        final String reporter,
-        final Instant systemCheckIn
-    ) {
-        return new Event.EventBuilder()
-            .withMetadata(null)
-            .withPayload(
-                new Payload.PayloadBuilder()
-                    .withAdditionalProperty("insights_id", insightsId)
-                    .withAdditionalProperty("subscription_manager_id", subscriptionManagerId)
-                    .withAdditionalProperty("satellite_id", satelliteId)
-                    .withAdditionalProperty("group_id", groupId)
-                    .withAdditionalProperty("group_name", groupName)
-                    .withAdditionalProperty("reporter", reporter)
-                    .withAdditionalProperty("system_check_in", systemCheckIn)
-                    .build()
-            )
-            .build();
-    }
-
-    /**
-     * Creates a minimal aggregation with the {@link #createMinimalEmailAggregationV2(String, UUID, String)}
-     * function, adds it to the given aggregator, and returns the generated
-     * elements in case they need to be used for later assertions.
-     * @param aggregator the aggregator to add the aggregations to.
-     * @param eventType the event type of the aggregation to generate.
-     * @param displayNames the display names of the systems to aggregate.
-     * @return the generated systems' values.
-     */
-    public static Map<UUID, String> addMinimalAggregation(final InventoryEmailAggregator aggregator, final String eventType, final Set<String> displayNames) {
-        final Map<UUID, String> systemsMap = new HashMap<>();
-
-        for (final String displayName : displayNames) {
-            final UUID systemId = UUID.randomUUID();
-
-            systemsMap.put(systemId, displayName);
-            aggregator.aggregate(
-                InventoryTestHelpers.createMinimalEmailAggregationV2(
-                    eventType,
-                    systemId,
-                    displayName
-                )
-            );
-        }
-
-        return systemsMap;
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
@@ -6,11 +6,16 @@ import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.processors.email.aggregators.InventoryEmailAggregator;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
@@ -82,6 +87,133 @@ public class InventoryTestHelpers {
         return aggregation;
     }
 
+    /**
+     * Creates a minimal email aggregation, and fills any other fields either
+     * by providing the given {@code inventoryId} or by prefixing that ID with
+     * the name of the field.
+     * @param eventType the type of the event to simulate the aggregation from.
+     * @param inventoryId the inventory ID of the event.
+     * @param displayName the display name of the host.
+     * @return the generated email aggregation.
+     */
+    public static EmailAggregation createMinimalEmailAggregationV2(
+        String eventType,
+        UUID inventoryId,
+        String displayName
+    ) {
+        return createEmailAggregationV2(
+            "rhel",
+            "inventory",
+            eventType,
+            inventoryId,
+            String.format("hostname-%s", inventoryId),
+            displayName,
+            String.format("rhel-version-%s", inventoryId),
+            "https://redhat.com",
+            Map.of("inventory-id", inventoryId.toString()),
+            inventoryId,
+            inventoryId,
+            inventoryId,
+            inventoryId,
+            String.format("group-name-%s", inventoryId),
+            String.format("reporter-%s", inventoryId)
+        );
+    }
+
+    /**
+     * Creates an email aggregation for the new event types and the new payload
+     * structure that Inventory is going to send.
+     * @param bundle the bundle of the event.
+     * @param application the application of the event.
+     * @param eventType the type of the event.
+     * @param inventoryId the ID of the inventory that originated the event.
+     * @param hostname the affected host's hostname.
+     * @param displayName the affected host's display name.
+     * @param rhelVersion the affected host's RHEL version.
+     * @param hostURL the affected host's URL.
+     * @param tags any custom tags specified by Inventory.
+     * @param insightsId the associated insights ID of the event.
+     * @param subscriptionManagerId the associated subscription manager ID of the event.
+     * @param satelliteId the associated satellite's ID.
+     * @param groupId the associated group's ID.
+     * @param groupName the associated group's name.
+     * @param reporter the reporter of the event.
+     * @return the generated email aggregation.
+     */
+    public static EmailAggregation createEmailAggregationV2(
+        String bundle,
+        String application,
+        String eventType,
+        UUID inventoryId,
+        String hostname,
+        String displayName,
+        String rhelVersion,
+        String hostURL,
+        Map<String, String> tags,
+        UUID insightsId,
+        UUID subscriptionManagerId,
+        UUID satelliteId,
+        UUID groupId,
+        String groupName,
+        String reporter
+    ) {
+        final EmailAggregation aggregation = new EmailAggregation();
+        aggregation.setBundleName(bundle);
+        aggregation.setApplicationName(application);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
+
+        final Action emailActionMessage = new Action();
+        emailActionMessage.setBundle(bundle);
+        emailActionMessage.setApplication(application);
+        emailActionMessage.setTimestamp(LocalDateTime.now());
+        emailActionMessage.setEventType(eventType);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+
+        // Transform the tags to the expected format.
+        record Tag(String value, String key) { }
+
+        final List<Tag> convertedTags = new ArrayList<>();
+        for (Map.Entry<String, String> entry : tags.entrySet()) {
+            convertedTags.add(
+                new Tag(entry.getKey(), entry.getValue())
+            );
+        }
+
+        emailActionMessage.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("inventory_id", inventoryId)
+                .withAdditionalProperty("hostname", hostname)
+                .withAdditionalProperty("display_name", displayName)
+                .withAdditionalProperty("rhel_version", rhelVersion)
+                .withAdditionalProperty("host_url", hostURL)
+                .withAdditionalProperty("tags", convertedTags)
+                .build()
+        );
+
+        emailActionMessage.setEvents(
+            List.of(
+                new Event.EventBuilder()
+                    .withMetadata(new Metadata.MetadataBuilder().build())
+                    .withPayload(
+                        new Payload.PayloadBuilder()
+                            .withAdditionalProperty("insights_id", insightsId)
+                            .withAdditionalProperty("subscription_manager_id", subscriptionManagerId)
+                            .withAdditionalProperty("satellite_id", satelliteId)
+                            .withAdditionalProperty("group_id", groupId)
+                            .withAdditionalProperty("group_name", groupName)
+                            .withAdditionalProperty("reporter", reporter)
+                            .withAdditionalProperty("system_check_in", Instant.now(Clock.systemUTC()))
+                            .build()
+                    )
+                    .build()
+            )
+        );
+
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));
+
+        return aggregation;
+    }
+
     public static Action createInventoryAction(String tenant, String bundle, String application, String event_name) {
         Action emailActionMessage = new Action();
         emailActionMessage.setBundle(bundle);
@@ -111,6 +243,8 @@ public class InventoryTestHelpers {
 
         return emailActionMessage;
     }
+
+
 
     /**
      * Creates an inventory action.
@@ -170,5 +304,33 @@ public class InventoryTestHelpers {
                     .build()
             )
             .build();
+    }
+
+    /**
+     * Creates a minimal aggregation with the {@link #createMinimalEmailAggregationV2(String, UUID, String)}
+     * function, adds it to the given aggregator, and returns the generated
+     * elements in case they need to be used for later assertions.
+     * @param aggregator the aggregator to add the aggregations to.
+     * @param eventType the event type of the aggregation to generate.
+     * @param displayNames the display names of the systems to aggregate.
+     * @return the generated systems' values.
+     */
+    public static Map<UUID, String> addMinimalAggregation(final InventoryEmailAggregator aggregator, final String eventType, final Set<String> displayNames) {
+        final Map<UUID, String> systemsMap = new HashMap<>();
+
+        for (final String displayName : displayNames) {
+            final UUID systemId = UUID.randomUUID();
+
+            systemsMap.put(systemId, displayName);
+            aggregator.aggregate(
+                InventoryTestHelpers.createMinimalEmailAggregationV2(
+                    eventType,
+                    systemId,
+                    displayName
+                )
+            );
+        }
+
+        return systemsMap;
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
@@ -125,31 +125,8 @@ public class InventoryTestHelpers {
         emailActionMessage.setContext(
             new Context.ContextBuilder()
                 .withAdditionalProperty("inventory_id", inventoryId)
-                .withAdditionalProperty("hostname", String.format("hostname-%s", inventoryId))
                 .withAdditionalProperty("display_name", displayName)
-                .withAdditionalProperty("rhel_version", String.format("rhel-version-%s", inventoryId))
-                .withAdditionalProperty("host_url", "https://redhat.com")
-                .withAdditionalProperty("tags", convertedTags)
                 .build()
-        );
-
-        emailActionMessage.setEvents(
-            List.of(
-                new Event.EventBuilder()
-                    .withMetadata(new Metadata.MetadataBuilder().build())
-                    .withPayload(
-                        new Payload.PayloadBuilder()
-                            .withAdditionalProperty("insights_id", inventoryId)
-                            .withAdditionalProperty("subscription_manager_id", inventoryId)
-                            .withAdditionalProperty("satellite_id", inventoryId)
-                            .withAdditionalProperty("group_id", inventoryId)
-                            .withAdditionalProperty("group_name", String.format("group-name-%s", inventoryId))
-                            .withAdditionalProperty("reporter", String.format("reporter-%s", inventoryId))
-                            .withAdditionalProperty("system_check_in", Instant.now(Clock.systemUTC()))
-                            .build()
-                    )
-                    .build()
-            )
         );
 
         aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage));

--- a/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/InventoryTestHelpers.java
@@ -7,8 +7,6 @@ import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
 
-import java.time.Clock;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregatorTest.java
@@ -37,7 +37,7 @@ public class InventoryEmailAggregatorTest {
 
     @Test
     void validatePayload() {
-        // Create a "validation error" aggregation.
+        // Add a "validation error" event type to the aggregation.
         this.aggregator.aggregate(InventoryTestHelpers.createEmailAggregation("tenant", "rhel", "inventory", "test event"));
 
         // Add two new system events.

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregatorTest.java
@@ -73,7 +73,7 @@ public class InventoryEmailAggregatorTest {
         Map<String, Object> context = aggregator.getContext();
         JsonObject inventory = JsonObject.mapFrom(context).getJsonObject("inventory");
 
-        // Validate the errors.
+        // Validate aggregated data from "validation error" event type.
         JsonArray errors = inventory.getJsonArray("errors");
 
         JsonObject error1 = errors.getJsonObject(0);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregatorTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
@@ -42,34 +41,34 @@ public class InventoryEmailAggregatorTest {
         this.aggregator.aggregate(InventoryTestHelpers.createEmailAggregation("tenant", "rhel", "inventory", "test event"));
 
         // Add two new system events.
-        final Map<UUID, String> newSystemsMap = InventoryTestHelpers.addMinimalAggregation(
-            this.aggregator,
-            InventoryEmailAggregator.EVENT_TYPE_NEW_SYSTEM_REGISTERED,
-            Set.of(
-                "new-system-display-name",
-                "new-second-system-display-name"
-            )
+        final Map<UUID, String> newSystemsMap = Map.of(
+            UUID.randomUUID(), "new-system-display-name",
+            UUID.randomUUID(), "new-second-system-display-name"
         );
+
+        for (final Map.Entry<UUID, String> entry : newSystemsMap.entrySet()) {
+            this.aggregator.aggregate(InventoryTestHelpers.createMinimalEmailAggregationV2(InventoryEmailAggregator.EVENT_TYPE_NEW_SYSTEM_REGISTERED, entry.getKey(), entry.getValue()));
+        }
 
         // Add two "system became stale" events.
-        final Map<UUID, String> staleSystemsMap = InventoryTestHelpers.addMinimalAggregation(
-            this.aggregator,
-            InventoryEmailAggregator.EVENT_TYPE_SYSTEM_BECAME_STALE,
-            Set.of(
-                "stale-system-display-name",
-                "second-stale-system-display-name"
-            )
+        final Map<UUID, String> staleSystemsMap = Map.of(
+            UUID.randomUUID(), "stale-system-display-name",
+            UUID.randomUUID(), "second-stale-system-display-name"
         );
 
+        for (final Map.Entry<UUID, String> entry : staleSystemsMap.entrySet()) {
+            this.aggregator.aggregate(InventoryTestHelpers.createMinimalEmailAggregationV2(InventoryEmailAggregator.EVENT_TYPE_SYSTEM_BECAME_STALE, entry.getKey(), entry.getValue()));
+        }
+
         // Add two "system deleted" events.
-        final Map<UUID, String> deletedSystemsMap = InventoryTestHelpers.addMinimalAggregation(
-            this.aggregator,
-            InventoryEmailAggregator.EVENT_TYPE_SYSTEM_DELETED,
-            Set.of(
-                "deleted-system-display-name",
-                "second-deleted-system-display-name"
-            )
+        final Map<UUID, String> deletedSystemsMap = Map.of(
+            UUID.randomUUID(), "deleted-system-display-name",
+            UUID.randomUUID(), "second-deleted-system-display-name"
         );
+
+        for (final Map.Entry<UUID, String> entry : deletedSystemsMap.entrySet()) {
+            this.aggregator.aggregate(InventoryTestHelpers.createMinimalEmailAggregationV2(InventoryEmailAggregator.EVENT_TYPE_SYSTEM_DELETED, entry.getKey(), entry.getValue()));
+        }
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject inventory = JsonObject.mapFrom(context).getJsonObject("inventory");

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestSingleDailyTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestSingleDailyTemplate.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.AdvisorTestHelpers.createEmailAggregation;
@@ -101,6 +102,10 @@ public class TestSingleDailyTemplate extends EmailTemplatesInDbHelper {
 
         InventoryEmailAggregator aggregator = new InventoryEmailAggregator();
         aggregator.aggregate(InventoryTestHelpers.createEmailAggregation("tenant", "rhel", "inventory", "test event"));
+        aggregator.aggregate(InventoryTestHelpers.createMinimalEmailAggregationV2(InventoryEmailAggregator.EVENT_TYPE_SYSTEM_DELETED, UUID.randomUUID(), "host-name"));
+        aggregator.aggregate(InventoryTestHelpers.createMinimalEmailAggregationV2(InventoryEmailAggregator.EVENT_TYPE_NEW_SYSTEM_REGISTERED, UUID.randomUUID(), "host-name"));
+        aggregator.aggregate(InventoryTestHelpers.createMinimalEmailAggregationV2(InventoryEmailAggregator.EVENT_TYPE_SYSTEM_BECAME_STALE, UUID.randomUUID(), "host-name"));
+
         generateAggregatedEmailBody(aggregator.getContext(), "inventory", dataMap);
 
         generateAggregatedEmailBody(buildPatchAggregatedPayload(), "patch", dataMap);


### PR DESCRIPTION
- Adds the required aggregation logic to be able to send the aggregated
daily digest emails with both the old and the new event types.
- Updates the daily digest email for the new Inventory events that we are
onboarding.

## Jira ticket
[[RHCLOUD-31525]](https://issues.redhat.com/browse/RHCLOUD-31525)