### PR TITLE
Add secalert contact information

### DIFF
--- a/engine/src/main/resources/templates/Errata/bugfixEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/bugfixEmailBodyV2.html
@@ -1,4 +1,5 @@
 {@boolean renderSection1=true}
+{@boolean renderSection2=true}
 {#include Common/insightsEmailBody}
 {#content-title}
     Errata - Subscription Services
@@ -29,4 +30,10 @@
         </tbody>
     </table>
 {/content-body-section1}
+{#content-title-section2}
+Contact
+{/content-title-section2}
+{#content-body-section2}
+The Red Hat security contact is <a href="mailto:secalert@redhat.com">secalert@redhat.com</a>. More contact details at <a href="https://access.redhat.com/security/team/contact/">https://access.redhat.com/security/team/contact/</a>.
+{/content-body-section2}
 {/include}

--- a/engine/src/main/resources/templates/Errata/enhancementEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/enhancementEmailBodyV2.html
@@ -1,4 +1,5 @@
 {@boolean renderSection1=true}
+{@boolean renderSection2=true}
 {#include Common/insightsEmailBody}
 {#content-title}
     Errata - Subscription Services
@@ -29,4 +30,10 @@
         </tbody>
     </table>
 {/content-body-section1}
+{#content-title-section2}
+Contact
+{/content-title-section2}
+{#content-body-section2}
+The Red Hat security contact is <a href="mailto:secalert@redhat.com">secalert@redhat.com</a>. More contact details at <a href="https://access.redhat.com/security/team/contact/">https://access.redhat.com/security/team/contact/</a>.
+{/content-body-section2}
 {/include}

--- a/engine/src/main/resources/templates/Errata/securityEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/securityEmailBodyV2.html
@@ -1,4 +1,5 @@
 {@boolean renderSection1=true}
+{@boolean renderSection2=true}
 {#include Common/insightsEmailBody}
 {#content-title}
     Errata - Subscription Services
@@ -29,4 +30,10 @@
         </tbody>
     </table>
 {/content-body-section1}
+{#content-title-section2}
+Contact
+{/content-title-section2}
+{#content-body-section2}
+The Red Hat security contact is <a href="mailto:secalert@redhat.com">secalert@redhat.com</a>. More contact details at <a href="https://access.redhat.com/security/team/contact/">https://access.redhat.com/security/team/contact/</a>.
+{/content-body-section2}
 {/include}

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestErrataTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestErrataTemplate.java
@@ -47,6 +47,7 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
         assertTrue(result.contains("There are 3 bug fixes affecting your subscriptions."));
         assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("secalert@redhat.com"));
     }
 
     @Test
@@ -61,6 +62,7 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
         assertTrue(result.contains("There are 3 security updates affecting your subscriptions."));
         assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("secalert@redhat.com"));
     }
 
     @Test
@@ -75,5 +77,6 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
         assertTrue(result.contains("There are 3 enhancements affecting your subscriptions."));
         assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("secalert@redhat.com"));
     }
 }


### PR DESCRIPTION
Adds a security contact section to the bottom of the Errata email notification template for security, bugfix, and enhancement emails.

![image](https://github.com/user-attachments/assets/5c71069b-8377-4ced-82ec-c3f6112cd634)
