### PR TITLE
[RHCLOUD-35533] don't include empty patch daily digest section

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -144,6 +144,7 @@ public class EmailAggregator {
         Log.infof("%d elements were aggregated for key %s", totalAggregatedElements, aggregationKey);
 
         return aggregated.entrySet().stream()
+                .filter(entry -> !entry.getValue().isEmpty())
                 .collect(toMap(
                         Entry::getKey,
                         entry -> entry.getValue().getContext()

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AbstractEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AbstractEmailPayloadAggregator.java
@@ -38,6 +38,10 @@ public abstract class AbstractEmailPayloadAggregator {
         return payload;
     }
 
+    public boolean isEmpty() {
+        return false;
+    }
+
     void copyStringField(JsonObject to, JsonObject from, final String field) {
         to.put(field, from.getString(field));
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregator.java
@@ -11,13 +11,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class PatchEmailPayloadAggregator extends AbstractEmailPayloadAggregator {
 
     // Notification common
-    private static final String CONTEXT_KEY = "context";
     private static final String EVENT_TYPE_KEY = "event_type";
     private static final String EVENTS_KEY = "events";
     private static final String PAYLOAD_KEY = "payload";
-
-    // Patch context
-    private static final String INVENTORY_ID = "inventory_id";
 
     // Patch event payload
     private static final String ADVISORY_NAME = "advisory_name";
@@ -26,7 +22,6 @@ public class PatchEmailPayloadAggregator extends AbstractEmailPayloadAggregator 
 
     // Patch aggregator
     private static final String PATCH_KEY = "patch";
-    private static final String ADVISORIES_KEY = "advisories";
 
     private static final String NEW_ADVISORIES_EVENT = "new-advisory";
     private static final List<String> EVENT_TYPES = Arrays.asList(NEW_ADVISORIES_EVENT);
@@ -54,6 +49,11 @@ public class PatchEmailPayloadAggregator extends AbstractEmailPayloadAggregator 
     }
 
     @Override
+    public boolean isEmpty() {
+        return totalAdvisories.get() == 0;
+    }
+
+    @Override
     void processEmailAggregation(EmailAggregation notification) {
         JsonObject patch = context.getJsonObject(PATCH_KEY);
         JsonObject notificationPayload = notification.getPayload();
@@ -62,8 +62,6 @@ public class PatchEmailPayloadAggregator extends AbstractEmailPayloadAggregator 
         if (!EVENT_TYPES.contains(eventType)) {
             return;
         }
-
-        JsonObject payloadContext = notificationPayload.getJsonObject(CONTEXT_KEY);
 
         // Put and group advisories
         notificationPayload.getJsonArray(EVENTS_KEY).stream().forEach(eventObject -> {

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/PatchEmailPayloadAggregatorTest.java
@@ -75,8 +75,6 @@ public class PatchEmailPayloadAggregatorTest {
         Map<String, Object> patch = aggregator.getContext();
         patch.put("start_time", startTime.toString());
         patch.put("end_time", endTime.toString());
-
-        //System.out.println(JsonObject.mapFrom(patch).toString());
     }
 
     @Test


### PR DESCRIPTION
In some cases, Patch daily email section could be empty:
![image](https://github.com/user-attachments/assets/ec75f027-ce53-42c9-8b50-b9d2d475199c)

In those cases, it should not be included in the daily digest.