### PR TITLE
 RHCLOUD-33637 | refactor: remove toggle for the faulty endpoints

### DIFF
--- a/.rhcicd/clowdapp-connector-google-chat.yaml
+++ b/.rhcicd/clowdapp-connector-google-chat.yaml
@@ -169,9 +169,6 @@ parameters:
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO
-- name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
-  description: Add flags on connector response to let engine disable endpoint regarding HTTP error type
-  value: "false"
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
 - name: QUARKUS_HTTP_PORT

--- a/.rhcicd/clowdapp-connector-microsoft-teams.yaml
+++ b/.rhcicd/clowdapp-connector-microsoft-teams.yaml
@@ -169,9 +169,6 @@ parameters:
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO
-- name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
-  description: Add flags on connector response to let engine disable endpoint regarding HTTP error type
-  value: "false"
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
 - name: QUARKUS_HTTP_PORT

--- a/.rhcicd/clowdapp-connector-servicenow.yaml
+++ b/.rhcicd/clowdapp-connector-servicenow.yaml
@@ -182,9 +182,6 @@ parameters:
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO
-- name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
-  description: Add flags on connector response to let engine disable endpoint regarding HTTP error type
-  value: "false"
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
 - name: QUARKUS_HTTP_PORT

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -182,9 +182,6 @@ parameters:
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO
-- name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
-  description: Add flags on connector response to let engine disable endpoint regarding HTTP error type
-  value: "false"
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
 - name: QUARKUS_HTTP_PORT

--- a/.rhcicd/clowdapp-connector-webhook.yaml
+++ b/.rhcicd/clowdapp-connector-webhook.yaml
@@ -190,9 +190,6 @@ parameters:
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level of Notifications
   value: INFO
-- name: NOTIFICATIONS_CONNECTOR_HTTP_DISABLE_FAULTY_ENDPOINTS
-  description: Add flags on connector response to let engine disable endpoint regarding HTTP error type
-  value: "false"
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
 - name: QUARKUS_HTTP_PORT

--- a/connector-common-http/src/main/java/com/redhat/cloud/notifications/connector/http/HttpConnectorConfig.java
+++ b/connector-common-http/src/main/java/com/redhat/cloud/notifications/connector/http/HttpConnectorConfig.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.connector.http;
 
 import com.redhat.cloud.notifications.connector.ConnectorConfig;
 import io.quarkus.arc.DefaultBean;
-import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -25,15 +24,9 @@ public class HttpConnectorConfig extends ConnectorConfig {
     private static final String COMPONENTS = "notifications.connector.http.components";
     private static final String CONNECT_TIMEOUT_MS = "notifications.connector.http.connect-timeout-ms";
     private static final String CONNECTIONS_PER_ROUTE = "notifications.connector.http.connections-per-route";
-    private static final String DISABLE_FAULTY_ENDPOINTS = "notifications.connector.http.disable-faulty-endpoints";
     private static final String MAX_TOTAL_CONNECTIONS = "notifications.connector.http.max-total-connections";
     private static final String SERVER_ERROR_LOG_LEVEL = "notifications.connector.http.server-error.log-level";
     private static final String SOCKET_TIMEOUT_MS = "notifications.connector.http.socket-timeout-ms";
-
-    /*
-     * Unleash configuration
-     */
-    private String disableFaultyEndpointsToggle;
 
     @ConfigProperty(name = CLIENT_ERROR_LOG_LEVEL, defaultValue = "DEBUG")
     Level clientErrorLogLevel;
@@ -47,10 +40,6 @@ public class HttpConnectorConfig extends ConnectorConfig {
     @ConfigProperty(name = CONNECTIONS_PER_ROUTE, defaultValue = "20")
     int httpConnectionsPerRoute;
 
-    @ConfigProperty(name = DISABLE_FAULTY_ENDPOINTS, defaultValue = "false")
-    @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
-    boolean disableFaultyEndpoints;
-
     @ConfigProperty(name = MAX_TOTAL_CONNECTIONS, defaultValue = "200")
     int httpMaxTotalConnections;
 
@@ -60,11 +49,6 @@ public class HttpConnectorConfig extends ConnectorConfig {
     @ConfigProperty(name = SOCKET_TIMEOUT_MS, defaultValue = "2500")
     int httpSocketTimeout;
 
-    @PostConstruct
-    void postConstruct() {
-        disableFaultyEndpointsToggle = toggleRegistry.register("disable-faulty-endpoints", true);
-    }
-
     @Override
     protected Map<String, Object> getLoggedConfiguration() {
         Map<String, Object> config = super.getLoggedConfiguration();
@@ -72,7 +56,6 @@ public class HttpConnectorConfig extends ConnectorConfig {
         config.put(COMPONENTS, httpComponents);
         config.put(CONNECT_TIMEOUT_MS, httpConnectTimeout);
         config.put(CONNECTIONS_PER_ROUTE, httpConnectionsPerRoute);
-        config.put(disableFaultyEndpointsToggle, isDisableFaultyEndpoints());
         config.put(MAX_TOTAL_CONNECTIONS, httpMaxTotalConnections);
         config.put(SERVER_ERROR_LOG_LEVEL, serverErrorLogLevel);
         config.put(SOCKET_TIMEOUT_MS, httpSocketTimeout);
@@ -93,19 +76,6 @@ public class HttpConnectorConfig extends ConnectorConfig {
 
     public int getHttpConnectionsPerRoute() {
         return httpConnectionsPerRoute;
-    }
-
-    public boolean isDisableFaultyEndpoints() {
-        if (unleashEnabled) {
-            return unleash.isEnabled(disableFaultyEndpointsToggle, false);
-        } else {
-            return disableFaultyEndpoints;
-        }
-    }
-
-    @Deprecated(forRemoval = true)
-    public void setDisableFaultyEndpoints(boolean disableFaultyEndpoints) {
-        this.disableFaultyEndpoints = disableFaultyEndpoints;
     }
 
     public int getHttpMaxTotalConnections() {

--- a/connector-common-http/src/main/java/com/redhat/cloud/notifications/connector/http/HttpExceptionProcessor.java
+++ b/connector-common-http/src/main/java/com/redhat/cloud/notifications/connector/http/HttpExceptionProcessor.java
@@ -40,53 +40,27 @@ public class HttpExceptionProcessor extends ExceptionProcessor {
         if (t instanceof HttpOperationFailedException e) {
             exchange.setProperty(HTTP_STATUS_CODE, e.getStatusCode());
             if (e.getStatusCode() >= 300 && e.getStatusCode() < 400) {
-                if (connectorConfig.isDisableFaultyEndpoints()) {
-                    exchange.setProperty(HTTP_ERROR_TYPE, HTTP_3XX);
-                }
+                exchange.setProperty(HTTP_ERROR_TYPE, HTTP_3XX);
                 logHttpError(connectorConfig.getServerErrorLogLevel(), e, exchange);
             } else if (e.getStatusCode() >= 400 && e.getStatusCode() < 500 && e.getStatusCode() != SC_TOO_MANY_REQUESTS) {
-                if (connectorConfig.isDisableFaultyEndpoints()) {
-                    exchange.setProperty(HTTP_ERROR_TYPE, HTTP_4XX);
-                }
+                exchange.setProperty(HTTP_ERROR_TYPE, HTTP_4XX);
                 logHttpError(connectorConfig.getClientErrorLogLevel(), e, exchange);
             } else if (e.getStatusCode() == SC_TOO_MANY_REQUESTS || e.getStatusCode() >= 500) {
-                if (connectorConfig.isDisableFaultyEndpoints()) {
-                    exchange.setProperty(HTTP_ERROR_TYPE, HTTP_5XX);
-                }
+                exchange.setProperty(HTTP_ERROR_TYPE, HTTP_5XX);
                 logHttpError(connectorConfig.getServerErrorLogLevel(), e, exchange);
             } else {
                 logHttpError(ERROR, e, exchange);
             }
         } else if (t instanceof ConnectTimeoutException) {
-            if (connectorConfig.isDisableFaultyEndpoints()) {
-                exchange.setProperty(HTTP_ERROR_TYPE, CONNECT_TIMEOUT);
-            } else {
-                logDefault(t, exchange);
-            }
+            exchange.setProperty(HTTP_ERROR_TYPE, CONNECT_TIMEOUT);
         } else if (t instanceof SocketTimeoutException) {
-            if (connectorConfig.isDisableFaultyEndpoints()) {
-                exchange.setProperty(HTTP_ERROR_TYPE, SOCKET_TIMEOUT);
-            } else {
-                logDefault(t, exchange);
-            }
+            exchange.setProperty(HTTP_ERROR_TYPE, SOCKET_TIMEOUT);
         } else if (t instanceof HttpHostConnectException) {
-            if (connectorConfig.isDisableFaultyEndpoints()) {
-                exchange.setProperty(HTTP_ERROR_TYPE, CONNECTION_REFUSED);
-            } else {
-                logDefault(t, exchange);
-            }
+            exchange.setProperty(HTTP_ERROR_TYPE, CONNECTION_REFUSED);
         } else if (t instanceof SSLHandshakeException) {
-            if (connectorConfig.isDisableFaultyEndpoints()) {
-                exchange.setProperty(HTTP_ERROR_TYPE, SSL_HANDSHAKE);
-            } else {
-                logDefault(t, exchange);
-            }
+            exchange.setProperty(HTTP_ERROR_TYPE, SSL_HANDSHAKE);
         } else if (t instanceof UnknownHostException) {
-            if (connectorConfig.isDisableFaultyEndpoints()) {
-                exchange.setProperty(HTTP_ERROR_TYPE, UNKNOWN_HOST);
-            } else {
-                logDefault(t, exchange);
-            }
+            exchange.setProperty(HTTP_ERROR_TYPE, UNKNOWN_HOST);
         } else {
             logDefault(t, exchange);
         }

--- a/connector-drawer/src/main/resources/application.properties
+++ b/connector-drawer/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 notifications.connector.http.client-error.log-level=ERROR
 notifications.connector.http.components=http
-notifications.connector.http.disable-faulty-endpoints=false
 notifications.connector.http.server-error.log-level=ERROR
 notifications.connector.kafka.incoming.group-id=notifications-connector-drawer
 notifications.connector.kafka.incoming.topic=${mp.messaging.tocamel.topic}

--- a/connector-email/src/main/resources/application.properties
+++ b/connector-email/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 notifications.connector.http.client-error.log-level=ERROR
-notifications.connector.http.disable-faulty-endpoints=false
 notifications.connector.http.server-error.log-level=ERROR
 notifications.connector.kafka.incoming.group-id=notifications-connector-email
 notifications.connector.kafka.incoming.topic=${mp.messaging.tocamel.topic}

--- a/connector-webhook/src/test/java/com/redhat/cloud/notifications/connector/webhook/WebhookConnectorRoutesTest.java
+++ b/connector-webhook/src/test/java/com/redhat/cloud/notifications/connector/webhook/WebhookConnectorRoutesTest.java
@@ -149,18 +149,13 @@ class WebhookConnectorRoutesTest extends ConnectorRoutesTest {
     }
 
     private void testFailedNotificationAndReturnedFlagsToEngine(int httpStatusCode, String returnedBodyMessage, HttpErrorType httpErrorType, final int expectedRedeliveriesCount) throws Exception {
-        connectorConfig.setDisableFaultyEndpoints(true);
-        try {
-            mockRemoteServerError(httpStatusCode, returnedBodyMessage);
-            JsonObject returnToEngine = super.testFailedNotification(expectedRedeliveriesCount);
-            JsonObject data = new JsonObject(returnToEngine.getString("data"));
-            JsonObject error = data.getJsonObject("error");
-            assertEquals(httpErrorType.name(), error.getString("error_type"));
-            assertEquals(expectedRedeliveriesCount + 1, error.getInteger("delivery_attempts"));
-            assertEquals(httpStatusCode, error.getInteger("http_status_code"));
-        } finally {
-            connectorConfig.setDisableFaultyEndpoints(false);
-        }
+        mockRemoteServerError(httpStatusCode, returnedBodyMessage);
+        JsonObject returnToEngine = super.testFailedNotification(expectedRedeliveriesCount);
+        JsonObject data = new JsonObject(returnToEngine.getString("data"));
+        JsonObject error = data.getJsonObject("error");
+        assertEquals(httpErrorType.name(), error.getString("error_type"));
+        assertEquals(expectedRedeliveriesCount + 1, error.getInteger("delivery_attempts"));
+        assertEquals(httpStatusCode, error.getInteger("http_status_code"));
     }
 
     @Test

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EndpointErrorFromConnectorHelper.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EndpointErrorFromConnectorHelper.java
@@ -76,7 +76,7 @@ public class EndpointErrorFromConnectorHelper {
                          * endpoint settings (URL, secret token...). The endpoint will most likely never return a
                          * successful status code with the current settings, so it is disabled immediately.
                          */
-                        boolean disabled = endpointRepository.disableEndpoint(endpoint.getId());
+                        final boolean disabled = this.endpointRepository.disableEndpoint(endpoint);
                         if (disabled) {
                             disabledWebhooksClientErrorCount.increment();
                             Log.infof("Endpoint %s was disabled because we received a %s status while calling it", endpoint.getId(), httpErrorType.get().name());

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.WebhookProperties;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -22,6 +23,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
@@ -126,7 +129,7 @@ public class EndpointRepositoryTest {
     void testDisableEndpointWithEnabledEndpoint() {
         Endpoint endpoint = resourceHelpers.createEndpoint(WEBHOOK, null, true, 3);
         assertTrue(endpoint.isEnabled());
-        assertTrue(endpointRepository.disableEndpoint(endpoint.getId()), "Enabled endpoints SHOULD be updated");
+        assertTrue(endpointRepository.disableEndpoint(endpoint), "Enabled endpoints SHOULD be updated");
         assertFalse(getEndpoint(endpoint.getId()).isEnabled());
     }
 
@@ -134,13 +137,41 @@ public class EndpointRepositoryTest {
     void testDisableEndpointWithDisabledEndpoint() {
         Endpoint endpoint = resourceHelpers.createEndpoint(WEBHOOK, null, false, 0);
         assertFalse(endpoint.isEnabled());
-        assertFalse(endpointRepository.disableEndpoint(endpoint.getId()), "Disabled endpoints SHOULD NOT be updated");
+        assertFalse(endpointRepository.disableEndpoint(endpoint), "Disabled endpoints SHOULD NOT be updated");
         assertFalse(getEndpoint(endpoint.getId()).isEnabled());
     }
 
     @Test
     void testDisableEndpointWithUnknownId() {
-        assertFalse(endpointRepository.disableEndpoint(UUID.randomUUID()));
+        final Endpoint endpoint = new Endpoint();
+        endpoint.setId(UUID.randomUUID());
+        endpoint.setType(WEBHOOK);
+
+        assertFalse(endpointRepository.disableEndpoint(endpoint));
+    }
+
+    /**
+     * Tests that the function under test does not disable system endpoints.
+     */
+    @Test
+    void testDoesNotDisableSystemEndpoints() {
+        // Create the enabled system endpoints.
+        final Set<Endpoint> systemEndpoints = new HashSet<>();
+        for (final EndpointType endpointType : EndpointType.values()) {
+            if (endpointType.isSystemEndpointType) {
+                systemEndpoints.add(this.resourceHelpers.createEndpoint(endpointType, null, true, 0));
+            }
+        }
+
+        for (final Endpoint systemEndpoint : systemEndpoints) {
+            // Call the function under test and assert that the endpoints were
+            // not disabled.
+            Assertions.assertFalse(this.endpointRepository.incrementEndpointServerErrors(systemEndpoint.getId(), 25), String.format("system endpoint with type \"%s\" should not have been disabled", systemEndpoint.getType()));
+
+            final Endpoint databaseEndpoint = this.entityManager.createQuery("FROM Endpoint WHERE id=:endpoint_id", Endpoint.class).setParameter("endpoint_id", systemEndpoint.getId()).getSingleResult();
+            Assertions.assertTrue(databaseEndpoint.isEnabled(), "the system endpoint got disabled even though it should have been");
+        }
+
     }
 
     Endpoint getEndpoint(UUID id) {
@@ -267,5 +298,30 @@ public class EndpointRepositoryTest {
     void persist(Endpoint endpoint, WebhookProperties webhookProperties) {
         entityManager.persist(endpoint);
         entityManager.persist(webhookProperties);
+    }
+
+    /**
+     * Tests that when the endpoint is a system endpoint, the function under
+     * test does not disable it.
+     */
+    @Test
+    void testSystemEndpointsNotDisabled() {
+        // Create the system endpoints.
+        final int originalServerErrors = 12;
+        final Set<Endpoint> systemEndpoints = new HashSet<>();
+        for (final EndpointType endpointType : EndpointType.values()) {
+            if (endpointType.isSystemEndpointType) {
+                systemEndpoints.add(this.resourceHelpers.createEndpoint(endpointType, null, true, originalServerErrors));
+            }
+        }
+
+        for (final Endpoint systemEndpoint : systemEndpoints) {
+            // Call the function under test and assert that the endpoints were
+            // not disabled, nor their server errors were incremented.
+            Assertions.assertFalse(this.endpointRepository.incrementEndpointServerErrors(systemEndpoint.getId(), 25), String.format("system endpoint with type \"%s\" should not have been disabled", systemEndpoint.getType()));
+
+            final Endpoint databaseEndpoint = this.entityManager.createQuery("FROM Endpoint WHERE id=:endpoint_id", Endpoint.class).setParameter("endpoint_id", systemEndpoint.getId()).getSingleResult();
+            Assertions.assertEquals(originalServerErrors, databaseEndpoint.getServerErrors(), "the server errors field was updated for a system endpoint, when it shouldn't have");
+        }
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/EndpointErrorFromConnectorHelperTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/EndpointErrorFromConnectorHelperTest.java
@@ -92,11 +92,11 @@ class EndpointErrorFromConnectorHelperTest {
     @Test
     void testDisableEndpointBecauseOfClientError() {
         final Endpoint endpoint = mockEndpointFromNotificationHistorySearch();
-        Mockito.when(endpointRepository.disableEndpoint(endpoint.getId())).thenReturn(true);
+        Mockito.when(endpointRepository.disableEndpoint(endpoint)).thenReturn(true);
 
         JsonObject payload = buildTestPayload(false, HTTP_4XX, 408);
         endpointErrorFromConnectorHelper.manageEndpointDisablingIfNeeded(endpoint, payload);
-        verify(endpointRepository, times(1)).disableEndpoint(endpoint.getId());
+        verify(endpointRepository, times(1)).disableEndpoint(endpoint);
         verify(integrationDisabledNotifier, times(1)).notify(endpoint, HTTP_4XX, 408, 1);
         assertMetrics(0, 1);
     }


### PR DESCRIPTION
The feature has been enabled in production and it was worked flawlessly. Therefore, we can leave it as a permanent enabled feature in our application.

## Jira application
[[RHCLOUD-33637]](https://issues.redhat.com/browse/RHCLOUD-33637)