### PR TITLE
RHCLOUD-31979 | feature: allow overriding the email sender

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -117,6 +117,12 @@ objects:
           value: ${NOTIFICATIONS_EMAIL_HCC_SENDER_NAME_ENABLED}
         - name: NOTIFICATIONS_EMAILS_ONLY_MODE_ENABLED
           value: ${NOTIFICATIONS_EMAILS_ONLY_MODE_ENABLED}
+        - name: NOTIFICATIONS_EMAIL_SENDER_HYBRID_CLOUD_CONSOLE
+          value: ${NOTIFICATIONS_EMAIL_SENDER_HYBRID_CLOUD_CONSOLE}
+        - name: NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE
+          value: ${NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE}
+        - name: NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD
+          value: ${NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD}
         - name: NOTIFICATIONS_KAFKA_CONSUMED_TOTAL_CHECKER_ENABLED
           value: ${KAFKA_CONSUMED_TOTAL_CHECKER_ENABLED}
         - name: NOTIFICATIONS_KAFKA_CONSUMED_TOTAL_CHECKER_INITIAL_DELAY
@@ -311,6 +317,15 @@ parameters:
 - name: NOTIFICATIONS_EMAILS_ONLY_MODE_ENABLED
   description: When this is true, all integration types except emails are disabled
   value: "true"
+- name: NOTIFICATIONS_EMAIL_SENDER_HYBRID_CLOUD_CONSOLE
+  description: The email sender address for the Red Hat Hybrid Cloud Console.
+  value: "\"Red Hat Hybrid Cloud Console\" noreply@redhat.com"
+- name: NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE
+  description: The email sender address for the OpenShift domain in stage.
+  value: "\"Red Hat OpenShift (staging)\" noreply@redhat.com"
+- name: NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD
+  description: The email sender address for the OpenShift domain in production.
+  value: "\"Red Hat OpenShift\" noreply@redhat.com"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
   value: INFO

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolver.java
@@ -4,22 +4,19 @@ import com.redhat.cloud.notifications.models.Event;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 @ApplicationScoped
 public class EmailActorsResolver {
+    @Deprecated
     public static final String RH_INSIGHTS_SENDER = "\"Red Hat Insights\" noreply@redhat.com";
-    /**
-     * Standard "Red Hat Hybrid Cloud Console" sender that the vast majority of the
-     * ConsoleDot applications will use.
-     */
-    public static final String RH_HCC_SENDER = "\"Red Hat Hybrid Cloud Console\" noreply@redhat.com";
+    @Deprecated
     public static final String OPENSHIFT_SENDER_STAGE = "\"Red Hat OpenShift (staging)\" no-reply@openshift.com";
+    @Deprecated
     public static final String OPENSHIFT_SENDER_PROD = "\"Red Hat OpenShift\" no-reply@openshift.com";
-    public static final String OPENSHIFT_SENDER_STAGE_NOREPLY_REDHAT = "\"Red Hat OpenShift (staging)\" noreply@redhat.com";
-    public static final String OPENSHIFT_SENDER_PROD_NOREPLY_REDHAT = "\"Red Hat OpenShift\" noreply@redhat.com";
     private static final String STAGE_ENVIRONMENT = "stage";
     public static String OCM_PENDO_MESSAGE = "The email sender address will soon be changing from no-reply@openshift.com to <br/><b>noreply@redhat.com</b>.<br/><br/>If you have filtering or forwarding logic in place, you will need to update<br/>those rules by <b>%s</b>.";
     public static String GENERAL_PENDO_MESSAGE = "The email sender name will soon be changing from Red Hat Insights to<br/><b>Red Hat Hybrid Cloud Console</b>.<br/><br/>If you have filtering or forwarding logic in place, you will need to update<br/>those rules by <b>%s</b>.";
@@ -29,6 +26,24 @@ public class EmailActorsResolver {
 
     @ConfigProperty(name = "notifications.email.show.pendo.until.date", defaultValue = "2024-05-01")
     LocalDate emailChangesActivationDate;
+
+    /**
+     * The email sender address for the Red Hat Hybrid Cloud Console.
+     */
+    @ConfigProperty(name = "notifications.email.sender.hybrid.cloud.console", defaultValue = "\"Red Hat Hybrid Cloud Console\" noreply@redhat.com")
+    protected String rhHccSender;
+
+    /**
+     * The email sender address for OpenShift in stage.
+     */
+    @ConfigProperty(name = "notifications.email.sender.openshift.stage", defaultValue = "\"Red Hat OpenShift (staging)\" noreply@redhat.com")
+    protected String rhOpenshiftSenderStage;
+
+    /**
+     * The email sender address for OpenShift in production.
+     */
+    @ConfigProperty(name = "notifications.email.sender.openshift.prod", defaultValue = "\"Red Hat OpenShift\" noreply@redhat.com")
+    protected String rhOpenshiftSenderProd;
 
     /**
      * Determines which sender should be set in the email from the given event.
@@ -55,9 +70,9 @@ public class EmailActorsResolver {
     private String getOCMEmailSender(Event event) {
         if (isHccEmailSenderNameEnabled()) {
             if (STAGE_ENVIRONMENT.equals(event.getSourceEnvironment())) {
-                return OPENSHIFT_SENDER_STAGE_NOREPLY_REDHAT;
+                return this.rhOpenshiftSenderStage;
             } else {
-                return OPENSHIFT_SENDER_PROD_NOREPLY_REDHAT;
+                return this.rhOpenshiftSenderProd;
             }
         } else {
             if (STAGE_ENVIRONMENT.equals(event.getSourceEnvironment())) {
@@ -95,7 +110,7 @@ public class EmailActorsResolver {
 
     private String getDefaultEmailSender() {
         if (isHccEmailSenderNameEnabled()) {
-            return RH_HCC_SENDER;
+            return this.rhHccSender;
         } else {
             return RH_INSIGHTS_SENDER;
         }
@@ -115,5 +130,17 @@ public class EmailActorsResolver {
 
     public void setEmailChangesActivationDate(LocalDate emailChangesActivationDate) {
         this.emailChangesActivationDate = emailChangesActivationDate;
+    }
+
+    public String getRhHccSender() {
+        return this.rhHccSender;
+    }
+
+    public String getOpenshiftSenderStage() {
+        return this.rhOpenshiftSenderStage;
+    }
+
+    public String getOpenshiftSenderProd() {
+        return this.rhOpenshiftSenderProd;
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolverTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolverTest.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.models.EventType;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
+
 import java.time.LocalDate;
 
 import static com.redhat.cloud.notifications.processors.email.EmailActorsResolver.GENERAL_PENDO_MESSAGE;
@@ -14,10 +15,7 @@ import static com.redhat.cloud.notifications.processors.email.EmailActorsResolve
 import static com.redhat.cloud.notifications.processors.email.EmailActorsResolver.OCM_PENDO_MESSAGE;
 import static com.redhat.cloud.notifications.processors.email.EmailActorsResolver.OCM_PENDO_TITLE;
 import static com.redhat.cloud.notifications.processors.email.EmailActorsResolver.OPENSHIFT_SENDER_PROD;
-import static com.redhat.cloud.notifications.processors.email.EmailActorsResolver.OPENSHIFT_SENDER_PROD_NOREPLY_REDHAT;
 import static com.redhat.cloud.notifications.processors.email.EmailActorsResolver.OPENSHIFT_SENDER_STAGE;
-import static com.redhat.cloud.notifications.processors.email.EmailActorsResolver.OPENSHIFT_SENDER_STAGE_NOREPLY_REDHAT;
-import static com.redhat.cloud.notifications.processors.email.EmailActorsResolver.RH_HCC_SENDER;
 import static com.redhat.cloud.notifications.processors.email.EmailActorsResolver.RH_INSIGHTS_SENDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -50,7 +48,7 @@ public class EmailActorsResolverTest {
         try {
             emailActorsResolver.setEmailChangesActivationDate(LocalDate.parse("2024-01-01"));
             Event event = buildEvent(null, "rhel", "policies");
-            assertEquals(RH_HCC_SENDER, emailActorsResolver.getEmailSender(event), "unexpected email sender returned from the function under test");
+            assertEquals(this.emailActorsResolver.getRhHccSender(), emailActorsResolver.getEmailSender(event), "unexpected email sender returned from the function under test");
         } finally {
             emailActorsResolver.setEmailChangesActivationDate(LocalDate.parse("2000-01-01"));
         }
@@ -62,7 +60,7 @@ public class EmailActorsResolverTest {
     @Test
     void testOpenshiftClusterManagerStageEmailSender() {
         Event event = buildEvent("stage", "openshift", "cluster-manager");
-        assertEquals(OPENSHIFT_SENDER_STAGE_NOREPLY_REDHAT, emailActorsResolver.getEmailSender(event), "unexpected email sender returned from the function under test");
+        assertEquals(this.emailActorsResolver.getOpenshiftSenderStage(), emailActorsResolver.getEmailSender(event), "unexpected email sender returned from the function under test");
         try {
             emailActorsResolver.setEmailChangesActivationDate(LocalDate.parse("2050-01-01"));
 
@@ -79,7 +77,7 @@ public class EmailActorsResolverTest {
     @Test
     void testOpenshiftClusterManagerDefaultEmailSender() {
         Event event = buildEvent("prod", "openshift", "cluster-manager");
-        assertEquals(OPENSHIFT_SENDER_PROD_NOREPLY_REDHAT, emailActorsResolver.getEmailSender(event), "unexpected email sender returned from the function under test");
+        assertEquals(this.emailActorsResolver.getOpenshiftSenderProd(), emailActorsResolver.getEmailSender(event), "unexpected email sender returned from the function under test");
         try {
             emailActorsResolver.setEmailChangesActivationDate(LocalDate.parse("2050-01-01"));
 


### PR DESCRIPTION
We need to provide a way to override the email sender for different clusters than the commercial one.

## Jira ticket
[[RHCLOUD-31979]](https://issues.redhat.com/browse/RHCLOUD-31979)