### PR TITLE
 RHCLOUD-32502 | fix: endpoint creation requires no permissions

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -316,7 +316,7 @@ public class EndpointResource {
         @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Endpoint.class))),
         @APIResponse(responseCode = "400", description = "Bad data passed, that does not correspond to the definition or Endpoint.properties are empty")
     })
-    //@RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
     public EndpointDTO createEndpoint(
         @Context                                        SecurityContext sec,
         @RequestBody(required = true) @NotNull @Valid   EndpointDTO endpointDTO


### PR DESCRIPTION
When dealing with the linked ticket, I initially started playing with the "endpoint creation" handler, and when I moved on to other handlers I forgot to return this handler's permissions back to the original ones.

## Related PR

https://github.com/RedHatInsights/notifications-backend/pull/2704

## Jira ticket
[[RHCLOUD-32502]](https://issues.redhat.com/browse/RHCLOUD-32502)