### PR TITLE
RHCLOUD-33112 | feature: more input and output graphs for Kafka

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
@@ -27,7 +27,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
-      "id": 707191,
+      "id": 707533,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -4477,7 +4477,7 @@ data:
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "description": "Shows the amount of bytes sent to the \"platform.notifications.ingress\" topic by the different producers.",
+          "description": "Shows the number of bytes each producer sends to Kafka to the \"platform.notifications.ingress\" channel.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4491,8 +4491,8 @@ data:
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
+                "fillOpacity": 100,
+                "gradientMode": "opacity",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
@@ -4500,6 +4500,9 @@ data:
                 },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
                 "lineWidth": 1,
                 "pointSize": 5,
                 "scaleDistribution": {
@@ -4539,7 +4542,7 @@ data:
             "x": 0,
             "y": 64
           },
-          "id": 297,
+          "id": 300,
           "options": {
             "legend": {
               "calcs": [],
@@ -4556,14 +4559,14 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PDD8BE47D10408F45"
+                "uid": "PC1EAC84DCBBF0697"
               },
               "editorMode": "code",
               "expr": "increase(kafka_producer_topic_byte_total{topic=\"platform.notifications.ingress\"}[5m])",
               "instant": false,
               "legendFormat": "{{pod}}",
               "range": true,
-              "refId": "Producers"
+              "refId": "Notifications producers"
             }
           ],
           "title": "\"ingress\" — bytes per producer",
@@ -4574,7 +4577,7 @@ data:
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "description": "Shows the amount of bytes sent to the \"platform.notifications.tocamel\" topic by the different producers.",
+          "description": "Shows the number of bytes each Kafka broker has received for the \"platform.notifications.fromcamel\" topic. The reason for using broker metrics instead of producer metrics is that our Apache Camel producers do not collect and send Kafka metrics by default.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4588,8 +4591,8 @@ data:
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
+                "fillOpacity": 100,
+                "gradientMode": "opacity",
                 "hideFrom": {
                   "legend": false,
                   "tooltip": false,
@@ -4636,7 +4639,7 @@ data:
             "x": 12,
             "y": 64
           },
-          "id": 296,
+          "id": 301,
           "options": {
             "legend": {
               "calcs": [],
@@ -4653,14 +4656,206 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PDD8BE47D10408F45"
+                "uid": "$datasource"
               },
               "editorMode": "code",
-              "expr": "increase(kafka_producer_topic_byte_total{topic=\"platform.notifications.tocamel\"}[5m])",
+              "expr": "increase(kafka_server_brokertopicmetrics_bytesin_total{topic=\"platform.notifications.fromcamel\"}[5m])",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "\"fromcamel\" — broker input bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Shows the number of bytes each Notifications producer sends to Kafka to the \"platform.notifications.ingress\" channel.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "dashed"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1048576
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 72
+          },
+          "id": 299,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "increase(kafka_producer_outgoing_byte_total{client_id=\"kafka-producer-egress\"}[5m])",
               "instant": false,
               "legendFormat": "{{pod}}",
               "range": true,
-              "refId": "Producers"
+              "refId": "Notifications producers"
+            }
+          ],
+          "title": "\"ingress\" — bytes per Notifications producer",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "description": "Shows the number of bytes each producer sends to Kafka to the \"platform.notifications.tocamel\" channel.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "dashed"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 1048576
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 72
+          },
+          "id": 298,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PC1EAC84DCBBF0697"
+              },
+              "editorMode": "code",
+              "expr": "increase(kafka_producer_outgoing_byte_total{client_id=\"kafka-producer-tocamel\"}[5m])",
+              "instant": false,
+              "legendFormat": "{{pod}}",
+              "range": true,
+              "refId": "A"
             }
           ],
           "title": "\"tocamel\" — bytes per producer",
@@ -4672,7 +4867,268 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 72
+            "y": 80
+          },
+          "id": 228,
+          "panels": [],
+          "title": "Aggregator",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 100,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 81
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "increase(aggregator_job_duration_seconds[5m])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "aggregator cron job",
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregator cronjob - duration in seconds",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 81
+          },
+          "id": 254,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "aggregation_time_consumed_seconds_max{}",
+              "legendFormat": "\"{{bundle}}/{{application}}\"",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregation consumed time - in seconds",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "dateTimeAsIso"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 81
+          },
+          "id": 205,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "aggregator_job_last_success * 1000",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Aggregator cronjob - last successful run",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 89
           },
           "id": 226,
           "panels": [],
@@ -4770,7 +5226,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 73
+            "y": 90
           },
           "id": 269,
           "options": {
@@ -4932,7 +5388,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 73
+            "y": 90
           },
           "id": 267,
           "options": {
@@ -5100,7 +5556,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 73
+            "y": 90
           },
           "id": 249,
           "options": {
@@ -5267,7 +5723,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 73
+            "y": 90
           },
           "id": 262,
           "options": {
@@ -5435,7 +5891,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 81
+            "y": 98
           },
           "id": 248,
           "options": {
@@ -5602,7 +6058,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 81
+            "y": 98
           },
           "id": 258,
           "options": {
@@ -5770,7 +6226,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 81
+            "y": 98
           },
           "id": 250,
           "options": {
@@ -5833,267 +6289,6 @@ data:
         },
         {
           "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 89
-          },
-          "id": 228,
-          "panels": [],
-          "title": "Aggregator",
-          "type": "row"
-        },
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "bars",
-                "fillOpacity": 100,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 0,
-            "y": 90
-          },
-          "id": 201,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "10.4.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "increase(aggregator_job_duration_seconds[5m])",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "aggregator cron job",
-              "refId": "A"
-            }
-          ],
-          "title": "Aggregator cronjob - duration in seconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 6,
-            "y": 90
-          },
-          "id": 254,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$datasource"
-              },
-              "editorMode": "code",
-              "exemplar": true,
-              "expr": "aggregation_time_consumed_seconds_max{}",
-              "legendFormat": "\"{{bundle}}/{{application}}\"",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Aggregation consumed time - in seconds",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "dateTimeAsIso"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 12,
-            "y": 90
-          },
-          "id": 205,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "text": {},
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "10.4.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "aggregator_job_last_success * 1000",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Aggregator cronjob - last successful run",
-          "type": "stat"
-        },
-        {
-          "collapsed": false,
           "datasource": {
             "type": "prometheus",
             "uid": "$datasource"
@@ -6102,7 +6297,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 98
+            "y": 106
           },
           "id": 188,
           "panels": [],
@@ -6173,7 +6368,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 99
+            "y": 107
           },
           "id": 153,
           "options": {
@@ -6284,7 +6479,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 99
+            "y": 107
           },
           "id": 161,
           "options": {
@@ -6381,7 +6576,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 99
+            "y": 107
           },
           "id": 252,
           "links": [
@@ -6579,7 +6774,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 107
+            "y": 115
           },
           "id": 280,
           "options": {
@@ -6678,7 +6873,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 107
+            "y": 115
           },
           "id": 281,
           "options": {
@@ -6799,7 +6994,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 107
+            "y": 115
           },
           "id": 276,
           "options": {
@@ -6997,7 +7192,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 115
+            "y": 123
           },
           "id": 293,
           "options": {
@@ -7094,7 +7289,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 115
+            "y": 123
           },
           "id": 294,
           "options": {
@@ -7137,7 +7332,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 123
+            "y": 131
           },
           "id": 179,
           "panels": [],
@@ -7205,7 +7400,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 124
+            "y": 132
           },
           "id": 174,
           "options": {
@@ -7299,7 +7494,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 124
+            "y": 132
           },
           "id": 208,
           "options": {
@@ -7393,7 +7588,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 124
+            "y": 132
           },
           "id": 189,
           "options": {
@@ -7489,7 +7684,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 132
+            "y": 140
           },
           "id": 113,
           "options": {
@@ -7582,7 +7777,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 132
+            "y": 140
           },
           "id": 175,
           "options": {
@@ -7675,7 +7870,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 132
+            "y": 140
           },
           "id": 176,
           "options": {
@@ -7777,7 +7972,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 132
+            "y": 140
           },
           "id": 177,
           "options": {
@@ -7835,7 +8030,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 140
+            "y": 148
           },
           "id": 24,
           "panels": [],
@@ -7909,7 +8104,7 @@ data:
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 141
+            "y": 149
           },
           "id": 22,
           "options": {
@@ -8001,7 +8196,7 @@ data:
             "h": 9,
             "w": 16,
             "x": 8,
-            "y": 141
+            "y": 149
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -8173,7 +8368,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 150
+            "y": 158
           },
           "id": 85,
           "options": {
@@ -8251,7 +8446,7 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "crcp01ue1-prometheus",
               "value": "crcp01ue1-prometheus"
             },
@@ -8316,7 +8511,7 @@ data:
       "timezone": "",
       "title": "Notifications Dashboard",
       "uid": "KQIVyFuMk",
-      "version": 4,
+      "version": 1,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
Adds a bunch of graphs for the bytes and messages intakes reported by the brokers.

## Jira ticket
[[RHCLOUD-33112]](https://issues.redhat.com/browse/RHCLOUD-33112)