### PR TITLE
[RHCLOUD-33227] Refactor OCM email templates to have a 1:1 mapping

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -192,6 +192,8 @@ objects:
           value: ${PROCESSOR_CONNECTORS_MAX_SERVER_ERRORS}
         - name: PROCESSOR_CONNECTORS_MIN_DELAY_SINCE_FIRST_SERVER_ERROR
           value: ${PROCESSOR_CONNECTORS_MIN_DELAY_SINCE_FIRST_SERVER_ERROR}
+        - name: NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES
+          value: ${NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES}
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
@@ -342,3 +344,5 @@ parameters:
 - name: PROCESSOR_CONNECTORS_MIN_DELAY_SINCE_FIRST_SERVER_ERROR
   description: min delay since the first error before an endpoint is eligible to be disabled
   value: P2D
+- name: NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES
+  value: "false"

--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -177,7 +177,7 @@ public class EngineConfig {
         config.put(NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD, rhOpenshiftSenderProd);
         config.put(toggleKafkaOutgoingHighVolumeTopic, isOutgoingKafkaHighVolumeTopicEnabled());
         config.put(asyncEventProcessingToggle, isAsyncEventProcessing());
-        config.put(NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES, isOutgoingKafkaHighVolumeTopicEnabled());
+        config.put(NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES, isUseOCMRefactoredTemplates());
 
         Log.info("=== Startup configuration ===");
         config.forEach((key, value) -> {

--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -43,6 +43,7 @@ public class EngineConfig {
     private static final String NOTIFICATIONS_EMAIL_SENDER_HYBRID_CLOUD_CONSOLE = "notifications.email.sender.hybrid.cloud.console";
     private static final String NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE = "notifications.email.sender.openshift.stage";
     private static final String NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD = "notifications.email.sender.openshift.prod";
+    private static final String NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES = "notifications.use-ocm-refactored-templates";
 
     /*
      * Unleash configuration
@@ -118,6 +119,9 @@ public class EngineConfig {
     @ConfigProperty(name = KAFKA_TOCAMEL_MAXIMUM_REQUEST_SIZE, defaultValue = "10485760")
     int kafkaToCamelMaximumRequestSize;
 
+    @ConfigProperty(name = NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES, defaultValue = "false")
+    boolean useOCMRefactoredTemplates;
+
     /**
      * The email sender address for the Red Hat Hybrid Cloud Console.
      */
@@ -173,6 +177,7 @@ public class EngineConfig {
         config.put(NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD, rhOpenshiftSenderProd);
         config.put(toggleKafkaOutgoingHighVolumeTopic, isOutgoingKafkaHighVolumeTopicEnabled());
         config.put(asyncEventProcessingToggle, isAsyncEventProcessing());
+        config.put(NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES, isOutgoingKafkaHighVolumeTopicEnabled());
 
         Log.info("=== Startup configuration ===");
         config.forEach((key, value) -> {
@@ -280,5 +285,9 @@ public class EngineConfig {
         } else {
             return this.outgoingKafkaHighVolumeTopicEnabled;
         }
+    }
+
+    public boolean isUseOCMRefactoredTemplates() {
+        return useOCMRefactoredTemplates;
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -314,7 +314,7 @@ public class EmailTemplateMigrationService {
                 "OCM/clusterUpdateInstantEmailBody", "html", "OCM cluster update email body"
             );
 
-            if (engineConfig.isUseOCMRefactoredTemplates()) {
+            if (!engineConfig.isUseOCMRefactoredTemplates()) {
                 createInstantEmailTemplate(
                     warnings, "openshift", "cluster-manager", List.of("cluster-lifecycle"),
                     "OCM/genericInstantEmailTitle", "txt", "OCM cluster lifecycle title",

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -313,66 +313,130 @@ public class EmailTemplateMigrationService {
                 "OCM/clusterUpdateInstantEmailTitle", "txt", "OCM cluster update title",
                 "OCM/clusterUpdateInstantEmailBody", "html", "OCM cluster update email body"
             );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("cluster-lifecycle"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM cluster lifecycle title",
-                "OCM/genericInstantEmailBody", "html", "OCM cluster lifecycle email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("cluster-configuration"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM cluster configuration title",
-                "OCM/genericInstantEmailBody", "html", "OCM cluster configuration email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("cluster-subscription"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM cluster subscription title",
-                "OCM/genericInstantEmailBody", "html", "OCM cluster subscription email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("cluster-ownership"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM cluster ownership title",
-                "OCM/genericInstantEmailBody", "html", "OCM cluster ownership email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("cluster-access"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM cluster access title",
-                "OCM/genericInstantEmailBody", "html", "OCM cluster access email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("cluster-scaling"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM cluster scaling title",
-                "OCM/genericInstantEmailBody", "html", "OCM cluster scaling email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("capacity-management"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM capacity management title",
-                "OCM/genericInstantEmailBody", "html", "OCM capacity management email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("cluster-security"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM cluster security title",
-                "OCM/genericInstantEmailBody", "html", "OCM cluster security email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("cluster-add-on"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM cluster add-on title",
-                "OCM/genericInstantEmailBody", "html", "OCM cluster add-on email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("customer-support"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM customer support title",
-                "OCM/genericInstantEmailBody", "html", "OCM customer support email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("cluster-networking"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM cluster networking title",
-                "OCM/genericInstantEmailBody", "html", "OCM cluster networking email body"
-            );
-            createInstantEmailTemplate(
-                warnings, "openshift", "cluster-manager", List.of("general-notification"),
-                "OCM/genericInstantEmailTitle", "txt", "OCM general notification title",
-                "OCM/genericInstantEmailBody", "html", "OCM general notification email body"
-            );
+
+            if (engineConfig.isUseOCMRefactoredTemplates()) {
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-lifecycle"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM cluster lifecycle title",
+                    "OCM/genericInstantEmailBody", "html", "OCM cluster lifecycle email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-configuration"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM cluster configuration title",
+                    "OCM/genericInstantEmailBody", "html", "OCM cluster configuration email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-subscription"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM cluster subscription title",
+                    "OCM/genericInstantEmailBody", "html", "OCM cluster subscription email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-ownership"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM cluster ownership title",
+                    "OCM/genericInstantEmailBody", "html", "OCM cluster ownership email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-access"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM cluster access title",
+                    "OCM/genericInstantEmailBody", "html", "OCM cluster access email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-scaling"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM cluster scaling title",
+                    "OCM/genericInstantEmailBody", "html", "OCM cluster scaling email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("capacity-management"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM capacity management title",
+                    "OCM/genericInstantEmailBody", "html", "OCM capacity management email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-security"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM cluster security title",
+                    "OCM/genericInstantEmailBody", "html", "OCM cluster security email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-add-on"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM cluster add-on title",
+                    "OCM/genericInstantEmailBody", "html", "OCM cluster add-on email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("customer-support"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM customer support title",
+                    "OCM/genericInstantEmailBody", "html", "OCM customer support email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-networking"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM cluster networking title",
+                    "OCM/genericInstantEmailBody", "html", "OCM cluster networking email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("general-notification"),
+                    "OCM/genericInstantEmailTitle", "txt", "OCM general notification title",
+                    "OCM/genericInstantEmailBody", "html", "OCM general notification email body"
+                );
+            } else {
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-lifecycle"),
+                    "OCM/clusterLifecycleInstantEmailTitle", "txt", "OCM cluster lifecycle title",
+                    "OCM/clusterLifecycleInstantEmailBody", "html", "OCM cluster lifecycle email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-configuration"),
+                    "OCM/clusterConfigurationInstantEmailTitle", "txt", "OCM cluster configuration title",
+                    "OCM/clusterConfigurationInstantEmailBody", "html", "OCM cluster configuration email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-subscription"),
+                    "OCM/clusterSubscriptionInstantEmailTitle", "txt", "OCM cluster subscription title",
+                    "OCM/clusterSubscriptionInstantEmailBody", "html", "OCM cluster subscription email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-ownership"),
+                    "OCM/clusterOwnershipInstantEmailTitle", "txt", "OCM cluster ownership title",
+                    "OCM/clusterOwnershipInstantEmailBody", "html", "OCM cluster ownership email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-access"),
+                    "OCM/clusterAccessInstantEmailTitle", "txt", "OCM cluster access title",
+                    "OCM/clusterAccessInstantEmailBody", "html", "OCM cluster access email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-scaling"),
+                    "OCM/clusterScalingInstantEmailTitle", "txt", "OCM cluster scaling title",
+                    "OCM/clusterScalingInstantEmailBody", "html", "OCM cluster scaling email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("capacity-management"),
+                    "OCM/capacityManagementInstantEmailTitle", "txt", "OCM capacity management title",
+                    "OCM/capacityManagementInstantEmailBody", "html", "OCM capacity management email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-security"),
+                    "OCM/clusterSecurityInstantEmailTitle", "txt", "OCM cluster security title",
+                    "OCM/clusterSecurityInstantEmailBody", "html", "OCM cluster security email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-add-on"),
+                    "OCM/clusterAddOnInstantEmailTitle", "txt", "OCM cluster add-on title",
+                    "OCM/clusterAddOnInstantEmailBody", "html", "OCM cluster add-on email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("customer-support"),
+                    "OCM/customerSupportInstantEmailTitle", "txt", "OCM customer support title",
+                    "OCM/customerSupportInstantEmailBody", "html", "OCM customer support email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("cluster-networking"),
+                    "OCM/clusterNetworkingInstantEmailTitle", "txt", "OCM cluster networking title",
+                    "OCM/clusterNetworkingInstantEmailBody", "html", "OCM cluster networking email body"
+                );
+                createInstantEmailTemplate(
+                    warnings, "openshift", "cluster-manager", List.of("general-notification"),
+                    "OCM/generalNotificationInstantEmailTitle", "txt", "OCM general notification title",
+                    "OCM/generalNotificationInstantEmailBody", "html", "OCM general notification email body"
+                );
+            }
 
             /*
              * Former src/main/resources/templates/Patch folder.

--- a/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
@@ -55,7 +55,7 @@ More info
     <p>
         <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
     </p>
-{#case 'ocm-approved-access-template'} --customer support
+{#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
         As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.

--- a/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'} --Cluster Lifecycle
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'} -- general notifications
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'} -- cluster subscription
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'} --customer support
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
@@ -51,7 +51,7 @@ More info
     <p>
         You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
     </p>
-{#case 'osd-trial-deletion-template'} -- cluster subscription
+{#case 'osd-trial-deletion-template'}
     <p>
         <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
     </p>

--- a/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
@@ -47,7 +47,7 @@ More info
     <p>
         To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
     </p>
-{#case 'osd-trial-reminder-template'} -- general notifications
+{#case 'osd-trial-reminder-template'}
     <p>
         You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
     </p>

--- a/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
@@ -43,7 +43,7 @@ More info
 {#content-body-section2}
 {#let global_vars=action.events[0].payload.global_vars}
 {#switch global_vars.template_sub_type.or("")}
-{#case 'osd-trial-creation-template'} --Cluster Lifecycle
+{#case 'osd-trial-creation-template'}
     <p>
         To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
     </p>

--- a/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/clusterAccessInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterAccessInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/clusterAccessInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/clusterAccessInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/clusterAddOnInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterAddOnInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/clusterAddOnInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/clusterAddOnInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/clusterConfigurationInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterConfigurationInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/clusterConfigurationInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/clusterConfigurationInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/clusterLifecycleInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterLifecycleInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/clusterLifecycleInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/clusterLifecycleInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/clusterNetworkingInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterNetworkingInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/clusterNetworkingInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/clusterNetworkingInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/clusterOwnershipInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterOwnershipInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/clusterOwnershipInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/clusterOwnershipInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/clusterScalingInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterScalingInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/clusterScalingInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/clusterScalingInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/clusterSecurityInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterSecurityInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/clusterSecurityInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/clusterSecurityInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/clusterSubscriptionInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterSubscriptionInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/clusterSubscriptionInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/clusterSubscriptionInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/customerSupportInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/customerSupportInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/customerSupportInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/customerSupportInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/main/resources/templates/OCM/generalNotificationInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/generalNotificationInstantEmailBodyV2.html
@@ -1,0 +1,76 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Cluster Manager - OpenShift
+{/content-title}
+{#content-title-section1}
+    {action.events[0].payload.title.or(action.events[0].payload.subject.or(""))}
+{/content-title-section1}
+{#content-body-section1}
+{#let global_vars=action.events[0].payload.global_vars}
+<p>
+    {#switch global_vars.template_sub_type.or("")}
+    {#case 'osd-trial-creation-template'}
+        Welcome to your OpenShift Dedicated trial! We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-reminder-template'}
+        We are notifying you about your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} OpenShift Dedicated trial cluster</a>.
+    {#case 'osd-trial-deletion-template'}
+        Thank you for trialing OpenShift Dedicated!
+    {#case}
+        This notification is for your <a href="https://cloud.redhat.com/openshift/details/s/{global_vars.subscription_id}#overview" target="_blank" title="{global_vars.cluster_display_name}">{global_vars.cluster_display_name} cluster</a>.
+    {/switch}
+</p>
+<p>
+    {global_vars.log_description}
+</p>
+
+{#if global_vars.doc_references.orEmpty.size > 0}
+    <p>
+        <b>Need help? Check these resources for more information:</b>
+    </p>
+    <ul>
+        {#each global_vars.doc_references}
+            <li><a href="{it}" target="_blank">{it}</a></li>
+        {/each}
+    </ul>
+{/if}
+{/let}
+{/content-body-section1}
+{#content-title-section2}
+More info
+{/content-title-section2}
+{#content-body-section2}
+{#let global_vars=action.events[0].payload.global_vars}
+{#switch global_vars.template_sub_type.or("")}
+{#case 'osd-trial-creation-template'}
+    <p>
+        To learn more about the OpenShift Dedicated trial, please refer to <a href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-reminder-template'}
+    <p>
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+    </p>
+{#case 'osd-trial-deletion-template'}
+    <p>
+        <a href="https://www.openshift.com/products/dedicated/" target="_blank">Learn more</a> about OpenShift Dedicated, and create a new cluster at any time in <a href="https://cloud.redhat.com/openshift/create" target="_blank">OpenShift Cluster Manager</a>!
+    </p>
+{#case 'ocm-approved-access-template'}
+    <p>
+        Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+    </p>
+{#case}
+    {#if global_vars.subscription_plan != 'OSDTrial'}
+        <p>
+            Your subscription provides <a href="https://access.redhat.com/support/offerings/openshift/sla" target="_blank">premium Red Hat support</a>. If you require any further assistance, or have any questions related to this message, please <a href="https://access.redhat.com/support/contact/technicalSupport/" target="_blank" title="Red Hat Support">open a support case</a>. Review the <a href="https://access.redhat.com/support/policy/support_process" target="_blank" title="Red Hat support process">support process</a> for guidance on working with Red Hat support.
+        </p>
+    {/if}
+{/switch}
+
+<p>
+    Thank you for choosing Red Hat OpenShift{#switch global_vars.subscription_plan}{#case 'OSD'} Dedicated{#case 'OSDTrial'} Dedicated Trial{#case 'MOA'} Service on AWS{/switch}.
+</p>
+{/let}
+{/content-body-section2}
+{/include}

--- a/engine/src/main/resources/templates/OCM/generalNotificationInstantEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/OCM/generalNotificationInstantEmailTitleV2.txt
@@ -1,0 +1,1 @@
+{action.events[0].payload.subject}

--- a/engine/src/test/java/com/redhat/cloud/notifications/EmailTemplatesInDbHelper.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/EmailTemplatesInDbHelper.java
@@ -88,7 +88,8 @@ public abstract class EmailTemplatesInDbHelper {
             eventTypes.put(eventTypeToCreate, eventType.getId());
         }
         when(engineConfig.isSecuredEmailTemplatesEnabled()).thenReturn(useSecuredTemplates());
-        if (engineConfig.isSecuredEmailTemplatesEnabled()) {
+        when(engineConfig.isUseOCMRefactoredTemplates()).thenReturn(useOcmRefactoredTemplates());
+        if (engineConfig.isSecuredEmailTemplatesEnabled() || engineConfig.isUseOCMRefactoredTemplates()) {
             emailTemplateMigrationService.deleteAllTemplates();
         }
         migrate();
@@ -204,6 +205,10 @@ public abstract class EmailTemplatesInDbHelper {
     }
 
     protected Boolean useSecuredTemplates() {
+        return false;
+    }
+
+    protected Boolean useOcmRefactoredTemplates() {
         return false;
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOcmRefactoredTemplates.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOcmRefactoredTemplates.java
@@ -1,0 +1,274 @@
+package com.redhat.cloud.notifications.templates;
+
+import com.redhat.cloud.notifications.EmailTemplatesInDbHelper;
+import com.redhat.cloud.notifications.OcmTestHelpers;
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.ingress.Action;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestOcmRefactoredTemplates extends EmailTemplatesInDbHelper {
+
+    private static final String CLUSTER_UPDATE = "cluster-update";
+    private static final String CLUSTER_LIFECYCLE = "cluster-lifecycle";
+    private static final String CLUSTER_CUSTOMER_SUPPORT = "customer-support";
+    private static final String CAPACITY_MANAGEMENT = "capacity-management";
+    private static final String CLUSTER_ACCESS = "cluster-access";
+    private static final String CLUSTER_ADD_ON = "cluster-add-on";
+    private static final String CLUSTER_CONFIGURATION = "cluster-configuration";
+    private static final String CLUSTER_NETWORKING = "cluster-networking";
+    private static final String CLUSTER_OWNERSHIP = "cluster-ownership";
+    private static final String CLUSTER_SCALING = "cluster-scaling";
+    private static final String CLUSTER_SECURITY = "cluster-security";
+    private static final String CLUSTER_SUBSCRIPTION = "cluster-subscription";
+    private static final String GENERAL_NOTIFICATION = "general-notification";
+
+    @Override
+    protected String getBundle() {
+        return "openshift";
+    }
+
+    @Override
+    protected String getApp() {
+        return "cluster-manager";
+    }
+
+    @Override
+    protected List<String> getUsedEventTypeNames() {
+        List<String> eventTypes = getIdenticalTemplateContentEventTypeNames();
+        eventTypes.addAll(List.of(CLUSTER_UPDATE, CLUSTER_LIFECYCLE, CLUSTER_CUSTOMER_SUPPORT));
+        return eventTypes;
+    }
+
+    static final List<String> getIdenticalTemplateContentEventTypeNames() {
+        return new ArrayList<>(Arrays.asList(CAPACITY_MANAGEMENT, CLUSTER_ACCESS, CLUSTER_ADD_ON, CLUSTER_CONFIGURATION, CLUSTER_NETWORKING, CLUSTER_OWNERSHIP, CLUSTER_SCALING, CLUSTER_SECURITY, CLUSTER_SUBSCRIPTION, GENERAL_NOTIFICATION));
+    }
+
+    @Override
+    protected Boolean useOcmRefactoredTemplates() {
+        return true;
+    }
+
+    @Test
+    public void testUpgradeEmailTitle() {
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", null, Optional.empty());
+
+        String result = generateEmailSubject(CLUSTER_UPDATE, action);
+        assertEquals("Awesome subject", result);
+    }
+
+    @Test
+    public void testUpgradeScheduledInstantEmailBody() {
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template")));
+        String result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Upgrade scheduled"));
+        assertTrue(result.contains(((Map<String, String>) action.getEvents().get(0).getPayload().getAdditionalProperties().get("global_vars")).get("log_description")));
+        assertTrue(result.contains("What can you expect"));
+        assertTrue(result.contains("Thank you for choosing Red Hat OpenShift Dedicated Trial."));
+        assertFalse(result.contains("Check these resources for more information"));
+        assertTrue(result.contains("What should you do to minimize impact"));
+
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains("Check these resources for more information"));
+        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://console.redhat.com/openshift"));
+
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template-rosa-hcp")));
+        result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Upgrade scheduled"));
+        assertTrue(result.contains(((Map<String, String>) action.getEvents().get(0).getPayload().getAdditionalProperties().get("global_vars")).get("log_description")));
+        assertTrue(result.contains("What can you expect"));
+        assertTrue(result.contains("Thank you for choosing Red Hat OpenShift Dedicated Trial."));
+        assertTrue(result.contains("The machine pools hosting the applications will not be upgraded. The machine pools must be upgraded separately."));
+        assertFalse(result.contains("What should you do to minimize impact"));
+    }
+
+    @Test
+    public void testUpgradeEndedInstantEmailBody() {
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "upgrade-ended-template")));
+        String result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains(((Map<String, String>) action.getEvents().get(0).getPayload().getAdditionalProperties().get("global_vars")).get("log_description")));
+        assertFalse(result.contains("What can you expect"));
+        assertTrue(result.contains("Thank you for choosing Red Hat OpenShift Service on AWS."));
+        assertFalse(result.contains("Check these resources for more information"));
+
+        Map<String, Object> additionalMapParameters = new HashMap<>();
+        additionalMapParameters.put("template_sub_type", "upgrade-ended-template");
+        additionalMapParameters.put("doc_references", null);
+        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(additionalMapParameters));
+        result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertFalse(result.contains("Check these resources for more information"));
+
+        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains("Check these resources for more information"));
+        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://console.redhat.com/openshift"));
+    }
+
+    @Test
+    public void testApprovedAccessEmailBody() {
+        // test generic template case
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> need a revision", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "ocm-approved-access-template")));
+        String result = generateEmailBody(CLUSTER_CUSTOMER_SUPPORT, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertTrue(result.contains("Your organization has enabled \"Approved Access\" for ROSA clusters"));
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+    }
+
+    @Test
+    public void testClusterLifecycleInstantEmailBody() {
+        // test generic template case
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "OSD", "<b>Batmobile</b> need a revision", "Awesome subject");
+        String result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertTrue(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with osd trial
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject");
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with trial_creation subtype
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial creation", Optional.of(Map.of("template_sub_type", "osd-trial-creation-template")));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Trial creation"));
+        assertFalse(result.contains("Awesome subject"));
+        assertFalse(result.contains("This notification is for your"));
+        assertTrue(result.contains("Welcome to your OpenShift Dedicated"));
+        assertTrue(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertTrue(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with trial_reminder subtype
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial reminder", Optional.of(Map.of("template_sub_type", "osd-trial-reminder-template")));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Trial reminder"));
+        assertFalse(result.contains("Awesome subject"));
+        assertFalse(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertTrue(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertTrue(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with trial_delete subtype
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template")));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Trial delete"));
+        assertFalse(result.contains("Awesome subject"));
+        assertFalse(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertTrue(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertTrue(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+        assertFalse(result.contains("Check these resources for more information"));
+
+        Map<String, Object> additionalMapParameters = new HashMap<>();
+        additionalMapParameters.put("template_sub_type", "osd-trial-deletion-template");
+        additionalMapParameters.put("doc_references", null);
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(additionalMapParameters));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertFalse(result.contains("Check these resources for more information"));
+
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains("Check these resources for more information"));
+        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://console.redhat.com/openshift"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIdenticalTemplateContentEventTypeNames")
+    public void testIdenticalInstantEmailBody(String eventType) {
+        // test generic template case
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "OSD", "<b>Batmobile</b> need a revision", "Awesome subject");
+        String result = generateEmailBody(eventType, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertTrue(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with osd trial
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject");
+        result = generateEmailBody(eventType, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+    }
+}


### PR DESCRIPTION
Refactor OCM email templates to have a 1:1 mapping with event types