### PR TITLE
[RHCLOUD-31320] Increased number of connector threads

### DIFF
--- a/.rhcicd/clowdapp-connector-drawer.yaml
+++ b/.rhcicd/clowdapp-connector-drawer.yaml
@@ -75,7 +75,7 @@ objects:
         - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
           value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-          value: ${NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE}
+          value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_UNLEASH_ENABLED
           value: ${NOTIFICATIONS_UNLEASH_ENABLED}
         - name: QUARKUS_HTTP_PORT
@@ -149,11 +149,8 @@ parameters:
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
   value: "0"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
-  description: Number of concurrent threads processing exchanges with SEDA
-  value: "20"
-- name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-  description: Maximum capacity of the SEDA queue
-  value: "20"
+  description: Number of concurrent threads processing exchanges with SEDA; Maximum capacity of the SEDA queue
+  value: "60"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO

--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -85,7 +85,7 @@ objects:
         - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
           value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-          value: ${NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE}
+          value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_USER_PROVIDER_BOP_API_TOKEN
           valueFrom:
             secretKeyRef:
@@ -201,10 +201,7 @@ parameters:
   description: Maximum number of redelivery attempts (initial call not included)
   value: "2"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
-  description: Number of concurrent threads processing exchanges with SEDA
-  value: "10"
-- name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-  description: Maximum capacity of the SEDA queue
+  description: Number of concurrent threads processing exchanges with SEDA; Maximum capacity of the SEDA queue
   value: "10"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications

--- a/.rhcicd/clowdapp-connector-google-chat.yaml
+++ b/.rhcicd/clowdapp-connector-google-chat.yaml
@@ -79,7 +79,7 @@ objects:
         - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
           value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-          value: ${NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE}
+          value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
           value: ${NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS}
         - name: NOTIFICATIONS_UNLEASH_ENABLED
@@ -164,11 +164,8 @@ parameters:
   description: Maximum number of redelivery attempts (initial call not included)
   value: "2"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
-  description: Number of concurrent threads processing exchanges with SEDA
-  value: "20"
-- name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-  description: Maximum capacity of the SEDA queue
-  value: "20"
+  description: Number of concurrent threads processing exchanges with SEDA; Maximum capacity of the SEDA queue
+  value: "40"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO

--- a/.rhcicd/clowdapp-connector-microsoft-teams.yaml
+++ b/.rhcicd/clowdapp-connector-microsoft-teams.yaml
@@ -79,7 +79,7 @@ objects:
         - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
           value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-          value: ${NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE}
+          value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
           value: ${NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS}
         - name: NOTIFICATIONS_UNLEASH_ENABLED
@@ -164,11 +164,8 @@ parameters:
   description: Maximum number of redelivery attempts (initial call not included)
   value: "2"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
-  description: Number of concurrent threads processing exchanges with SEDA
-  value: "20"
-- name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-  description: Maximum capacity of the SEDA queue
-  value: "20"
+  description: Number of concurrent threads processing exchanges with SEDA; Maximum capacity of the SEDA queue
+  value: "40"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO

--- a/.rhcicd/clowdapp-connector-servicenow.yaml
+++ b/.rhcicd/clowdapp-connector-servicenow.yaml
@@ -92,7 +92,7 @@ objects:
         - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
           value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-          value: ${NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE}
+          value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
           value: ${NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS}
         - name: NOTIFICATIONS_UNLEASH_ENABLED
@@ -177,11 +177,8 @@ parameters:
   description: Maximum number of redelivery attempts (initial call not included)
   value: "2"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
-  description: Number of concurrent threads processing exchanges with SEDA
-  value: "20"
-- name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-  description: Maximum capacity of the SEDA queue
-  value: "20"
+  description: Number of concurrent threads processing exchanges with SEDA; Maximum capacity of the SEDA queue
+  value: "50"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO

--- a/.rhcicd/clowdapp-connector-slack.yaml
+++ b/.rhcicd/clowdapp-connector-slack.yaml
@@ -79,7 +79,7 @@ objects:
         - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
           value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-          value: ${NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE}
+          value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_UNLEASH_ENABLED
           value: ${NOTIFICATIONS_UNLEASH_ENABLED}
         - name: QUARKUS_HTTP_PORT
@@ -156,11 +156,8 @@ parameters:
   description: Maximum number of redelivery attempts (initial call not included)
   value: "2"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
-  description: Number of concurrent threads processing exchanges with SEDA
-  value: "5"
-- name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-  description: Maximum capacity of the SEDA queue
-  value: "5"
+  description: Number of concurrent threads processing exchanges with SEDA; Maximum capacity of the SEDA queue
+  value: "50"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -92,7 +92,7 @@ objects:
         - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
           value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-          value: ${NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE}
+          value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
           value: ${NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS}
         - name: NOTIFICATIONS_UNLEASH_ENABLED
@@ -177,11 +177,8 @@ parameters:
   description: Maximum number of redelivery attempts (initial call not included)
   value: "2"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
-  description: Number of concurrent threads processing exchanges with SEDA
-  value: "20"
-- name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-  description: Maximum capacity of the SEDA queue
-  value: "20"
+  description: Number of concurrent threads processing exchanges with SEDA; Maximum capacity of the SEDA queue
+  value: "50"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO

--- a/.rhcicd/clowdapp-connector-webhook.yaml
+++ b/.rhcicd/clowdapp-connector-webhook.yaml
@@ -94,7 +94,7 @@ objects:
         - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
           value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-          value: ${NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE}
+          value: ${NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
           value: ${NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS}
         - name: NOTIFICATIONS_UNLEASH_ENABLED
@@ -185,11 +185,8 @@ parameters:
   description: Maximum number of redelivery attempts (initial call not included)
   value: "2"
 - name: NOTIFICATIONS_CONNECTOR_SEDA_CONCURRENT_CONSUMERS
-  description: Number of concurrent threads processing exchanges with SEDA
-  value: "20"
-- name: NOTIFICATIONS_CONNECTOR_SEDA_QUEUE_SIZE
-  description: Maximum capacity of the SEDA queue
-  value: "20"
+  description: Number of concurrent threads processing exchanges with SEDA; Maximum capacity of the SEDA queue
+  value: "50"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-31320

## Changes

All connectors _(except email)_ now have between 40 and 70 threads available:

- 10x Slack threads, due to generous API limits and currently low count.
- 3x drawer threads (limit is unknown)
- 2.5x Splunk, ServiceNow, webhook threads
- 2x Gchat, Teams threads for lower API limits
- ~~7x email threads, due to high demand for aggregated reports~~ no change to email threads due to backend limits

How I decided on the new thread counts:

- Peak and average lag for the different connectors when sending notifications
- Current CPU/memory usage
- Current demand and expected near-term demand
- API rate limits
  - while research was done on looking into rate limits for the APIs, it isn't the main driver for determining whether threads should be increased or not