### PR TITLE
[RHCLOUD-31596] Exclude eventType for default behavior groups

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -180,10 +180,12 @@ public class BehaviorGroupRepository {
      * @param orgId    Organization ID
      * @param bundleId Optionally filter by bundle ID.
      * @return A list of event type {@link UUID} connected to at least one behavior group.
+     * @apiNote Event types associated with default behavior groups (those without an {@code orgId})
+     *          will <em>not</em> be returned by this method.
      */
     public List<UUID> findUnmutedEventTypes(String orgId, UUID bundleId) {
         String query = "SELECT DISTINCT e.id FROM BehaviorGroup b JOIN b.behaviors etb JOIN etb.eventType e " +
-                "WHERE (b.orgId = :orgId OR b.orgId IS NULL)";
+                "WHERE b.orgId = :orgId";
         if (bundleId != null) {
             query += " AND b.bundle.id = :bundleId";
         }


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-31596

## Description

The `api/notifications/v1.0/notifications/eventTypes?excludeMutedTypes=true` query parameter is slightly modified, so that event types associated with default behavior groups are no longer returned. This change is slightly inconsistent with other endpoints, which typically do consider default behavior groups. However, this allows for the endpoint to return a list of event types which the user is able to mute.

##  Compatibility

**Breaks compatibility** with the previous implementation (#2820), as event types associated with default behaviour groups will no longer be returned.

## Testing

- Cases `testEventFetchingAndExcludeMutedTypes` and `testEventFetchingByBundleApplicationEventTypeNameAndExcludeMutedTypes` now verify that event types which are only associated with a default behavior group are not returned when `excludeMutedTypes` is true