### PR TITLE
[RHCLOUD-34067] Avoid useless SQL requests

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -32,6 +32,10 @@ public class EventRepository {
         query.setDefaultSortBy("created:DESC");
         Optional<Query.Sort> sort = query.getSort();
         List<UUID> eventIds = getEventIds(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, query);
+        if (eventIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+
         String hql;
         if (fetchNotificationHistory) {
             hql = "SELECT DISTINCT e FROM Event e LEFT JOIN FETCH e.historyEntries he WHERE e.id IN (:eventIds)";

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EventResource.java
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.jboss.resteasy.reactive.RestQuery;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -95,6 +96,20 @@ public class EventResource {
 
         String orgId = getOrgId(securityContext);
         List<Event> events = eventRepository.getEvents(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, query);
+
+        if (events.isEmpty()) {
+            Meta meta = new Meta();
+            meta.setCount(0L);
+
+            Map<String, String> links = PageLinksBuilder.build(uriInfo.getPath(), 0, query);
+
+            Page<EventLogEntry> page = new Page<>();
+            page.setData(new ArrayList<>());
+            page.setMeta(meta);
+            page.setLinks(links);
+            return page;
+        }
+
         List<EventLogEntry> eventLogEntries = events.stream().map(event -> {
             List<EventLogEntryAction> actions;
             if (!includeActions) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
@@ -102,6 +102,7 @@ public class EventResourceTest extends DbIsolatedTest {
 
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "user", FULL_ACCESS);
         Header otherIdentityHeader = mockRbac(OTHER_ACCOUNT_ID, OTHER_ORG_ID, "other-username", FULL_ACCESS);
+        Header emptyIdentityHeader = mockRbac(OTHER_ACCOUNT_ID, "none", "other-username", FULL_ACCESS);
 
         Bundle bundle1 = resourceHelpers.createBundle("bundle-1", "Bundle 1");
         Bundle bundle2 = resourceHelpers.createBundle("bundle-2", "Bundle 2");
@@ -523,6 +524,17 @@ public class EventResourceTest extends DbIsolatedTest {
         assertSameEvent(page.getData().get(0), event3, history4, history5, history7);
         assertSameEvent(page.getData().get(1), event1, history1, history2, history6);
         assertNull(page.getData().get(0).getPayload());
+        assertLinks(page.getLinks(), "first", "last");
+
+        /*
+         * Test #32
+         * Request: No filter
+         * Expected response: Empty event log page should be returned
+         */
+        page = getEventLogPage(emptyIdentityHeader, null, null, null, null, null, null, null, null, null, null, null, false, true);
+        assertEquals(0, page.getMeta().getCount());
+        assertEquals(0, page.getData().size());
+        assertTrue(page.getData().isEmpty());
         assertLinks(page.getLinks(), "first", "last");
     }
 


### PR DESCRIPTION
Event log fetch is split into 3 SQL requests, it the first one has no results, we can skip 2 other requests because they will have no results as well