### PR TITLE
RHCLOUD-28271 - Add backend as optional dependecy for testing

### DIFF
--- a/.rhcicd/clowdapp-connector-google-chat.yaml
+++ b/.rhcicd/clowdapp-connector-google-chat.yaml
@@ -11,6 +11,8 @@ objects:
   spec:
     dependencies:
     - notifications-engine
+    optionalDependencies:
+    - notifications-backend
     envName: ${ENV_NAME}
     testing:
       iqePlugin: notifications

--- a/.rhcicd/clowdapp-connector-microsoft-teams.yaml
+++ b/.rhcicd/clowdapp-connector-microsoft-teams.yaml
@@ -11,6 +11,8 @@ objects:
   spec:
     dependencies:
     - notifications-engine
+    optionalDependencies:
+    - notifications-backend
     envName: ${ENV_NAME}
     featureFlags: true
     testing:


### PR DESCRIPTION
Backend set as an optional dependency will make clowder fill its details on the IQE pod while not modifying the deployment