### PR TITLE
RHCLOUD-34317 | refactor: move the high volume topic env var to Unleash

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -120,6 +120,8 @@ objects:
           value: ${KAFKA_CONSUMED_TOTAL_CHECKER_INITIAL_DELAY}
         - name: NOTIFICATIONS_KAFKA_CONSUMED_TOTAL_CHECKER_PERIOD
           value: ${KAFKA_CONSUMED_TOTAL_CHECKER_PERIOD}
+        - name: NOTIFICATIONS_KAFKA_OUTGOING_HIGH_VOLUME_TOPIC_ENABLED
+          value: ${NOTIFICATIONS_KAFKA_OUTGOING_HIGH_VOLUME_TOPIC_ENABLED}
         - name: QUARKUS_HIBERNATE_ORM_LOG_SQL
           value: ${QUARKUS_HIBERNATE_ORM_LOG_SQL}
         - name: QUARKUS_HTTP_PORT
@@ -255,6 +257,9 @@ parameters:
 - name: NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD
   description: The email sender address for the OpenShift domain in production.
   value: "\"Red Hat OpenShift\" noreply@redhat.com"
+- name: NOTIFICATIONS_KAFKA_OUTGOING_HIGH_VOLUME_TOPIC_ENABLED
+  description: Specifies whether the high volume topic is enabled in the engine or not.
+  value: "false"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
   value: INFO

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/config/EmailConnectorConfig.java
@@ -77,10 +77,12 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
     Optional<String> recipientsResolverTrustStoreType;
 
     private String enableBopEmailServiceWithSslChecks;
+    private String toggleKafkaIncomingHighVolumeTopic;
 
     @PostConstruct
     void emailConnectorPostConstruct() {
         enableBopEmailServiceWithSslChecks = toggleRegistry.register("enable-bop-service-ssl-checks", true);
+        toggleKafkaIncomingHighVolumeTopic = toggleRegistry.register("kafka-incoming-high-volume-topic", true);
     }
 
     @Override
@@ -103,6 +105,7 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
         config.put(MAX_RECIPIENTS_PER_EMAIL, maxRecipientsPerEmail);
         config.put(NOTIFICATIONS_EMAILS_INTERNAL_ONLY_ENABLED, emailsInternalOnlyEnabled);
         config.put(enableBopEmailServiceWithSslChecks, isEnableBopServiceWithSslChecks());
+        config.put(toggleKafkaIncomingHighVolumeTopic, isIncomingKafkaHighVolumeTopicEnabled());
 
         /*
          * /!\ WARNING /!\
@@ -149,7 +152,11 @@ public class EmailConnectorConfig extends HttpConnectorConfig {
     }
 
     public boolean isIncomingKafkaHighVolumeTopicEnabled() {
-        return this.incomingKafkaHighVolumeTopicEnabled;
+        if (unleashEnabled) {
+            return unleash.isEnabled(toggleKafkaIncomingHighVolumeTopic, false);
+        } else {
+            return this.incomingKafkaHighVolumeTopicEnabled;
+        }
     }
 
     public int getMaxRecipientsPerEmail() {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
@@ -111,10 +111,12 @@ public class ConnectorSender {
         try {
             Message<JsonObject> message = buildMessage(payload, history.getId(), connector);
 
-            if (this.isEventFromHighVolumeApplication(event)) {
+            if (this.engineConfig.isOutgoingKafkaHighVolumeTopicEnabled() && this.isEventFromHighVolumeApplication(event)) {
                 this.highVolumeEmitter.send(message);
+                Log.debugf("[event_id: %s] Event sent through high volume Kafka topic", event.getId());
             } else {
                 this.emitter.send(message);
+                Log.debugf("[event_id: %s] Event sent through regular Kafka topic", event.getId());
             }
         } catch (Exception e) {
             history.setStatus(FAILED_INTERNAL);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/ConnectorSenderTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/ConnectorSenderTest.java
@@ -75,6 +75,9 @@ public class ConnectorSenderTest {
         final JsonObject payload = new JsonObject();
         payload.put("Red Hat", "Red Hat Enterprise Linux");
 
+        // Enable the high volume topic for the test.
+        Mockito.when(this.engineConfig.isOutgoingKafkaHighVolumeTopicEnabled()).thenReturn(true);
+
         // Call the function under test.
         this.connectorSender.send(event, endpoint, payload);
 


### PR DESCRIPTION
The reason for the change is that this way we will be able to manually control when we enable and disable the production and consumption of messages in that topic.

## Jira ticket
[[RHCLOUD-34317]](https://issues.redhat.com/browse)