### PR TITLE
RHCLOUD-31165 | fix: Endpoint's "updated" field not included in payload

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
@@ -96,6 +96,7 @@ public class EndpointMapperTest {
         endpoint.setType(EndpointType.CAMEL);
         endpoint.setSubType("slack");
         endpoint.setCreated(LocalDateTime.now());
+        endpoint.setUpdated(LocalDateTime.now());
 
         final CamelProperties camelProperties = new CamelProperties();
         camelProperties.setDisableSslVerification(false);

--- a/backend/src/test/resources/json-schemas/v1/endpoint/endpoint-schema-read.json
+++ b/backend/src/test/resources/json-schemas/v1/endpoint/endpoint-schema-read.json
@@ -76,6 +76,11 @@
       "title": "Creation timestamp of the endpoint",
       "type": "string"
     },
+    "updated": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{1,12}$",
+      "title": "Update timestamp of the endpoint",
+      "type": "string"
+    },
     "properties": {
       "title": "Properties of the endpoint",
       "type": "object",

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -52,6 +52,11 @@ public final class EndpointDTO {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime created;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private LocalDateTime updated;
+
     @JsonSubTypes({
         @JsonSubTypes.Type(value = CamelPropertiesDTO.class, name = "camel"),
         @JsonSubTypes.Type(value = SystemSubscriptionPropertiesDTO.class, name = "drawer"),
@@ -149,6 +154,14 @@ public final class EndpointDTO {
 
     public void setCreated(final LocalDateTime created) {
         this.created = created;
+    }
+
+    public LocalDateTime getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(final LocalDateTime updated) {
+        this.updated = updated;
     }
 
     public EndpointPropertiesDTO getProperties() {


### PR DESCRIPTION
I forgot to map the "updated" field in the DTO and that's why the mapper didn't pick it up to map it.

## Jira ticket
[[RHCLOUD-31165]](https://issues.redhat.com/browse/RHCLOUD-31165)