### PR TITLE
RHCLOUD-34830 | feature: generate accurate metrics for the recipients resolver

### DIFF
--- a/recipients-resolver/pom.xml
+++ b/recipients-resolver/pom.xml
@@ -97,6 +97,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServices.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServices.java
@@ -53,8 +53,10 @@ import static java.lang.Boolean.TRUE;
 @ApplicationScoped
 public class FetchUsersFromExternalServices {
 
-    public static final String COUNTER_FAILURES = "notifications.recipients-resolver.failures";
-    public static final String COUNTER_SUCCESSES = "notifications.recipients-resolver.successes";
+    public static final String COUNTER_REQUESTS = "notifications.recipients.resolver.requests";
+    protected static final String COUNTER_TAG_FAILURES = "failures";
+    protected static final String COUNTER_TAG_REQUEST_RESULT = "result";
+    protected static final String COUNTER_TAG_SUCCESSES = "successes";
     protected static final String COUNTER_TAG_USER_PROVIDER = "user-provider";
     protected static final String COUNTER_TAG_USER_PROVIDER_RBAC = "rbac";
     protected static final String COUNTER_TAG_USER_PROVIDER_MBOP = "mbop";
@@ -364,12 +366,12 @@ public class FetchUsersFromExternalServices {
     }
 
     /**
-     * Increments a counter.
-     * @param counterName the name of the counter to increment.
+     * Increments the requests counter.
+     * @param requestResult the resulting state of the request.
      * @param userProvider the user provider to add to the counter's tag.
      */
-    private void incrementCounter(final String counterName, final String userProvider) {
-        this.meterRegistry.counter(counterName, Tags.of(COUNTER_TAG_USER_PROVIDER, userProvider)).increment();
+    private void incrementCounter(final String requestResult, final String userProvider) {
+        this.meterRegistry.counter(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, requestResult, COUNTER_TAG_USER_PROVIDER, userProvider)).increment();
     }
 
     /**
@@ -388,18 +390,18 @@ public class FetchUsersFromExternalServices {
     }
 
     /**
-     * Increments the failures counter.
+     * Increments the "failed requests" count.
      * @param userProvider the user provider to add to the counter's tag.
      */
     private void incrementFailuresCounterWithTag(final String userProvider) {
-        this.incrementCounter(COUNTER_FAILURES, userProvider);
+        this.incrementCounter(COUNTER_TAG_FAILURES, userProvider);
     }
 
     /**
-     * Increments the successes counter.
+     * Increments the "succeeded requests" counter.
      * @param userProvider the user provider to add to the counter's tag.
      */
     private void incrementSuccessesCounterWithTag(final String userProvider) {
-        this.incrementCounter(COUNTER_SUCCESSES, userProvider);
+        this.incrementCounter(COUNTER_TAG_SUCCESSES, userProvider);
     }
 }

--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServicesTest.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServicesTest.java
@@ -19,6 +19,7 @@ import com.redhat.cloud.notifications.recipients.resolver.rbac.RbacGroup;
 import com.redhat.cloud.notifications.recipients.resolver.rbac.RbacServiceToService;
 import com.redhat.cloud.notifications.recipients.resolver.rbac.RbacUser;
 import dev.failsafe.FailsafeException;
+import io.micrometer.core.instrument.Tags;
 import io.quarkus.cache.CacheInvalidateAll;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -39,8 +40,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
-import static com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices.COUNTER_FAILURES;
-import static com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices.COUNTER_SUCCESSES;
+import static com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices.COUNTER_REQUESTS;
+import static com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices.COUNTER_TAG_FAILURES;
+import static com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices.COUNTER_TAG_REQUEST_RESULT;
+import static com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices.COUNTER_TAG_SUCCESSES;
 import static com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices.COUNTER_TAG_USER_PROVIDER;
 import static com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices.COUNTER_TAG_USER_PROVIDER_IT;
 import static com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices.COUNTER_TAG_USER_PROVIDER_MBOP;
@@ -364,39 +367,40 @@ public class FetchUsersFromExternalServicesTest {
 
         // Test that the RBAC failures counter gets incremented.
         when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC);
+
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
         // Call the function under test.
         assertThrows(FailsafeException.class,
             () -> this.fetchUsersFromExternalServices.getUsers("12345", true)
         );
 
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC, this.recipientsResolverConfig.getMaxRetryAttempts());
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, this.recipientsResolverConfig.getMaxRetryAttempts(), Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
         // Test that the MBOP failures counter gets incremented.
         when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(false);
         when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(true);
 
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP);
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
 
         // Call the function under test.
         assertThrows(FailsafeException.class,
             () -> this.fetchUsersFromExternalServices.getUsers("12345", true)
         );
 
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP, this.recipientsResolverConfig.getMaxRetryAttempts());
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, this.recipientsResolverConfig.getMaxRetryAttempts(), Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
 
         // Test that the IT failures counter gets incremented.
         when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
 
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT);
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT));
 
         // Call the function under test.
         assertThrows(FailsafeException.class,
             () -> this.fetchUsersFromExternalServices.getUsers("12345", true)
         );
 
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT, this.recipientsResolverConfig.getMaxRetryAttempts());
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, this.recipientsResolverConfig.getMaxRetryAttempts(), Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT));
     }
 
     /**
@@ -412,39 +416,40 @@ public class FetchUsersFromExternalServicesTest {
         // Test that the RBAC failures counter gets incremented.
         when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
         when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC);
+
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
         // Call the function under test.
         assertThrows(WebApplicationException.class,
             () -> this.fetchUsersFromExternalServices.getUsers("12345", true)
         );
 
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC, 1);
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, 1, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
         // Test that the MBOP failures counter gets incremented.
         when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(false);
         when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(true);
 
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP);
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
 
         // Call the function under test.
         assertThrows(WebApplicationException.class,
             () -> this.fetchUsersFromExternalServices.getUsers("12345", true)
         );
 
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP, 1);
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, 1, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
 
         // Test that the IT failures counter gets incremented.
         when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
 
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT);
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT));
 
         // Call the function under test.
         assertThrows(WebApplicationException.class,
             () -> this.fetchUsersFromExternalServices.getUsers("12345", true)
         );
 
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT, 1);
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, 1, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT));
     }
 
     /**
@@ -458,12 +463,13 @@ public class FetchUsersFromExternalServicesTest {
         // Test that the RBAC failures counter gets incremented.
         when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
         when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC);
+
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
         // Call the function under test.
         this.fetchUsersFromExternalServices.getGroupUsers("12345", true, UUID.randomUUID());
 
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC, 1);
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, 1, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
     }
 
     /**
@@ -478,14 +484,16 @@ public class FetchUsersFromExternalServicesTest {
         // Test that the RBAC failures counter gets incremented.
         when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
         when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC);
+
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
         // Call the function under test.
         assertThrows(FailsafeException.class,
             () -> this.fetchUsersFromExternalServices.getGroupUsers("12345", true, UUID.randomUUID())
         );
 
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC, this.recipientsResolverConfig.getMaxRetryAttempts());    }
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, this.recipientsResolverConfig.getMaxRetryAttempts(), Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
+    }
 
     /**
      * Tests that when fetching users from RBAC succeeds, the success counter
@@ -502,13 +510,15 @@ public class FetchUsersFromExternalServicesTest {
         final int mockedRbacPagesToFetch = 2;
         this.mockGetUsersRBAC(this.recipientsResolverConfig.getMaxResultsPerPage() * mockedRbacPagesToFetch, false);
 
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC);
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
         // Call the function under test.
         this.fetchUsersFromExternalServices.getUsers(DEFAULT_ORG_ID, false);
 
         // Assert that the success counter with the "rbac" tag got incremented.
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC, mockedRbacPagesToFetch + 1);
+        // We will simulate fetching 2 full pages, which means that we will
+        // trigger one last call to fetch the fourth page that will be empty.
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, mockedRbacPagesToFetch + 1, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
     }
 
     /**
@@ -529,13 +539,13 @@ public class FetchUsersFromExternalServicesTest {
             .when(this.mbopService.getUsersByOrgId(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyInt(), anyInt(), anyBoolean(), anyString(), anyBoolean()))
             .thenReturn(this.mockGetMBOPUsersPage(mockedMbopElements), this.mockGetMBOPUsersPage(mockedMbopElements), this.mockGetMBOPUsersPage(5));
 
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP);
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
 
         // Call the function under test.
         this.fetchUsersFromExternalServices.getUsers(DEFAULT_ORG_ID, false);
 
         // Assert that the success counter with the "mbop" tag got incremented.
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP, mockedMbopPagesToFetch);
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, mockedMbopPagesToFetch, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
     }
 
     /**
@@ -550,17 +560,21 @@ public class FetchUsersFromExternalServicesTest {
         when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(false);
         when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
 
-        final int mockedITUserPagesToFetch = 2;
+        final int mockedITUserPagesToFetch = 3;
         this.mockGetUsers(this.recipientsResolverConfig.getMaxResultsPerPage() * mockedITUserPagesToFetch, false);
 
-        this.micrometerAssertionHelper.saveCounterValueFilteredByTagsBeforeTest(COUNTER_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT);
+        // Clear the cached results so that we don't fetch the cached results.
+        // Otherwise, we wouldn't simulate a call to the user provider.
+        this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT));
         this.clearCached();
 
         // Call the function under test.
         this.fetchUsersFromExternalServices.getUsers(DEFAULT_ORG_ID, false);
 
-        // Assert that the success counter with the "rbac" tag got incremented.
-        this.micrometerAssertionHelper.assertCounterValueFilteredByTagsIncrement(COUNTER_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT, mockedITUserPagesToFetch + 1);
+        // Assert that the success counter with the "it" tag got incremented.
+        // We will simulate fetching 3 full pages, which means that we will
+        // trigger one last call to fetch the fourth page that will be empty.
+        this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, mockedITUserPagesToFetch + 1, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_SUCCESSES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT));
     }
 
     private void mockGetUsers(int elements, boolean adminsOnly) {

--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/MicrometerAssertionHelper.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/MicrometerAssertionHelper.java
@@ -1,0 +1,151 @@
+package com.redhat.cloud.notifications.recipients.resolver;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link MeterRegistry#clear()} cannot be called between tests to reset counters because it would remove the counters
+ * instances from the registry while we use many {@link ApplicationScoped} beans which hold references pointing at the
+ * aforementioned counters instances. That's why we need this helper to assert increments in a reliable way.
+ */
+@ApplicationScoped
+public class MicrometerAssertionHelper {
+
+    @Inject
+    MeterRegistry registry;
+
+    private final Map<String, Double> counterValuesBeforeTest = new ConcurrentHashMap<>();
+
+    public void saveCounterValuesBeforeTest(String... counterNames) {
+        for (String counterName : counterNames) {
+            counterValuesBeforeTest.put(counterName, registry.counter(counterName).count());
+        }
+    }
+
+    public void saveCounterValueWithTagsBeforeTest(String counterName, String... tagKeys) {
+        Collection<Counter> counters = registry.find(counterName)
+            .tagKeys(tagKeys)
+                    .counters();
+        for (Counter counter : counters) {
+            Meter.Id id = counter.getId();
+            List<String> tags = new ArrayList<>();
+            for (Tag tag : id.getTags()) {
+                tags.add(tag.getKey());
+                tags.add(tag.getValue());
+            }
+            counterValuesBeforeTest.put(counterName + tags, registry.counter(counterName, id.getTags()).count());
+        }
+    }
+
+    public void assertCounterIncrement(String counterName, double expectedIncrement, String... tags) {
+        double actualIncrement = registry.counter(counterName, tags).count() - counterValuesBeforeTest.getOrDefault(
+                counterName + Arrays.toString(tags), 0D);
+        assertEquals(expectedIncrement, actualIncrement);
+    }
+
+    public void saveCounterValueFilteredByTagsBeforeTest(String counterName, String tagKeys, String tagValue) {
+        Collection<Counter> counters = registry.find(counterName)
+            .tagKeys(tagKeys)
+            .counters();
+        for (Counter counter : counters) {
+            Meter.Id id = counter.getId();
+            if (id.getTag(tagKeys).equals(tagValue)) {
+                counterValuesBeforeTest.put(counterName + tagKeys + tagValue, counter.count());
+                break;
+            }
+        }
+    }
+
+    public void assertCounterValueFilteredByTagsIncrement(String counterName, String tagKeys, String tagValue, double expectedIncrement) {
+        Collection<Counter> counters = registry.find(counterName)
+            .tagKeys(tagKeys)
+            .counters();
+        for (Counter counter : counters) {
+            Meter.Id id = counter.getId();
+            if (id.getTag(tagKeys).equals(tagValue)) {
+                double actualIncrement = counter.count() - counterValuesBeforeTest.getOrDefault(
+                    counterName + tagKeys + tagValue, 0D);
+                assertEquals(expectedIncrement, actualIncrement);
+                break;
+            }
+        }
+    }
+
+    public void assertCounterIncrement(String counterName, double expectedIncrement) {
+        double actualIncrement = registry.counter(counterName).count() - counterValuesBeforeTest.getOrDefault(counterName, 0D);
+        assertEquals(expectedIncrement, actualIncrement);
+    }
+
+    public void awaitAndAssertCounterIncrement(String counterName, double expectedIncrement) {
+        await().atMost(Duration.ofSeconds(30L)).until(() -> {
+            double actualIncrement = registry.counter(counterName).count() - counterValuesBeforeTest.getOrDefault(counterName, 0D);
+            return expectedIncrement == actualIncrement;
+        });
+    }
+
+    public void awaitAndAssertCounterIncrementFilteredByTags(final String counterName, final String tagKey, final String tagValue, final double expectedIncrement) {
+        await().atMost(Duration.ofSeconds(30L)).until(() -> {
+            double actualIncrement = this.registry.counter(counterName, Tags.of(tagKey, tagValue)).count() - counterValuesBeforeTest.getOrDefault(
+                counterName + tagKey + tagValue, 0D);
+
+            return expectedIncrement == actualIncrement;
+        });
+    }
+
+    public void awaitAndAssertTimerIncrement(String timerName, long expectedIncrement) {
+        await().atMost(Duration.ofSeconds(30L)).until(() -> {
+            Timer timer = findTimerByNameOnly(timerName);
+            if (timer == null) {
+                // The timer may be created after this method is executed.
+                return false;
+            } else {
+                long actualIncrement = Optional.ofNullable(timer.count()).orElse(0L);
+                return expectedIncrement == actualIncrement;
+            }
+        });
+    }
+
+    public void clearSavedValues() {
+        counterValuesBeforeTest.clear();
+    }
+
+    public void removeDynamicTimer(String timerName) {
+        for (Timer timer : findTimersByNameOnly(timerName)) {
+            registry.remove(timer);
+        }
+    }
+
+    /**
+     * Finds a timer from its name only, tags are ignored.
+     * If multiple timers match the name, the first one will be returned.
+     */
+    private Timer findTimerByNameOnly(String name) {
+        return registry.find(name).timer();
+    }
+
+    /**
+     * Finds a collection of timers from their name only, tags are ignored.
+     */
+    private Collection<Timer> findTimersByNameOnly(String name) {
+        return registry.find(name).timers();
+    }
+
+}


### PR DESCRIPTION
By reporting the total requests, the successes and the failures, we will be able to set up some alerts for when the external services we depend on start returning unsuccessful responses.

## Jira ticket
[[RHCLOUD-34830]](https://issues.redhat.com/browse/RHCLOUD-34830)