### PR TITLE
OCM-7765 | feat: Update OCM generic template with additional footer for approved access

### DIFF
--- a/engine/src/main/resources/templates/OCM/genericInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/genericInstantEmailBodyV2.html
@@ -55,6 +55,11 @@ More info
     <p>
         <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
     </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="" target="_blank">here</a>.
+    </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}
         <p>

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOcmTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOcmTemplate.java
@@ -99,6 +99,25 @@ public class TestOcmTemplate extends EmailTemplatesInDbHelper  {
     }
 
     @Test
+    public void testApprovedAccessEmailBody() {
+        // test generic template case
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> need a revision", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "ocm-approved-access-template")));
+        String result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertTrue(result.contains("Your organization has enabled \"Approved Access\" for ROSA clusters"));
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+    }
+
+    @Test
     public void testClusterLifecycleInstantEmailBody() {
         // test generic template case
         Action action = OcmTestHelpers.createOcmAction("Batcave", "OSD", "<b>Batmobile</b> need a revision", "Awesome subject");


### PR DESCRIPTION
This PR updates the switch statement in the footer of the OCM generic email to account for the requirements of ROSA Approved Access, where a particular message to customers is required.