### PR TITLE
Fine-tune microdnf commands used while building images

### DIFF
--- a/docker/Dockerfile.notifications-aggregator.jvm
+++ b/docker/Dockerfile.notifications-aggregator.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-backend.jvm
+++ b/docker/Dockerfile.notifications-backend.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-drawer.jvm
+++ b/docker/Dockerfile.notifications-connector-drawer.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-email.jvm
+++ b/docker/Dockerfile.notifications-connector-email.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 # Add RedHat CAs on OS truststore (check https://certs.corp.redhat.com/ for more details)
 COPY --from=build /home/jboss/recipients-resolver/src/main/resources/mtls-ca-validators.crt /etc/pki/ca-trust/source/anchors/mtls-ca-validators.crt
 RUN update-ca-trust

--- a/docker/Dockerfile.notifications-connector-google-chat.jvm
+++ b/docker/Dockerfile.notifications-connector-google-chat.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
+++ b/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-servicenow.jvm
+++ b/docker/Dockerfile.notifications-connector-servicenow.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-slack.jvm
+++ b/docker/Dockerfile.notifications-connector-slack.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-splunk.jvm
+++ b/docker/Dockerfile.notifications-connector-splunk.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-connector-webhook.jvm
+++ b/docker/Dockerfile.notifications-connector-webhook.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-recipients-resolver.jvm
+++ b/docker/Dockerfile.notifications-recipients-resolver.jvm
@@ -14,7 +14,9 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 # Update the base image packages
 USER root
-RUN microdnf update --refresh --nodocs && microdnf clean all
+# See https://www.mankier.com/8/microdnf
+RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN microdnf clean all
 # Add RedHat CAs on OS truststore (check https://certs.corp.redhat.com/ for more details)
 COPY --from=build /home/jboss/recipients-resolver/src/main/resources/mtls-ca-validators.crt /etc/pki/ca-trust/source/anchors/mtls-ca-validators.crt
 RUN update-ca-trust


### PR DESCRIPTION
The images build is currently unstable (timeouts). I'm trying to fix that.

- `microdnf update` is an alias for `microdnf upgrade` which is the actual command
- `--setopt=install_weak_deps=0`: prevents microdnf from installing additional packages (weak dependencies) we don't need
- `-y`: automatically answer yes for all questions