### PR TITLE
RHCLOUD-33871 | fix: null pointer exception when the "extras" object is null

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessor.java
@@ -7,6 +7,8 @@ import com.redhat.cloud.notifications.processors.camel.CamelNotification;
 import com.redhat.cloud.notifications.processors.camel.CamelProcessor;
 import jakarta.enterprise.context.ApplicationScoped;
 
+import java.util.Map;
+
 import static com.redhat.cloud.notifications.events.EndpointProcessor.SLACK_ENDPOINT_SUBTYPE;
 
 @ApplicationScoped
@@ -29,7 +31,12 @@ public class SlackProcessor extends CamelProcessor {
 
         SlackNotification notification = new SlackNotification();
         notification.webhookUrl = properties.getUrl();
-        notification.channel = properties.getExtras().get("channel");
+
+        final Map<String, String> extras = properties.getExtras();
+        if (null != extras) {
+            notification.channel = properties.getExtras().get("channel");
+        }
+
         notification.message = message;
         return notification;
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessor.java
@@ -34,7 +34,7 @@ public class SlackProcessor extends CamelProcessor {
 
         final Map<String, String> extras = properties.getExtras();
         if (null != extras) {
-            notification.channel = properties.getExtras().get("channel");
+            notification.channel = extras.get("channel");
         }
 
         notification.message = message;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessorTest.java
@@ -1,6 +1,8 @@
 package com.redhat.cloud.notifications.processors.camel.slack;
 
 import com.redhat.cloud.notifications.models.CamelProperties;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.processors.camel.CamelProcessor;
 import com.redhat.cloud.notifications.processors.camel.CamelProcessorTest;
 import com.redhat.cloud.notifications.templates.models.EnvironmentTest;
@@ -9,7 +11,9 @@ import io.smallrye.reactive.messaging.ce.CloudEventMetadata;
 import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
@@ -17,6 +21,7 @@ import static com.redhat.cloud.notifications.events.EndpointProcessor.SLACK_ENDP
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @QuarkusTest
 public class SlackProcessorTest extends CamelProcessorTest {
@@ -83,5 +88,46 @@ public class SlackProcessorTest extends CamelProcessorTest {
     @Override
     protected String getExpectedConnectorHeader() {
         return SLACK_ENDPOINT_SUBTYPE;
+    }
+
+    /**
+     * Tests that when the endpoint's {@link CamelProperties} does not contain
+     * an {@link CamelProperties#extras} property, the Slack message gets sent
+     * to the connector without the Slack channel. It's a regression test for
+     * <a href="https://issues.redhat.com/browse/RHCLOUD-33871">RHCLOUD-33871</a>.
+     */
+    @Test
+    void testEmptyExtrasSendsSlackMessage() {
+        // Create a default template for the test.
+        this.mockTemplate();
+
+        // Build the required data.
+        final Event event = buildEvent();
+        final Endpoint endpoint = this.buildEndpoint();
+        // Remove the "extras" object from the endpoint.
+        final CamelProperties camelProperties = endpoint.getProperties(CamelProperties.class);
+        camelProperties.setExtras(null);
+
+        // Call the processor under test.
+        this.slackProcessor.process(event, List.of(endpoint));
+
+        await().until(() -> inMemorySink.received().size() == 1);
+        Message<JsonObject> message = inMemorySink.received().get(0);
+
+        // Make sure the message was sent with the expected headers and payload.
+        assertNotificationsConnectorHeader(message);
+
+        CloudEventMetadata cloudEventMetadata = message.getMetadata(CloudEventMetadata.class).get();
+        assertNotNull(cloudEventMetadata.getId());
+        assertEquals(getExpectedCloudEventType(), cloudEventMetadata.getType());
+
+        JsonObject notification = message.getPayload();
+
+        assertEquals(DEFAULT_ORG_ID, notification.getString("org_id"));
+        assertEquals(WEBHOOK_URL, notification.getString("webhookUrl"));
+        // The channel should be null in this case, since we removed the
+        // "extras" object.
+        assertNull(notification.getString("channel"), "the channel should be null since the endpoint's camel properties did not contain an \"extras\" object");
+        assertEquals(SLACK_EXPECTED_MSG, notification.getString("message"));
     }
 }


### PR DESCRIPTION
We are no longer storing Slack's channel when setting up a Slack endpoint, and that means that the "extras" object might be null or empty. We forgot to add a null check for that object which is causing some payloads to not be sent because of it.

## Jira ticket
[[RHCLOUD-33871]](https://issues.redhat.com/browse/RHCLOUD-33871)