### PR TITLE
RHCLOUD-35479 | feature: fetch workspace IDs from RBAC

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/Constants.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/Constants.java
@@ -2,11 +2,6 @@ package com.redhat.cloud.notifications.auth.kessel;
 
 public interface Constants {
     /**
-     * A placeholder value for the workspace ID for those checks which require
-     * querying Kessel about a workspace permission.
-     */
-    String WORKSPACE_ID_PLACEHOLDER = "workspace-id";
-    /**
      * Represents the key for the "resource_type" tag used in the timer.
      */
     String KESSEL_METRICS_TAG_RESOURCE_TYPE_KEY = "resource_type";

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacServer.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.auth.rbac;
 
+import com.redhat.cloud.notifications.auth.rbac.workspace.RbacWorkspace;
+import com.redhat.cloud.notifications.routers.models.Page;
 import io.smallrye.mutiny.Uni;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -8,6 +10,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
@@ -16,14 +19,13 @@ import java.util.UUID;
 
 import static com.redhat.cloud.notifications.Constants.X_RH_IDENTITY_HEADER;
 
-@Path("/api/rbac/v1")
 @RegisterRestClient(configKey = "rbac-authentication")
 @RegisterProvider(RbacRestClientRequestFilter.class)
 @RegisterProvider(RbacClientResponseFilter.class)
 public interface RbacServer {
 
     @GET
-    @Path("/access/") // trailing slash is required by api
+    @Path("/api/rbac/v1/access/") // trailing slash is required by api
     @Consumes("application/json")
     @Produces("application/json")
     Uni<RbacRaw> getRbacInfo(@QueryParam("application") String application,
@@ -32,7 +34,25 @@ public interface RbacServer {
     );
 
     @GET
-    @Path("/groups/{groupID}/") // trailing slash is required by api
+    @Path("/api/rbac/v1/groups/{groupID}/") // trailing slash is required by api
     @Produces("application/json")
     Response getGroup(@PathParam("groupID") UUID groupId, @HeaderParam(X_RH_IDENTITY_HEADER) String rhIdentity);
+
+    /**
+     * Gets the organization's workspaces.
+     * @param orgId the organization ID to get the workspaces from.
+     * @param workspaceType the type of the workspace to fetch.
+     * @return a page of workspaces.
+     */
+    @GET
+    @Path("/api/rbac/v2/workspaces/")
+    @Produces(MediaType.APPLICATION_JSON)
+    Page<RbacWorkspace> getWorkspaces(
+        @HeaderParam("x-rh-rbac-psk") String rbacPsk,
+        @HeaderParam("x-rh-rbac-client-id") String clientId,
+        @HeaderParam("x-rh-rbac-org-id") String orgId,
+        @QueryParam("type") String workspaceType,
+        @QueryParam("offset") Integer offset,
+        @QueryParam("limit") Integer limit
+    );
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/RbacWorkspace.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/RbacWorkspace.java
@@ -1,0 +1,28 @@
+package com.redhat.cloud.notifications.auth.rbac.workspace;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Represents the Kessel's Workspace entity as defined by RBAC.
+ * @param uuid the identifier of the workspace.
+ * @param parentId the identifier of the parent workspace.
+ * @param workspaceType the type of the workspace.
+ * @param name the name of the workspace.
+ * @param description the description of the workspace.
+ * @param created the date when the workspace was created.
+ * @param modified the date when the workspace was modified.
+ */
+public record RbacWorkspace(
+    @JsonProperty("uuid") UUID uuid,
+    @JsonProperty("parent_id") UUID parentId,
+    @JsonProperty("type") WorkspaceType workspaceType,
+    @JsonProperty("name") String name,
+    @JsonProperty("description") String description,
+    @JsonProperty("created") LocalDateTime created,
+    @JsonProperty("modified") LocalDateTime modified
+) {
+
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceType.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceType.java
@@ -1,0 +1,12 @@
+package com.redhat.cloud.notifications.auth.rbac.workspace;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum WorkspaceType {
+    @JsonProperty("default")
+    DEFAULT,
+    @JsonProperty("root")
+    ROOT,
+    @JsonProperty("standard")
+    STANDARD
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
@@ -1,0 +1,98 @@
+package com.redhat.cloud.notifications.auth.rbac.workspace;
+
+import com.redhat.cloud.notifications.auth.rbac.RbacServer;
+import com.redhat.cloud.notifications.config.BackendConfig;
+import com.redhat.cloud.notifications.routers.models.Page;
+import io.quarkus.cache.CacheResult;
+import io.quarkus.logging.Log;
+import io.quarkus.security.UnauthorizedException;
+import io.vertx.core.json.JsonObject;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.UUID;
+
+@ApplicationScoped
+public class WorkspaceUtils {
+    /**
+     * The application key that is present in RBAC's PSKs file.
+     */
+    public static final String APPLICATION_KEY = "notifications";
+
+    /**
+     * Specifies the default offset for the workspaces. We don't expect to
+     * fetch any pages so it can be a constant "0".
+     */
+    public static final int REQUEST_DEFAULT_OFFSET = 0;
+
+    /**
+     * The default limit for the requests. We are expecting to just fetch the
+     * default namespace from RBAC, but we are setting the limit to "2" in case
+     * we fetch more than one, and so that we can raise an error about it.
+     */
+    public static final int REQUEST_DEFAULT_LIMIT = 2;
+
+    /**
+     * Holds the pre-shared-key Notifications has to use with RBAC to be
+     * authorized to make calls.
+     */
+    private String notificationsPsk;
+
+    @Inject
+    BackendConfig backendConfig;
+
+    @Inject
+    @RestClient
+    RbacServer rbacServer;
+
+    /**
+     * Extracts the PSK we need to use to talk to RBAC.
+     */
+    @PostConstruct
+    public void extractNotificationsPsk() {
+        final JsonObject psks = this.backendConfig.getRbacPskSecrets();
+        final JsonObject notifications = psks.getJsonObject(APPLICATION_KEY);
+        this.notificationsPsk = notifications.getString("secret");
+    }
+
+    /**
+     * Returns the identifier of the default workspace for the given
+     * organization. The result is cached because the identifier is not going
+     * to change as long as we are fetching this data from RBAC.
+     * @param orgId the organization to get the default workspace from.
+     * @return the identifier of the workspace.
+     */
+    @CacheResult(cacheName = "kessel-rbac-workspace-id")
+    public UUID getDefaultWorkspaceId(final String orgId) {
+        // Call RBAC.
+        final Page<RbacWorkspace> workspacePage = this.rbacServer.getWorkspaces(
+            this.notificationsPsk,
+            APPLICATION_KEY,
+            orgId,
+            WorkspaceType.DEFAULT.toString().toLowerCase(),
+            REQUEST_DEFAULT_OFFSET,
+            REQUEST_DEFAULT_LIMIT
+        );
+
+        // We have been told we are only going to have one workspace per
+        // organization.
+        if (workspacePage.getMeta().getCount() > 1) {
+            Log.errorf("[org_id: %s] More than one workspace found for the organization: %s", orgId, workspacePage.getData());
+
+            throw new UnauthorizedException();
+        }
+
+        final RbacWorkspace rbacWorkspace = workspacePage.getData().getFirst();
+
+        // Double check that the fetched workspace is the default one.
+        if (!rbacWorkspace.workspaceType().equals(WorkspaceType.DEFAULT)) {
+            Log.errorf("[org_id: %s][workspace_id: %s][workspace_type: %s] The fetched workspace is not a default workspace", orgId, rbacWorkspace.uuid(), rbacWorkspace.workspaceType());
+
+            throw new UnauthorizedException();
+        }
+
+        return rbacWorkspace.uuid();
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.config;
 import com.redhat.cloud.notifications.unleash.ToggleRegistry;
 import io.getunleash.Unleash;
 import io.quarkus.logging.Log;
+import io.vertx.core.json.JsonObject;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -28,6 +29,7 @@ public class BackendConfig {
     private static final String KESSEL_INVENTORY_INTEGRATIONS_REMOVAL_ENABLED = "notifications.kessel-inventory.integrations-removal.enabled";
     private static final String KESSEL_RELATIONS_ENABLED = "notifications.kessel-relations.enabled";
     private static final String KESSEL_DOMAIN = "notifications.kessel.domain";
+    private static final String RBAC_PSKS = "notifications.rbac.psks";
     private static final String UNLEASH = "notifications.unleash.enabled";
 
     /*
@@ -79,6 +81,9 @@ public class BackendConfig {
 
     @ConfigProperty(name = KESSEL_DOMAIN, defaultValue = "redhat")
     String kesselDomain;
+
+    @ConfigProperty(name = RBAC_PSKS, defaultValue = "{\"notifications\": {\"secret\": \"development-psk-value\"}}")
+    protected String rbacPskSecrets;
 
     @Inject
     ToggleRegistry toggleRegistry;
@@ -186,5 +191,9 @@ public class BackendConfig {
 
     public String getKesselDomain() {
         return kesselDomain;
+    }
+
+    public JsonObject getRbacPskSecrets() {
+        return new JsonObject(this.rbacPskSecrets);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
@@ -1,14 +1,20 @@
 package com.redhat.cloud.notifications;
 
+import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpStatus;
 import org.mockserver.model.ClearType;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
+import org.mockserver.model.Parameter;
+import org.mockserver.verify.VerificationTimes;
 
 import java.io.InputStream;
 
 import static com.redhat.cloud.notifications.Constants.X_RH_IDENTITY_HEADER;
 import static com.redhat.cloud.notifications.MockServerLifecycleManager.getClient;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockserver.model.HttpRequest.request;
@@ -65,6 +71,101 @@ public class MockServerConfig {
             .withSecure(secure)
             .when(request)
             .respond(response);
+    }
+
+    /**
+     * Adds a path in the MockServer for the {@link com.redhat.cloud.notifications.auth.rbac.RbacServer#getWorkspaces(String, String, String, String, Integer, Integer)}
+     * method, which simulates RBAC returning more than one workspace in the
+     * response.
+     */
+    public static void addMultipleReturningMultipleWorkspacesRbacEndpoint() {
+        getClient()
+            .when(
+                request()
+                    .withHeader("x-rh-rbac-psk", "development-psk-value")
+                    .withHeader("x-rh-rbac-client-id", WorkspaceUtils.APPLICATION_KEY)
+                    .withHeader("x-rh-rbac-org-id", DEFAULT_ORG_ID)
+                    .withQueryStringParameter(Parameter.param("offset", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_OFFSET)))
+                    .withQueryStringParameter(Parameter.param("limit", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_LIMIT)))
+                    .withPath("/api/rbac/v2/workspaces/")
+            ).respond(
+                response()
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                    .withStatusCode(HttpStatus.SC_OK)
+                    .withBody(getFileAsString("rbac-examples/workspaces/multiple-workspaces-response.json"))
+            );
+    }
+
+    /**
+     * Adds a path in the MockServer for the {@link com.redhat.cloud.notifications.auth.rbac.RbacServer#getWorkspaces(String, String, String, String, Integer, Integer)}
+     * method, which simulates RBAC returning a default workspace in the
+     * response.
+     */
+    public static void addMultipleReturningSingleDefaultWorkspaceRbacEndpoint() {
+        getClient()
+            .when(
+                request()
+                    .withHeader("x-rh-rbac-psk", "development-psk-value")
+                    .withHeader("x-rh-rbac-client-id", WorkspaceUtils.APPLICATION_KEY)
+                    .withHeader("x-rh-rbac-org-id", DEFAULT_ORG_ID)
+                    .withQueryStringParameter(Parameter.param("offset", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_OFFSET)))
+                    .withQueryStringParameter(Parameter.param("limit", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_LIMIT)))
+                    .withPath("/api/rbac/v2/workspaces/")
+            ).respond(
+                response()
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                    .withStatusCode(HttpStatus.SC_OK)
+                    .withBody(getFileAsString("rbac-examples/workspaces/single-default-workspace-response.json"))
+            );
+    }
+
+    /**
+     * Adds a path in the MockServer for the {@link com.redhat.cloud.notifications.auth.rbac.RbacServer#getWorkspaces(String, String, String, String, Integer, Integer)}
+     * method, which simulates RBAC returning a "root" workspace instead of the
+     * expected "default" workspace.
+     */
+    public static void addReturningSingleRootWorkspaceRbacEndpoint() {
+        getClient()
+            .when(
+                request()
+                    .withHeader("x-rh-rbac-psk", "development-psk-value")
+                    .withHeader("x-rh-rbac-client-id", WorkspaceUtils.APPLICATION_KEY)
+                    .withHeader("x-rh-rbac-org-id", DEFAULT_ORG_ID)
+                    .withQueryStringParameter(Parameter.param("offset", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_OFFSET)))
+                    .withQueryStringParameter(Parameter.param("limit", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_LIMIT)))
+                    .withPath("/api/rbac/v2/workspaces/")
+            ).respond(
+                response()
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                    .withStatusCode(HttpStatus.SC_OK)
+                    .withBody(getFileAsString("rbac-examples/workspaces/single-root-workspace-response.json"))
+            );
+    }
+
+    /**
+     * Verifies that the default workspace for an organization has been only
+     * fetched once from RBAC, since Notifications should have cached it.
+     */
+    public static void verifyDefaultWorkspaceFetchedOnlyOnce() {
+        getClient()
+            .verify(
+                request()
+                    .withHeader("x-rh-rbac-psk", "development-psk-value")
+                    .withHeader("x-rh-rbac-client-id", WorkspaceUtils.APPLICATION_KEY)
+                    .withHeader("x-rh-rbac-org-id", DEFAULT_ORG_ID)
+                    .withQueryStringParameter(Parameter.param("offset", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_OFFSET)))
+                    .withQueryStringParameter(Parameter.param("limit", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_LIMIT)))
+                    .withPath("/api/rbac/v2/workspaces/"),
+                VerificationTimes.once()
+            );
+    }
+
+    public static void clearRbacWorkspaces() {
+        getClient()
+            .clear(
+                request()
+                .withPath("/api/rbac/v2/workspaces/")
+            );
     }
 
     public static void clearRbac() {

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselTestHelper.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselTestHelper.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.auth.kessel;
 
 import com.redhat.cloud.notifications.auth.kessel.permission.KesselPermission;
+import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -33,6 +34,15 @@ public class KesselTestHelper {
 
     @Inject
     LookupClient lookupClient;
+
+    @Inject
+    WorkspaceUtils workspaceUtils;
+
+    /**
+     * The {@link UUID} that the {@link WorkspaceUtils#getDefaultWorkspaceId(String)}
+     * method will return no matter what workspace is passed to it. The re
+     */
+    public static final UUID RBAC_DEFAULT_WORKSPACE_ID = UUID.randomUUID();
 
     /**
      * Mocks the {@link LookupClient} so that it simulates that no authorized
@@ -73,6 +83,28 @@ public class KesselTestHelper {
         ).thenReturn(
             lookupResourcesResponses.iterator()
         );
+    }
+
+    /**
+     * Mocks the call to {@link WorkspaceUtils#getDefaultWorkspaceId(String)}
+     * and returns the identifier defined in {@link KesselTestHelper#RBAC_DEFAULT_WORKSPACE_ID}.
+     * @param orgId the organization identifier the mocked method is expecting
+     *              to be able to return the mocked value.
+     */
+    public void mockDefaultWorkspaceId(final String orgId) {
+        Mockito.when(this.workspaceUtils.getDefaultWorkspaceId(orgId)).thenReturn(RBAC_DEFAULT_WORKSPACE_ID);
+    }
+
+    /**
+     * Mocks the call to {@link WorkspaceUtils#getDefaultWorkspaceId(String)}
+     * by returning the given ID for the given org ID.
+     * @param orgId the organization identifier the mocked method is expecting
+     *              to be able to return the mocked value.
+     * @param returningWorkspaceId the mocked identifier we are going to
+     *                             simulate that RBAC returns.
+     */
+    public void mockDefaultWorkspaceId(final String orgId, final UUID returningWorkspaceId) {
+        Mockito.when(this.workspaceUtils.getDefaultWorkspaceId(orgId)).thenReturn(returningWorkspaceId);
     }
 
     /**

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtilsTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtilsTest.java
@@ -1,0 +1,69 @@
+package com.redhat.cloud.notifications.auth.rbac.workspace;
+
+import com.redhat.cloud.notifications.MockServerConfig;
+import io.quarkus.security.UnauthorizedException;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
+@QuarkusTest
+public class WorkspaceUtilsTest {
+    @Inject
+    WorkspaceUtils workspaceUtils;
+
+    /**
+     * Make sure we clear the workspace path from the MockServer even if tests
+     * fail.
+     */
+    @AfterAll
+    public static void clearRbacWorkspaceRoutes() {
+        MockServerConfig.clearRbacWorkspaces();
+    }
+
+    /**
+     * Tests that a default workspace is fetched from RBAC and then cached for
+     * a given organization.
+     */
+    @Test
+    void testFetchDefaultWorkspace() {
+        MockServerConfig.addMultipleReturningSingleDefaultWorkspaceRbacEndpoint();
+
+        for (int i = 0; i < 5; i++) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID);
+            Assertions.assertNotNull(workspaceId, "a workspace ID should have been returned from the function under test");
+        }
+
+        MockServerConfig.verifyDefaultWorkspaceFetchedOnlyOnce();
+        MockServerConfig.clearRbacWorkspaces();
+    }
+
+    /**
+     * Tests that when more than one workspace is received, or the single
+     * received workspace is not the default one, an exception is raised.
+     */
+    @Test
+    void testInvalidNonDefaultWorkspacesReturnedThrowsException() {
+        MockServerConfig.addMultipleReturningMultipleWorkspacesRbacEndpoint();
+
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () -> this.workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)
+        );
+
+        MockServerConfig.clearRbacWorkspaces();
+        MockServerConfig.addReturningSingleRootWorkspaceRbacEndpoint();
+
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () -> this.workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)
+        );
+
+        MockServerConfig.clearRbacWorkspaces();
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EmailsOnlyModeTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EmailsOnlyModeTest.java
@@ -9,6 +9,7 @@ import com.redhat.cloud.notifications.auth.kessel.KesselTestHelper;
 import com.redhat.cloud.notifications.auth.kessel.ResourceType;
 import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
 import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
+import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
@@ -34,7 +35,6 @@ import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.FULL_AC
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
-import static com.redhat.cloud.notifications.auth.kessel.Constants.WORKSPACE_ID_PLACEHOLDER;
 import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
 import static com.redhat.cloud.notifications.routers.EndpointResource.UNSUPPORTED_ENDPOINT_TYPE;
@@ -55,11 +55,26 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
     @InjectMock
     EndpointRepository endpointRepository;
 
+    /**
+     * Mocked RBAC's workspace utilities so that the {@link KesselTestHelper}
+     * can be used.
+     */
     @InjectMock
     CheckClient checkClient;
 
+    /**
+     * Mocked RBAC's workspace utilities so that the {@link KesselTestHelper}
+     * can be used.
+     */
     @InjectMock
     LookupClient lookupClient;
+
+    /**
+     * Mocked RBAC's workspace utilities so that the {@link KesselTestHelper}
+     * can be used.
+     */
+    @InjectMock
+    WorkspaceUtils workspaceUtils;
 
     @Inject
     KesselTestHelper kesselTestHelper;
@@ -96,7 +111,8 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
         endpoint.setName("name");
         endpoint.setDescription("description");
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         String responseBody = given()
                 .basePath(apiPath)
                 .header(identityHeader)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -10,6 +10,7 @@ import com.redhat.cloud.notifications.auth.kessel.ResourceType;
 import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
 import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
 import com.redhat.cloud.notifications.auth.principal.ConsoleIdentity;
+import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
@@ -102,7 +103,6 @@ import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockS
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
-import static com.redhat.cloud.notifications.auth.kessel.Constants.WORKSPACE_ID_PLACEHOLDER;
 import static com.redhat.cloud.notifications.models.EndpointStatus.READY;
 import static com.redhat.cloud.notifications.models.EndpointType.ANSIBLE;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
@@ -202,6 +202,13 @@ public class EndpointResourceTest extends DbIsolatedTest {
     SourcesService sourcesServiceMock;
 
     /**
+     * Mocked RBAC's workspace utilities so that the {@link KesselTestHelper}
+     * can be used.
+     */
+    @InjectMock
+    WorkspaceUtils workspaceUtils;
+
+    /**
      * Required to set up the mock calls to the sources service mock.
      */
     @ConfigProperty(name = "sources.psk")
@@ -268,7 +275,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         mockSources(properties);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         Response response = given()
                 .header(identityHeader)
@@ -468,7 +476,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         mockSources(properties);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         Response response = given()
                 .header(identityHeader)
@@ -641,7 +650,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      * @param ep the endpoint to create.
      */
     private void expectReturn400(final String DEFAULT_USER, final Header identityHeader, final Endpoint ep) {
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         given()
                  .header(identityHeader)
@@ -694,7 +704,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         // the secrets from Sources too.
         when(this.sourcesServiceMock.getById(anyString(), anyString(), eq(basicAuthSecret.id))).thenReturn(basicAuthSecret);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         String responseBody = given()
                 .header(identityHeader)
@@ -769,7 +780,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         ep.setEnabled(true);
         ep.setProperties(cAttr);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         given()
                 .header(identityHeader)
@@ -795,7 +807,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
     void testForbidSlackChannelUsage(final boolean isKesselRelationsApiEnabled) {
         this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("account-id", "org-id", DEFAULT_USER);
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
@@ -811,7 +823,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         endpoint.setDescription("description");
         endpoint.setProperties(camelProperties);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         String responseBody = given()
             .header(identityHeader)
@@ -918,7 +931,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         endpoint.setDescription("description");
         endpoint.setProperties(camelProperties);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         String invalidResp = given()
                 .header(identityHeader)
@@ -1026,7 +1040,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         ep.setProperties(cAttr);
         ep.setStatus(EndpointStatus.DELETING); // Trying to set other status
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         String responseBody = given()
                 .header(identityHeader)
@@ -1131,7 +1146,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         Secret secretTokenSecret = mockSources(properties);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         Response response = given()
                 .header(identityHeader)
@@ -1268,7 +1284,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         mockSources(properties);
 
         final Set<UUID> createdEndpointIds = new HashSet<>();
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         Response response = given()
                 .header(identityHeader)
                 .when()
@@ -1376,7 +1393,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
 
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         final Set<UUID> createdEndpointsIdentifiers = addEndpoints(29, identityHeader);
 
@@ -1581,7 +1599,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(this.sourcesServiceMock.getById(anyString(), anyString(), eq(secretTokenSecret.id))).thenReturn(secretTokenSecret);
         when(this.sourcesServiceMock.getById(anyString(), anyString(), eq(bearerTokenSecret.id))).thenReturn(bearerTokenSecret);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         Response response = given()
                 .header(identityHeader)
@@ -1637,7 +1656,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         ep.setEnabled(true);
         ep.setProperties(properties);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         String stringResponse = given()
                 .header(identityHeader)
@@ -1653,8 +1673,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         RequestSystemSubscriptionProperties requestProps = new RequestSystemSubscriptionProperties();
 
-        // EmailSubscription can be fetch from the properties
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        // EmailSubscription can be fetched from the properties
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         Response response = given()
                 .header(identityHeader)
@@ -1815,7 +1836,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         ep.setEnabled(true);
         ep.setProperties(properties);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         String stringResponse = given()
             .header(identityHeader)
@@ -1832,7 +1854,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         RequestSystemSubscriptionProperties requestProps = new RequestSystemSubscriptionProperties();
 
         // Drawer endpoints can be created from the dedicated endpoint
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.CREATE_DRAWER_INTEGRATION, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.CREATE_DRAWER_INTEGRATION, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         Response response = given()
             .header(identityHeader)
@@ -1989,7 +2012,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         MockServerConfig.addGroupResponse(identityHeaderValue, unknownGroupId, HttpStatus.SC_NOT_FOUND);
 
         // valid group id
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         RequestSystemSubscriptionProperties requestProps = new RequestSystemSubscriptionProperties();
         requestProps.setGroupId(UUID.fromString(validGroupId));
@@ -2111,7 +2135,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 .contentType(JSON)
                 .body(is("{\"data\":[],\"links\":{},\"meta\":{\"count\":0}}"));
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         final Set<UUID> createdEndpointIds = new HashSet<>();
         for (int i = 0; i < 200; i++) {
             // Add new endpoints
@@ -2231,7 +2256,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         final Set<UUID> createdEndpoints = addEndpoints(10, identityHeader);
 
@@ -2280,7 +2306,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         final Set<UUID> createdEndpoints = addEndpoints(10, identityHeader);
 
@@ -2398,7 +2425,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         );
         try {
             LaunchMode.set(LaunchMode.NORMAL);
-            this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+            this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+            this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
             // Test the URLs with both camel and webhook endpoints.
             for (final var testCase : testCases) {
@@ -2498,7 +2526,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(this.sourcesServiceMock.create(anyString(), anyString(), any()))
             .thenReturn(secret);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         for (final String url : ValidNonPrivateUrlValidatorTest.validUrls) {
             // Test with a camel endpoint.
             camelProperties.setUrl(url);
@@ -2552,8 +2581,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
     public void testEndpointSubtypeIsOnlyAllowedWhenRequired(final boolean isKesselRelationsApiEnabled) {
         this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
-        String EMPTY = "empty";
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(EMPTY, EMPTY, DEFAULT_USER);
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
 
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
@@ -2573,7 +2601,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         ep.setProperties(properties);
         ep.setServerErrors(3);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         given()
                 .header(identityHeader)
                 .when()
@@ -2797,7 +2826,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         endpoint.setStatus(EndpointStatus.PROVISIONING);
         endpoint.setType(EndpointType.WEBHOOK);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         final String response = given()
             .header(identityHeader)
             .when()
@@ -2922,7 +2952,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
             mockedSecretTokenSecret
         );
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         final String response = given()
             .header(identityHeader)
             .when()
@@ -3030,7 +3061,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
             mockedSecretTokenSecret
         );
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         final String response = given()
             .header(identityHeader)
             .when()
@@ -3134,7 +3166,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         endpoint.setProperties(properties);
 
         // POST the endpoint.
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         String responseBody = given()
                 .header(identityHeader)
                 .contentType(JSON)
@@ -3231,7 +3264,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         // the secrets from Sources too.
         when(this.sourcesServiceMock.getById(anyString(), anyString(), eq(secretTokenSecret.id))).thenReturn(secretTokenSecret);
 
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         Response response = given()
                 .header(identityHeader)
                 .when()
@@ -3327,7 +3361,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         Mockito.doThrow(new RuntimeException()).when(this.endpointRepository).createEndpoint(Mockito.any());
 
         // Call the endpoint under test.
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
         given()
             .header(identityHeader)
             .when()
@@ -3428,6 +3463,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .body("meta.count", Matchers.is(0));
 
         // Create an endpoint.
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
         given()
             .header(identityHeader)
             .when()
@@ -4161,7 +4197,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
         // Give the principal the "create endpoints" permission.
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         // Create the integration.
         final Set<UUID> createdIntegration = this.addEndpoints(1, identityHeader);
@@ -4177,7 +4214,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                     NotificationsIntegration.newBuilder()
                         .setMetadata(Metadata.newBuilder()
                             .setResourceType(ResourceType.INTEGRATION.getKesselRepresentation())
-                            .setWorkspace(WORKSPACE_ID_PLACEHOLDER)
+                            .setWorkspace(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString())
                             .build()
                         ).setReporterData(ReporterData.newBuilder()
                             .setLocalResourceId(integrationId.toString())
@@ -4235,7 +4272,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
         // Mock the Kessel permission to be able to create the integration.
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         // Simulate an error when saving the integration in our database.
         Mockito.doThrow(IllegalStateException.class).when(this.endpointRepository).createEndpoint(Mockito.any());
@@ -4293,7 +4331,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
         // Mock the Kessel permission to be able to create the integration.
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
 
         // Simulate an error when saving the integration in the Inventory API.
         Mockito.when(this.notificationsIntegrationClient.CreateNotificationsIntegration(Mockito.any(CreateNotificationsIntegrationRequest.class))).thenThrow(StatusRuntimeException.class);
@@ -4454,6 +4493,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.DELETE, ResourceType.INTEGRATION, integration.getId().toString());
 
         // Attempt deleting the integration.
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
         given()
             .header(identityHeader)
             .pathParam("id", integration.getId())

--- a/backend/src/test/resources/rbac-examples/workspaces/multiple-workspaces-response.json
+++ b/backend/src/test/resources/rbac-examples/workspaces/multiple-workspaces-response.json
@@ -1,0 +1,33 @@
+{
+  "meta": {
+    "count": 2,
+    "limit": 2,
+    "offset": 0
+  },
+  "links": {
+    "first": "/api/rbac/v2/workspaces/?limit=2&offset=0",
+    "next": "/api/rbac/v2/workspaces/?limit=2&offset=2",
+    "previous": "/api/rbac/v2/workspaces/?limit=2&offset=0",
+    "last": "/api/rbac/v2/workspaces/?limit=2&offset=2"
+  },
+  "data": [
+    {
+      "uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "parent_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "type": "default",
+      "name": "Workspace A",
+      "description": "Description of Workspace A",
+      "created": "2024-10-01T00:00:00.000Z",
+      "modified": "2024-10-01T00:00:00.000Z"
+    },
+    {
+      "uuid": "79d410d8-80ca-11ef-aba6-c3907103cb82",
+      "parent_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "type": "default",
+      "name": "Workspace B",
+      "description": "Description of Workspace B",
+      "created": "2024-10-01T00:00:00.000Z",
+      "modified": "2024-10-01T00:00:00.000Z"
+    }
+  ]
+}

--- a/backend/src/test/resources/rbac-examples/workspaces/single-default-workspace-response.json
+++ b/backend/src/test/resources/rbac-examples/workspaces/single-default-workspace-response.json
@@ -1,0 +1,24 @@
+{
+  "meta": {
+    "count": 1,
+    "limit": 2,
+    "offset": 0
+  },
+  "links": {
+    "first": "/api/rbac/v2/workspaces/?limit=2&offset=0",
+    "next": "/api/rbac/v2/workspaces/?limit=2&offset=2",
+    "previous": "/api/rbac/v2/workspaces/?limit=2&offset=0",
+    "last": "/api/rbac/v2/workspaces/?limit=2&offset=2"
+  },
+  "data": [
+    {
+      "uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "parent_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "type": "default",
+      "name": "Workspace A",
+      "description": "Description of Workspace A",
+      "created": "2024-10-01T00:00:00.000Z",
+      "modified": "2024-10-01T00:00:00.000Z"
+    }
+  ]
+}

--- a/backend/src/test/resources/rbac-examples/workspaces/single-root-workspace-response.json
+++ b/backend/src/test/resources/rbac-examples/workspaces/single-root-workspace-response.json
@@ -1,0 +1,24 @@
+{
+  "meta": {
+    "count": 1,
+    "limit": 2,
+    "offset": 0
+  },
+  "links": {
+    "first": "/api/rbac/v2/workspaces/?limit=2&offset=0",
+    "next": "/api/rbac/v2/workspaces/?limit=2&offset=2",
+    "previous": "/api/rbac/v2/workspaces/?limit=2&offset=0",
+    "last": "/api/rbac/v2/workspaces/?limit=2&offset=2"
+  },
+  "data": [
+    {
+      "uuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "parent_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "type": "root",
+      "name": "Workspace A",
+      "description": "Description of Workspace A",
+      "created": "2024-10-01T00:00:00.000Z",
+      "modified": "2024-10-01T00:00:00.000Z"
+    }
+  ]
+}


### PR DESCRIPTION
In order to be able to check on users' permissions with Kessel, we need to know which workspace they are trying to act upon. And for now, RBAC is going to provide that information.

## Jira ticket
[[RHCLOUD-35479]](https://issues.redhat.com/browse/RHCLOUD-35479)