### PR TITLE
RHCLOUD-34047 | feature: incrase transaction timeouts for the bundles operations

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -207,7 +207,7 @@ public class InternalResource {
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
     @Transactional
-    @TransactionConfiguration(timeout = 300)
+    @TransactionConfiguration(timeout = 600)
     /*
      * We need to increase the transaction timeout for this method because it involves
      * an update of 'event' table records based on 'bundleId' column which is not indexed.
@@ -226,7 +226,7 @@ public class InternalResource {
     @Path("/bundles/{bundleId}")
     @Produces(APPLICATION_JSON)
     @Transactional
-    @TransactionConfiguration(timeout = 300)
+    @TransactionConfiguration(timeout = 600)
     /*
      * We need to increase the transaction timeout for this method because it involves
      * a full scan of 'event' table based on 'bundleId' column which is not indexed.


### PR DESCRIPTION
We are suffering from timeouts in production when we attempt to modify or delete an existing bundle. This is due to the "events" table being huge, and the "bundle_id" column not being indexed.

Adding an index to that column for this purpose seems overkill for now, especially because these endpoints don't get used very often.

## Jira ticket
[[RHCLOUD-34047]](https://issues.redhat.com/browse/RHCLOUD-34047)