### PR TITLE
RHCLOUD-32001 | Improve dockerfile builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore the internal configuration directories that might contain secrets.
+.docker
+.kube
+.podman

--- a/.rhcicd/build_deploy.sh
+++ b/.rhcicd/build_deploy.sh
@@ -7,7 +7,25 @@ if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     exit 1
 fi
 
-DOCKER_CONF="$PWD/.docker"
+# Create a temporary directory isolated from $WORKSPACE to store the Docker config and prevent leaking that config in the Docker image.
+readonly job_directory_path=$(mktemp --directory -p "${HOME}" -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}.XXXXXX")
+echo "Temporary directory location for the Docker config: ${job_directory_path}"
+
+# job_directory_cleanup cleans forcefully and recursively removes the
+#                       specified directory path.
+# @param directory_path the path of the directory to remove.
+function job_directory_cleanup() {
+  echo "Cleaning up the temporary directory for the Docker config: ${1}"
+
+  rm --force --recursive "${1}"
+}
+
+# Make sure the temporary directory and all of its contents are removed in the
+# case where this script does not finish successfully.
+trap 'job_directory_cleanup ${job_directory_path}' ERR EXIT SIGINT SIGTERM
+
+# Place our docker configuration in the freshly created temporary directory.
+DOCKER_CONF="${job_directory_path}/.docker"
 mkdir -p "$DOCKER_CONF"
 
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)


### PR DESCRIPTION
* By generating a unique temporary directory for our builds, we ensure
that we will not share the workspace with the rest of the builds of the
platform.

* By explicitly ignoring the internal directories we ensure that we will
not copy them to our images by accident.

## Jira ticket
[[RHCLOUD-32001]](https://issues.redhat.com/browse/RHCLOUD32001)