### PR TITLE
RHCLOUD-35145 | feature: Disable microprofile fault tolerance metrics

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -103,3 +103,7 @@ quarkus.unleash.url=http://localhost:4242
 
 # Kessel
 notifications.kessel.target-url=localhost:9000
+
+# Disable the fault tolerance metrics for the MicroProfile REST Clients. The
+# reason for this can be found in the following ticket: https://issues.redhat.com/browse/RHCLOUD-35145
+MP_Fault_Tolerance_Metrics_Enabled=false


### PR DESCRIPTION
AppSre has pinged us because apparently some of those metrics are making the production instance of Prometheus to crash. In order to avoid it, they've asked us to remove them.

According to the [Microprofile docs](https://download.eclipse.org/microprofile/microprofile-fault-tolerance-3.0/microprofile-fault-tolerance-spec-3.0.html#_configuring_metrics_integration), there is no fine tuning the metrics. Either we enable them all or we disable them.

Since we are not using those metrics, we can simply disable them for now.

## Jira ticket
[[RHCLOUD-35145]](https://issues.redhat.com/browse/RHCLOUD-35145)