### PR TITLE
Remove pip from base image

### DIFF
--- a/docker/Dockerfile.notifications-aggregator.jvm
+++ b/docker/Dockerfile.notifications-aggregator.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-backend.jvm
+++ b/docker/Dockerfile.notifications-backend.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-drawer.jvm
+++ b/docker/Dockerfile.notifications-connector-drawer.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-email.jvm
+++ b/docker/Dockerfile.notifications-connector-email.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 # Add RedHat CAs on OS truststore (check https://certs.corp.redhat.com/ for more details)
 COPY --from=build /home/jboss/recipients-resolver/src/main/resources/mtls-ca-validators.crt /etc/pki/ca-trust/source/anchors/mtls-ca-validators.crt
 RUN update-ca-trust

--- a/docker/Dockerfile.notifications-connector-google-chat.jvm
+++ b/docker/Dockerfile.notifications-connector-google-chat.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
+++ b/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-servicenow.jvm
+++ b/docker/Dockerfile.notifications-connector-servicenow.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-slack.jvm
+++ b/docker/Dockerfile.notifications-connector-slack.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-splunk.jvm
+++ b/docker/Dockerfile.notifications-connector-splunk.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-webhook.jvm
+++ b/docker/Dockerfile.notifications-connector-webhook.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-recipients-resolver.jvm
+++ b/docker/Dockerfile.notifications-recipients-resolver.jvm
@@ -17,6 +17,7 @@ USER root
 RUN microdnf update --refresh --nodocs && microdnf clean all
 # Temporary workaround for packages affected by a CVE and not needed to run our app which is why we're removing them from the base image
 RUN rpm -e --nodeps platform-python-setuptools
+RUN rpm -e --nodeps platform-python-pip
 # Add RedHat CAs on OS truststore (check https://certs.corp.redhat.com/ for more details)
 COPY --from=build /home/jboss/recipients-resolver/src/main/resources/mtls-ca-validators.crt /etc/pki/ca-trust/source/anchors/mtls-ca-validators.crt
 RUN update-ca-trust


### PR DESCRIPTION
We aleady removed it in the past (https://github.com/RedHatInsights/notifications-backend/pull/2725) then we restored it because the CVE was fixed on base image.
Unfortunately, a new cve on the same pip package was raised (https://github.com/RedHatInsights/notifications-backend/actions/runs/9256269567/job/25461895905?pr=2725)