### PR TITLE
[RHCLOUD-29412] require HTTPS URLs for ServiceNow and Splunk endpoints

### DIFF
--- a/common/src/test/java/com/redhat/cloud/notifications/TestConstants.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/TestConstants.java
@@ -12,4 +12,5 @@ public class TestConstants {
     public static final String API_INTEGRATIONS_V_2 = "/api/integrations/v2";
     public static final String DEFAULT_ACCOUNT_ID = "default-account-id";
     public static final String DEFAULT_ORG_ID = "default-org-id";
+    public static final String DEFAULT_USER = "default-user";
 }


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-29412

## Description

Adds a check when creating or updating ServiceNow and Splunk endpoints for a HTTPS URI scheme, throwing a BadRequestException otherwise.

## Testing

- Added two wrapper tests for ServiceNow and Splunk, which call `testRequireHttpsScheme()`
  - Validates that `http` endpoints are rejected when creating or updating a URL, and are accepted when `https` is used
  - Validates that other Camel endpoints without an HTTPS requirement (ex. Slack) are not affected.