### PR TITLE
[RHCLOUD-33799] Add disabled post-deploy tests for PagerDuty

### DIFF
--- a/.rhcicd/stage-pagerduty-post-deployment-tests.yaml
+++ b/.rhcicd/stage-pagerduty-post-deployment-tests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: notifications-pagerduty-post-deployment-tests
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: notifications-connector-pagerduty-tests-${UID}
+  spec:
+    appName: notifications-connector-pagerduty
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        marker: '' # 'notif_pagerduty and api'
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-33799

## Description

- Add service configuration of post-deploy tests for `notifications-connector-pagerduty`
  - The marker `'notif_pagerduty and api'` has been commented out until the backend tests are implemented

## Compatibility

No expected impact as per [Slack thread](https://redhat-internal.slack.com/archives/C024CDDPRHD/p1727103498109279)

cc: @Fynardo 