### PR TITLE
RHCLOUd-34317 | refactor: correct the high volume Kafka topic names

### DIFF
--- a/connector-email/src/main/resources/application.properties
+++ b/connector-email/src/main/resources/application.properties
@@ -35,7 +35,7 @@ camel.component.kafka.retry-backoff-ms=200
 
 camel.context.name=notifications-connector-email
 
-mp.messaging.high-volume.topic=wrong.name.on.purpose.to.test.behavior.when.it.doesnt.exist
+mp.messaging.high-volume.topic=platform.notifications.connector.email.high.volume
 mp.messaging.tocamel.topic=platform.notifications.tocamel
 mp.messaging.fromcamel.topic=platform.notifications.fromcamel
 

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -46,7 +46,7 @@ mp.messaging.outgoing.tocamel.cloud-events-mode=structured
 # contain the fully rendered email.
 mp.messaging.outgoing.highvolume.compression.type=snappy
 mp.messaging.outgoing.highvolume.connector=smallrye-kafka
-mp.messaging.outgoing.highvolume.topic=wrong.name.on.purpose.to.test.behavior.when.it.doesnt.exist
+mp.messaging.outgoing.highvolume.topic=platform.notifications.connector.email.high.volume
 mp.messaging.outgoing.highvolume.group.id=integrations
 mp.messaging.outgoing.highvolume.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.highvolume.value.serializer=org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
We have seen that things don't break if the topic name is not correct. The email connector shows lots of warnings, but it keeps processing the events. The engine does not complain about it.

This means that until the high volume topic is enabled in other environments, we should not suffer from errors or crashloops.

## Jira ticket
[[RHCLOUD-34317]](https://issues.redhat.com/browse/RHCLOUD-34317)