### PR TITLE
Add additional validation for PagerDutyTransformer

### DIFF
--- a/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyCloudEventDataExtractor.java
+++ b/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyCloudEventDataExtractor.java
@@ -28,7 +28,7 @@ public class PagerDutyCloudEventDataExtractor extends CloudEventDataExtractor {
     @Override
     public void extract(Exchange exchange, JsonObject cloudEventData) throws IllegalArgumentException {
 
-        validatePayload(cloudEventData);
+        validateCloudEventData(cloudEventData);
 
         String providedUrl = cloudEventData.getString(URL);
         if (providedUrl == null || providedUrl.isEmpty()) {
@@ -43,7 +43,7 @@ public class PagerDutyCloudEventDataExtractor extends CloudEventDataExtractor {
         exchange.getIn().setBody(cloudEventData.getJsonObject(PAYLOAD));
     }
 
-    private void validatePayload(JsonObject cloudEventData) {
+    private void validateCloudEventData(JsonObject cloudEventData) {
         String endpointUrl = cloudEventData.getString(URL);
         if (endpointUrl != null && !endpointUrl.isEmpty() && !URL_VALIDATOR.isValid(endpointUrl)) {
             throw new IllegalArgumentException("URL validation failed");

--- a/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
+++ b/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
@@ -58,16 +58,12 @@ public class PagerDutyTransformer implements Processor {
         messagePayload.put(SUMMARY, cloudEventPayload.getString(EVENT_TYPE));
 
         String timestamp = cloudEventPayload.getString(TIMESTAMP);
-        if (timestamp != null) {
-            try {
-                messagePayload.put(TIMESTAMP, LocalDateTime.parse(timestamp).format(PD_DATE_TIME_FORMATTER));
-            } catch (DateTimeParseException e) {
-                Log.warnf(e, "Unable to parse timestamp %s, dropped from payload", timestamp);
-            } catch (DateTimeException e) {
-                Log.warnf(e, "Timestamp %s was successfully parsed, but could not be reformatted for PagerDuty, dropped from payload", timestamp);
-            }
-        } else {
-            Log.warn("Timestamp not provided for payload, ignored");
+        try {
+            messagePayload.put(TIMESTAMP, LocalDateTime.parse(timestamp).format(PD_DATE_TIME_FORMATTER));
+        } catch (DateTimeParseException e) {
+            Log.warnf(e, "Unable to parse timestamp %s, dropped from payload", timestamp);
+        } catch (DateTimeException e) {
+            Log.warnf(e, "Timestamp %s was successfully parsed, but could not be reformatted for PagerDuty, dropped from payload", timestamp);
         }
 
         messagePayload.put(SEVERITY, PagerDutySeverity.fromJson(cloudEventPayload.getString(SEVERITY)));
@@ -82,7 +78,7 @@ public class PagerDutyTransformer implements Processor {
         // Add source names, if provided
         JsonObject cloudSource = getSourceNames(cloudEventPayload.getJsonObject(SOURCE));
         if (cloudSource != null) {
-            customDetails.put(SOURCE, cloudSource);
+            customDetails.put(SOURCE_NAMES, cloudSource);
         }
 
         // Keep events, if provided

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyConnectorRoutesTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyConnectorRoutesTest.java
@@ -7,40 +7,16 @@ import com.redhat.cloud.notifications.connector.authentication.secrets.SecretsLo
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Predicate;
 
-import java.time.LocalDateTime;
-
-import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
-import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.connector.authentication.AuthenticationExchangeProperty.AUTHENTICATION_TYPE;
 import static com.redhat.cloud.notifications.connector.authentication.AuthenticationExchangeProperty.SECRET_ID;
 import static com.redhat.cloud.notifications.connector.authentication.AuthenticationType.SECRET_TOKEN;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTestUtils.createCloudEventData;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ACCOUNT_ID;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.APPLICATION;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.BUNDLE;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CLIENT;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CLIENT_URL;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CONTEXT;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CUSTOM_DETAILS;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.DISPLAY_NAME;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ENVIRONMENT_URL;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENTS;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENT_ACTION;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENT_TYPE;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.GROUP;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ORG_ID;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTestUtils.buildExpectedOutgoingPayload;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTestUtils.createIncomingPayload;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.PAYLOAD;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.PD_DATE_TIME_FORMATTER;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SEVERITY;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SOURCE;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SOURCE_NAMES;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SUMMARY;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.TIMESTAMP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -66,41 +42,13 @@ public class PagerDutyConnectorRoutesTest extends ConnectorRoutesTest {
 
     @Override
     protected JsonObject buildIncomingPayload(String targetUrl) {
-        JsonObject cloudEventData = createCloudEventData(targetUrl);
-
-        JsonObject payload = new JsonObject();
-        payload.put(ACCOUNT_ID, DEFAULT_ACCOUNT_ID);
-        payload.put(APPLICATION, "default-application");
-        payload.put(BUNDLE, "default-bundle");
-        payload.put(EVENT_TYPE, "default-event-type");
-        payload.put(EVENTS, JsonArray.of(
-                JsonObject.of("event-1-key", "event-1-value"),
-                JsonObject.of("event-2-key", "event-2-value"),
-                JsonObject.of("event-3-key", "event-3-value")
-        ));
-        payload.put(ORG_ID, DEFAULT_ORG_ID);
-        payload.put(TIMESTAMP, LocalDateTime.of(2024, 8, 12, 17, 26, 19).toString());
-
-        JsonObject source = JsonObject.of(
-                APPLICATION, JsonObject.of(DISPLAY_NAME, "Default Application Name"),
-                BUNDLE, JsonObject.of(DISPLAY_NAME, "Default Bundle Name"),
-                EVENT_TYPE, JsonObject.of(DISPLAY_NAME, "Default Event Type Name")
-        );
-
-        payload.put(SOURCE, source);
-        payload.put(ENVIRONMENT_URL, "https://console.redhat.com");
-        payload.put(SEVERITY, PagerDutySeverity.WARNING);
-        cloudEventData.put(PAYLOAD, payload);
-
-        return cloudEventData;
+        return createIncomingPayload(targetUrl);
     }
 
     @Override
     protected Predicate checkOutgoingPayload(JsonObject incomingPayload) {
 
         JsonObject expectedPayload = incomingPayload.copy();
-        expectedPayload.remove(PagerDutyCloudEventDataExtractor.URL);
-        expectedPayload.remove(PagerDutyCloudEventDataExtractor.AUTHENTICATION);
 
         return exchange -> {
             JsonObject outgoingPayload = new JsonObject(exchange.getIn().getBody(String.class));
@@ -112,48 +60,12 @@ public class PagerDutyConnectorRoutesTest extends ConnectorRoutesTest {
             assertNull(outgoingPayload.getJsonObject(PAYLOAD).getString("class"));
             assertNull(outgoingPayload.getString("dedup_key"));
 
-            JsonObject expected = buildExpectedPayload(expectedPayload);
+            JsonObject expected = buildExpectedOutgoingPayload(expectedPayload);
             assertEquals(expected.encode(), exchange.getIn().getBody(String.class));
 
             // In case of assertion failure, this return value won't be used.
             return true;
         };
-    }
-
-    private JsonObject buildExpectedPayload(JsonObject expected) {
-        expected.remove(PagerDutyCloudEventDataExtractor.URL);
-        expected.remove(PagerDutyCloudEventDataExtractor.AUTHENTICATION);
-
-        JsonObject oldInnerPayload = expected.getJsonObject(PAYLOAD);
-        expected.put(EVENT_ACTION, PagerDutyEventAction.TRIGGER);
-        expected.put(CLIENT, String.format("Open %s", oldInnerPayload.getString(APPLICATION)));
-        expected.put(CLIENT_URL, String.format("%s/insights/%s", oldInnerPayload.getString(ENVIRONMENT_URL), oldInnerPayload.getString(APPLICATION)));
-
-        JsonObject newInnerPayload = new JsonObject();
-        newInnerPayload.put(SUMMARY, oldInnerPayload.getString(EVENT_TYPE));
-        newInnerPayload.put(TIMESTAMP, LocalDateTime.parse(oldInnerPayload.getString(TIMESTAMP)).format(PD_DATE_TIME_FORMATTER));
-        newInnerPayload.put(SEVERITY, PagerDutySeverity.fromJson(oldInnerPayload.getString(SEVERITY)));
-        newInnerPayload.put(SOURCE, oldInnerPayload.getString(APPLICATION));
-        newInnerPayload.put(GROUP, oldInnerPayload.getString(BUNDLE));
-
-        JsonObject sourceNames = JsonObject.of(
-                APPLICATION, oldInnerPayload.getJsonObject(SOURCE).getJsonObject(APPLICATION).getString(DISPLAY_NAME),
-                BUNDLE, oldInnerPayload.getJsonObject(SOURCE).getJsonObject(BUNDLE).getString(DISPLAY_NAME),
-                EVENT_TYPE, oldInnerPayload.getJsonObject(SOURCE).getJsonObject(EVENT_TYPE).getString(DISPLAY_NAME)
-        );
-
-        JsonObject customDetails = JsonObject.of(
-                ACCOUNT_ID, DEFAULT_ACCOUNT_ID,
-                ORG_ID, DEFAULT_ORG_ID,
-                CONTEXT, null,
-                SOURCE_NAMES, sourceNames
-        );
-        customDetails.put(EVENTS, oldInnerPayload.getJsonArray(EVENTS));
-
-        newInnerPayload.put(CUSTOM_DETAILS, customDetails);
-        expected.remove(PAYLOAD);
-        expected.put(PAYLOAD, newInnerPayload);
-        return expected;
     }
 
     @Override

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTestUtils.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTestUtils.java
@@ -28,6 +28,7 @@ import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransf
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.PD_DATE_TIME_FORMATTER;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SEVERITY;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SOURCE;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SOURCE_NAMES;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SUMMARY;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.TIMESTAMP;
 
@@ -114,7 +115,7 @@ public class PagerDutyTestUtils {
         );
         JsonObject newInnerSourceNames = getSourceNames(oldInnerPayload.getJsonObject(SOURCE));
         if (newInnerSourceNames != null) {
-            customDetails.put(SOURCE, newInnerSourceNames);
+            customDetails.put(SOURCE_NAMES, newInnerSourceNames);
         }
 
         if (oldInnerPayload.containsKey(EVENTS)) {

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTestUtils.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTestUtils.java
@@ -1,9 +1,35 @@
 package com.redhat.cloud.notifications.connector.pagerduty;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.connector.authentication.AuthenticationType.SECRET_TOKEN;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyCloudEventDataExtractor.AUTHENTICATION;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ACCOUNT_ID;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.APPLICATION;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.BUNDLE;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CLIENT;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CLIENT_URL;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CONTEXT;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CUSTOM_DETAILS;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.DISPLAY_NAME;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ENVIRONMENT_URL;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENTS;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENT_ACTION;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENT_TYPE;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.GROUP;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ORG_ID;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.PAYLOAD;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.PD_DATE_TIME_FORMATTER;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SEVERITY;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SOURCE;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SUMMARY;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.TIMESTAMP;
 
 public class PagerDutyTestUtils {
 
@@ -17,5 +43,144 @@ public class PagerDutyTestUtils {
         cloudEventData.put(AUTHENTICATION, authentication);
 
         return cloudEventData;
+    }
+
+    static JsonObject createIncomingPayload(String url) {
+        JsonObject cloudEventData = createCloudEventData(url);
+        return createIncomingPayload(cloudEventData);
+    }
+
+    static JsonObject createIncomingPayload(JsonObject cloudEventData) {
+        JsonObject payload = new JsonObject();
+        payload.put(ACCOUNT_ID, DEFAULT_ACCOUNT_ID);
+        payload.put(APPLICATION, "default-application");
+        payload.put(BUNDLE, "default-bundle");
+        payload.put(EVENT_TYPE, "default-event-type");
+        payload.put(EVENTS, JsonArray.of(
+                JsonObject.of("event-1-key", "event-1-value"),
+                JsonObject.of("event-2-key", "event-2-value"),
+                JsonObject.of("event-3-key", "event-3-value"),
+                JsonObject.of("event-4-with-metadata-and-payload", JsonObject.of(
+                        "metadata", "some metadata could be placed here",
+                        "payload", "Here is a test payload message"
+                ))
+        ));
+        payload.put(ORG_ID, DEFAULT_ORG_ID);
+        payload.put(TIMESTAMP, LocalDateTime.of(2024, 8, 12, 17, 26, 19).toString());
+
+        JsonObject source = JsonObject.of(
+                APPLICATION, JsonObject.of(DISPLAY_NAME, "Default Application Name"),
+                BUNDLE, JsonObject.of(DISPLAY_NAME, "Default Bundle Name"),
+                EVENT_TYPE, JsonObject.of(DISPLAY_NAME, "Default Event Type Name")
+        );
+
+        payload.put(SOURCE, source);
+        payload.put(ENVIRONMENT_URL, "https://console.redhat.com");
+        payload.put(SEVERITY, PagerDutySeverity.WARNING);
+        cloudEventData.put(PAYLOAD, payload);
+
+        return cloudEventData;
+    }
+
+    static JsonObject buildExpectedOutgoingPayload(final JsonObject incoming) {
+        JsonObject expected = incoming.copy();
+        expected.remove(PagerDutyCloudEventDataExtractor.URL);
+        expected.remove(PagerDutyCloudEventDataExtractor.AUTHENTICATION);
+
+        JsonObject oldInnerPayload = expected.getJsonObject(PAYLOAD);
+        expected.put(EVENT_ACTION, PagerDutyEventAction.TRIGGER);
+        expected.mergeIn(getClientLink(oldInnerPayload, oldInnerPayload.getString(ENVIRONMENT_URL)));
+
+        JsonObject newInnerPayload = new JsonObject();
+        newInnerPayload.put(SUMMARY, oldInnerPayload.getString(EVENT_TYPE));
+
+        String timestamp = oldInnerPayload.getString(TIMESTAMP);
+        if (timestamp != null) {
+            try {
+                newInnerPayload.put(TIMESTAMP, LocalDateTime.parse(timestamp).format(PD_DATE_TIME_FORMATTER));
+            } catch (DateTimeException ignored) {
+                // Not added
+            }
+        }
+
+        newInnerPayload.put(SEVERITY, PagerDutySeverity.fromJson(oldInnerPayload.getString(SEVERITY)));
+        newInnerPayload.put(SOURCE, oldInnerPayload.getString(APPLICATION));
+        newInnerPayload.put(GROUP, oldInnerPayload.getString(BUNDLE));
+
+        JsonObject customDetails = JsonObject.of(
+                ACCOUNT_ID, DEFAULT_ACCOUNT_ID,
+                ORG_ID, DEFAULT_ORG_ID,
+                CONTEXT, oldInnerPayload.getJsonObject(CONTEXT)
+        );
+        JsonObject newInnerSourceNames = getSourceNames(oldInnerPayload.getJsonObject(SOURCE));
+        if (newInnerSourceNames != null) {
+            customDetails.put(SOURCE, newInnerSourceNames);
+        }
+
+        if (oldInnerPayload.containsKey(EVENTS)) {
+            customDetails.put(EVENTS, oldInnerPayload.getJsonArray(EVENTS));
+        }
+
+        newInnerPayload.put(CUSTOM_DETAILS, customDetails);
+        expected.remove(PAYLOAD);
+        expected.put(PAYLOAD, newInnerPayload);
+        return expected;
+    }
+
+    private static JsonObject getClientLink(final JsonObject oldInnerPayload, String environmentUrl) {
+        JsonObject clientLink = new JsonObject();
+
+        String contextName = oldInnerPayload.containsKey(CONTEXT)
+                ? oldInnerPayload.getJsonObject(CONTEXT).getString(DISPLAY_NAME)
+                : null;
+
+        if (contextName != null) {
+            clientLink.put(CLIENT, contextName);
+
+            String inventoryId = oldInnerPayload.getJsonObject(CONTEXT).getString("inventory_id");
+            if (environmentUrl != null && !environmentUrl.isEmpty() && inventoryId != null && !inventoryId.isEmpty()) {
+                clientLink.put(CLIENT_URL, String.format("%s/insights/inventory/%s",
+                        environmentUrl,
+                        oldInnerPayload.getJsonObject(CONTEXT).getString("inventory_id")
+                ));
+            }
+        } else {
+            if (environmentUrl != null && !environmentUrl.isEmpty()) {
+                clientLink.put(CLIENT, String.format("Open %s", oldInnerPayload.getString(APPLICATION)));
+                clientLink.put(CLIENT_URL, String.format("%s/insights/%s",
+                        environmentUrl,
+                        oldInnerPayload.getString(APPLICATION)
+                ));
+            } else {
+                clientLink.put(CLIENT, oldInnerPayload.getString(APPLICATION));
+            }
+        }
+
+        return clientLink;
+    }
+
+    private static JsonObject getSourceNames(final JsonObject oldInnerSourceNames) {
+        if (oldInnerSourceNames != null) {
+            JsonObject newInnerSourceNames = new JsonObject();
+
+            JsonObject application = oldInnerSourceNames.getJsonObject(APPLICATION);
+            if (application != null) {
+                newInnerSourceNames.put(APPLICATION, application.getString(DISPLAY_NAME));
+            }
+            JsonObject bundle = oldInnerSourceNames.getJsonObject(BUNDLE);
+            if (bundle != null) {
+                newInnerSourceNames.put(BUNDLE, bundle.getString(DISPLAY_NAME));
+            }
+            JsonObject eventType = oldInnerSourceNames.getJsonObject(EVENT_TYPE);
+            if (eventType != null) {
+                newInnerSourceNames.put(EVENT_TYPE, eventType.getString(DISPLAY_NAME));
+            }
+
+            if (!newInnerSourceNames.isEmpty()) {
+                return newInnerSourceNames;
+            }
+        }
+
+        return null;
     }
 }

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
@@ -1,0 +1,213 @@
+package com.redhat.cloud.notifications.connector.pagerduty;
+
+import com.redhat.cloud.notifications.connector.TestLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.json.JsonObject;
+import jakarta.inject.Inject;
+import org.apache.camel.Exchange;
+import org.apache.camel.quarkus.test.CamelQuarkusTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTestUtils.buildExpectedOutgoingPayload;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTestUtils.createIncomingPayload;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.APPLICATION;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CONTEXT;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.DISPLAY_NAME;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ENVIRONMENT_URL;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENTS;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENT_TYPE;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.PAYLOAD;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SEVERITY;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SOURCE;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.TIMESTAMP;
+import static org.apache.camel.test.junit5.TestSupport.createExchangeWithBody;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** These test cases are intended to verify that the {@link PagerDutyTransformer} can handle various possible inputs. */
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
+    static final String TEST_URL = "https://example.com/";
+
+    @Inject
+    PagerDutyCloudEventDataExtractor extractor;
+
+    @Inject
+    PagerDutyTransformer transformer;
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Test
+    void testMissingEventType() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.remove(EVENT_TYPE);
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        verifyTransformExceptionThrown(cloudEventData, IllegalArgumentException.class, "Event type must be specified for PagerDuty payload summary");
+    }
+
+    @Test
+    void testMissingSource() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.remove(APPLICATION);
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        verifyTransformExceptionThrown(cloudEventData, IllegalArgumentException.class, "Application must be specified for PagerDuty payload source");
+    }
+
+    @Test
+    void testMissingSeverity() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.remove(SEVERITY);
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        verifyTransformExceptionThrown(cloudEventData, IllegalArgumentException.class, "Severity must be specified for PagerDuty payload");
+    }
+
+    @Test
+    void testSuccessfulPayloadTransform() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testMissingTimestamp() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.remove(TIMESTAMP);
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testInvalidTimestampDropped() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.put(TIMESTAMP, "not a timestamp");
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testMissingSourceNames() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudEventData.remove(SOURCE);
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testMissingApplicationDisplayName() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        JsonObject sourceNames = cloudPayload.getJsonObject(SOURCE);
+
+        sourceNames.remove(APPLICATION);
+        cloudPayload.put(SOURCE, sourceNames);
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testSourceWithoutDisplayNames() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.put(SOURCE, new JsonObject());
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testMissingEvents() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.remove(EVENTS);
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testWithClientDisplayName() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.put(CONTEXT, JsonObject.of(
+                DISPLAY_NAME, "console",
+                "inventory_id", "8a4a4f75-5319-4255-9eb5-1ee5a92efd7f"
+        ));
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testWithClientDisplayNameAndInventoryId() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.put(CONTEXT, JsonObject.of(
+                DISPLAY_NAME, "console",
+                "inventory_id", "8a4a4f75-5319-4255-9eb5-1ee5a92efd7f"
+        ));
+        cloudEventData.put(PAYLOAD, cloudPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testMissingEnvironmentUrl() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.remove(ENVIRONMENT_URL);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    void verifyTransformExceptionThrown(JsonObject cloudEventData, Class<? extends Throwable> exceptionType, String exceptionMessage) {
+        Exchange exchange = createExchangeWithBody(context, "I am not used!");
+
+        extractor.extract(exchange, cloudEventData);
+        assertThrows(exceptionType, () -> transformer.process(exchange), exceptionMessage);
+    }
+
+    /**
+     *
+     * @param cloudEventData the cloud event, as provided to the connector
+     * @param expectedPayload the PagerDuty payload expected to be sent
+     */
+    void validatePayloadTransform(JsonObject cloudEventData, JsonObject expectedPayload) {
+        Exchange exchange = createExchangeWithBody(context, "I am not used!");
+
+        extractor.extract(exchange, cloudEventData);
+        transformer.process(exchange);
+
+        /* This test does not check whether authentication fields are included,
+         * as only the PagerDuty payload is validated
+         */
+        assertEquals(expectedPayload.encode(), exchange.getIn().getBody(String.class));
+    }
+}

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
@@ -116,17 +116,6 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
     }
 
     @Test
-    void testMissingTimestamp() {
-        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
-        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
-        cloudPayload.remove(TIMESTAMP);
-        cloudEventData.put(PAYLOAD, cloudPayload);
-
-        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
-        validatePayloadTransform(cloudEventData, expectedPayload);
-    }
-
-    @Test
     void testInvalidTimestampDropped() {
         JsonObject cloudEventData = createIncomingPayload(TEST_URL);
         JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);


### PR DESCRIPTION
In testing I discovered that the `PagerDutyTransformer` (part of `notifications-connector-pagerduty`) failed to handle cases where optional fields were not provided. This PR fixes the handling of missing fields, and also adds a new `PagerDutyTransformerTest` class to validate it's handled gracefully.