### PR TITLE
Change wording from systems to subscriptions

### DIFF
--- a/engine/src/main/resources/templates/Errata/bugfixEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/bugfixEmailBodyV2.html
@@ -7,7 +7,7 @@
     Bug Fixes
 {/content-title-section1}
 {#content-subtitle-section1}
-    There are {action.events.size()} bug fixes affecting your systems.
+    There are {action.events.size()} bug fixes affecting your subscriptions.
 {/content-subtitle-section1}
 {#content-body-section1}
     <table class="rh-data-table-bordered">

--- a/engine/src/main/resources/templates/Errata/enhancementEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/enhancementEmailBodyV2.html
@@ -7,7 +7,7 @@
     Enhancements
 {/content-title-section1}
 {#content-subtitle-section1}
-    There are {action.events.size()} enhancements affecting your systems.
+    There are {action.events.size()} enhancements affecting your subscriptions.
 {/content-subtitle-section1}
 {#content-body-section1}
     <table class="rh-data-table-bordered">

--- a/engine/src/main/resources/templates/Errata/securityEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/securityEmailBodyV2.html
@@ -7,7 +7,7 @@
     Security updates
 {/content-title-section1}
 {#content-subtitle-section1}
-    There are {action.events.size()} security updates affecting your systems.
+    There are {action.events.size()} security updates affecting your subscriptions.
 {/content-subtitle-section1}
 {#content-body-section1}
     <table class="rh-data-table-bordered">

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestErrataTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestErrataTemplate.java
@@ -44,7 +44,7 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
     @Test
     public void testNewSubscriptionBugfixErrataEmailBody() {
         String result = generateEmailBody(NEW_SUBSCRIPTION_BUGFIX_ERRATA, ACTION);
-        assertTrue(result.contains("There are 3 bug fixes affecting your systems."));
+        assertTrue(result.contains("There are 3 bug fixes affecting your subscriptions."));
         assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
@@ -58,7 +58,7 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
     @Test
     public void testNewSubscriptionSecurityUpdateErrataEmailBody() {
         String result = generateEmailBody(NEW_SUBSCRIPTION_SECURITY_UPDATE_ERRATA, ACTION);
-        assertTrue(result.contains("There are 3 security updates affecting your systems."));
+        assertTrue(result.contains("There are 3 security updates affecting your subscriptions."));
         assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
@@ -72,7 +72,7 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
     @Test
     public void testNewSubscriptionEnhancementErrataEmailBody() {
         String result = generateEmailBody(NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA, ACTION);
-        assertTrue(result.contains("There are 3 enhancements affecting your systems."));
+        assertTrue(result.contains("There are 3 enhancements affecting your subscriptions."));
         assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }


### PR DESCRIPTION
Update the wording of subscription errata notifications to say that subscriptions are impacted rather than systems.l