### PR TITLE
RHCLOUD-33635 | feature: forbid duplicate integration names

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -46,7 +46,7 @@ public class BackendConfig {
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
     boolean enforceBehaviorGroupNameUnicity;
 
-    @ConfigProperty(name = "notifications.enforce-integration-name-unicity", defaultValue = "false")
+    @ConfigProperty(name = "notifications.enforce-integration-name-unicity", defaultValue = "true")
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
     boolean enforceIntegrationNameUnicity;
 
@@ -146,7 +146,7 @@ public class BackendConfig {
 
     public boolean isUniqueIntegrationNameEnabled() {
         if (unleashEnabled) {
-            return unleash.isEnabled(uniqueIntegrationNameToggle, false);
+            return unleash.isEnabled(uniqueIntegrationNameToggle, true);
         } else {
             return enforceIntegrationNameUnicity;
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -142,13 +142,20 @@ public class EndpointRepository {
         if (endpointOptional.isPresent()) {
             return endpointOptional.get();
         }
-        Endpoint endpoint = new Endpoint();
+
+        // In order to avoid having duplicated names which could end up in the
+        // "unique endpoint name" constraint being triggered, we generate and
+        // assign the endpoint's UUID ourselves.
+        final UUID endpointId = UUID.randomUUID();
+
+        final Endpoint endpoint = new Endpoint();
+        endpoint.setId(endpointId);
         endpoint.setProperties(properties);
         endpoint.setAccountId(accountId);
         endpoint.setOrgId(orgId);
         endpoint.setEnabled(true);
         endpoint.setDescription(String.format("System %s endpoint", label.toLowerCase()));
-        endpoint.setName(String.format("%s endpoint", label));
+        endpoint.setName(String.format("%s endpoint %s", label, endpointId));
         endpoint.setType(endpointType);
         endpoint.setStatus(READY);
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -147,7 +147,7 @@ public class ResourceHelpers {
     }
 
     public Endpoint createEndpoint(String accountId, String orgId, EndpointType type, String subType) {
-        return createEndpoint(accountId, orgId, type, subType, "name", "description", null, FALSE, null);
+        return createEndpoint(accountId, orgId, type, subType, UUID.randomUUID().toString(), "description", null, FALSE, null);
     }
 
     public UUID createWebhookEndpoint(String accountId, String orgId) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -536,7 +536,7 @@ public class LifecycleITest extends DbIsolatedTest {
 
         Endpoint endpoint = new Endpoint();
         endpoint.setType(EndpointType.WEBHOOK);
-        endpoint.setName("endpoint");
+        endpoint.setName(UUID.randomUUID().toString());
         endpoint.setDescription("Endpoint");
         endpoint.setEnabled(true);
         endpoint.setProperties(properties);

--- a/database/src/main/resources/db/migration/V1.98.0__RHCLOUD-33635_add_constraint_integrations_unique_name.sql
+++ b/database/src/main/resources/db/migration/V1.98.0__RHCLOUD-33635_add_constraint_integrations_unique_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE endpoints ADD CONSTRAINT endpoints_name_org_id_key UNIQUE ("name", org_id);


### PR DESCRIPTION
Prevents creating integrations with duplicate names in the same organization.

## Dependency
* https://github.com/RedHatInsights/notifications-backend/pull/2801

## Jira ticket
[[RHCLOUD-33635]](https://issues.redhat.com/browse/RHCLOUD-33635)