### PR TITLE
RHCLOUD-34317 | Send high volume events to the new Kafka topic

### DIFF
--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -19,6 +19,9 @@ objects:
     envName: ${ENV_NAME}
     featureFlags: true
     kafkaTopics:
+    - topicName: platform.notifications.connector.email.high.volume
+      partitions: 6
+      replicas: 3
     - topicName: platform.notifications.tocamel
       partitions: 3
       replicas: 3
@@ -71,6 +74,14 @@ objects:
           value: ${NOTIFICATIONS_CONNECTOR_HTTP_CONNECT_TIMEOUT_MS}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS
           value: ${NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_INTERVAL_MS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_INTERVAL_MS}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_RECORDS
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_RECORDS}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_POLL_ON_ERROR
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_POLL_ON_ERROR}
+        - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_TOPIC_ENABLED
+          value: ${NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_TOPIC_ENABLED}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_INTERVAL_MS
           value: ${KAFKA_MAX_POLL_INTERVAL_MS}
         - name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_MAX_POLL_RECORDS
@@ -192,6 +203,18 @@ parameters:
 - name: NOTIFICATIONS_CONNECTOR_HTTP_SOCKET_TIMEOUT_MS
   description: Maximum time in milliseconds allowed to wait for HTTP data
   value: "180000"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_INTERVAL_MS
+  description: Maximum delay in milliseconds between two calls of poll(). Defaults to 300000 (5 minutes).
+  value: "300000"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_RECORDS
+  description: Maximum number of records returned in a single call of poll(). Defaults to 500.
+  value: "500"
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_POLL_ON_ERROR
+  description: What to do if kafka threw an exception while polling for new messages. See https://camel.apache.org/components/latest/kafka-component.html for more details.
+  value: RECONNECT
+- name: NOTIFICATIONS_CONNECTOR_KAFKA_INCOMING_HIGH_VOLUME_TOPIC_ENABLED
+  description: Specifies whether the high volume topic is enabled for the connector or not.
+  value: "false"
 - name: NOTIFICATIONS_CONNECTOR_KAFKA_MAXIMUM_REINJECTIONS
   description: Maximum times a message will be reinjected in the incoming queue after having failed to deliver the notification
   value: "0"

--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -23,6 +23,9 @@ objects:
       sharedDbAppName: notifications-backend
     featureFlags: true
     kafkaTopics:
+    - topicName: platform.notifications.connector.email.high.volume
+      partitions: 6
+      replicas: 3
     - topicName: platform.notifications.ingress
       partitions: 3
       replicas: 3

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
@@ -12,6 +12,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.camel.Predicate;
 import org.apache.camel.builder.endpoint.dsl.HttpEndpointBuilderFactory;
+import org.apache.camel.builder.endpoint.dsl.KafkaEndpointBuilderFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 
 import java.util.Set;
@@ -30,6 +31,7 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
 
     static final String BOP_RESPONSE_TIME_METRIC = "micrometer:timer:email.bop.response.time";
     static final String RECIPIENTS_RESOLVER_RESPONSE_TIME_METRIC = "micrometer:timer:email.recipients_resolver.response.time";
+    static final String ROUTE_ID_KAFKA_HIGH_VOLUME_ROUTE = "kafka-high-volume-entrypoint";
     static final String TIMER_ACTION_START = "?action=start";
     static final String TIMER_ACTION_STOP = "?action=stop";
 
@@ -60,6 +62,11 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
      */
     @Override
     public void configureRoutes() {
+        // Read events from the high volume topic and forward them to the
+        // entrypoint, so that they get processed as usual.
+        from(this.buildKafkaHighVolumeEndpoint())
+            .routeId(ROUTE_ID_KAFKA_HIGH_VOLUME_ROUTE)
+            .to(direct(ENTRYPOINT));
 
         /*
          * Prepares the payload accepted by BOP and sends the request to
@@ -142,5 +149,17 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
         } else {
             return http(fullURL.replace("http://", ""));
         }
+    }
+
+    /**
+     * Builds the Kafka consumer for the high volume Kafka topic.
+     * @return the built endpoint for the high volume Kafka consumer.
+     */
+    private KafkaEndpointBuilderFactory.KafkaEndpointConsumerBuilder buildKafkaHighVolumeEndpoint() {
+        return kafka(this.emailConnectorConfig.getIncomingKafkaHighVolumeTopic())
+            .groupId(this.emailConnectorConfig.getIncomingKafkaGroupId())
+            .maxPollRecords(this.emailConnectorConfig.getIncomingKafkaHighVolumeMaxPollRecords())
+            .maxPollIntervalMs(this.emailConnectorConfig.getIncomingKafkaHighVolumeMaxPollIntervalMs())
+            .pollOnError(this.emailConnectorConfig.getIncomingKafkaHighVolumePollOnError());
     }
 }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilder.java
@@ -64,9 +64,11 @@ public class EmailRouteBuilder extends EngineToConnectorRouteBuilder {
     public void configureRoutes() {
         // Read events from the high volume topic and forward them to the
         // entrypoint, so that they get processed as usual.
-        from(this.buildKafkaHighVolumeEndpoint())
-            .routeId(ROUTE_ID_KAFKA_HIGH_VOLUME_ROUTE)
-            .to(direct(ENTRYPOINT));
+        if (this.emailConnectorConfig.isIncomingKafkaHighVolumeTopicEnabled()) {
+            from(this.buildKafkaHighVolumeEndpoint())
+                .routeId(ROUTE_ID_KAFKA_HIGH_VOLUME_ROUTE)
+                .to(direct(ENTRYPOINT));
+        }
 
         /*
          * Prepares the payload accepted by BOP and sends the request to

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
@@ -17,6 +17,11 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
     private static final String BOP_CLIENT_ID = "notifications.connector.user-provider.bop.client_id";
     private static final String BOP_ENV = "notifications.connector.user-provider.bop.env";
     private static final String BOP_URL = "notifications.connector.user-provider.bop.url";
+    private static final String KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_INTERVAL_MS = "notifications.connector.kafka.incoming.high-volume.max-poll-interval-ms";
+    private static final String KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_RECORDS = "notifications.connector.kafka.incoming.high-volume.max-poll-records";
+    private static final String KAFKA_INCOMING_HIGH_VOLUME_POLL_ON_ERROR = "notifications.connector.kafka.incoming.high-volume.poll-on-error";
+    private static final String KAFKA_INCOMING_HIGH_VOLUME_TOPIC = "notifications.connector.kafka.incoming.high-volume.topic";
+    private static final String KAFKA_INCOMING_HIGH_VOLUME_TOPIC_ENABLED = "notifications.connector.kafka.incoming.high-volume.topic.enabled";
     private static final String MAX_RECIPIENTS_PER_EMAIL = "notifications.connector.max-recipients-per-email";
     private static final String RECIPIENTS_RESOLVER_USER_SERVICE_URL = "notifications.connector.recipients-resolver.url";
     private static final String NOTIFICATIONS_EMAILS_INTERNAL_ONLY_ENABLED = "notifications.emails-internal-only.enabled";
@@ -32,6 +37,20 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
 
     @ConfigProperty(name = BOP_URL)
     String bopURL;
+
+    // https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#max-poll-interval-ms
+    @ConfigProperty(name = KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_INTERVAL_MS, defaultValue = "300000")
+    int incomingKafkaHighVolumeMaxPollIntervalMs;
+
+    // https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#max-poll-records
+    @ConfigProperty(name = KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_RECORDS, defaultValue = "500")
+    int incomingKafkaHighVolumeMaxPollRecords;
+
+    @ConfigProperty(name = KAFKA_INCOMING_HIGH_VOLUME_POLL_ON_ERROR, defaultValue = "RECONNECT")
+    String incomingKafkaHighVolumePollOnError;
+
+    @ConfigProperty(name = KAFKA_INCOMING_HIGH_VOLUME_TOPIC)
+    String incomingKafkaHighVolumeTopic;
 
     @ConfigProperty(name = RECIPIENTS_RESOLVER_USER_SERVICE_URL)
     String recipientsResolverServiceURL;
@@ -60,6 +79,10 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
 
         config.put(BOP_ENV, bopEnv);
         config.put(BOP_URL, bopURL);
+        config.put(KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_INTERVAL_MS, incomingKafkaHighVolumeMaxPollIntervalMs);
+        config.put(KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_RECORDS, incomingKafkaHighVolumeMaxPollRecords);
+        config.put(KAFKA_INCOMING_HIGH_VOLUME_POLL_ON_ERROR, incomingKafkaHighVolumePollOnError);
+        config.put(KAFKA_INCOMING_HIGH_VOLUME_TOPIC, incomingKafkaHighVolumeTopic);
         config.put(RECIPIENTS_RESOLVER_USER_SERVICE_URL, recipientsResolverServiceURL);
         config.put(MAX_RECIPIENTS_PER_EMAIL, maxRecipientsPerEmail);
         config.put(NOTIFICATIONS_EMAILS_INTERNAL_ONLY_ENABLED, emailsInternalOnlyEnabled);
@@ -91,6 +114,22 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
 
     public String getRecipientsResolverServiceURL() {
         return recipientsResolverServiceURL;
+    }
+
+    public int getIncomingKafkaHighVolumeMaxPollIntervalMs() {
+        return this.incomingKafkaHighVolumeMaxPollIntervalMs;
+    }
+
+    public int getIncomingKafkaHighVolumeMaxPollRecords() {
+        return this.incomingKafkaHighVolumeMaxPollRecords;
+    }
+
+    public String getIncomingKafkaHighVolumePollOnError() {
+        return this.incomingKafkaHighVolumePollOnError;
+    }
+
+    public String getIncomingKafkaHighVolumeTopic() {
+        return this.incomingKafkaHighVolumeTopic;
     }
 
     public int getMaxRecipientsPerEmail() {

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
@@ -52,6 +52,9 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
     @ConfigProperty(name = KAFKA_INCOMING_HIGH_VOLUME_TOPIC)
     String incomingKafkaHighVolumeTopic;
 
+    @ConfigProperty(name = KAFKA_INCOMING_HIGH_VOLUME_TOPIC_ENABLED, defaultValue = "false")
+    Boolean incomingKafkaHighVolumeTopicEnabled;
+
     @ConfigProperty(name = RECIPIENTS_RESOLVER_USER_SERVICE_URL)
     String recipientsResolverServiceURL;
 
@@ -83,6 +86,7 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
         config.put(KAFKA_INCOMING_HIGH_VOLUME_MAX_POLL_RECORDS, incomingKafkaHighVolumeMaxPollRecords);
         config.put(KAFKA_INCOMING_HIGH_VOLUME_POLL_ON_ERROR, incomingKafkaHighVolumePollOnError);
         config.put(KAFKA_INCOMING_HIGH_VOLUME_TOPIC, incomingKafkaHighVolumeTopic);
+        config.put(KAFKA_INCOMING_HIGH_VOLUME_TOPIC_ENABLED, incomingKafkaHighVolumeTopicEnabled);
         config.put(RECIPIENTS_RESOLVER_USER_SERVICE_URL, recipientsResolverServiceURL);
         config.put(MAX_RECIPIENTS_PER_EMAIL, maxRecipientsPerEmail);
         config.put(NOTIFICATIONS_EMAILS_INTERNAL_ONLY_ENABLED, emailsInternalOnlyEnabled);
@@ -130,6 +134,10 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
 
     public String getIncomingKafkaHighVolumeTopic() {
         return this.incomingKafkaHighVolumeTopic;
+    }
+
+    public boolean isIncomingKafkaHighVolumeTopicEnabled() {
+        return this.incomingKafkaHighVolumeTopicEnabled;
     }
 
     public int getMaxRecipientsPerEmail() {

--- a/connector-email/src/main/resources/application.properties
+++ b/connector-email/src/main/resources/application.properties
@@ -35,7 +35,7 @@ camel.component.kafka.retry-backoff-ms=200
 
 camel.context.name=notifications-connector-email
 
-mp.messaging.high-volume.topic=platform.notifications.connector.email.high.volume
+mp.messaging.high-volume.topic=wrong.name.on.purpose.to.test.behavior.when.it.doesnt.exist
 mp.messaging.tocamel.topic=platform.notifications.tocamel
 mp.messaging.fromcamel.topic=platform.notifications.fromcamel
 

--- a/connector-email/src/main/resources/application.properties
+++ b/connector-email/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 notifications.connector.http.client-error.log-level=ERROR
 notifications.connector.http.server-error.log-level=ERROR
 notifications.connector.kafka.incoming.group-id=notifications-connector-email
+notifications.connector.kafka.incoming.high-volume.topic=${mp.messaging.high-volume.topic}
 notifications.connector.kafka.incoming.topic=${mp.messaging.tocamel.topic}
 notifications.connector.kafka.outgoing.topic=${mp.messaging.fromcamel.topic}
 notifications.connector.name=email_subscription
@@ -34,6 +35,7 @@ camel.component.kafka.retry-backoff-ms=200
 
 camel.context.name=notifications-connector-email
 
+mp.messaging.high-volume.topic=platform.notifications.connector.email.high.volume
 mp.messaging.tocamel.topic=platform.notifications.tocamel
 mp.messaging.fromcamel.topic=platform.notifications.fromcamel
 

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -40,6 +40,19 @@ mp.messaging.outgoing.tocamel.value.serializer=org.apache.kafka.common.serializa
 mp.messaging.outgoing.tocamel.cloud-events-source=notifications
 mp.messaging.outgoing.tocamel.cloud-events-mode=structured
 
+# Output queue to the high volume topic (notifications-sender)
+# The compression is enabled for the producers because some messages might end
+# up being significantly big, like the ones for the email connector, which
+# contain the fully rendered email.
+mp.messaging.outgoing.highvolume.compression.type=snappy
+mp.messaging.outgoing.highvolume.connector=smallrye-kafka
+mp.messaging.outgoing.highvolume.topic=platform.notifications.connector.email.high.volume
+mp.messaging.outgoing.highvolume.group.id=integrations
+mp.messaging.outgoing.highvolume.key.serializer=org.apache.kafka.common.serialization.StringSerializer
+mp.messaging.outgoing.highvolume.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+mp.messaging.outgoing.highvolume.cloud-events-source=notifications
+mp.messaging.outgoing.highvolume.cloud-events-mode=structured
+
 # Input queue from camel senders
 mp.messaging.incoming.fromcamel.connector=smallrye-kafka
 mp.messaging.incoming.fromcamel.topic=platform.notifications.fromcamel

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -46,7 +46,7 @@ mp.messaging.outgoing.tocamel.cloud-events-mode=structured
 # contain the fully rendered email.
 mp.messaging.outgoing.highvolume.compression.type=snappy
 mp.messaging.outgoing.highvolume.connector=smallrye-kafka
-mp.messaging.outgoing.highvolume.topic=platform.notifications.connector.email.high.volume
+mp.messaging.outgoing.highvolume.topic=wrong.name.on.purpose.to.test.behavior.when.it.doesnt.exist
 mp.messaging.outgoing.highvolume.group.id=integrations
 mp.messaging.outgoing.highvolume.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.highvolume.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -18,6 +18,7 @@ import static com.redhat.cloud.notifications.events.ConnectorReceiver.EGRESS_CHA
 import static com.redhat.cloud.notifications.events.ConnectorReceiver.FROMCAMEL_CHANNEL;
 import static com.redhat.cloud.notifications.events.EventConsumer.INGRESS_CHANNEL;
 import static com.redhat.cloud.notifications.exports.ExportEventListener.EXPORT_CHANNEL;
+import static com.redhat.cloud.notifications.processors.ConnectorSender.HIGH_VOLUME_CHANNEL;
 import static com.redhat.cloud.notifications.processors.ConnectorSender.TOCAMEL_CHANNEL;
 import static com.redhat.cloud.notifications.routers.DailyDigestResource.AGGREGATION_OUT_CHANNEL;
 
@@ -50,6 +51,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
          * We'll use an in-memory Reactive Messaging connector to send payloads.
          * See https://smallrye.io/smallrye-reactive-messaging/smallrye-reactive-messaging/2/testing/testing.html
          */
+        properties.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory(HIGH_VOLUME_CHANNEL));
         properties.putAll(InMemoryConnector.switchIncomingChannelsToInMemory(INGRESS_CHANNEL));
         properties.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory(AGGREGATION_OUT_CHANNEL));
         properties.putAll(InMemoryConnector.switchOutgoingChannelsToInMemory(TOCAMEL_CHANNEL));

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.Event;
@@ -163,7 +164,10 @@ public abstract class CamelProcessorTest {
         event.setOrgId(DEFAULT_ORG_ID);
         event.setEventWrapper(new EventWrapperAction(action));
         event.setApplicationDisplayName("policies");
+        Application application = new Application();
+        application.setName("policies");
         EventType eventType = new EventType();
+        eventType.setApplication(application);
         eventType.setName("policy-triggered");
         event.setEventType(eventType);
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/eventing/EventingTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/eventing/EventingTypeProcessorTest.java
@@ -11,6 +11,7 @@ import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.ingress.Recipient;
+import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.Event;
@@ -234,7 +235,10 @@ class EventingTypeProcessorTest {
         event.setEventWrapper(new EventWrapperAction(action));
         event.setOrgId(DEFAULT_ORG_ID);
         event.setApplicationDisplayName("policies");
+        Application application = new Application();
+        application.setName("policies");
         EventType eventType = new EventType();
+        eventType.setApplication(application);
         eventType.setName("policy-triggered");
         event.setEventType(eventType);
         return event;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/webhook/WebhookTest.java
@@ -9,6 +9,7 @@ import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
@@ -98,7 +99,10 @@ public class WebhookTest {
         Event event = new Event();
         event.setEventWrapper(new EventWrapperAction(webhookActionMessage));
         event.setApplicationDisplayName("policies");
+        Application application = new Application();
+        application.setName("policies");
         EventType eventType = new EventType();
+        eventType.setApplication(application);
         eventType.setName("policy-triggered");
         event.setEventType(eventType);
         event.setOrgId(DEFAULT_ORG_ID);


### PR DESCRIPTION
We are about to integrate with a tenant that is going to send millions
of events per day, and in order to avoid clogging our main Kafka topic
with those events alone, we are going to create:

1. A separate Kafka topic for those events.
2. Allow the email connector to enable consuming from the high volume Kafka
   topic.

That way we will keep processing the regular events as normal, without
the high volume traffic affecting that flow.

## Jira ticket
[[RHCLOUD-34317]](https://issues.redhat.com/browse/RHCLOUD-34317)