### PR TITLE
add filter for unmuted event types to endpoint `/notifications/eventTypes`

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -246,12 +246,12 @@ public class ApplicationRepository {
         return rowCount > 0;
     }
 
-    public List<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId, String eventTypeName) {
+    public List<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId, String eventTypeName, boolean excludeMutedTypes) {
         if (limiter != null) {
             limiter.setSortFields(EventType.SORT_FIELDS);
         }
 
-        return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName)
+        return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName, excludeMutedTypes)
                 .join(JoinBuilder.builder().leftJoinFetch("e.application"))
                 .limit(limiter != null ? limiter.getLimit() : null)
                 .sort(limiter != null ? limiter.getSort() : null)
@@ -259,8 +259,8 @@ public class ApplicationRepository {
                 .getResultList();
     }
 
-    public Long getEventTypesCount(Set<UUID> appIds, UUID bundleId, String eventTypeName) {
-        return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName)
+    public Long getEventTypesCount(Set<UUID> appIds, UUID bundleId, String eventTypeName, boolean excludeMutedTypes) {
+        return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName, excludeMutedTypes)
                 .buildCount(entityManager::createQuery)
                 .getSingleResult();
     }
@@ -298,7 +298,9 @@ public class ApplicationRepository {
         }
     }
 
-    private QueryBuilder<EventType> getEventTypesQueryBuilder(Set<UUID> appIds, UUID bundleId, String eventTypeName) {
+    private QueryBuilder<EventType> getEventTypesQueryBuilder(Set<UUID> appIds, UUID bundleId, String eventTypeName, boolean excludeMutedTypes) {
+        final String unmutedEventTypesQuery = "SELECT etb.eventType.id FROM EventTypeBehavior AS etb";
+
         return QueryBuilder
                 .builder(EventType.class)
                 .alias("e")
@@ -308,6 +310,7 @@ public class ApplicationRepository {
                                 .ifAnd(appIds != null && appIds.size() > 0, "e.application.id IN (:appIds)", "appIds", appIds)
                                 .ifAnd(bundleId != null, "e.application.bundle.id = :bundleId", "bundleId", bundleId)
                                 .ifAnd(eventTypeName != null, "(LOWER(e.displayName) LIKE :eventTypeName OR LOWER(e.name) LIKE :eventTypeName)", "eventTypeName", (Supplier<String>) () -> "%" + eventTypeName.toLowerCase() + "%")
+                                .ifAnd(excludeMutedTypes, "e.id IN (" + unmutedEventTypesQuery + ")")
                                 .and("e.visible = true")
                 );
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -124,14 +124,14 @@ public class NotificationResource {
     @GET
     @Path("/eventTypes")
     @Produces(APPLICATION_JSON)
-    @Operation(summary = "List all event types", description = "Lists all event types. You can filter the returned list by bundle or application name.")
+    @Operation(summary = "List all event types", description = "Lists all event types. You can filter the returned list by bundle, application name, or unmuted types.")
     @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public Page<EventType> getEventTypes(
             @Context UriInfo uriInfo, @BeanParam @Valid Query query, @QueryParam("applicationIds") Set<UUID> applicationIds, @QueryParam("bundleId") UUID bundleId,
-            @QueryParam("eventTypeName") String eventTypeName
+            @QueryParam("eventTypeName") String eventTypeName, @QueryParam("excludeMutedTypes") boolean excludeMutedTypes
     ) {
-        List<EventType> eventTypes = applicationRepository.getEventTypes(query, applicationIds, bundleId, eventTypeName);
-        Long count = applicationRepository.getEventTypesCount(applicationIds, bundleId, eventTypeName);
+        List<EventType> eventTypes = applicationRepository.getEventTypes(query, applicationIds, bundleId, eventTypeName, excludeMutedTypes);
+        Long count = applicationRepository.getEventTypesCount(applicationIds, bundleId, eventTypeName, excludeMutedTypes);
         return new Page<>(
                 eventTypes,
                 PageLinksBuilder.build(uriInfo.getPath(), count, query.getLimit().getLimit(), query.getLimit().getOffset()),


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-31596

## Description

- Adds a new Boolean query parameter `excludeMutedTypes` to the /api/notifications/v1.0/notifications/eventTypes endpoint, which filters out event types that are [not associated with any behaviorGroup](https://github.com/cam-rod/notifications-backend/blob/9c6e51846d7b62a0a16fcfd8de3a2410fe6ed0e7/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java#L302)
  - Example: `GET /api/notifications/v1.0/notifications/eventTypes?excludeMutedTypes=true`

## Compatibility

The new query parameter defaults to false and leaves current requests unmodified.

## Testing

- Added `testEventTypeFetchingAndExcludeMutedTypes()` to validate that event types across different behaviour groups are included
- Added `testEventTypeFetchingByBundleApplicationEventTypeNameAndExcludeMutedTypes()`[^1] for testing with the other filters


[^1]: Open to renaming this one 😄