### PR TITLE
Fix build warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,6 @@
                 <configuration>
                     <configLocation>${maven.multiModuleProjectDirectory}/checkstyle/src/main/resources/checkstyle/checkstyle.xml</configLocation>
                     <suppressionsLocation>${maven.multiModuleProjectDirectory}/checkstyle/src/main/resources/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
-                    <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <linkXRef>false</linkXRef>


### PR DESCRIPTION
Fixes
```
[WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.5.0:check (validate)'
```