### PR TITLE
fix(build_deploy): only create sc tag when building sc branch

### DIFF
--- a/.rhcicd/build_deploy.sh
+++ b/.rhcicd/build_deploy.sh
@@ -36,11 +36,11 @@ function buildAndDeploy() {
     IMAGE="quay.io/cloudservices/${IMAGE_NAME}"
     docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
     docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" . -f docker/Dockerfile.${IMAGE_NAME}.jvm
-    docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
-    if [[ $GIT_BRANCH == *"security-compliance"* ]]; then
+    if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
         docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
         docker --config="$DOCKER_CONF" push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
     else
+        docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
         docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
         docker --config="$DOCKER_CONF" push "${IMAGE}:qa"
         docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"


### PR DESCRIPTION
It has been observed  that the `build_deploy` script is set up so that when the SC build Job runs, it write a new image over the original `image_tag` on which the commit is based. 

This update fixes that issue. 
