### PR TITLE
Udpate errata email body templates

### DIFF
--- a/engine/src/main/resources/templates/Errata/bugfixEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/bugfixEmailBodyV2.html
@@ -21,7 +21,7 @@
             {#if action.events.size() > 0}
                 {#each action.events}
                 <tr style="font-size: 14px;">
-                    <td><a href="{it.payload.url}" target="_blank">{it.payload.id}</a></td>
+                    <td><a href="{action.context.base_url}{it.payload.id}" target="_blank">{it.payload.id}</a></td>
                     <td>{it.payload.synopsis}</td>
                 </tr>
                 {/each}

--- a/engine/src/main/resources/templates/Errata/enhancementEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/enhancementEmailBodyV2.html
@@ -21,7 +21,7 @@
             {#if action.events.size() > 0}
                 {#each action.events}
                 <tr style="font-size: 14px;">
-                    <td><a href="{it.payload.url}" target="_blank">{it.payload.id}</a></td>
+                    <td><a href="{action.context.base_url}{it.payload.id}" target="_blank">{it.payload.id}</a></td>
                     <td>{it.payload.synopsis}</td>
                 </tr>
                 {/each}

--- a/engine/src/main/resources/templates/Errata/enhancementEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/enhancementEmailBodyV2.html
@@ -4,7 +4,7 @@
     Errata - Subscription Services
 {/content-title}
 {#content-title-section1}
-    Security updates
+    Enhancements
 {/content-title-section1}
 {#content-subtitle-section1}
     There are {action.events.size()} enhancements affecting your systems.

--- a/engine/src/main/resources/templates/Errata/securityEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/securityEmailBodyV2.html
@@ -21,7 +21,7 @@
             {#if action.events.size() > 0}
                 {#each action.events}
                 <tr style="font-size: 14px;">
-                    <td><a href="{it.payload.url}" target="_blank">{it.payload.id}</a></td>
+                    <td><a href="{action.context.base_url}{it.payload.id}" target="_blank">{it.payload.id}</a></td>
                     <td>{it.payload.synopsis}</td>
                 </tr>
                 {/each}

--- a/engine/src/test/java/com/redhat/cloud/notifications/ErrataTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ErrataTestHelpers.java
@@ -25,6 +25,7 @@ public class ErrataTestHelpers {
             new Context.ContextBuilder()
                 .withAdditionalProperty("system_check_in", "2022-08-03T15:22:42.199046")
                 .withAdditionalProperty("start_time", "2022-08-03T15:22:42.199046")
+                .withAdditionalProperty("base_url", "https://access.redhat.com/errata/")
                 .build()
         );
 
@@ -35,7 +36,6 @@ public class ErrataTestHelpers {
                     new Payload.PayloadBuilder()
                         .withAdditionalProperty("id", "RHSA-2024:2106")
                         .withAdditionalProperty("synopsis", "Moderate: Red Hat build of Quarkus 3.8.4 release")
-                        .withAdditionalProperty("url", "https://access.redhat.com/errata/RHSA-2024:2106")
                         .build()
                 )
                 .build(),
@@ -45,7 +45,6 @@ public class ErrataTestHelpers {
                     new Payload.PayloadBuilder()
                         .withAdditionalProperty("id", "RHSA-2024:3842")
                         .withAdditionalProperty("synopsis", "Low: c-ares security update")
-                        .withAdditionalProperty("url", "https://access.redhat.com/errata/RHSA-2024:3842")
                         .build()
                 )
                 .build(),
@@ -55,7 +54,6 @@ public class ErrataTestHelpers {
                     new Payload.PayloadBuilder()
                         .withAdditionalProperty("id", "RHSA-2024:3843")
                         .withAdditionalProperty("synopsis", "Moderate: cockpit security update")
-                        .withAdditionalProperty("url", "https://access.redhat.com/errata/RHSA-2024:3843")
                         .build()
                 )
                 .build()

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestErrataTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestErrataTemplate.java
@@ -45,6 +45,7 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
     public void testNewSubscriptionBugfixErrataEmailBody() {
         String result = generateEmailBody(NEW_SUBSCRIPTION_BUGFIX_ERRATA, ACTION);
         assertTrue(result.contains("There are 3 bug fixes affecting your systems."));
+        assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
@@ -58,6 +59,7 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
     public void testNewSubscriptionSecurityUpdateErrataEmailBody() {
         String result = generateEmailBody(NEW_SUBSCRIPTION_SECURITY_UPDATE_ERRATA, ACTION);
         assertTrue(result.contains("There are 3 security updates affecting your systems."));
+        assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
@@ -71,6 +73,7 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
     public void testNewSubscriptionEnhancementErrataEmailBody() {
         String result = generateEmailBody(NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA, ACTION);
         assertTrue(result.contains("There are 3 enhancements affecting your systems."));
+        assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 }


### PR DESCRIPTION
Updates to the Errata  email body templates:

- Move advisory base URL to context to cut down on message size
- Update enhancement email body to read "Enhancements" rather than "Security updates."