### PR TITLE
RHCLOUD-33780 | feature: Kessel tests for the "EndpointResource"

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -184,6 +184,10 @@ public class EndpointResource {
                 )
         })
         public List<NotificationHistory> getEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID id, @QueryParam("includeDetail") Boolean includeDetail, @BeanParam Query query) {
+            if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(sec))) {
+                throw new NotFoundException("Endpoint not found");
+            }
+
             if (this.backendConfig.isKesselRelationsEnabled()) {
                 this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.VIEW_HISTORY, ResourceType.INTEGRATION, id.toString());
 
@@ -238,6 +242,10 @@ public class EndpointResource {
                 @QueryParam("includeDetail") Boolean includeDetail,
                 @BeanParam Query query
         ) {
+            if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(sec))) {
+                throw new NotFoundException("Endpoint not found");
+            }
+
             if (this.backendConfig.isKesselRelationsEnabled()) {
                 this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.VIEW_HISTORY, ResourceType.INTEGRATION, id.toString());
 
@@ -272,9 +280,14 @@ public class EndpointResource {
         @Operation(summary = "Retrieve an endpoint", description = "Retrieves the public information associated with an endpoint such as its description, name, and properties.")
         public EndpointDTO getEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
             if (this.backendConfig.isKesselRelationsEnabled()) {
+                // First get the endpoint so that a "not found" is returned in case
+                // it doesn't exist in our database, as Kessel returns "non
+                // authorized" for the integrations that do not exist in their end.
+                final EndpointDTO endpoint = this.internalGetEndpoint(sec, id, false);
+
                 this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.VIEW, ResourceType.INTEGRATION, id.toString());
 
-                return internalGetEndpoint(sec, id, true);
+                return endpoint;
             } else {
                 return legacyGetEndpoint(sec, id, true);
             }
@@ -650,9 +663,14 @@ public class EndpointResource {
     @Operation(summary = "Retrieve an endpoint", description = "Retrieves the public information associated with an endpoint such as its description, name, and properties.")
     public EndpointDTO getEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         if (this.backendConfig.isKesselRelationsEnabled()) {
+            // First get the endpoint so that a "not found" is returned in case
+            // it doesn't exist in our database, as Kessel returns "non
+            // authorized" for the integrations that do not exist in their end.
+            final EndpointDTO endpoint = this.internalGetEndpoint(sec, id, false);
+
             this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.VIEW, ResourceType.INTEGRATION, id.toString());
 
-            return this.internalGetEndpoint(sec, id, false);
+            return endpoint;
         } else {
             return this.legacyGetEndpoint(sec, id, false);
         }
@@ -689,6 +707,10 @@ public class EndpointResource {
     @APIResponse(responseCode = "204", description = "The integration has been deleted", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
     public Response deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(sec))) {
+            throw new NotFoundException("Endpoint not found");
+        }
+
         if (this.backendConfig.isKesselRelationsEnabled()) {
             this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.DELETE, ResourceType.INTEGRATION, id.toString());
 
@@ -736,6 +758,10 @@ public class EndpointResource {
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
     public Response enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(sec))) {
+            throw new NotFoundException("Endpoint not found");
+        }
+
         if (this.backendConfig.isKesselRelationsEnabled()) {
             this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.ENABLE, ResourceType.INTEGRATION, id.toString());
 
@@ -767,6 +793,10 @@ public class EndpointResource {
     @APIResponse(responseCode = "204", description = "The integration has been disabled", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
     public Response disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(sec))) {
+            throw new NotFoundException("Endpoint not found");
+        }
+
         if (this.backendConfig.isKesselRelationsEnabled()) {
             this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.DISABLE, ResourceType.INTEGRATION, id.toString());
 
@@ -803,6 +833,10 @@ public class EndpointResource {
         @PathParam("id")                                UUID id,
         @RequestBody(required = true) @NotNull @Valid   EndpointDTO endpointDTO
     ) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(securityContext))) {
+            throw new NotFoundException("Endpoint not found");
+        }
+
         if (this.backendConfig.isKesselRelationsEnabled()) {
             this.kesselAuthorization.hasPermissionOnResource(securityContext, IntegrationPermission.EDIT, ResourceType.INTEGRATION, id.toString());
 
@@ -848,9 +882,6 @@ public class EndpointResource {
         endpoint.setId(id);
 
         final Endpoint dbEndpoint = endpointRepository.getEndpoint(orgId, id);
-        if (dbEndpoint == null) {
-            throw new NotFoundException("Endpoint not found");
-        }
         EndpointType endpointType = dbEndpoint.getType();
 
         // This prevents from updating an endpoint from system EndpointType to a whatever EndpointType
@@ -891,6 +922,10 @@ public class EndpointResource {
     @Operation(summary = "Retrieve event notification details", description = "Retrieves extended information about the outcome of an event notification related to the specified endpoint. Use this endpoint to learn why an event delivery failed.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     public Response getDetailedEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID endpointId, @PathParam("history_id") UUID historyId) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(endpointId, getOrgId(sec))) {
+            throw new NotFoundException("Endpoint not found");
+        }
+
         if (this.backendConfig.isKesselRelationsEnabled()) {
             this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.VIEW_HISTORY, ResourceType.INTEGRATION, endpointId.toString());
 
@@ -938,6 +973,10 @@ public class EndpointResource {
             )
     })
     public void testEndpoint(@Context SecurityContext sec, @RestPath UUID uuid, @RequestBody final EndpointTestRequest requestBody) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(uuid, getOrgId(sec))) {
+            throw new NotFoundException("integration not found");
+        }
+
         if (this.backendConfig.isKesselRelationsEnabled()) {
             this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.TEST, ResourceType.INTEGRATION, uuid.toString());
 
@@ -953,15 +992,9 @@ public class EndpointResource {
     }
 
     protected void internalTestEndpoint(final SecurityContext securityContext, final UUID uuid, @Valid final EndpointTestRequest requestBody) {
-        final String orgId = SecurityContextUtil.getOrgId(securityContext);
-
-        if (!this.endpointRepository.existsByUuidAndOrgId(uuid, orgId)) {
-            throw new NotFoundException("integration not found");
-        }
-
         final InternalEndpointTestRequest internalEndpointTestRequest = new InternalEndpointTestRequest();
         internalEndpointTestRequest.endpointUuid = uuid;
-        internalEndpointTestRequest.orgId = orgId;
+        internalEndpointTestRequest.orgId = getOrgId(securityContext);
         if (requestBody != null) {
             internalEndpointTestRequest.message = requestBody.message;
         }
@@ -1038,6 +1071,10 @@ public class EndpointResource {
     })
     @Transactional
     public void deleteEventTypeFromEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID eventTypeId, @RestPath final UUID endpointId) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(endpointId, getOrgId(securityContext))) {
+            throw new NotFoundException("Endpoint not found");
+        }
+
         if (this.backendConfig.isKesselRelationsEnabled()) {
             this.kesselAuthorization.hasPermissionOnResource(securityContext, IntegrationPermission.EDIT, ResourceType.INTEGRATION, endpointId.toString());
             internalDeleteEventTypeFromEndpoint(securityContext, eventTypeId, endpointId);
@@ -1078,6 +1115,10 @@ public class EndpointResource {
     })
     @Transactional
     public void addEventTypeToEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID eventTypeId, @RestPath final UUID endpointId) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(endpointId, getOrgId(securityContext))) {
+            throw new NotFoundException("Endpoint not found");
+        }
+
         if (this.backendConfig.isKesselRelationsEnabled()) {
             this.kesselAuthorization.hasPermissionOnResource(securityContext, IntegrationPermission.EDIT, ResourceType.INTEGRATION, endpointId.toString());
 
@@ -1112,6 +1153,10 @@ public class EndpointResource {
     })
     @Transactional
     public void updateEventTypesLinkedToEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID endpointId, @Parameter(description = "Set of event type ids to associate") Set<UUID> eventTypeIds) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(endpointId, getOrgId(securityContext))) {
+            throw new NotFoundException("Endpoint not found");
+        }
+
         if (this.backendConfig.isKesselRelationsEnabled()) {
             kesselAuthorization.hasPermissionOnResource(securityContext, IntegrationPermission.EDIT, ResourceType.INTEGRATION, endpointId.toString());
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications;
 
+import com.redhat.cloud.notifications.auth.principal.ConsoleIdentity;
 import com.redhat.cloud.notifications.db.Query;
 import io.restassured.http.Header;
 import io.vertx.core.json.JsonArray;
@@ -128,5 +129,25 @@ public class TestHelpers {
         final JsonObject arrayElement = constraintViolations.getJsonObject(0);
 
         return arrayElement.getString("message");
+    }
+
+    /**
+     * Decodes the Base64 encoded x-rh-identity header back into a complex
+     * object.
+     * @param header the header to decode the identity from.
+     * @return a complex {@link ConsoleIdentity} object.
+     */
+    public static ConsoleIdentity decodeRhIdentityHeader(final String header) {
+        final JsonObject xRhIdentity = new JsonObject(Base64Utils.decode(header));
+
+        // In order to be able to map the identity object we mock in the
+        // "encodeRHIdentityInfo" method of this class, we need to get the
+        // inner object, as otherwise Jackson cannot deserialize the identity
+        // object.
+        //
+        // Check "ConsoleIdentityProvider#getRhIdentityFromString" to
+        // understand how we do it for incoming "x-rh-identity" headers to the
+        // application, and understand why we are doing it here.
+        return xRhIdentity.getJsonObject("identity").mapTo(ConsoleIdentity.class);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselTestHelper.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselTestHelper.java
@@ -1,0 +1,146 @@
+package com.redhat.cloud.notifications.auth.kessel;
+
+import com.redhat.cloud.notifications.auth.kessel.permission.KesselPermission;
+import com.redhat.cloud.notifications.config.BackendConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.mockito.Mockito;
+import org.project_kessel.api.relations.v1beta1.CheckRequest;
+import org.project_kessel.api.relations.v1beta1.CheckResponse;
+import org.project_kessel.api.relations.v1beta1.LookupResourcesResponse;
+import org.project_kessel.api.relations.v1beta1.ObjectReference;
+import org.project_kessel.api.relations.v1beta1.ObjectType;
+import org.project_kessel.api.relations.v1beta1.SubjectReference;
+import org.project_kessel.relations.client.CheckClient;
+import org.project_kessel.relations.client.LookupClient;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Helps mocking Kessel's responses for testing purposes. It requires the
+ * Kessel clients to be mocked by the test class for these to work.
+ */
+@ApplicationScoped
+public class KesselTestHelper {
+    @Inject
+    BackendConfig backendConfig;
+
+    @Inject
+    CheckClient checkClient;
+
+    @Inject
+    LookupClient lookupClient;
+
+    /**
+     * Mocks the {@link LookupClient} so that it simulates that no authorized
+     * integrations were fetched from Kessel.
+     */
+    public void mockAuthorizedIntegrationsLookup() {
+        this.mockAuthorizedIntegrationsLookup(Collections.emptySet());
+    }
+
+    /**
+     * Mocks the {@link LookupClient} so that it simulates an incoming response
+     * from Kessel which contains the specified integrations.
+     * @param authorizedIntegrationsIds the set of IDs that the lookup client
+     *                                  will return in an iterator.
+     */
+    public void mockAuthorizedIntegrationsLookup(final Set<UUID> authorizedIntegrationsIds) {
+        // It does not make sense to mock anything if we are not testing with
+        // Kessel.
+        if (!this.backendConfig.isKesselRelationsEnabled()) {
+            return;
+        }
+
+        final Set<LookupResourcesResponse> lookupResourcesResponses = new HashSet<>();
+        for (final UUID id : authorizedIntegrationsIds) {
+            final LookupResourcesResponse mockedResponse = LookupResourcesResponse
+                .newBuilder()
+                .setResource(
+                    ObjectReference
+                        .newBuilder()
+                        .setId(id.toString())
+                ).build();
+
+            lookupResourcesResponses.add(mockedResponse);
+        }
+
+        Mockito.when(
+            this.lookupClient.lookupResources(Mockito.any())
+        ).thenReturn(
+            lookupResourcesResponses.iterator()
+        );
+    }
+
+    /**
+     * Mocks the {@link CheckClient} so that it returns an authorized response
+     * for the given permission.
+     * @param subjectUsername the subject's name as sent in the "x-rh-identity"
+     *                        header.
+     * @param permission the permission that will be checked in the handler.
+     * @param resourceType the resource type against which the permission will
+     *                     be checked.
+     * @param resourceId the reource's identifier.
+     */
+    public void mockKesselPermission(final String subjectUsername, final KesselPermission permission, final ResourceType resourceType, final String resourceId) {
+        if (!this.backendConfig.isKesselRelationsEnabled()) {
+            return;
+        }
+
+        Mockito.when(
+            this.checkClient.check(
+                CheckRequest.newBuilder()
+                    .setResource(
+                        ObjectReference.newBuilder()
+                            .setType(resourceType.getKesselObjectType())
+                            .setId(resourceId)
+                            .build()
+                    )
+                    .setRelation(permission.getKesselPermissionName())
+                    .setSubject(
+                        SubjectReference.newBuilder()
+                            .setSubject(
+                                ObjectReference.newBuilder()
+                                    .setType(ObjectType.newBuilder().setName(KesselAuthorization.KESSEL_IDENTITY_SUBJECT_TYPE).setNamespace(KesselAuthorization.KESSEL_RBAC_NAMESPACE).build())
+                                    .setId(subjectUsername)
+                                    .build()
+                            ).build()
+                    ).build()
+            )
+        ).thenReturn(
+            CheckResponse
+                .newBuilder()
+                .setAllowed(CheckResponse.Allowed.ALLOWED_TRUE)
+                .build()
+        );
+    }
+
+    /**
+     * Mocks the {@link BackendConfig#isKesselRelationsEnabled()} so that it
+     * returns the given boolean flag when asked, and also makes the {@link CheckClient}
+     * return an "allowed" response when the flag is {@code true}.
+     * @param isKesselRelationsEnabled is the Kessel relations enabled for the
+     *                                 test?
+     */
+    public void mockKesselRelations(final boolean isKesselRelationsEnabled) {
+        Mockito
+            .when(this.backendConfig.isKesselRelationsEnabled())
+            .thenReturn(isKesselRelationsEnabled);
+
+        if (!this.backendConfig.isKesselRelationsEnabled()) {
+            return;
+        }
+
+        // Default to an unauthorized response.
+        Mockito
+            .when(this.checkClient.check(Mockito.any()))
+            .thenReturn(CheckResponse
+                .newBuilder()
+                .setAllowed(CheckResponse.Allowed.ALLOWED_FALSE)
+                .build()
+            );
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -216,6 +216,8 @@ public class ResourceHelpers {
             ep.setAccountId(accountId);
             ep.setOrgId(orgId);
             endpointRepository.createEndpoint(ep);
+
+            stats.addEndpointId(ep.getId());
         }
         return stats;
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/model/Stats.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/model/Stats.java
@@ -2,17 +2,23 @@ package com.redhat.cloud.notifications.db.model;
 
 import com.redhat.cloud.notifications.routers.EndpointResourceTest;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
 /**
  * A helper class for the {@link com.redhat.cloud.notifications.db.ResourceHelpers#createTestEndpoints(String, String, int)}
  * function. It then gets used in {@link EndpointResourceTest#testSortingOrder()} and {@link EndpointResourceTest#testActive()}.
  */
 public final class Stats {
     private final int createdEndpointsCount;
+    private final Set<UUID> createdEndpointIds;
     private int disabledCount;
     private int webhookCount;
 
     public Stats(final int createdEndpointsCount) {
         this.createdEndpointsCount = createdEndpointsCount;
+        this.createdEndpointIds = new HashSet<>(createdEndpointsCount);
     }
 
     public int getCreatedEndpointsCount() {
@@ -33,5 +39,13 @@ public final class Stats {
 
     public void increaseWebhookCount() {
         this.webhookCount++;
+    }
+
+    public void addEndpointId(final UUID endpointId) {
+        this.createdEndpointIds.add(endpointId);
+    }
+
+    public Set<UUID> getEndpointIds() {
+        return this.createdEndpointIds;
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EmailsOnlyModeTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EmailsOnlyModeTest.java
@@ -5,20 +5,36 @@ import com.redhat.cloud.notifications.Json;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.auth.kessel.KesselTestHelper;
+import com.redhat.cloud.notifications.auth.kessel.ResourceType;
+import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
+import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.models.Endpoint;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.Header;
+import jakarta.inject.Inject;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.project_kessel.relations.client.CheckClient;
+import org.project_kessel.relations.client.LookupClient;
 
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.FULL_ACCESS;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
+import static com.redhat.cloud.notifications.auth.kessel.Constants.WORKSPACE_ID_PLACEHOLDER;
 import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
 import static com.redhat.cloud.notifications.routers.EndpointResource.UNSUPPORTED_ENDPOINT_TYPE;
@@ -39,12 +55,39 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
     @InjectMock
     EndpointRepository endpointRepository;
 
+    @InjectMock
+    CheckClient checkClient;
+
+    @InjectMock
+    LookupClient lookupClient;
+
+    @Inject
+    KesselTestHelper kesselTestHelper;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    /**
+     * Provides the required arguments for the tests.
+     * @return a stream which contains argument tuples. The first element is
+     * the integration API's different versioned paths and the second argument
+     * states whether Kessel is enabled or not.
+     */
+    private static Stream<Arguments> argumentsProvider() {
+        return Stream.of(
+            Arguments.of(Constants.API_INTEGRATIONS_V_1_0, false),
+            Arguments.of(Constants.API_INTEGRATIONS_V_2_0, true)
+        );
+    }
+
+    @MethodSource("argumentsProvider")
     @ParameterizedTest
-    @ValueSource(strings = {Constants.API_INTEGRATIONS_V_1_0, Constants.API_INTEGRATIONS_V_2_0})
-    void testCreateUnsupportedEndpointType(String apiPath) {
+    void testCreateUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("account-id", "org-id", "username");
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
@@ -53,6 +96,7 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
         endpoint.setName("name");
         endpoint.setDescription("description");
 
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
         String responseBody = given()
                 .basePath(apiPath)
                 .header(identityHeader)
@@ -61,17 +105,19 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
                 .body(Json.encode(endpoint))
                 .post("/endpoints")
                 .then()
-                .statusCode(400)
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .extract().asString();
         assertEquals(UNSUPPORTED_ENDPOINT_TYPE, responseBody);
     }
 
+    @MethodSource("argumentsProvider")
     @ParameterizedTest
-    @ValueSource(strings = {Constants.API_INTEGRATIONS_V_1_0, Constants.API_INTEGRATIONS_V_2_0})
-    void testUpdateUnsupportedEndpointType(String apiPath) {
+    void testUpdateUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("account-id", "org-id", "username");
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
@@ -80,85 +126,107 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
         endpoint.setName("name");
         endpoint.setDescription("description");
 
+        final UUID endpointId = UUID.randomUUID();
+        Mockito.when(this.endpointRepository.existsByUuidAndOrgId(endpointId, DEFAULT_ORG_ID)).thenReturn(true);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.EDIT, ResourceType.INTEGRATION, endpointId.toString());
+
         String responseBody = given()
                 .basePath(apiPath)
                 .header(identityHeader)
-                .pathParam("id", UUID.randomUUID().toString())
+                .pathParam("id", endpointId)
                 .when()
                 .contentType(JSON)
                 .body(Json.encode(endpoint))
                 .put("/endpoints/{id}")
                 .then()
-                .statusCode(400)
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .extract().asString();
         assertEquals(UNSUPPORTED_ENDPOINT_TYPE, responseBody);
     }
 
+    @MethodSource("argumentsProvider")
     @ParameterizedTest
-    @ValueSource(strings = {Constants.API_INTEGRATIONS_V_1_0, Constants.API_INTEGRATIONS_V_2_0})
-    void testDeleteUnsupportedEndpointType(String apiPath) {
+    void testDeleteUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("account-id", "org-id", "username");
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
         when(endpointRepository.getEndpointTypeById(anyString(), any(UUID.class))).thenReturn(CAMEL);
 
+        final UUID endpointId = UUID.randomUUID();
+        Mockito.when(this.endpointRepository.existsByUuidAndOrgId(endpointId, DEFAULT_ORG_ID)).thenReturn(true);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.DELETE, ResourceType.INTEGRATION, endpointId.toString());
+
         String responseBody = given()
                 .basePath(apiPath)
                 .header(identityHeader)
-                .pathParam("id", UUID.randomUUID().toString())
+                .pathParam("id", endpointId)
                 .when()
                 .delete("/endpoints/{id}")
                 .then()
-                .statusCode(400)
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .extract().asString();
         assertEquals(UNSUPPORTED_ENDPOINT_TYPE, responseBody);
     }
 
+    @MethodSource("argumentsProvider")
     @ParameterizedTest
-    @ValueSource(strings = {Constants.API_INTEGRATIONS_V_1_0, Constants.API_INTEGRATIONS_V_2_0})
-    void testEnableUnsupportedEndpointType(String apiPath) {
+    void testEnableUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("account-id", "org-id", "username");
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
         when(endpointRepository.getEndpointTypeById(anyString(), any(UUID.class))).thenReturn(CAMEL);
 
+        final UUID endpointId = UUID.randomUUID();
+        Mockito.when(this.endpointRepository.existsByUuidAndOrgId(endpointId, DEFAULT_ORG_ID)).thenReturn(true);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.ENABLE, ResourceType.INTEGRATION, endpointId.toString());
+
         String responseBody = given()
                 .basePath(apiPath)
                 .header(identityHeader)
-                .pathParam("id", UUID.randomUUID().toString())
+                .pathParam("id", endpointId)
                 .when()
                 .put("/endpoints/{id}/enable")
                 .then()
-                .statusCode(400)
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .extract().asString();
         assertEquals(UNSUPPORTED_ENDPOINT_TYPE, responseBody);
     }
 
+    @MethodSource("argumentsProvider")
     @ParameterizedTest
-    @ValueSource(strings = {Constants.API_INTEGRATIONS_V_1_0, Constants.API_INTEGRATIONS_V_2_0})
-    void testDisableUnsupportedEndpointType(String apiPath) {
+    void testDisableUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("account-id", "org-id", "username");
+        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
 
         when(endpointRepository.getEndpointTypeById(anyString(), any(UUID.class))).thenReturn(CAMEL);
 
+        final UUID endpointId = UUID.randomUUID();
+        Mockito.when(this.endpointRepository.existsByUuidAndOrgId(endpointId, DEFAULT_ORG_ID)).thenReturn(true);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.DISABLE, ResourceType.INTEGRATION, endpointId.toString());
+
         String responseBody = given()
                 .basePath(apiPath)
                 .header(identityHeader)
-                .pathParam("id", UUID.randomUUID().toString())
+                .pathParam("id", endpointId)
                 .when()
                 .delete("/endpoints/{id}/enable")
                 .then()
-                .statusCode(400)
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .extract().asString();
         assertEquals(UNSUPPORTED_ENDPOINT_TYPE, responseBody);
     }


### PR DESCRIPTION
Implements the tests and the required helper classes to test making
authenticated and authorized requests while using Kessel as the
authentication and authorization back end.

## Dependency
- https://github.com/RedHatInsights/notifications-backend/pull/3032

## Jira ticket
[[RHCLOUD-33780]](https://issues.redhat.com/browse/RHCLOUD-33780)