### PR TITLE
refactor(dev): update postgresql-rds image tag

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -37,7 +37,7 @@ objects:
           limits:
             cpu: 200m
             memory: 200Mi
-        image: quay.io/cloudservices/postgresql-rds:12-1
+        image: quay.io/cloudservices/postgresql-rds:12
         volumes:
           - name: notifications-db-cleaner-volume
             configMap:


### PR DESCRIPTION
postgresql-rds "-1" images are being deprecated; moving to postgresql-rds:12 instead
