### PR TITLE
RHCLOUD-32875 | fix: the links for User Access are broken

### DIFF
--- a/engine/src/main/resources/templates/Rbac/customGroupCreatedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/customGroupCreatedEmailBodyV2.html
@@ -13,6 +13,6 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/groups/detail/{action.events[0].payload.uuid}">Check this group in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/groups/detail/{action.events[0].payload.uuid}">Check this group in Insights</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/customGroupUpdatedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/customGroupUpdatedEmailBodyV2.html
@@ -13,7 +13,7 @@
     </p>
     {#if action.events[0].payload.role}
         <p>
-            The role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> has been
+            The role <a class="rh-url" href="{environment.url}/iam/user-access/roles/detail/{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> has been
             {action.events[0].payload.operation} {#if action.events[0].payload.operation == "added"}to{#else}from{/if}
             the group.
         </p>
@@ -27,6 +27,6 @@
     {/if}
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/groups/detail/{action.events[0].payload.uuid}">Check the updated group in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/groups/detail/{action.events[0].payload.uuid}">Check the updated group in Insights</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/customPlatformGroupUpdatedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/customPlatformGroupUpdatedEmailBodyV2.html
@@ -13,14 +13,14 @@
     </p>
     {#if action.events[0].payload.role}
         <p>
-            The role <a class="rh-url" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> has been
+            The role <a class="rh-url" href="{environment.url}/iam/user-access/roles/detail/{action.events[0].payload.role.uuid}"><b>{action.events[0].payload.role.name}</b></a> has been
             {action.events[0].payload.operation} {#if action.events[0].payload.operation == "added"}to{#else}from{/if}
             the group.
         </p>
     {/if}
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/groups/detail/{action.events[0].payload.uuid}">Check the updated group in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/groups/detail/{action.events[0].payload.uuid}">Check the updated group in Insights</a>
 {/content-button-section1}
 {/include}
 

--- a/engine/src/main/resources/templates/Rbac/customRoleCreatedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/customRoleCreatedEmailBodyV2.html
@@ -13,6 +13,6 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}">Check this role in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/roles/detail/{action.events[0].payload.uuid}">Check this role in Insights</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/customRoleUpdatedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/customRoleUpdatedEmailBodyV2.html
@@ -13,6 +13,6 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}">Check the updated role in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/roles/detail/{action.events[0].payload.uuid}">Check the updated role in Insights</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/nonPlatformRoleUpdatedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/nonPlatformRoleUpdatedEmailBodyV2.html
@@ -16,6 +16,6 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}">Check the updated role in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/roles/detail/{action.events[0].payload.uuid}">Check the updated role in Insights</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/platformGroupToCustomEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/platformGroupToCustomEmailBodyV2.html
@@ -13,6 +13,6 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/groups/detail/{action.events[0].payload.uuid}">Check custom platform default group in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/groups/detail/{action.events[0].payload.uuid}">Check custom platform default group in Insights</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/platformRoleUpdatedEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/platformRoleUpdatedEmailBodyV2.html
@@ -16,7 +16,7 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}">Check the updated role in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/roles/detail/{action.events[0].payload.uuid}">Check the updated role in Insights</a>
 {/content-button-section1}
 {/include}
 

--- a/engine/src/main/resources/templates/Rbac/requestAccessEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/requestAccessEmailBodyV2.html
@@ -23,12 +23,12 @@
         <br/>
         <strong>Action Required:</strong>
         <ul>
-            <li><strong>Granting Access:</strong>If you decide to grant access, please log in to the console and add the user to the appropriate <a target="blank" href="{environment.url}/iam/user-access/groups/">User Access Group(s).</a></li>
+            <li><strong>Granting Access:</strong>If you decide to grant access, please log in to the console and add the user to the appropriate <a target="blank" href="{environment.url}/iam/user-access/groups">User Access Group(s).</a></li>
             <li><strong>Denying Access:</strong> If you choose to deny access, kindly reach out to the user directly to explain the reason for the denial.</li>
         </ul>
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/iam/user-access/groups/">Review your user access groups in the console</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/groups">Review your user access groups in the console</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/roleAddedToPlatformGroupEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/roleAddedToPlatformGroupEmailBodyV2.html
@@ -13,6 +13,6 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.role.uuid}">Check this role in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/roles/detail/{action.events[0].payload.role.uuid}">Check this role in Insights</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/roleRemovedFromPlatformGroupEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/roleRemovedFromPlatformGroupEmailBodyV2.html
@@ -13,6 +13,6 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.role.uuid}">Check this role in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/roles/detail/{action.events[0].payload.role.uuid}">Check this role in Insights</a>
 {/content-button-section1}
 {/include}

--- a/engine/src/main/resources/templates/Rbac/systemRoleAvailableEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Rbac/systemRoleAvailableEmailBodyV2.html
@@ -13,6 +13,6 @@
     </p>
 {/content-body-section1}
 {#content-button-section1}
-    <a target="_blank" href="{environment.url}/settings/rbac/roles/detail/{action.events[0].payload.uuid}">Check this role in Insights</a>
+    <a target="_blank" href="{environment.url}/iam/user-access/roles/detail/{action.events[0].payload.uuid}">Check this role in Insights</a>
 {/content-button-section1}
 {/include}


### PR DESCRIPTION
The links that customers are receiving were broken, and therefore when customers clicked on them they were redirected to pages that didn't exist.

## Jira ticket
[[RHCLOUD-32875]](https://issues.rehdat.com/browse/RHCLOUD-32875)