### PR TITLE
Add PagerDuty to createEndpoint, fix severity enum

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -86,6 +86,7 @@ public class EndpointRepository {
                 case WEBHOOK:
                 case EMAIL_SUBSCRIPTION:
                 case DRAWER:
+                case PAGERDUTY:
                     entityManager.persist(endpoint.getProperties());
                 default:
                     // Do nothing.

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
@@ -21,6 +21,7 @@ import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointStatusDTO;
 import com.redhat.cloud.notifications.models.dto.v1.endpoint.EndpointTypeDTO;
 import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.CamelPropertiesDTO;
 import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.PagerDutyPropertiesDTO;
+import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.PagerDutySeverityDTO;
 import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.WebhookPropertiesDTO;
 import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets.BasicAuthenticationDTO;
 import io.quarkus.test.junit.QuarkusTest;
@@ -312,7 +313,7 @@ public class EndpointMapperTest {
         Assertions.assertInstanceOf(PagerDutyPropertiesDTO.class, dto.getProperties(), "the properties of the PagerDuty endpoint were not properly deserialized as webhook properties");
         final PagerDutyPropertiesDTO pagerDutyPropertiesDTO = (PagerDutyPropertiesDTO) dto.getProperties();
 
-        Assertions.assertEquals(PagerDutySeverity.CRITICAL, pagerDutyPropertiesDTO.getSeverity(), "the severity property of the PagerDuty endpoint was not properly deserialized");
+        Assertions.assertEquals(PagerDutySeverityDTO.CRITICAL, pagerDutyPropertiesDTO.getSeverity(), "the severity property of the PagerDuty endpoint was not properly deserialized");
         Assertions.assertEquals("p8g3rduty-sup3r-s3cr3t-t0k3n", pagerDutyPropertiesDTO.getSecretToken(), "the secret token was not properly deserialized");
 
         final Endpoint entity = this.endpointMapper.toEntity(dto);

--- a/common/src/main/java/com/redhat/cloud/notifications/models/PagerDutyProperties.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/PagerDutyProperties.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
@@ -20,6 +22,7 @@ import jakarta.validation.constraints.Size;
 public class PagerDutyProperties extends EndpointProperties implements SourcesSecretable {
 
     @NotNull
+    @Enumerated(EnumType.STRING)
     private PagerDutySeverity severity;
 
     @NotNull

--- a/common/src/main/java/com/redhat/cloud/notifications/models/PagerDutySeverity.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/PagerDutySeverity.java
@@ -3,6 +3,9 @@ package com.redhat.cloud.notifications.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+import java.util.Locale;
+
+/** @apiNote For converting from a JSON string, use {@link #fromJson(String)} instead of {@link #valueOf(String)}. */
 @Schema(enumeration = { "critical", "error", "warning", "info" })
 public enum PagerDutySeverity {
     @JsonProperty("critical")
@@ -12,6 +15,14 @@ public enum PagerDutySeverity {
     @JsonProperty("warning")
     WARNING,
     @JsonProperty("info")
-    INFO
+    INFO;
+
+    /** Parses the lowercase or uppercase severity into this enum
+     *
+     * @return a {@link PagerDutySeverity} constant
+     */
+    public static PagerDutySeverity fromJson(String value) {
+        return valueOf(value.toUpperCase(Locale.ENGLISH));
+    }
 }
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/PagerDutyPropertiesDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/PagerDutyPropertiesDTO.java
@@ -1,6 +1,5 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
 
-import com.redhat.cloud.notifications.models.PagerDutySeverity;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -10,17 +9,17 @@ import jakarta.validation.constraints.Size;
 public class PagerDutyPropertiesDTO extends EndpointPropertiesDTO {
 
     @NotNull
-    private PagerDutySeverity severity;
+    private PagerDutySeverityDTO severity;
 
     @Size(max = 32)
     @NotNull
     private String secretToken;
 
-    public PagerDutySeverity getSeverity() {
+    public PagerDutySeverityDTO getSeverity() {
         return severity;
     }
 
-    public void setSeverity(PagerDutySeverity severity) {
+    public void setSeverity(PagerDutySeverityDTO severity) {
         this.severity = severity;
     }
 

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/PagerDutySeverityDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/PagerDutySeverityDTO.java
@@ -1,0 +1,17 @@
+package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(enumeration = { "critical", "error", "warning", "info" })
+public enum PagerDutySeverityDTO {
+    @JsonProperty("critical")
+    CRITICAL,
+    @JsonProperty("error")
+    ERROR,
+    @JsonProperty("warning")
+    WARNING,
+    @JsonProperty("info")
+    INFO
+}
+

--- a/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/PagerDutySeverityDTO.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/PagerDutySeverityDTO.java
@@ -3,6 +3,9 @@ package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+import java.util.Locale;
+
+/** @apiNote For converting from a JSON string, use {@link #fromJson(String)} instead of {@link #valueOf(String)}. */
 @Schema(enumeration = { "critical", "error", "warning", "info" })
 public enum PagerDutySeverityDTO {
     @JsonProperty("critical")
@@ -12,6 +15,14 @@ public enum PagerDutySeverityDTO {
     @JsonProperty("warning")
     WARNING,
     @JsonProperty("info")
-    INFO
+    INFO;
+
+    /** Parses the lowercase or uppercase severity into this enum
+     *
+     * @return a {@link PagerDutySeverityDTO} constant
+     */
+    public static PagerDutySeverityDTO fromJson(String value) {
+        return valueOf(value.toUpperCase(Locale.ENGLISH));
+    }
 }
 

--- a/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutySeverity.java
+++ b/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutySeverity.java
@@ -2,6 +2,9 @@ package com.redhat.cloud.notifications.connector.pagerduty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Locale;
+
+/** @apiNote For converting from a string, use {@link #fromJson(String)} instead of {@link #valueOf(String)}. */
 public enum PagerDutySeverity {
     @JsonProperty("critical")
     CRITICAL,
@@ -10,5 +13,13 @@ public enum PagerDutySeverity {
     @JsonProperty("warning")
     WARNING,
     @JsonProperty("info")
-    INFO
+    INFO;
+
+    /** Parses the lowercase or uppercase severity into this enum
+     *
+     * @return a {@link PagerDutySeverity} constant
+     */
+    public static PagerDutySeverity fromJson(String value) {
+        return valueOf(value.toUpperCase(Locale.ENGLISH));
+    }
 }

--- a/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
+++ b/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
@@ -53,7 +53,7 @@ public class PagerDutyTransformer implements Processor {
         JsonObject messagePayload = new JsonObject();
         messagePayload.put(SUMMARY, cloudEventPayload.getString(EVENT_TYPE));
         messagePayload.put(TIMESTAMP, LocalDateTime.parse(cloudEventPayload.getString(TIMESTAMP)).format(PD_DATE_TIME_FORMATTER));
-        messagePayload.put(SEVERITY, cloudEventPayload.getString(SEVERITY));
+        messagePayload.put(SEVERITY, PagerDutySeverity.valueOf(cloudEventPayload.getString(SEVERITY)));
         messagePayload.put(SOURCE, cloudEventPayload.getString(APPLICATION));
         messagePayload.put(GROUP, cloudEventPayload.getString(BUNDLE));
 

--- a/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
+++ b/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
@@ -53,7 +53,7 @@ public class PagerDutyTransformer implements Processor {
         JsonObject messagePayload = new JsonObject();
         messagePayload.put(SUMMARY, cloudEventPayload.getString(EVENT_TYPE));
         messagePayload.put(TIMESTAMP, LocalDateTime.parse(cloudEventPayload.getString(TIMESTAMP)).format(PD_DATE_TIME_FORMATTER));
-        messagePayload.put(SEVERITY, PagerDutySeverity.valueOf(cloudEventPayload.getString(SEVERITY)));
+        messagePayload.put(SEVERITY, PagerDutySeverity.fromJson(cloudEventPayload.getString(SEVERITY)));
         messagePayload.put(SOURCE, cloudEventPayload.getString(APPLICATION));
         messagePayload.put(GROUP, cloudEventPayload.getString(BUNDLE));
 

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyConnectorRoutesTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyConnectorRoutesTest.java
@@ -132,7 +132,7 @@ public class PagerDutyConnectorRoutesTest extends ConnectorRoutesTest {
         JsonObject newInnerPayload = new JsonObject();
         newInnerPayload.put(SUMMARY, oldInnerPayload.getString(EVENT_TYPE));
         newInnerPayload.put(TIMESTAMP, LocalDateTime.parse(oldInnerPayload.getString(TIMESTAMP)).format(PD_DATE_TIME_FORMATTER));
-        newInnerPayload.put(SEVERITY, PagerDutySeverity.valueOf(oldInnerPayload.getString(SEVERITY)));
+        newInnerPayload.put(SEVERITY, PagerDutySeverity.fromJson(oldInnerPayload.getString(SEVERITY)));
         newInnerPayload.put(SOURCE, oldInnerPayload.getString(APPLICATION));
         newInnerPayload.put(GROUP, oldInnerPayload.getString(BUNDLE));
 

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyConnectorRoutesTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyConnectorRoutesTest.java
@@ -89,7 +89,7 @@ public class PagerDutyConnectorRoutesTest extends ConnectorRoutesTest {
 
         payload.put(SOURCE, source);
         payload.put(ENVIRONMENT_URL, "https://console.redhat.com");
-        payload.put(SEVERITY, PagerDutySeverity.WARNING.toString());
+        payload.put(SEVERITY, PagerDutySeverity.WARNING);
         cloudEventData.put(PAYLOAD, payload);
 
         return cloudEventData;
@@ -132,7 +132,7 @@ public class PagerDutyConnectorRoutesTest extends ConnectorRoutesTest {
         JsonObject newInnerPayload = new JsonObject();
         newInnerPayload.put(SUMMARY, oldInnerPayload.getString(EVENT_TYPE));
         newInnerPayload.put(TIMESTAMP, LocalDateTime.parse(oldInnerPayload.getString(TIMESTAMP)).format(PD_DATE_TIME_FORMATTER));
-        newInnerPayload.put(SEVERITY, oldInnerPayload.getString(SEVERITY));
+        newInnerPayload.put(SEVERITY, PagerDutySeverity.valueOf(oldInnerPayload.getString(SEVERITY)));
         newInnerPayload.put(SOURCE, oldInnerPayload.getString(APPLICATION));
         newInnerPayload.put(GROUP, oldInnerPayload.getString(BUNDLE));
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
@@ -74,7 +74,7 @@ public class PagerDutyProcessor extends EndpointTypeProcessor {
         JsonObject connectorData = new JsonObject();
         JsonObject transformedEvent = transformer.toJsonObject(event);
         transformedEvent.put("environment_url", environment.url());
-        transformedEvent.put("severity", properties.getSeverity().toString());
+        transformedEvent.put("severity", properties.getSeverity());
 
         connectorData.put(PAYLOAD, transformedEvent);
 


### PR DESCRIPTION
- Adds PagerDuty Endpoint to `EndpointRepository.createEndpoint` to be persisted
- Adds annotation `@Enumerated(EnumType.STRING)` to field `PagerDutyProperties#severity`
- Creates enum `PagerDutySeverityDTO` for properties DTO
- Fixes parsing of severity in `PagerDutyProcessor` (engine) and `PagerDutyTransformer` (connector) to ensure it remains in lowercase