### PR TITLE
RHCLOUD-34808 | feature: reduce event retention days

### DIFF
--- a/database/src/main/resources/db/migration/V1.102.0__RHCLOUD-34808_reduce_event_retention_days.sql
+++ b/database/src/main/resources/db/migration/V1.102.0__RHCLOUD-34808_reduce_event_retention_days.sql
@@ -1,0 +1,12 @@
+-- This stored procedure deletes the event log entries that are no longer needed.
+-- It is executed from an OpenShift CronJob.
+CREATE OR REPLACE PROCEDURE cleanEventLog() AS $$
+DECLARE
+    deleted INTEGER;
+BEGIN
+    RAISE INFO '% Event log purge starting. Entries older than 15 days will be deleted.', NOW();
+    DELETE FROM event WHERE created < NOW() AT TIME ZONE 'UTC' - INTERVAL '15 days';
+    GET DIAGNOSTICS deleted = ROW_COUNT;
+    RAISE INFO '% Event log purge ended. % entries were deleted from the database.', NOW(), deleted;
+END;
+$$ LANGUAGE PLPGSQL;

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/EventLogCleanerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/EventLogCleanerTest.java
@@ -32,8 +32,9 @@ public class EventLogCleanerTest {
         deleteAllEvents();
         EventType eventType = createEventType();
         createEvent(eventType, now().minus(Duration.ofHours(1L)));
+        createEvent(eventType, now().minus(Duration.ofDays(16L)));
         createEvent(eventType, now().minus(Duration.ofDays(62L)));
-        assertEquals(2L, count());
+        assertEquals(3L, count());
         entityManager.createNativeQuery("CALL cleanEventLog()").executeUpdate();
         assertEquals(1L, count());
     }


### PR DESCRIPTION
We are reducing the event retention to 15 days to be able to handle the huge incoming load that we are about to face due to the TeamNado integration. The UI does not show more than 14 days, so we can safely reduce the event retention to 15 days. This way, we can be sure that all the timezones across the globe will have the 14 days of events available to be able to check them from the UI.

## Jira ticket

[[RHCLOUD-34808]](https://issues.redhat.com/browse/RHCLOUD-34808)