### PR TITLE
[RHCLOUD-30766] Update the blue button text in the integration-disabled email template

### DIFF
--- a/engine/src/main/resources/templates/Integrations/integrationDisabledBodyV2.html
+++ b/engine/src/main/resources/templates/Integrations/integrationDisabledBodyV2.html
@@ -28,6 +28,6 @@
     {/if}
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/integrations?category={action.context.endpoint_category}&name={action.context.endpoint_name}">Open Integrations in Insights</a>
+    <a target="_blank" href="{environment.url}/settings/integrations?category={action.context.endpoint_category}&name={action.context.endpoint_name}">Open Integrations</a>
 {/content-button-section1}
 {/include}


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-30766

## Description

Update the text in the blue button at the bottom of the [integrations-disabled email](https://github.com/RedHatInsights/notifications-backend/blob/25b612fec66f365fc80148e407183cf74fac4c7a/engine/src/main/resources/templates/Integrations/integrationDisabledBodyV2.html) from "Open Integrations in Insights" to "Open Integrations".

## Local Testing

Run IntegrationsTemplatesTest and place a breakpoint in [testIntegrationDisabledBodyWithClientError](https://github.com/RedHatInsights/notifications-backend/blob/33e60839a24741fcb5f1b2c5828a858a86c28989/engine/src/test/java/com/redhat/cloud/notifications/templates/IntegrationsTemplatesTest.java#L53) to manually validate the HTML. No automated test as I'm unsure if the HTML structure is stable.