### PR TITLE
RHCLOUD-31927 | fix: Floorist queries giving error

### DIFF
--- a/.rhcicd/floorist/floorplan.yaml
+++ b/.rhcicd/floorist/floorplan.yaml
@@ -60,10 +60,10 @@ objects:
       - prefix: insights/notifications/email_subscriptions_by_org_id
         query: >-
           SELECT
-            bun.display_name::TEXT,
-            apps.display_name::TEXT,
+            bun.display_name::TEXT AS bundle,
+            apps.display_name::TEXT AS application,
             es.org_id::TEXT,
-            et.display_name::TEXT,
+            et.display_name::TEXT AS event_type,
             es.subscription_type::TEXT,
             es.subscribed::BOOLEAN,
             count(es.*)::INTEGER AS "count"


### PR DESCRIPTION
One of the queries was returning three "display_name" columns instead of having aliased names, and that was causing Floorist to break for having multiple columns in a data frame.

## Jira ticket
[[RHCLOUD-31927]](https://issues.redhat.com/browse/RHCLOUD-31927)