### PR TITLE
Revert "Bump io.quarkiverse.logging.cloudwatch:quarkus-logging-cloudwatch from 6.9.0 to 6.11.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <insights-notification-schemas-java.version>0.21</insights-notification-schemas-java.version>
         <clowder-quarkus-config-source.version>2.6.1</clowder-quarkus-config-source.version>
 
-        <quarkus-logging-cloudwatch.version>6.11.0</quarkus-logging-cloudwatch.version>
+        <quarkus-logging-cloudwatch.version>6.9.0</quarkus-logging-cloudwatch.version>
         <quarkus-logging-sentry.version>2.0.7</quarkus-logging-sentry.version>
         <quarkus-unleash.version>1.7.0</quarkus-unleash.version>
 


### PR DESCRIPTION
Reverts RedHatInsights/notifications-backend#2843