### PR TITLE
OCM-8731 | Remove "Your" from OCM cluster update template

### DIFF
--- a/engine/src/main/resources/templates/OCM/clusterUpdateInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterUpdateInstantEmailBodyV2.html
@@ -13,7 +13,7 @@
 This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_var.subscription_id}#overview" target="_blank" title="{global_var.cluster_display_name}">{global_var.cluster_display_name} cluster</a>.
 </p>
 <p>
-Your {global_var.log_description}.
+    {global_var.log_description}
 </p>
 {#if global_var.template_sub_type == 'upgrade-scheduled-template'}
     <p>


### PR DESCRIPTION
The template clusterUpdateInstantEmailBodyV2.html contains a "Your" prefix for the event description. This can cause unexpected behaviour as it appends it to all events.