### PR TITLE
RHCLOUD-28721 | Onboard more connectors into post-deploy-testing

### DIFF
--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -9,8 +9,12 @@ objects:
   metadata:
     name: notifications-connector-email
   spec:
+    testing:
+      iqePlugin: notifications
     dependencies:
     - notifications-recipients-resolver
+    optionalDependencies:
+    - notifications-backend
     envName: ${ENV_NAME}
     featureFlags: true
     kafkaTopics:

--- a/.rhcicd/clowdapp-connector-slack.yaml
+++ b/.rhcicd/clowdapp-connector-slack.yaml
@@ -10,6 +10,10 @@ objects:
     name: notifications-connector-slack
   spec:
     envName: ${ENV_NAME}
+    testing:
+      iqePlugin: notifications
+    optionalDependencies:
+    - notifications-backend
     featureFlags: true
     kafkaTopics:
     - topicName: platform.notifications.tocamel

--- a/.rhcicd/stage-email-post-deployment-tests.yaml
+++ b/.rhcicd/stage-email-post-deployment-tests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: notifications-email-post-deployment-tests
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: notifications-connector-email-tests-${UID}
+  spec:
+    appName: notifications-connector-email
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        marker: 'notif_email and api'
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"

--- a/.rhcicd/stage-slack-post-deployment-tests.yaml
+++ b/.rhcicd/stage-slack-post-deployment-tests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: notifications-slack-post-deployment-tests
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: notifications-connector-slack-tests-${UID}
+  spec:
+    appName: notifications-connector-slack
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        marker: 'notif_slack and api'
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"


### PR DESCRIPTION
This PR configures Email and Slack connectors for post-deploy testing