### PR TITLE
RHCLOUD-32502 | Kessel: proper exception handling

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/exception/KesselExceptionMapper.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/exception/KesselExceptionMapper.java
@@ -1,0 +1,41 @@
+package com.redhat.cloud.notifications.auth.kessel.exception;
+
+import io.grpc.StatusRuntimeException;
+import io.vertx.core.json.JsonObject;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.apache.http.HttpStatus;
+
+/**
+ * Handles Kessel runtime exceptions by omitting the exception details from the
+ * response's body, and by returning a proper "internal server error" response
+ * to the client instead. The implementation follows the "Exception Mapping
+ * Providers" guidelines from the <a href="https://jakarta.ee/specifications/restful-ws/3.1/jakarta-restful-ws-spec-3.1.html#exceptionmapper">
+ * Jakarta specification</a>.
+ */
+@Provider
+public class KesselExceptionMapper implements ExceptionMapper<StatusRuntimeException> {
+
+    /**
+     * Maps the {@link StatusRuntimeException} to an internal server error
+     * response, hiding the details of the exception from the body to the
+     * client.
+     * @param e the {@link StatusRuntimeException} to be mapped.
+     * @return a response with a {@link HttpStatus#SC_INTERNAL_SERVER_ERROR}
+     * status code and a JSON message stating that an internal server error
+     * occurred.
+     */
+    @Override
+    public Response toResponse(final StatusRuntimeException e) {
+        final JsonObject payload = new JsonObject();
+        payload.put("error", "Internal server error");
+
+        return Response
+            .status(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+            .type(MediaType.APPLICATION_JSON)
+            .entity(payload.encode())
+            .build();
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/exception/KesselExceptionMapperTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/exception/KesselExceptionMapperTest.java
@@ -1,0 +1,65 @@
+package com.redhat.cloud.notifications.auth.kessel.exception;
+
+import com.redhat.cloud.notifications.TestConstants;
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.config.BackendConfig;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.vertx.core.json.JsonObject;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.project_kessel.relations.client.CheckClient;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class KesselExceptionMapperTest {
+    @InjectMock
+    BackendConfig backendConfig;
+
+    @InjectMock
+    CheckClient checkClient;
+
+    /**
+     * Tests that when a {@link io.grpc.StatusRuntimeException} is thrown in
+     * our codebase, the exception is handled gracefully and an "Internal
+     * server error" error is returned to the client.
+     */
+    @Test
+    void testInternalServerErrorReturned() {
+        // Enable Kessel as the authorization back end.
+        Mockito.when(this.backendConfig.isKesselBackendEnabled()).thenReturn(true);
+
+        // Simulate that an error occurred when calling Kessel.
+        Mockito.when(this.checkClient.check(Mockito.any())).thenThrow(new StatusRuntimeException(Status.INVALID_ARGUMENT));
+
+        // Call an endpoint and verify that the response has been gracefully
+        // handled.
+        RestAssured.basePath = TestConstants.API_INTEGRATIONS_V_1_0;
+
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, TestConstants.DEFAULT_ORG_ID, "Red Hat user");
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+
+        final JsonObject expectedPayload = new JsonObject();
+        expectedPayload.put("error", "Internal server error");
+
+        given()
+            .header(identityHeader)
+            .when()
+            .get("/endpoints")
+            .then()
+            .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+            .contentType(JSON)
+            .body(is(expectedPayload.encode()));
+    }
+}


### PR DESCRIPTION
When gRPC throws exceptions Quarkus simply returns the entire body of
the exception in the response to the client. It usually it is not useful
because it's hard to follow, and the client should not really receive
this kind of information.
    
This change logs the exception with all kinds of information and returns
an "internal server error" response to the client omitting the details
of what caused the error.

## Dependencies

- https://github.com/RedHatInsights/notifications-backend/pull/2704

## Jira ticket
[[RHCLOUD-32502]](https://issues.redhat.com/browse/RHCLOUD-32502)
