### PR TITLE
Default  prometheus push gateway value.

### DIFF
--- a/.rhcicd/clowdapp-aggregator.yaml
+++ b/.rhcicd/clowdapp-aggregator.yaml
@@ -85,6 +85,7 @@ parameters:
   required: true
 - name: PROMETHEUS_PUSHGATEWAY
   description: Prometheus Pushgateway URL
+  value: "http://localhost:8080"
 - name: IMAGE
   description: Image URL
   value: quay.io/cloudservices/notifications-aggregator

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -52,7 +52,7 @@ public class DailyEmailAggregationJob {
     @Inject
     AggregationOrgConfigRepository aggregationOrgConfigRepository;
 
-    @ConfigProperty(name = "prometheus.pushgateway.url")
+    @ConfigProperty(name = "prometheus.pushgateway.url", defaultValue = "http://localhost:8080")
     String prometheusPushGatewayUrl;
 
     @ConfigProperty(name = "notifications.default.daily.digest.time", defaultValue = "00:00")


### PR DESCRIPTION
This PR changes the following:
- defaults the value for the prometheus push gateway. 
   - This ensures that there will not be deployment errors if prometheus push gateway is not set in a cluster's env. 

The following error occurs if the value is not set.
```
Caused by: io.quarkus.runtime.configuration.ConfigurationException: Failed to load config value of type class java.lang.String for: prometheus.pushgateway.url
```