### PR TITLE
[RHCLOUD-31596] Fix filtering for muted eventTypes

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -174,6 +174,29 @@ public class BehaviorGroupRepository {
         return behaviorGroups;
     }
 
+    /**
+     * Iterates behavior groups within an organization to get IDs of all unmuted {@link EventType EventTypes}.
+     *
+     * @param orgId    Organization ID
+     * @param bundleId Optionally filter by bundle ID.
+     * @return A list of event type {@link UUID} connected to at least one behavior group.
+     */
+    public List<UUID> findUnmutedEventTypes(String orgId, UUID bundleId) {
+        String query = "SELECT DISTINCT e.id FROM BehaviorGroup b JOIN b.behaviors etb JOIN etb.eventType e " +
+                "WHERE (b.orgId = :orgId OR b.orgId IS NULL)";
+        if (bundleId != null) {
+            query += " AND b.bundle.id = :bundleId";
+        }
+
+        TypedQuery<UUID> queryBuilder = entityManager.createQuery(query, UUID.class)
+                .setParameter("orgId", orgId);
+        if (bundleId != null) {
+            queryBuilder.setParameter("bundleId", bundleId);
+        }
+
+        return queryBuilder.getResultList();
+    }
+
     public void update(String orgId, BehaviorGroup behaviorGroup) {
         this.update(orgId, behaviorGroup, false);
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -127,11 +127,15 @@ public class NotificationResource {
     @Operation(summary = "List all event types", description = "Lists all event types. You can filter the returned list by bundle, application name, or unmuted types.")
     @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public Page<EventType> getEventTypes(
-            @Context UriInfo uriInfo, @BeanParam @Valid Query query, @QueryParam("applicationIds") Set<UUID> applicationIds, @QueryParam("bundleId") UUID bundleId,
-            @QueryParam("eventTypeName") String eventTypeName, @QueryParam("excludeMutedTypes") boolean excludeMutedTypes
+            @Context SecurityContext securityContext, @Context UriInfo uriInfo, @BeanParam @Valid Query query, @QueryParam("applicationIds") Set<UUID> applicationIds,
+            @QueryParam("bundleId") UUID bundleId, @QueryParam("eventTypeName") String eventTypeName, @QueryParam("excludeMutedTypes") boolean excludeMutedTypes
     ) {
-        List<EventType> eventTypes = applicationRepository.getEventTypes(query, applicationIds, bundleId, eventTypeName, excludeMutedTypes);
-        Long count = applicationRepository.getEventTypesCount(applicationIds, bundleId, eventTypeName, excludeMutedTypes);
+        List<UUID> unmutedEventTypeIds = excludeMutedTypes
+                ? behaviorGroupRepository.findUnmutedEventTypes(getOrgId(securityContext), bundleId)
+                : null;
+
+        List<EventType> eventTypes = applicationRepository.getEventTypes(query, applicationIds, bundleId, eventTypeName, excludeMutedTypes, unmutedEventTypeIds);
+        Long count = applicationRepository.getEventTypesCount(applicationIds, bundleId, eventTypeName, excludeMutedTypes, unmutedEventTypeIds);
         return new Page<>(
                 eventTypes,
                 PageLinksBuilder.build(uriInfo.getPath(), count, query.getLimit().getLimit(), query.getLimit().getOffset()),


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-31596

## Description

This fixes issues with the original version of the `excludeMutedTypes` param on the `notifications/eventTypes` endpoint. The new version works as follows:

- Endpoint captures security context, and if the parameter is set to `excludeMutedTypes=true`, retrieves a list of event type IDs tied to an organization or default behavior group
- IDs are passed into the main query, and if parameter is set to true, will filter the list

## Compatibility

The previous implementation listed event types linked to any behavior group globally, making it (almost) a no-op. This fix restores the intended functionality.

## Testing

- `testEventFetchingAndExcludeMutedTypes` now also adds event types to a default behavior group, and to a different organization. Only event types assigned to behaviour groups in the organization, or default behavior groups, are accepted.
- `testEventFetchingByBundleApplicationEventTypeNameAndExcludeMutedTypes` tests the same, showing that even when matching by all parameters, it will only filter if the organization ID matches