### PR TITLE
RHCLOUD-31165 | fix: endpoint subentities not properly serialized

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CamelProperties.java
@@ -1,5 +1,8 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.db.converters.MapConverter;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.persistence.Column;
@@ -14,6 +17,7 @@ import jakarta.validation.constraints.Size;
 import java.util.Map;
 
 @Entity
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class) // TODO remove them once the transition to DTOs have been completed.
 @Table(name = "camel_properties")
 public class CamelProperties extends EndpointProperties implements SourcesSecretable {
 
@@ -32,6 +36,7 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
      * The ID of the "secret token" secret in the Sources backend.
      */
     @Column(name = "secret_token_id")
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     private Long secretTokenSourcesId;
 
     @Transient
@@ -42,6 +47,7 @@ public class CamelProperties extends EndpointProperties implements SourcesSecret
      * The ID of the "basic authentication" secret in the Sources backend.
      */
     @Column(name = "basic_authentication_id")
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     private Long basicAuthenticationSourcesId;
 
     @Convert(converter = MapConverter.class)

--- a/common/src/main/java/com/redhat/cloud/notifications/models/CompositeEndpointType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/CompositeEndpointType.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.redhat.cloud.notifications.db.converters.EndpointTypeConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -18,6 +19,7 @@ public class CompositeEndpointType {
     private EndpointType type;
 
     @Column(name = "endpoint_sub_type")
+    @JsonInclude(JsonInclude.Include.NON_NULL) // TODO remove them once the transition to DTOs have been completed.
     @Size(max = 20)
     private String subType;
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
@@ -1,7 +1,9 @@
 package com.redhat.cloud.notifications.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+@Schema(enumeration = { "ansible", "camel", "drawer", "email_subscription", "webhook" }) // TODO remove them once the transition to DTOs have been completed.
 public enum EndpointType {
     @JsonProperty("webhook") // TODO remove them once the transition to DTOs have been completed.
     WEBHOOK(false, false),

--- a/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/EndpointType.java
@@ -1,12 +1,17 @@
 package com.redhat.cloud.notifications.models;
 
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum EndpointType {
+    @JsonProperty("webhook") // TODO remove them once the transition to DTOs have been completed.
     WEBHOOK(false, false),
+    @JsonProperty("email_subscription") // TODO remove them once the transition to DTOs have been completed.
     EMAIL_SUBSCRIPTION(false, true),
+    @JsonProperty("camel") // TODO remove them once the transition to DTOs have been completed.
     CAMEL(true, false),
+    @JsonProperty("ansible") // TODO remove them once the transition to DTOs have been completed.
     ANSIBLE(false, false),
+    @JsonProperty("drawer") // TODO remove them once the transition to DTOs have been completed.
     DRAWER(false, true);
 
     public final boolean requiresSubType;
@@ -15,29 +20,5 @@ public enum EndpointType {
     EndpointType(boolean requiresSubType, boolean isSystemEndpointType) {
         this.requiresSubType = requiresSubType;
         this.isSystemEndpointType = isSystemEndpointType;
-    }
-
-    /**
-     * Transforms the enum values to lowercase. It is required for the
-     * following tests to work:
-     * <ul>
-     *     <li>
-     *         {@link EndpointResourceTest#testAddEndpointDrawerSubscription}
-     *         {@link EndpointResourceTest#testAddEndpointEmailSubscription}
-     *         {@link EndpointResourceTest#testAnsibleEndpointCRUD}
-     *     </li>
-     * </ul>
-     *
-     * The reason for this is that we use the entities to build the payloads
-     * that we send to the endpoints, and since the enum values get written in
-     * uppercase letters by default, the target endpoints were not recognizing
-     * the type of the endpoints being managed, since they expect the lowercase
-     * values.
-     *
-     * @return the enum value in lowercase.
-     */
-    @JsonValue
-    public String toLowerCase() {
-        return this.toString().toLowerCase();
     }
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/models/SystemSubscriptionProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/SystemSubscriptionProperties.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 
@@ -7,6 +9,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 @Entity
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class) // TODO remove them once the transition to DTOs have been completed.
 @Table(name = "email_properties")
 public class SystemSubscriptionProperties extends EndpointProperties {
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/WebhookProperties.java
@@ -1,5 +1,8 @@
 package com.redhat.cloud.notifications.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.db.converters.HttpTypeConverter;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.persistence.Column;
@@ -12,6 +15,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Entity
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class) // TODO remove them once the transition to DTOs have been completed.
 @Table(name = "endpoint_webhooks")
 public class WebhookProperties extends EndpointProperties implements SourcesSecretable {
 
@@ -34,6 +38,7 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
      * The ID of the "secret token" secret in the Sources backend.
      */
     @Column(name = "secret_token_id")
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     private Long secretTokenSourcesId;
 
     @Transient
@@ -44,9 +49,11 @@ public class WebhookProperties extends EndpointProperties implements SourcesSecr
      * The ID of the "basic authentication" secret in the Sources backend.
      */
     @Column(name = "basic_authentication_id")
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     private Long basicAuthenticationSourcesId;
 
     @Column(name = "bearer_authentication_id")
+    @JsonIgnore // TODO remove them once the transition to DTOs have been completed.
     private Long bearerAuthenticationSourcesId;
 
     @Transient

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointTypeDTO.java
@@ -1,14 +1,19 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint;
 
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-@Schema(enumeration = { "webhook", "email_subscription", "camel", "ansible", "drawer" })
+@Schema(enumeration = { "ansible", "camel",  "drawer", "email_subscription", "webhook" })
 public enum EndpointTypeDTO {
+    @JsonProperty("ansible")
     ANSIBLE(false, false),
+    @JsonProperty("camel")
     CAMEL(true, false),
+    @JsonProperty("drawer")
     DRAWER(false, true),
+    @JsonProperty("email_subscription")
     EMAIL_SUBSCRIPTION(false, true),
+    @JsonProperty("webhook")
     WEBHOOK(false, false);
 
     public final boolean requiresSubType;
@@ -17,14 +22,5 @@ public enum EndpointTypeDTO {
     EndpointTypeDTO(boolean requiresSubType, boolean isSystemEndpointType) {
         this.requiresSubType = requiresSubType;
         this.isSystemEndpointType = isSystemEndpointType;
-    }
-
-    /**
-     * Transforms the enum values to lowercase.
-     * @return the enum value in lowercase.
-     */
-    @JsonValue
-    public String toLowerCase() {
-        return this.toString().toLowerCase();
     }
 }


### PR DESCRIPTION
I removed all the annotations for the internal entities, because I assumed we had all the bases covered when I changed the response entity from "Endpoint" to "EndpointDTO" in all of the REST endpoints that we have.

However, there are some other endpoints that return some other entities like behavior groups, which also serialize endpoints. But they serialize the internal model's endpoint, not the DTO model's one. And since we are changing our model slowly by slowly, we decided not to create DTOs for our entire internal model in one single step, since it would be too much work and very hard to review.

Gwenneg suggested bringing the JSON serialization annotations back, and all the tests passed everywhere, but we faced another problem in the UI: it was breaking in certain calls where the endpoints where being listed.

I realized that even though I reverted the "Endpoint"'s entity's JSON serialization annotations, I did not do it for the "Endpoint"'s properties. That is what probably is causing the issue with the UI, since the properties are not being properly serialized.

Finally, I'm reverting the functions that change the case of the
"EndpointType"'s enum values, because we are supposed to return the
values in snake case, and that was not working for the
"EMAIL_SUBSCRIPTION" enum value.

## Jira ticket
[[RHCLOUD-31165]](https://issues.redhat.com/browse/RHCLOUD-31165)