### PR TITLE
RHCLOUD-32502 | Kessel gRPC integration

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -121,6 +121,12 @@ objects:
               name: notifications-ephemeral-data
               key: ephemeral_data.json
               optional: true
+        - name: NOTIFICATIONS_KESSEL_BACKEND_ENABLED
+          value: ${NOTIFICATIONS_KESSEL_BACKEND_ENABLED}
+        - name: NOTIFICATIONS_KESSEL_SECURE_CLIENT
+          value: ${NOTIFICATIONS_KESSEL_SECURE_CLIENT}
+        - name: NOTIFICATIONS_KESSEL_TARGET_URL
+          value: ${NOTIFICATIONS_KESSEL_TARGET_URL}
         - name: NOTIFICATIONS_UNLEASH_ENABLED
           value: ${NOTIFICATIONS_UNLEASH_ENABLED}
         - name: QUARKUS_REST_CLIENT_RBAC_AUTHENTICATION_READ_TIMEOUT
@@ -229,6 +235,15 @@ parameters:
 - name: NOTIFICATIONS_EMAILS_ONLY_MODE_ENABLED
   description: When this is true, all integration types except emails are disabled
   value: "true"
+- name: NOTIFICATIONS_KESSEL_BACKEND_ENABLED
+  description: Enables using Kessel as the authentication and authorization back end.
+  value: "false"
+- name: NOTIFICATIONS_KESSEL_SECURE_CLIENT
+  description: Is the Notifications gRPC client going to connect to Kessel using a secure channel?
+  value: "false"
+- name: NOTIFICATIONS_KESSEL_TARGET_URL
+  description: The hostname and the port for the Kessel service. The expected format is "hostname:port".
+  value: "localhost:9000"
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
 - name: QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>org.project-kessel</groupId>
             <artifactId>relations-client-java</artifactId>
-            <version>0.1</version>
+            <version>${kessel.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -151,6 +151,13 @@
             <version>${quarkus-logging-cloudwatch.version}</version>
         </dependency>
 
+        <!-- gRPC client for the interactions with Kessel -->
+        <dependency>
+            <groupId>org.project-kessel</groupId>
+            <artifactId>relations-client-java</artifactId>
+            <version>0.1</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.redhat.cloud.notifications</groupId>

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
@@ -1,10 +1,5 @@
 package com.redhat.cloud.notifications.auth.kessel;
 
-import api.check.v1.CheckRequest;
-import api.check.v1.CheckResponse;
-import api.relations.v1.ObjectReference;
-import api.relations.v1.SubjectReference;
-import client.CheckClient;
 import com.redhat.cloud.notifications.auth.principal.ConsoleIdentity;
 import com.redhat.cloud.notifications.auth.principal.ConsolePrincipal;
 import com.redhat.cloud.notifications.auth.principal.rhid.RhIdentity;
@@ -18,6 +13,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.SecurityContext;
+import org.project_kessel.api.relations.v0.CheckRequest;
+import org.project_kessel.api.relations.v0.CheckResponse;
+import org.project_kessel.api.relations.v0.ObjectReference;
+import org.project_kessel.api.relations.v0.ObjectType;
+import org.project_kessel.api.relations.v0.SubjectReference;
+import org.project_kessel.relations.client.CheckClient;
 
 import java.security.Principal;
 
@@ -119,23 +120,22 @@ public class KesselAuthorization {
         }
 
         return CheckRequest.newBuilder()
-            .setObject(
+            .setResource(
                 ObjectReference.newBuilder()
-                    .setType(resourceType.getKesselName())
+                    .setType(ObjectType.newBuilder().setName(resourceType.getKesselName()).build())
                     .setId(resourceId)
                     .build()
             )
             .setRelation(permission.getKesselPermissionName())
             .setSubject(
                 SubjectReference.newBuilder()
-                    .setObject(
+                    .setSubject(
                         ObjectReference.newBuilder()
-                            .setType(type)
+                            .setType(ObjectType.newBuilder().setName(type).build())
                             .setId(identity.getName())
-                    )
-                    .build()
-            )
-            .build();
+                            .build()
+                    ).build()
+            ).build();
     }
 
     /**

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
@@ -1,0 +1,132 @@
+package com.redhat.cloud.notifications.auth.kessel;
+
+import api.check.v1.CheckRequest;
+import api.check.v1.CheckResponse;
+import api.relations.v1.ObjectReference;
+import api.relations.v1.SubjectReference;
+import client.CheckClient;
+import com.redhat.cloud.notifications.auth.principal.ConsoleIdentity;
+import com.redhat.cloud.notifications.auth.principal.ConsolePrincipal;
+import com.redhat.cloud.notifications.auth.principal.rhid.RhIdentity;
+import com.redhat.cloud.notifications.auth.principal.rhid.RhServiceAccountIdentity;
+import com.redhat.cloud.notifications.config.BackendConfig;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.core.SecurityContext;
+
+import java.security.Principal;
+
+@ApplicationScoped
+public class KesselAuthorization {
+    /**
+     * Represents the "service account"'s subject's name in Kessel.
+     */
+    public static final String KESSEL_IDENTITY_SUBJECT_SERVICE_ACCOUNT = "service-account";
+    /**
+     * Represents the "user"'s subject's name in Kessel.
+     */
+    public static final String KESSEL_IDENTITY_SUBJECT_USER = "user";
+
+    @Inject
+    BackendConfig backendConfig;
+
+    @Inject
+    CheckClient checkClient;
+
+    /**
+     * Checks if the subject on the security context has permission on the
+     * given resource. Throws
+     * @param securityContext the security context to extract the subject from.
+     * @param permission the permission we want to check.
+     * @param resourceType the resource type we should check the permission
+     *                     against.
+     * @param resourceId the identifier of the resource.
+     * @throws ForbiddenException in case of not being authorized.
+     */
+    public void hasPermissionOnResource(final SecurityContext securityContext, final KesselPermission permission, final ResourceType resourceType, final String resourceId) {
+        // Skip the authorization step with Kessel if it is not enabled.
+        if (!this.backendConfig.isKesselBackendEnabled()) {
+            return;
+        }
+
+        // Identify the subject.
+        final RhIdentity identity = this.extractRhIdentity(securityContext);
+
+        // Build the request for Kessel.
+        final CheckRequest permissionCheckRequest = this.buildCheckRequest(identity, permission, resourceType, resourceId);
+
+        Log.tracef("[identity: %s][permission: %s][resource_type: %s][resource_id: %s] Payload for the permission check: %s", identity, permission, resourceType, resourceId, permissionCheckRequest);
+
+        final CheckResponse response = this.checkClient.check(permissionCheckRequest);
+
+        Log.tracef("[identity: %s][permission: %s][resource_type: %s][resource_id: %s] Received payload for the permission check: %s", identity, permission, resourceType, resourceId, response);
+
+        if (CheckResponse.Allowed.ALLOWED_TRUE != response.getAllowed()) {
+            Log.debugf("[identity: %s][permission: %s][resource_type: %s][resource_id: %s] Permission denied", identity, permission, resourceType, resourceId);
+
+            throw new ForbiddenException();
+        }
+
+        Log.debugf("[identity: %s][permission: %s][resource_type: %s][resource_id: %s] Permission granted", identity, resourceType, permission, resourceId);
+    }
+
+    /**
+     * Build a check request for a particular resource, to see if the subject
+     * of the identity has permission on it.
+     * @param identity the subject's identity.
+     * @param permission the permission we want to check for the given subject
+     *                   and resource.
+     * @param resourceType the resource type we are attempting to verify.
+     * @param resourceId the resource's identifier.
+     * @return the built check request for Kessel ready to be sent.
+     */
+    protected CheckRequest buildCheckRequest(final RhIdentity identity, final KesselPermission permission, final ResourceType resourceType, final String resourceId) {
+        //
+        final String type;
+        if (identity instanceof RhServiceAccountIdentity) {
+            type = KESSEL_IDENTITY_SUBJECT_SERVICE_ACCOUNT;
+        } else {
+            type = KESSEL_IDENTITY_SUBJECT_USER;
+        }
+
+        return CheckRequest.newBuilder()
+            .setObject(
+                ObjectReference.newBuilder()
+                    .setType(resourceType.getKesselName())
+                    .setId(resourceId)
+                    .build()
+            )
+            .setRelation(permission.getKesselPermissionName())
+            .setSubject(
+                SubjectReference.newBuilder()
+                    .setObject(
+                        ObjectReference.newBuilder()
+                            .setType(type)
+                            .setId(identity.getName())
+                    )
+                    .build()
+            )
+            .build();
+    }
+
+    /**
+     * Extracts the {@link RhIdentity} object from the security context.
+     * @param securityContext the security context to extract the object from.
+     * @return the extracted {@link RhIdentity} object.
+     */
+    protected RhIdentity extractRhIdentity(final SecurityContext securityContext) {
+        final Principal genericPrincipal = securityContext.getUserPrincipal();
+        if (!(genericPrincipal instanceof ConsolePrincipal<?> principal)) {
+            throw new IllegalStateException(String.format("unable to extract RH Identity object from principal. Expected \"Console Principal\" object type, got \"%s\"", genericPrincipal.getClass().getName()));
+        }
+
+        final ConsoleIdentity genericIdentity = principal.getIdentity();
+        if (!(genericIdentity instanceof RhIdentity identity)) {
+            throw new IllegalStateException(String.format("unable to extract RH Identity object from principal. Expected \"RhIdentity\" object type, got \"%s\"", genericIdentity.getClass().getName()));
+        }
+
+        return identity;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
@@ -10,6 +10,9 @@ import com.redhat.cloud.notifications.auth.principal.ConsolePrincipal;
 import com.redhat.cloud.notifications.auth.principal.rhid.RhIdentity;
 import com.redhat.cloud.notifications.auth.principal.rhid.RhServiceAccountIdentity;
 import com.redhat.cloud.notifications.config.BackendConfig;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -28,12 +31,28 @@ public class KesselAuthorization {
      * Represents the "user"'s subject's name in Kessel.
      */
     public static final String KESSEL_IDENTITY_SUBJECT_USER = "user";
+    /**
+     * Represents the key for the "permission" tag used in the timer.
+     */
+    private static final String KESSEL_METRICS_TAG_PERMISSION_KEY = "permission";
+    /**
+     * Represents the key for the "resource_type" tag used in the timer.
+     */
+    private static final String KESSEL_METRICS_TAG_RESOURCE_TYPE_KEY = "resource_type";
+    /**
+     * Represents the timer's name to measure the time spent sending requests
+     * and receiving responses from Kessel.
+     */
+    private static final String KESSEL_METRICS_TIMER_NAME = "notifications.kessel.requests";
 
     @Inject
     BackendConfig backendConfig;
 
     @Inject
     CheckClient checkClient;
+
+    @Inject
+    MeterRegistry meterRegistry;
 
     /**
      * Checks if the subject on the security context has permission on the
@@ -59,10 +78,18 @@ public class KesselAuthorization {
 
         Log.tracef("[identity: %s][permission: %s][resource_type: %s][resource_id: %s] Payload for the permission check: %s", identity, permission, resourceType, resourceId, permissionCheckRequest);
 
+        // Measure the time it takes to perform the operation with Kessel.
+        final Timer.Sample timer = Timer.start(this.meterRegistry);
+
+        // Call Kessel.
         final CheckResponse response = this.checkClient.check(permissionCheckRequest);
+
+        // Stop the timer.
+        timer.stop(this.meterRegistry.timer(KESSEL_METRICS_TIMER_NAME, Tags.of(KESSEL_METRICS_TAG_PERMISSION_KEY, permission.getKesselPermissionName(), KESSEL_METRICS_TAG_RESOURCE_TYPE_KEY, resourceType.getKesselName())));
 
         Log.tracef("[identity: %s][permission: %s][resource_type: %s][resource_id: %s] Received payload for the permission check: %s", identity, permission, resourceType, resourceId, response);
 
+        // Verify whether the subject has permission on the resource or not.
         if (CheckResponse.Allowed.ALLOWED_TRUE != response.getAllowed()) {
             Log.debugf("[identity: %s][permission: %s][resource_type: %s][resource_id: %s] Permission denied", identity, permission, resourceType, resourceId);
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselPermission.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselPermission.java
@@ -1,0 +1,14 @@
+package com.redhat.cloud.notifications.auth.kessel;
+
+/**
+ * Defines common methods that the Kessel enumerations will hold, since our
+ * internal permission representation is not the same as the
+ */
+public interface KesselPermission {
+    /**
+     * Get the permission's name as defined Kessel.
+     * @return the String representation of the permission's name as defined in
+     * Kessel.
+     */
+    String getKesselPermissionName();
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/ResourcePermission.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/ResourcePermission.java
@@ -1,0 +1,21 @@
+package com.redhat.cloud.notifications.auth.kessel;
+
+/**
+ * Represents the permissions an individual resource might have.
+ */
+public enum ResourcePermission implements KesselPermission {
+    VIEW,
+    WRITE,
+    DELETE;
+
+    /**
+     * Get the permission's name as defined Kessel.
+     *
+     * @return the String representation of the permission's name as defined in
+     * Kessel.
+     */
+    @Override
+    public String getKesselPermissionName() {
+        return this.name().toLowerCase();
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/ResourceType.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/ResourceType.java
@@ -1,0 +1,26 @@
+package com.redhat.cloud.notifications.auth.kessel;
+
+/**
+ * Enumerates the resource types that are present in Kessel.
+ */
+public enum ResourceType {
+    ENDPOINT("integration"),
+    WORKSPACE("workspace");
+
+    /**
+     * The resource type's name in Kessel.
+     */
+    private final String kesselName;
+
+    ResourceType(final String kesselName) {
+        this.kesselName = kesselName;
+    }
+
+    /**
+     * Get the resource type's name as seen in Kessel.
+     * @return the resource type's name as seen in Kesel.
+     */
+    public String getKesselName() {
+        return this.kesselName;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/WorkspacePermission.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/WorkspacePermission.java
@@ -1,0 +1,33 @@
+package com.redhat.cloud.notifications.auth.kessel;
+
+public enum WorkspacePermission implements KesselPermission {
+    EVENTS_READ("notifications_events_read"),
+    INTEGRATIONS_READ("notifications_integrations_view"),
+    INTEGRATIONS_WRITE("notifications_integrations_write"),
+    NOTIFICATIONS_READ("notifications_notifications_view"),
+    NOTIFICATIONS_WRITE("notifications_notifications_write");
+
+    /**
+     * The permission's name in Kessel's schema.
+     */
+    private final String kesselPermission;
+
+    /**
+     * Builds an enum value for the workspace permissions.
+     * @param kesselPermission the permission's name in Kessel.
+     */
+    WorkspacePermission(final String kesselPermission) {
+        this.kesselPermission = kesselPermission;
+    }
+
+    /**
+     * Get the permission's name as defined Kessel.
+     *
+     * @return the String representation of the permission's name as defined in
+     * Kessel.
+     */
+    @Override
+    public String getKesselPermissionName() {
+        return this.kesselPermission;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/producer/KesselClientsProducer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/producer/KesselClientsProducer.java
@@ -2,25 +2,23 @@ package com.redhat.cloud.notifications.auth.kessel.producer;
 
 import client.CheckClient;
 import client.RelationsGrpcClientsManager;
+import com.redhat.cloud.notifications.config.BackendConfig;
 import io.quarkus.logging.Log;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
 @Priority(1)
 public class KesselClientsProducer {
-    private static final String KESSEL_SECURE_CLIENT = "notifications.kessel.secure-client";
     private static final String KESSEL_TARGET_URL = "notifications.kessel.target-url";
 
-    /**
-     * Is the gRPC client supposed to connect to a secure, HTTPS endpoint?
-     */
-    @ConfigProperty(name = KESSEL_SECURE_CLIENT, defaultValue = "false")
-    boolean secureClient;
+    @Inject
+    BackendConfig backendConfig;
 
     /**
      * The target URL the gRPC client will connect to.
@@ -37,7 +35,7 @@ public class KesselClientsProducer {
     @ApplicationScoped
     @Produces
     protected RelationsGrpcClientsManager getRelationsGrpcClientsManager() {
-        if (this.secureClient) {
+        if (this.backendConfig.isKesselUseSecureClientEnabled()) {
             Log.infof("Generated secure gRPC client manager with target url \"%s\"", this.targetUrl);
 
             return RelationsGrpcClientsManager.forSecureClients(this.targetUrl);

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/producer/KesselClientsProducer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/producer/KesselClientsProducer.java
@@ -1,7 +1,5 @@
 package com.redhat.cloud.notifications.auth.kessel.producer;
 
-import client.CheckClient;
-import client.RelationsGrpcClientsManager;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import io.quarkus.logging.Log;
 import jakarta.annotation.Priority;
@@ -11,6 +9,8 @@ import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.project_kessel.relations.client.CheckClient;
+import org.project_kessel.relations.client.RelationsGrpcClientsManager;
 
 @ApplicationScoped
 @Priority(1)

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/producer/KesselClientsProducer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/producer/KesselClientsProducer.java
@@ -1,0 +1,72 @@
+package com.redhat.cloud.notifications.auth.kessel.producer;
+
+import client.CheckClient;
+import client.RelationsGrpcClientsManager;
+import io.quarkus.logging.Log;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+@Priority(1)
+public class KesselClientsProducer {
+    private static final String KESSEL_SECURE_CLIENT = "notifications.kessel.secure-client";
+    private static final String KESSEL_TARGET_URL = "notifications.kessel.target-url";
+
+    /**
+     * Is the gRPC client supposed to connect to a secure, HTTPS endpoint?
+     */
+    @ConfigProperty(name = KESSEL_SECURE_CLIENT, defaultValue = "false")
+    boolean secureClient;
+
+    /**
+     * The target URL the gRPC client will connect to.
+     */
+    @ConfigProperty(name = KESSEL_TARGET_URL)
+    String targetUrl;
+
+    /**
+     * Produces a gRPC clients manager. Useful for being able to safely shut
+     * down all the clients when destroying the objects.
+     * @return a gRPC clients manager.
+     */
+    @Alternative
+    @ApplicationScoped
+    @Produces
+    protected RelationsGrpcClientsManager getRelationsGrpcClientsManager() {
+        if (this.secureClient) {
+            Log.infof("Generated secure gRPC client manager with target url \"%s\"", this.targetUrl);
+
+            return RelationsGrpcClientsManager.forSecureClients(this.targetUrl);
+        }
+
+        Log.infof("Generated insecure gRPC client manager with target url \"%s\"", this.targetUrl);
+        return RelationsGrpcClientsManager.forInsecureClients(this.targetUrl);
+    }
+
+    /**
+     * Safely shuts down the gRPC clients manager and all the clients it
+     * created.
+     * @param relationsGrpcClientsManager the gRPC clients to shut down.
+     */
+    protected void shutdownClientsManager(@Disposes RelationsGrpcClientsManager relationsGrpcClientsManager) {
+        RelationsGrpcClientsManager.shutdownManager(relationsGrpcClientsManager);
+    }
+
+    /**
+     * Produces a "check client" in order to be able to perform permission
+     * checks.
+     * @param relationsGrpcClientsManager the gRPC manager to create the client
+     *                                    from.
+     * @return a check client ready to be used for permission checks.
+     */
+    @Alternative
+    @ApplicationScoped
+    @Produces
+    public CheckClient getCheckClient(final RelationsGrpcClientsManager relationsGrpcClientsManager) {
+        return relationsGrpcClientsManager.getCheckClient();
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/rhid/RhServiceAccountIdentity.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/rhid/RhServiceAccountIdentity.java
@@ -38,4 +38,13 @@ public class RhServiceAccountIdentity extends RhIdentity {
     public String getName() {
         return getServiceAccount().getClientId();
     }
+
+    @Override
+    public String toString() {
+        return "RhServiceAccountIdentity{" +
+            "orgId='" + this.orgId + '\'' +
+            ", serviceAccount=" + this.serviceAccount.username +
+            ", type='" + this.type + '\'' +
+            '}';
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/rhid/RhUserIdentity.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/principal/rhid/RhUserIdentity.java
@@ -42,4 +42,14 @@ public class RhUserIdentity extends RhIdentity {
     public String getName() {
         return getUser().getUsername();
     }
+
+    @Override
+    public String toString() {
+        return "RhUserIdentity{" +
+            "accountNumber='" + this.accountNumber + '\'' +
+            ", orgId='" + this.orgId + '\'' +
+            ", username='" + this.user.username + '\'' +
+            ", type='" + this.type + '\'' +
+            '}';
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -22,12 +22,14 @@ public class BackendConfig {
     private static final String DEFAULT_TEMPLATE = "notifications.use-default-template";
     private static final String EMAILS_ONLY_MODE = "notifications.emails-only-mode.enabled";
     private static final String INSTANT_EMAILS = "notifications.instant-emails.enabled";
+    private static final String KESSEL_BACKEND_ENABLED = "notifications.kessel.backend.enabled";
     private static final String UNLEASH = "notifications.unleash.enabled";
 
     /*
      * Unleash configuration
      */
     private String drawerToggle;
+    private String kesselBackendToggle;
     private String uniqueBgNameToggle;
     private String uniqueIntegrationNameToggle;
 
@@ -63,6 +65,9 @@ public class BackendConfig {
     @ConfigProperty(name = INSTANT_EMAILS, defaultValue = "false")
     boolean instantEmailsEnabled;
 
+    @ConfigProperty(name = KESSEL_BACKEND_ENABLED, defaultValue = "false")
+    boolean kesselBackendEnabled;
+
     @Inject
     ToggleRegistry toggleRegistry;
 
@@ -74,6 +79,7 @@ public class BackendConfig {
         drawerToggle = toggleRegistry.register("drawer", true);
         uniqueBgNameToggle = toggleRegistry.register("unique-bg-name", true);
         uniqueIntegrationNameToggle = toggleRegistry.register("unique-integration-name", true);
+        kesselBackendToggle = toggleRegistry.register("kessel-backend", true);
     }
 
     void logConfigAtStartup(@Observes Startup event) {
@@ -82,6 +88,7 @@ public class BackendConfig {
         config.put(DEFAULT_TEMPLATE, isDefaultTemplateEnabled());
         config.put(drawerToggle, isDrawerEnabled());
         config.put(EMAILS_ONLY_MODE, isEmailsOnlyModeEnabled());
+        config.put(KESSEL_BACKEND_ENABLED, isKesselBackendEnabled());
         config.put(INSTANT_EMAILS, isInstantEmailsEnabled());
         config.put(uniqueBgNameToggle, isUniqueBgNameEnabled());
         config.put(uniqueIntegrationNameToggle, isUniqueIntegrationNameEnabled());
@@ -111,6 +118,14 @@ public class BackendConfig {
 
     public boolean isInstantEmailsEnabled() {
         return instantEmailsEnabled;
+    }
+
+    public boolean isKesselBackendEnabled() {
+        if (unleashEnabled) {
+            return unleash.isEnabled(kesselBackendToggle, false);
+        } else {
+            return kesselBackendEnabled;
+        }
     }
 
     public boolean isUniqueBgNameEnabled() {

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -23,6 +23,7 @@ public class BackendConfig {
     private static final String EMAILS_ONLY_MODE = "notifications.emails-only-mode.enabled";
     private static final String INSTANT_EMAILS = "notifications.instant-emails.enabled";
     private static final String KESSEL_BACKEND_ENABLED = "notifications.kessel.backend.enabled";
+    private static final String KESSEL_USE_SECURE_CLIENT = "notifications.kessel.secure-client";
     private static final String UNLEASH = "notifications.unleash.enabled";
 
     /*
@@ -68,6 +69,12 @@ public class BackendConfig {
     @ConfigProperty(name = KESSEL_BACKEND_ENABLED, defaultValue = "false")
     boolean kesselBackendEnabled;
 
+    /**
+     * Is the gRPC client supposed to connect to a secure, HTTPS endpoint?
+     */
+    @ConfigProperty(name = KESSEL_USE_SECURE_CLIENT, defaultValue = "false")
+    boolean kesselUseSecureClientEnabled;
+
     @Inject
     ToggleRegistry toggleRegistry;
 
@@ -89,6 +96,7 @@ public class BackendConfig {
         config.put(drawerToggle, isDrawerEnabled());
         config.put(EMAILS_ONLY_MODE, isEmailsOnlyModeEnabled());
         config.put(KESSEL_BACKEND_ENABLED, isKesselBackendEnabled());
+        config.put(KESSEL_USE_SECURE_CLIENT, isKesselUseSecureClientEnabled());
         config.put(INSTANT_EMAILS, isInstantEmailsEnabled());
         config.put(uniqueBgNameToggle, isUniqueBgNameEnabled());
         config.put(uniqueIntegrationNameToggle, isUniqueIntegrationNameEnabled());
@@ -142,5 +150,9 @@ public class BackendConfig {
         } else {
             return enforceIntegrationNameUnicity;
         }
+    }
+
+    public boolean isKesselUseSecureClientEnabled() {
+        return kesselUseSecureClientEnabled;
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -314,7 +314,7 @@ public class EndpointResource {
         @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Endpoint.class))),
         @APIResponse(responseCode = "400", description = "Bad data passed, that does not correspond to the definition or Endpoint.properties are empty")
     })
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    //@RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public EndpointDTO createEndpoint(
         @Context                                        SecurityContext sec,
         @RequestBody(required = true) @NotNull @Valid   EndpointDTO endpointDTO
@@ -369,7 +369,7 @@ public class EndpointResource {
 
         endpoint.setStatus(EndpointStatus.READY);
 
-        this.secretUtils.createSecretsForEndpoint(endpoint);
+        //this.secretUtils.createSecretsForEndpoint(endpoint);
 
         return this.endpointRepository.createEndpoint(endpoint);
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -252,7 +252,7 @@ public class EndpointResource {
 
     /**
      * Gets the list of endpoints.
-     * @param securityContext the security context of the request.
+     * @param sec the security context of the request.
      * @param query the page related query elements.
      * @param targetType the types of the endpoints to fetch.
      * @param activeOnly should only the active endpoints be fetched?

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -2,6 +2,10 @@ package com.redhat.cloud.notifications.routers;
 
 import com.redhat.cloud.notifications.Constants;
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
+import com.redhat.cloud.notifications.auth.kessel.KesselAuthorization;
+import com.redhat.cloud.notifications.auth.kessel.ResourcePermission;
+import com.redhat.cloud.notifications.auth.kessel.ResourceType;
+import com.redhat.cloud.notifications.auth.kessel.WorkspacePermission;
 import com.redhat.cloud.notifications.auth.principal.rhid.RhIdPrincipal;
 import com.redhat.cloud.notifications.auth.rbac.RbacGroupValidator;
 import com.redhat.cloud.notifications.config.BackendConfig;
@@ -97,6 +101,9 @@ public class EndpointResource {
     @Inject
     @RestClient
     EndpointTestService endpointTestService;
+
+    @Inject
+    KesselAuthorization kesselAuthorization;
 
     @Inject
     NotificationRepository notificationRepository;
@@ -195,7 +202,6 @@ public class EndpointResource {
 
     @GET
     @Produces(APPLICATION_JSON)
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
     @Operation(summary = "List endpoints", description = "Provides a list of endpoints. Use this endpoint to find specific endpoints.")
     @Parameters({
         @Parameter(
@@ -212,11 +218,55 @@ public class EndpointResource {
             )
     })
     public EndpointPage getEndpoints(
-            @Context SecurityContext sec,
-            @BeanParam @Valid Query query,
-            @QueryParam("type") List<String> targetType,
-            @QueryParam("active") Boolean activeOnly,
-            @QueryParam("name") String name) {
+        @Context                SecurityContext sec,
+        @BeanParam @Valid       Query query,
+        @QueryParam("type")     List<String> targetType,
+        @QueryParam("active")   Boolean activeOnly,
+        @QueryParam("name")     String name
+    ) {
+        if (this.backendConfig.isKesselBackendEnabled()) {
+            // Check that the principal has the proper permission to list the
+            // endpoints.
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.INTEGRATIONS_READ, ResourceType.WORKSPACE, "TODO get workspace from request");
+
+            return this.internalGetEndpoints(sec, query, targetType, activeOnly, name);
+        }
+
+        return this.getEndpointsLegacyRBACRoles(sec, query, targetType, activeOnly, name);
+    }
+
+    /**
+     * Gets the list of endpoints. Checks the principal's authorization by
+     * looking at its roles.
+     * @param securityContext the security context of the request.
+     * @param query the page related query elements.
+     * @param targetType the types of the endpoints to fetch.
+     * @param activeOnly should only the active endpoints be fetched?
+     * @param name filter endpoints by name.
+     * @return a page containing the requested endpoints.
+     */
+    @Deprecated(forRemoval = true, since = "The Kessel integration began on 2024Q2.")
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
+    public EndpointPage getEndpointsLegacyRBACRoles(final SecurityContext securityContext, final Query query, final List<String> targetType, final Boolean activeOnly, final String name) {
+        return this.internalGetEndpoints(securityContext, query, targetType, activeOnly, name);
+    }
+
+    /**
+     * Gets the list of endpoints.
+     * @param securityContext the security context of the request.
+     * @param query the page related query elements.
+     * @param targetType the types of the endpoints to fetch.
+     * @param activeOnly should only the active endpoints be fetched?
+     * @param name filter endpoints by name.
+     * @return a page containing the requested endpoints.
+     */
+    public EndpointPage internalGetEndpoints(
+        final SecurityContext sec,
+        final Query query,
+        final List<String> targetType,
+        final Boolean activeOnly,
+        final String name
+    ) {
         String orgId = getOrgId(sec);
 
         List<Endpoint> endpoints;
@@ -472,17 +522,49 @@ public class EndpointResource {
         return Response.noContent().build();
     }
 
-    @PUT
-    @Path("/{id}")
-    @Consumes(APPLICATION_JSON)
-    @Produces(TEXT_PLAIN)
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
-    @Operation(summary = "Update an endpoint", description = "Updates the endpoint configuration. Use this to update an existing endpoint. Any changes to the endpoint take place immediately.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Consumes(APPLICATION_JSON)
+    @Operation(summary = "Update an endpoint", description = "Updates the endpoint configuration. Use this to update an existing endpoint. Any changes to the endpoint take place immediately.")
+    @Path("/{id}")
+    @Produces(TEXT_PLAIN)
+    @PUT
+    public Response updateEndpoint(
+        @Context                                        SecurityContext securityContext,
+        @PathParam("id")                                UUID id,
+        @RequestBody(required = true) @NotNull @Valid   EndpointDTO endpointDTO
+    ) {
+        if (this.backendConfig.isKesselBackendEnabled()) {
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, ResourcePermission.WRITE, ResourceType.ENDPOINT, id.toString());
+
+            return this.internalUpdateEndpoint(securityContext, id, endpointDTO);
+        }
+
+        return this.updateEndpointLegacyRBACRoles(securityContext, id, endpointDTO);
+    }
+
+    /**
+     * Updates an endpoint. Checks the principal's authorization by looking at
+     * its roles.
+     * @param securityContext the security context of the request.
+     * @param endpointId the ID of the endpoint to be updated.
+     * @param endpointDTO the received request body.
+     * @return a response specifying the outcome of the operation.
+     */
+    @Deprecated(forRemoval = true, since = "The Kessel integration began on 2024Q2.")
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    public Response updateEndpointLegacyRBACRoles(final SecurityContext securityContext, final UUID endpointId, final EndpointDTO endpointDTO) {
+        return this.internalUpdateEndpoint(securityContext, endpointId, endpointDTO);
+    }
+
+    /**
+     * Updates an endpoint.
+     * @param sec the security context of the request.
+     * @param id the endpoint's identifier.
+     * @param endpointDTO the updated endpoint's body.
+     * @return a response specifying the outcome of the oeration.
+     */
     @Transactional
-    public Response updateEndpoint(@Context SecurityContext sec,
-                                   @PathParam("id") UUID id,
-                                   @RequestBody(required = true) @NotNull @Valid EndpointDTO endpointDTO) {
+    public Response internalUpdateEndpoint(final SecurityContext sec, final UUID id, final @NotNull @Valid EndpointDTO endpointDTO) {
         final Endpoint endpoint = this.endpointMapper.toEntity(endpointDTO);
 
         if (!isEndpointTypeAllowed(endpoint.getType())) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -245,7 +245,6 @@ public class EndpointResource {
      * @param name filter endpoints by name.
      * @return a page containing the requested endpoints.
      */
-    @Deprecated(forRemoval = true, since = "The Kessel integration began on 2024Q2.")
     @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
     public EndpointPage getEndpointsLegacyRBACRoles(final SecurityContext securityContext, final Query query, final List<String> targetType, final Boolean activeOnly, final String name) {
         return this.internalGetEndpoints(securityContext, query, targetType, activeOnly, name);
@@ -550,7 +549,6 @@ public class EndpointResource {
      * @param endpointDTO the received request body.
      * @return a response specifying the outcome of the operation.
      */
-    @Deprecated(forRemoval = true, since = "The Kessel integration began on 2024Q2.")
     @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public Response updateEndpointLegacyRBACRoles(final SecurityContext securityContext, final UUID endpointId, final EndpointDTO endpointDTO) {
         return this.internalUpdateEndpoint(securityContext, endpointId, endpointDTO);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -369,7 +369,7 @@ public class EndpointResource {
 
         endpoint.setStatus(EndpointStatus.READY);
 
-        //this.secretUtils.createSecretsForEndpoint(endpoint);
+        this.secretUtils.createSecretsForEndpoint(endpoint);
 
         return this.endpointRepository.createEndpoint(endpoint);
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,7 +9,7 @@ quarkus.http.port=8085
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
 quarkus.datasource.password=postgres
-quarkus.datasource.jdbc.url=jdbc:postgresql://127.0.0.1:55432/notifications
+quarkus.datasource.jdbc.url=jdbc:postgresql://127.0.0.1:5432/notifications
 quarkus.datasource.jdbc.telemetry=false
 
 quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.notifications.db.naming.SnakeCasePhysicalNamingStrategy
@@ -103,6 +103,3 @@ quarkus.unleash.url=http://localhost:4242
 
 # Kessel
 notifications.kessel.target-url=localhost:9000
-
-quarkus.log.category."com.redhat.cloud.notifications.auth.kessel".min-level=TRACE
-quarkus.log.category."com.redhat.cloud.notifications.auth.kessel".level=TRACE

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -100,3 +100,6 @@ sources.psk=development-value-123
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242
+
+# Kessel
+notifications.kessel.target-url=localhost:9000

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,7 +9,7 @@ quarkus.http.port=8085
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
 quarkus.datasource.password=postgres
-quarkus.datasource.jdbc.url=jdbc:postgresql://127.0.0.1:5432/notifications
+quarkus.datasource.jdbc.url=jdbc:postgresql://127.0.0.1:55432/notifications
 quarkus.datasource.jdbc.telemetry=false
 
 quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.notifications.db.naming.SnakeCasePhysicalNamingStrategy
@@ -103,3 +103,6 @@ quarkus.unleash.url=http://localhost:4242
 
 # Kessel
 notifications.kessel.target-url=localhost:9000
+
+quarkus.log.category."com.redhat.cloud.notifications.auth.kessel".min-level=TRACE
+quarkus.log.category."com.redhat.cloud.notifications.auth.kessel".level=TRACE

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorizationTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorizationTest.java
@@ -1,10 +1,5 @@
 package com.redhat.cloud.notifications.auth.kessel;
 
-import api.check.v1.CheckRequest;
-import api.check.v1.CheckResponse;
-import api.relations.v1.ObjectReference;
-import api.relations.v1.SubjectReference;
-import client.CheckClient;
 import com.redhat.cloud.notifications.auth.principal.ConsolePrincipal;
 import com.redhat.cloud.notifications.auth.principal.rhid.RhIdPrincipal;
 import com.redhat.cloud.notifications.auth.principal.rhid.RhIdentity;
@@ -21,6 +16,11 @@ import jakarta.ws.rs.core.SecurityContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.project_kessel.api.relations.v0.CheckRequest;
+import org.project_kessel.api.relations.v0.CheckResponse;
+import org.project_kessel.api.relations.v0.ObjectReference;
+import org.project_kessel.api.relations.v0.SubjectReference;
+import org.project_kessel.relations.client.CheckClient;
 
 import java.security.Principal;
 import java.util.List;
@@ -156,16 +156,17 @@ public class KesselAuthorizationTest {
             final CheckRequest checkRequest = this.kesselAuthorization.buildCheckRequest(tc.identity(), tc.permission(), tc.resourceType(), tc.resourceId());
 
             // Make sure the request was built appropriately.
-            final ObjectReference objectReference = checkRequest.getObject();
-            Assertions.assertEquals(tc.resourceType().getKesselName(), objectReference.getType(), String.format("unexpected resource type obtained for the object's reference on test case: %s", tc));
+
+            final ObjectReference objectReference = checkRequest.getResource();
+            Assertions.assertEquals(tc.resourceType().getKesselName(), objectReference.getType().getName(), String.format("unexpected resource type obtained for the object's reference on test case: %s", tc));
             Assertions.assertEquals(tc.resourceId(), objectReference.getId(), String.format("unexpected resource ID obtained for the object's reference on test case: %s", tc));
             Assertions.assertEquals(tc.resourceId(), objectReference.getId(), String.format("unexpected resource ID obtained for the object's reference on test case: %s", tc));
 
             Assertions.assertEquals(tc.permission().getKesselPermissionName(), checkRequest.getRelation(), String.format("unexpected relation obtained on test case: %s", tc));
 
             final SubjectReference subjectReference = checkRequest.getSubject();
-            Assertions.assertEquals(tc.expectedIdentityType(), subjectReference.getObject().getType(), String.format("unexpected resource type obtained for the subject's reference on test case: %s", tc));
-            Assertions.assertEquals(tc.identity().getName(), subjectReference.getObject().getId(), String.format("unexpected resource ID obtained for the subject's reference on test case: %s", tc));
+            Assertions.assertEquals(tc.expectedIdentityType(), subjectReference.getSubject().getType().getName(), String.format("unexpected resource type obtained for the subject's reference on test case: %s", tc));
+            Assertions.assertEquals(tc.identity().getName(), subjectReference.getSubject().getId(), String.format("unexpected resource ID obtained for the subject's reference on test case: %s", tc));
         }
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorizationTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorizationTest.java
@@ -19,7 +19,6 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.SecurityContext;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -42,7 +41,6 @@ public class KesselAuthorizationTest {
      * Tests that when the principal is authorized, the function under test
      * does not raise an exception.
      */
-    @Disabled
     @Test
     void testAuthorized() {
         // Mock the security context.
@@ -79,7 +77,6 @@ public class KesselAuthorizationTest {
      * Tests that when the principal is authorized, the function under test
      * throws an exception.
      */
-    @Disabled
     @Test
     void testUnauthorized() {
         // Mock the security context.

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorizationTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorizationTest.java
@@ -160,7 +160,6 @@ public class KesselAuthorizationTest {
             final ObjectReference objectReference = checkRequest.getResource();
             Assertions.assertEquals(tc.resourceType().getKesselName(), objectReference.getType().getName(), String.format("unexpected resource type obtained for the object's reference on test case: %s", tc));
             Assertions.assertEquals(tc.resourceId(), objectReference.getId(), String.format("unexpected resource ID obtained for the object's reference on test case: %s", tc));
-            Assertions.assertEquals(tc.resourceId(), objectReference.getId(), String.format("unexpected resource ID obtained for the object's reference on test case: %s", tc));
 
             Assertions.assertEquals(tc.permission().getKesselPermissionName(), checkRequest.getRelation(), String.format("unexpected relation obtained on test case: %s", tc));
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorizationTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorizationTest.java
@@ -1,0 +1,265 @@
+package com.redhat.cloud.notifications.auth.kessel;
+
+import api.check.v1.CheckRequest;
+import api.check.v1.CheckResponse;
+import api.relations.v1.ObjectReference;
+import api.relations.v1.SubjectReference;
+import client.CheckClient;
+import com.redhat.cloud.notifications.auth.principal.ConsolePrincipal;
+import com.redhat.cloud.notifications.auth.principal.rhid.RhIdPrincipal;
+import com.redhat.cloud.notifications.auth.principal.rhid.RhIdentity;
+import com.redhat.cloud.notifications.auth.principal.rhid.RhServiceAccountIdentity;
+import com.redhat.cloud.notifications.auth.principal.rhid.RhUserIdentity;
+import com.redhat.cloud.notifications.auth.principal.turnpike.TurnpikePrincipal;
+import com.redhat.cloud.notifications.auth.principal.turnpike.TurnpikeSamlIdentity;
+import com.redhat.cloud.notifications.config.BackendConfig;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.core.SecurityContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.UUID;
+
+@QuarkusTest
+public class KesselAuthorizationTest {
+    @InjectMock
+    BackendConfig backendConfig;
+
+    @InjectMock
+    CheckClient checkClient;
+
+    @Inject
+    KesselAuthorization kesselAuthorization;
+
+    /**
+     * Tests that when the principal is authorized, the function under test
+     * does not raise an exception.
+     */
+    @Disabled
+    @Test
+    void testAuthorized() {
+        // Mock the security context.
+        final SecurityContext mockedSecurityContext = Mockito.mock(SecurityContext.class);
+
+        // Create a RhIdentity principal and assign it to the mocked security
+        // context.
+        final RhIdentity identity = Mockito.mock(RhIdentity.class);
+        Mockito.when(identity.getName()).thenReturn("Red Hat user");
+
+        final ConsolePrincipal<?> principal = new RhIdPrincipal(identity);
+        Mockito.when(mockedSecurityContext.getUserPrincipal()).thenReturn(principal);
+
+        // Enable the Kessel back end integration for this test.
+        Mockito.when(this.backendConfig.isKesselBackendEnabled()).thenReturn(true);
+
+        // Simulate that Kessel returns a positive response.
+        final CheckResponse positiveCheckResponse = CheckResponse.newBuilder().setAllowed(CheckResponse.Allowed.ALLOWED_TRUE).build();
+        Mockito.when(this.checkClient.check(Mockito.any())).thenReturn(positiveCheckResponse);
+
+        // Call the function under test.
+        this.kesselAuthorization.hasPermissionOnResource(
+            mockedSecurityContext,
+            WorkspacePermission.INTEGRATIONS_READ,
+            ResourceType.WORKSPACE,
+            "workspace-uuid"
+        );
+
+        // Verify that we called Kessel.
+        Mockito.verify(this.checkClient, Mockito.times(1)).check(Mockito.any());
+    }
+
+    /**
+     * Tests that when the principal is authorized, the function under test
+     * throws an exception.
+     */
+    @Disabled
+    @Test
+    void testUnauthorized() {
+        // Mock the security context.
+        final SecurityContext mockedSecurityContext = Mockito.mock(SecurityContext.class);
+
+        // Create a RhIdentity principal and assign it to the mocked security
+        // context.
+        final RhIdentity identity = Mockito.mock(RhIdentity.class);
+        Mockito.when(identity.getName()).thenReturn("Red Hat user");
+
+        final ConsolePrincipal<?> principal = new RhIdPrincipal(identity);
+        Mockito.when(mockedSecurityContext.getUserPrincipal()).thenReturn(principal);
+
+        // Enable the Kessel back end integration for this test.
+        Mockito.when(this.backendConfig.isKesselBackendEnabled()).thenReturn(true);
+
+        // Simulate that Kessel returns a negative response.
+        final CheckResponse positiveCheckResponse = CheckResponse.newBuilder().setAllowed(CheckResponse.Allowed.ALLOWED_FALSE).build();
+        Mockito.when(this.checkClient.check(Mockito.any())).thenReturn(positiveCheckResponse);
+
+        // Call the function under test and expect that it throws a "Forbidden"
+        // exception.
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () -> this.kesselAuthorization.hasPermissionOnResource(
+                mockedSecurityContext,
+                WorkspacePermission.INTEGRATIONS_READ,
+                ResourceType.WORKSPACE,
+                "workspace-uuid"
+            ),
+            "unexpected exception thrown, as with a negative response from Kessel it should throw a \"Forbidden exception\""
+        );
+
+        // Verify that we called Kessel.
+        Mockito.verify(this.checkClient, Mockito.times(1)).check(Mockito.any());
+    }
+
+    /**
+     * Test that permission check requests are properly built for both service
+     * accounts and users.
+     */
+    @Test
+    void testBuildCheckRequest() {
+        record TestCase(RhIdentity identity, String expectedIdentityType, ResourceType resourceType, KesselPermission permission, String resourceId) {
+            @Override
+            public String toString() {
+                return "TestCase{" +
+                    "identity='" + this.identity + '\'' +
+                    ", expectedIdentityType='" + this.expectedIdentityType + '\'' +
+                    ", resourceType='" + this.resourceType + '\'' +
+                    ", kesselPermission='" + this.permission + '\'' +
+                    ", resourceId='" + this.resourceId + '\'' +
+                    '}';
+            }
+        }
+
+        // Create a user identity object.
+        final String username = "Red Hat user";
+        final RhIdentity userIdentity = Mockito.mock(RhUserIdentity.class);
+        Mockito.when(userIdentity.getName()).thenReturn(username);
+
+        // Create a service account identity object.
+        final String serviceAccountName = String.format("service-account-%s", UUID.randomUUID());
+        final RhIdentity serviceAccountIdentity = Mockito.mock(RhServiceAccountIdentity.class);
+        Mockito.when(serviceAccountIdentity.getName()).thenReturn(serviceAccountName);
+
+        // Loop through the supported identities.
+        final List<TestCase> testCases = List.of(
+            new TestCase(userIdentity, KesselAuthorization.KESSEL_IDENTITY_SUBJECT_USER, ResourceType.ENDPOINT, ResourcePermission.VIEW, "12345"),
+            new TestCase(serviceAccountIdentity, KesselAuthorization.KESSEL_IDENTITY_SUBJECT_SERVICE_ACCOUNT, ResourceType.ENDPOINT, ResourcePermission.WRITE, "54321"),
+            new TestCase(userIdentity, KesselAuthorization.KESSEL_IDENTITY_SUBJECT_USER, ResourceType.WORKSPACE, WorkspacePermission.INTEGRATIONS_READ, "workspace-a"),
+            new TestCase(serviceAccountIdentity, KesselAuthorization.KESSEL_IDENTITY_SUBJECT_SERVICE_ACCOUNT, ResourceType.WORKSPACE, WorkspacePermission.EVENTS_READ, "workspace-b")
+        );
+
+        for (final TestCase tc : testCases) {
+            // Call the function under test.
+            final CheckRequest checkRequest = this.kesselAuthorization.buildCheckRequest(tc.identity(), tc.permission(), tc.resourceType(), tc.resourceId());
+
+            // Make sure the request was built appropriately.
+            final ObjectReference objectReference = checkRequest.getObject();
+            Assertions.assertEquals(tc.resourceType().getKesselName(), objectReference.getType(), String.format("unexpected resource type obtained for the object's reference on test case: %s", tc));
+            Assertions.assertEquals(tc.resourceId(), objectReference.getId(), String.format("unexpected resource ID obtained for the object's reference on test case: %s", tc));
+            Assertions.assertEquals(tc.resourceId(), objectReference.getId(), String.format("unexpected resource ID obtained for the object's reference on test case: %s", tc));
+
+            Assertions.assertEquals(tc.permission().getKesselPermissionName(), checkRequest.getRelation(), String.format("unexpected relation obtained on test case: %s", tc));
+
+            final SubjectReference subjectReference = checkRequest.getSubject();
+            Assertions.assertEquals(tc.expectedIdentityType(), subjectReference.getObject().getType(), String.format("unexpected resource type obtained for the subject's reference on test case: %s", tc));
+            Assertions.assertEquals(tc.identity().getName(), subjectReference.getObject().getId(), String.format("unexpected resource ID obtained for the subject's reference on test case: %s", tc));
+        }
+    }
+
+    /**
+     * Test that the {@link RhIdentity} is correctly extracted from a security
+     * context.
+     */
+    @Test
+    void testExtractRhIdentity() {
+        // Mock the security context.
+        final SecurityContext mockedSecurityContext = Mockito.mock(SecurityContext.class);
+
+        // Create a RhIdentity principal and assign it to the mocked security
+        // context.
+        final RhIdentity identity = Mockito.mock(RhIdentity.class);
+        Mockito.when(identity.getName()).thenReturn("Red Hat user");
+
+        final ConsolePrincipal<?> principal = new RhIdPrincipal(identity);
+        Mockito.when(mockedSecurityContext.getUserPrincipal()).thenReturn(principal);
+
+        // Call the function under test.
+        final RhIdentity result = this.kesselAuthorization.extractRhIdentity(mockedSecurityContext);
+
+        // Assert that the objects are the same. Just by checking the object's
+        // reference we can be sure that our stubbed principal above is the
+        // one that was extracted.
+        Assertions.assertEquals(
+            identity,
+            result,
+            "the extracted identity object was not the same"
+        );
+    }
+
+    /**
+     * Test that when a "non-console" principal is extracted from the security
+     * context, an exception is raised.
+     */
+    @Test
+    void testExtractRhIdentityNoConsolePrincipalThrowsException() {
+        // Mock the security context.
+        final SecurityContext mockedSecurityContext = Mockito.mock(SecurityContext.class);
+
+        // Mock a generic principal and make the context return it when asked
+        // for it.
+        final Principal mockedPrincipal = Mockito.mock(Principal.class);
+        Mockito.when(mockedSecurityContext.getUserPrincipal()).thenReturn(Mockito.mock(Principal.class));
+
+        // Call the function under test.
+        final IllegalStateException e = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.kesselAuthorization.extractRhIdentity(mockedSecurityContext)
+        );
+
+        // Assert that the correct exception has been thrown.
+        Assertions.assertEquals(
+            String.format("unable to extract RH Identity object from principal. Expected \"Console Principal\" object type, got \"%s\"", mockedPrincipal.getClass().getName()),
+            e.getMessage(),
+            "unexpected exception message"
+        );
+    }
+
+    /**
+     * Test that a "non-RhIdentity" identity inside a principal raises an
+     * exception.
+     */
+    @Test
+    void testExtractRhIdentityNoSupportedIdentityThrowsException() {
+        // Mock the security context.
+        final SecurityContext mockedSecurityContext = Mockito.mock(SecurityContext.class);
+
+        // Mock an unexpected identity which should trigger an exception.
+        final TurnpikeSamlIdentity turnpikeSamlIdentity = new TurnpikeSamlIdentity();
+        turnpikeSamlIdentity.associate = new TurnpikeSamlIdentity.Associate();
+        turnpikeSamlIdentity.associate.email = "example@redhat.com";
+        turnpikeSamlIdentity.type = "turnpike";
+
+        // Make the identity part of the principal.
+        final ConsolePrincipal<?> turnpikePrincipal = new TurnpikePrincipal(turnpikeSamlIdentity);
+        Mockito.when(mockedSecurityContext.getUserPrincipal()).thenReturn(turnpikePrincipal);
+
+        // Call the function under test.
+        final IllegalStateException e = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.kesselAuthorization.extractRhIdentity(mockedSecurityContext)
+        );
+
+        // Assert that the correct exception has been thrown.
+        Assertions.assertEquals(
+            String.format("unable to extract RH Identity object from principal. Expected \"RhIdentity\" object type, got \"%s\"", turnpikeSamlIdentity.getClass().getName()),
+            e.getMessage(),
+            "unexpected exception message"
+        );
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 
     <properties>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <kessel.version>0.1</kessel.version>
 
         <enforcer-plugin.version>3.4.1</enforcer-plugin.version>
         <maven-minimum-version>3.8.4</maven-minimum-version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <properties>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
-        <kessel.version>0.1</kessel.version>
+        <kessel.version>0.2</kessel.version>
 
         <enforcer-plugin.version>3.4.1</enforcer-plugin.version>
         <maven-minimum-version>3.8.4</maven-minimum-version>


### PR DESCRIPTION
Integrates Kessel within Notifications, so that we use that as the authorization back end to build our internal Quarkus Security Identity.

In order to test this locally the following requirements must be met:

* Build the [relations-client-java](https://github.com/project-kessel/relations-client-java) locally.
* Launch Kessel with the following schema and test relations: https://play.authzed.com/s/_FPmZhrf-I06/schema
* Create an integration.
* Attempt to update it.

## Jira ticket
[[RHCLOUD-32502]](https://issues.redhat.com/browse/RHCLOUD-32502)