### PR TITLE
OCM-7765 | chore: Updated the link to the Approved Access documentation in the OCM generic email template

### DIFF
--- a/engine/src/main/resources/templates/OCM/genericInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/genericInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}


### PR DESCRIPTION
This PR updates the OCM generic email template to correctly include the link to the ROSA Approved Access documentation in the footer section when the template_sub_ type is `ocm-approved-access-template`