### PR TITLE
RHCLOUD-35454 | feature: Kessel bulk import

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -130,6 +130,8 @@ objects:
               optional: true
         - name: NOTIFICATIONS_KESSEL_INVENTORY_ENABLED
           value: ${NOTIFICATIONS_KESSEL_INVENTORY_ENABLED}
+        - name: NOTIFICATIONS_KESSEL_MIGRATION_BATCH_SIZE
+          value: ${NOTIFICATIONS_KESSEL_MIGRATION_BATCH_SIZE}
         - name: NOTIFICATIONS_KESSEL_RELATIONS_ENABLED
           value: ${NOTIFICATIONS_KESSEL_RELATIONS_ENABLED}
         - name: NOTIFICATIONS_KESSEL_BACKEND_ENABLED
@@ -276,6 +278,9 @@ parameters:
 - name: NOTIFICATIONS_KESSEL_INVENTORY_SECURE_CLIENTS
   description: Should the inventory gRPC client open channels over TLS?
   value: "false"
+- name: NOTIFICATIONS_KESSEL_MIGRATION_BATCH_SIZE
+  description: Defines the number of integration assets that will be loaded into memory before sending them to Kessel.
+  value: "1000"
 - name: NOTIFICATIONS_KESSEL_RELATIONS_ENABLED
   description: Is the integration with Kessel's relations enabled?
   value: "false"

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -28,6 +28,7 @@ public class BackendConfig {
     private static final String KESSEL_INVENTORY_CLIENT_ID = "inventory-api.authn.client.id";
     private static final String KESSEL_INVENTORY_URL = "inventory-api.target-url";
     private static final String KESSEL_INVENTORY_ENABLED = "notifications.kessel-inventory.enabled";
+    private static final String KESSEL_MIGRATION_BATCH_SIZE = "notifications.kessel.migration.batch.size";
     private static final String KESSEL_RELATIONS_ENABLED = "notifications.kessel-relations.enabled";
     private static final String KESSEL_RELATIONS_URL = "relations-api.target-url";
     private static final String KESSEL_DOMAIN = "notifications.kessel.domain";
@@ -73,6 +74,9 @@ public class BackendConfig {
 
     @ConfigProperty(name = KESSEL_INVENTORY_ENABLED, defaultValue = "false")
     boolean kesselInventoryEnabled;
+
+    @ConfigProperty(name = KESSEL_MIGRATION_BATCH_SIZE, defaultValue = "1000")
+    int kesselMigrationBatchSize;
 
     @ConfigProperty(name = KESSEL_RELATIONS_ENABLED, defaultValue = "false")
     boolean kesselRelationsEnabled;
@@ -175,6 +179,10 @@ public class BackendConfig {
      */
     public String getKesselInventoryReporterInstanceId() {
         return "service-account-" + kesselInventoryClientId;
+    }
+
+    public int getKesselMigrationBatchSize() {
+        return this.kesselMigrationBatchSize;
     }
 
     public boolean isKesselRelationsEnabled(String orgId) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -391,7 +391,8 @@ public class EndpointRepository {
     }
 
     /**
-     * Retrieves a list of endpoints.
+     * Retrieves a list of endpoints ordered by their creadtion date in
+     * ascending order —oldest first—.
      * @param limit the size of the list to retrieve.
      * @param offset the offset we should apply to skip the already read
      *               endpoints.
@@ -399,7 +400,7 @@ public class EndpointRepository {
      */
     public List<Endpoint> getNonSystemEndpointsWithLimitAndOffset(final int limit, final int offset) {
         return this.entityManager
-            .createQuery("FROM Endpoint WHERE orgId IS NOT NULL", Endpoint.class)
+            .createQuery("FROM Endpoint WHERE orgId IS NOT NULL ORDER BY created ASC", Endpoint.class)
             .setFirstResult(offset)
             .setMaxResults(limit)
             .getResultList();

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -397,9 +397,9 @@ public class EndpointRepository {
      *               endpoints.
      * @return a list of endpoints.
      */
-    public List<Endpoint> getEndpointsWithLimitAndOffset(final int limit, final int offset) {
+    public List<Endpoint> getNonSystemEndpointsWithLimitAndOffset(final int limit, final int offset) {
         return this.entityManager
-            .createQuery("FROM Endpoint", Endpoint.class)
+            .createQuery("FROM Endpoint WHERE orgId IS NOT NULL", Endpoint.class)
             .setFirstResult(offset)
             .setMaxResults(limit)
             .getResultList();

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -389,4 +389,19 @@ public class EndpointRepository {
             return Optional.empty();
         }
     }
+
+    /**
+     * Retrieves a list of endpoints.
+     * @param limit the size of the list to retrieve.
+     * @param offset the offset we should apply to skip the already read
+     *               endpoints.
+     * @return a list of endpoints.
+     */
+    public List<Endpoint> getEndpointsWithLimitAndOffset(final int limit, final int offset) {
+        return this.entityManager
+            .createQuery("FROM Endpoint", Endpoint.class)
+            .setFirstResult(offset)
+            .setMaxResults(limit)
+            .getResultList();
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
@@ -68,7 +68,7 @@ public class KesselAssetsMigrationService {
         int fetchedEndpointsSize = 0;
         int offset = 0;
         do {
-            final List<Endpoint> fetchedEndpoints = this.endpointRepository.getEndpointsWithLimitAndOffset(this.backendConfig.getKesselMigrationBatchSize(), offset);
+            final List<Endpoint> fetchedEndpoints = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(this.backendConfig.getKesselMigrationBatchSize(), offset);
 
             // If for some reason we have fetched full pages from the database
             // all the time, the last one might be empty, so there is no need

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
@@ -10,6 +10,9 @@ import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.Status;
 import io.grpc.stub.StreamObserver;
 import io.quarkus.logging.Log;
+import io.quarkus.security.UnauthorizedException;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -18,6 +21,8 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import org.project_kessel.api.relations.v1beta1.CreateTuplesRequest;
 import org.project_kessel.api.relations.v1beta1.CreateTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.ImportBulkTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.ImportBulkTuplesResponse;
 import org.project_kessel.api.relations.v1beta1.ObjectReference;
 import org.project_kessel.api.relations.v1beta1.ObjectType;
 import org.project_kessel.api.relations.v1beta1.Relationship;
@@ -26,6 +31,8 @@ import org.project_kessel.relations.client.RelationTuplesClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
 
@@ -38,7 +45,7 @@ public class KesselAssetsMigrationService {
      * the tuple to Kessel. <a href="https://github.com/RedHatInsights/rbac-config/blob/a806fb03c95959391eceb0b42c7eefd8ae2350ae/configs/prod/schemas/schema.zed#L3">
      * Reference</a>
      */
-    public static final String RELATION = "t_workspace";
+    public static final String RELATION = "workspace";
 
     @Inject
     BackendConfig backendConfig;
@@ -102,6 +109,44 @@ public class KesselAssetsMigrationService {
         Log.infof("Finished migrating integrations to the Kessel inventory");
     }
 
+    @Path("/kessel/migrate-assets/async")
+    @POST
+    public void migrateAssetsAsync() {
+        final int limit = this.backendConfig.getKesselMigrationBatchSize();
+
+        final AtomicInteger offsetContainer = new AtomicInteger(0);
+        final Multi<List<Endpoint>> integrationBatch = Multi
+            .createBy()
+            .repeating()
+            .supplier(
+                () -> offsetContainer.addAndGet(limit),
+                offset -> {
+                    final List<Endpoint> endpoints = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(limit, offset);
+                    Log.infof("[limit: %s][offset: %s] Fetched endpoint batch from the database", limit, offset);
+
+                    return endpoints;
+                }
+            ).whilst(endpoints -> endpoints.size() == limit);
+
+        final Multi<ImportBulkTuplesRequest> importBulkTuplesRequestMulti = integrationBatch
+            .map(endpoints -> endpoints.stream().map(this::mapEndpointToRelationship).toList())
+            .map(relationships -> ImportBulkTuplesRequest.newBuilder().addAllTuples(relationships).build());
+
+        final Uni<ImportBulkTuplesResponse> importBulkTuplesResponseUni = this.relationTuplesClient.importBulkTuplesUni(importBulkTuplesRequestMulti);
+
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final ImportBulkTuplesResponse response = importBulkTuplesResponseUni
+            .onFailure().invoke(failure::set)
+            .onFailure().recoverWithNull()
+            .await().indefinitely();
+
+        if (response == null) {
+            Log.errorf(failure.get(), "Unable to import integrations into Kessel");
+        } else {
+            Log.infof("%s endpoints imported into Kessel", response.getNumImported());
+        }
+    }
+
     /**
      * Creates a bulk import request ready to be sent to kessel.
      * @param endpoints the list of endpoints to create the bulk import request
@@ -113,25 +158,8 @@ public class KesselAssetsMigrationService {
 
         for (final Endpoint endpoint : endpoints) {
             try {
-                relations.add(
-                    Relationship.newBuilder()
-                        .setResource(
-                            ObjectReference.newBuilder()
-                                .setType(ResourceType.INTEGRATION.getKesselObjectType())
-                                .setId(endpoint.getId().toString())
-                                .build()
-                        ).setRelation(RELATION)
-                        .setSubject(
-                            SubjectReference.newBuilder()
-                                .setSubject(
-                                    ObjectReference.newBuilder()
-                                        .setType(ObjectType.newBuilder().setNamespace("rbac").setName("workspace").build())
-                                        .setId(this.workspaceUtils.getDefaultWorkspaceId(endpoint.getOrgId()).toString())
-                                        .build()
-                                ).build()
-                        ).build()
-                );
-            } catch (final IllegalStateException e) {
+                relations.add(this.mapEndpointToRelationship(endpoint));
+            } catch (final UnauthorizedException e) {
                 Log.errorf("[org_id: %s][endpoint_id: %s] Unable to get the default workspace");
             }
         }
@@ -140,5 +168,29 @@ public class KesselAssetsMigrationService {
             .newBuilder()
             .addAllTuples(relations)
             .build();
+    }
+
+    /**
+     * Maps an endpoint to a Kessel relationship.
+     * @param endpoint the endpoint to map.
+     * @return the generated relationship.
+     */
+    protected Relationship mapEndpointToRelationship(final Endpoint endpoint) {
+        return Relationship.newBuilder()
+            .setResource(
+                ObjectReference.newBuilder()
+                    .setType(ResourceType.INTEGRATION.getKesselObjectType())
+                    .setId(endpoint.getId().toString())
+                    .build()
+            ).setRelation(RELATION)
+            .setSubject(
+                SubjectReference.newBuilder()
+                    .setSubject(
+                        ObjectReference.newBuilder()
+                            .setType(ObjectType.newBuilder().setNamespace("rbac").setName("workspace").build())
+                            .setId(this.workspaceUtils.getDefaultWorkspaceId(endpoint.getOrgId()).toString())
+                            .build()
+                    ).build()
+            ).build();
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
@@ -1,0 +1,144 @@
+package com.redhat.cloud.notifications.routers.internal.kessel;
+
+import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
+import com.redhat.cloud.notifications.auth.kessel.ResourceType;
+import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
+import com.redhat.cloud.notifications.config.BackendConfig;
+import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
+import com.redhat.cloud.notifications.db.repositories.StatusRepository;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.Status;
+import io.grpc.stub.StreamObserver;
+import io.quarkus.logging.Log;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import org.project_kessel.api.relations.v1beta1.CreateTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.CreateTuplesResponse;
+import org.project_kessel.api.relations.v1beta1.ObjectReference;
+import org.project_kessel.api.relations.v1beta1.ObjectType;
+import org.project_kessel.api.relations.v1beta1.Relationship;
+import org.project_kessel.api.relations.v1beta1.SubjectReference;
+import org.project_kessel.relations.client.RelationTuplesClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+
+@ApplicationScoped
+@RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)
+@Path(API_INTERNAL)
+public class KesselAssetsMigrationService {
+    /**
+     * Defines the relation between the subject and the resource when passing
+     * the tuple to Kessel. <a href="https://github.com/RedHatInsights/rbac-config/blob/a806fb03c95959391eceb0b42c7eefd8ae2350ae/configs/prod/schemas/schema.zed#L3">
+     * Reference</a>
+     */
+    public static final String RELATION = "t_workspace";
+
+    @Inject
+    BackendConfig backendConfig;
+
+    @Inject
+    EndpointRepository endpointRepository;
+
+    @Inject
+    RelationTuplesClient relationTuplesClient;
+
+    @Inject
+    StatusRepository statusRepository;
+
+    @Inject
+    WorkspaceUtils workspaceUtils;
+
+    @Path("/kessel/migrate-assets")
+    @POST
+    public void migrateAssets() {
+        // We need the application to be in maintenance mode to avoid any
+        // updates to the database, which could cause the Notifications
+        // database and the Kessel inventory to be out of sync.
+        if (Status.MAINTENANCE != this.statusRepository.getCurrentStatus().getStatus()) {
+            throw new BadRequestException("Unable to execute migration because the application is not in maintenance mode");
+        }
+
+        int fetchedEndpointsSize = 0;
+        int offset = 0;
+        do {
+            final List<Endpoint> fetchedEndpoints = this.endpointRepository.getEndpointsWithLimitAndOffset(this.backendConfig.getKesselMigrationBatchSize(), offset);
+
+            // If for some reason we have fetched full pages from the database
+            // all the time, the last one might be empty, so there is no need
+            // to attempt calling Kessel.
+            if (fetchedEndpoints.isEmpty()) {
+                break;
+            }
+
+            final CreateTuplesRequest request = this.createTuplesRequest(fetchedEndpoints);
+            final int finalOffset = offset;
+            this.relationTuplesClient.createTuples(request, new StreamObserver<>() {
+                @Override
+                public void onNext(final CreateTuplesResponse createTuplesResponse) {
+                }
+
+                @Override
+                public void onError(final Throwable throwable) {
+                    Log.errorf(throwable, "[offset: %s][first_integration: %s][last_integration: %s] Unable to send batch of tuples to Kessel with offset %s", finalOffset, fetchedEndpoints.getFirst().getId(), fetchedEndpoints.getLast().getId());
+                }
+
+                @Override
+                public void onCompleted() {
+                    Log.infof("[offset: %s][first_integration: %s][last_integration: %s] Sent % integrations to Kessel", finalOffset, fetchedEndpoints.getFirst().getId(), fetchedEndpoints.getLast().getId(), fetchedEndpoints.size());
+                }
+            });
+
+            fetchedEndpointsSize = fetchedEndpoints.size();
+            offset += fetchedEndpoints.size();
+        } while (fetchedEndpointsSize == this.backendConfig.getKesselMigrationBatchSize());
+
+        Log.infof("Finished migrating integrations to the Kessel inventory");
+    }
+
+    /**
+     * Creates a bulk import request ready to be sent to kessel.
+     * @param endpoints the list of endpoints to create the bulk import request
+     *                  from.
+     * @return the bulk import request ready to be sent.
+     */
+    protected CreateTuplesRequest createTuplesRequest(final List<Endpoint> endpoints) {
+        final List<Relationship> relations = new ArrayList<>(endpoints.size());
+
+        for (final Endpoint endpoint : endpoints) {
+            try {
+                relations.add(
+                    Relationship.newBuilder()
+                        .setResource(
+                            ObjectReference.newBuilder()
+                                .setType(ResourceType.INTEGRATION.getKesselObjectType())
+                                .setId(endpoint.getId().toString())
+                                .build()
+                        ).setRelation(RELATION)
+                        .setSubject(
+                            SubjectReference.newBuilder()
+                                .setSubject(
+                                    ObjectReference.newBuilder()
+                                        .setType(ObjectType.newBuilder().setNamespace("rbac").setName("workspace").build())
+                                        .setId(this.workspaceUtils.getDefaultWorkspaceId(endpoint.getOrgId()).toString())
+                                        .build()
+                                ).build()
+                        ).build()
+                );
+            } catch (final IllegalStateException e) {
+                Log.errorf("[org_id: %s][endpoint_id: %s] Unable to get the default workspace");
+            }
+        }
+
+        return CreateTuplesRequest
+            .newBuilder()
+            .addAllTuples(relations)
+            .build();
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -6,7 +6,9 @@ import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
+import com.redhat.cloud.notifications.models.WebhookProperties;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.persistence.TypedQuery;
@@ -14,8 +16,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -300,13 +305,32 @@ public class EndpointRepositoryTest {
      */
     @Test
     void testGetNonSystemEndpointsWithLimitAndOffset() {
-        // Create a few regular endpoints.
-        for (int i = 0; i < 5; i++) {
-            this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, EndpointType.WEBHOOK);
+        // Create a few regular and migratable endpoints.
+        final int regularEndpointsToCreate = 10;
+        final ArrayList<Endpoint> createdEndpoints = new ArrayList<>(regularEndpointsToCreate);
+        final Random random = new Random();
+        for (int i = 0; i < regularEndpointsToCreate; i++) {
+            final WebhookProperties webhookProperties = new WebhookProperties();
+            webhookProperties.setDisableSslVerification(random.nextBoolean());
+            webhookProperties.setMethod(HttpType.GET);
+            webhookProperties.setUrl("https://redhat.com");
+
+            final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(
+                DEFAULT_ACCOUNT_ID,
+                DEFAULT_ORG_ID,
+                EndpointType.WEBHOOK,
+                null,
+                String.format("Webhook integration %s", i),
+                String.format("Webhook integration %s", i),
+                webhookProperties,
+                true,
+                LocalDateTime.now(ZoneOffset.UTC).minusDays(i)
+            );
+
+            createdEndpoints.add(createdEndpoint);
         }
 
         // Create a few system endpoints.
-        final Random random = new Random();
         for (int i = 0; i < 5; i++) {
             final SystemSubscriptionProperties properties = new SystemSubscriptionProperties();
             properties.setOnlyAdmins(random.nextBoolean());
@@ -326,7 +350,7 @@ public class EndpointRepositoryTest {
 
         // Call the function under test.
         final List<Endpoint> fetchedEndpoints = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(50, 0);
-        Assertions.assertEquals(5, fetchedEndpoints.size(), "unexpected number of endpoints fetched");
+        Assertions.assertEquals(regularEndpointsToCreate, fetchedEndpoints.size(), "unexpected number of endpoints fetched");
 
         // Make sure all the endpoints are non system endpoints.
         fetchedEndpoints.forEach(
@@ -340,8 +364,30 @@ public class EndpointRepositoryTest {
         final List<Endpoint> limitedEndpoints = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(1, 0);
         Assertions.assertEquals(1, limitedEndpoints.size(), "only one endpoint should have been fetched. The limit option has not been respected");
 
-        // Call the function under test with an offset.
-        final List<Endpoint> offsetedEndpoints = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(5, 3);
-        Assertions.assertEquals(2, offsetedEndpoints.size(), "since the offset was \"3\", only the two last endpoints should have been fetched");
+        // Call the function under test with an offset. Reverse the created
+        // endpoints so that the "oldest" one goes first in the list.+
+        final List<Endpoint> reversedEndpoints = createdEndpoints.reversed();
+        final Iterator<Endpoint> expectedEndpoints = reversedEndpoints.iterator();
+        for (int i = 0; i < regularEndpointsToCreate; i++) {
+            final List<Endpoint> offsetedEndpoint = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(1, i);
+            Assertions.assertEquals(1, offsetedEndpoint.size(), "only a single endpoint should hav been fetched since the limit is set to \"1\"");
+
+            // Compare the fetched endpoint from the database with the one we
+            // expect. ChronoUnit is used because the nanoseconds get trimmed
+            // when getting stored in the database, so technically both
+            // instants are not the same, but we know they are.
+            final Endpoint expectedEndpoint = expectedEndpoints.next();
+            Assertions.assertEquals(0, ChronoUnit.DAYS.between(expectedEndpoint.getCreated(), offsetedEndpoint.getFirst().getCreated()), String.format("the function under test should have fetched an endpoint created \"%s\" days ago", i));
+        }
+
+        // When applied the offset "0", we should get the oldest integration by
+        // default due to the "order by" clause.
+        final List<Endpoint> oldestEndpoint = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(1, 0);
+        Assertions.assertEquals(0, ChronoUnit.DAYS.between(reversedEndpoints.getFirst().getCreated(), oldestEndpoint.getFirst().getCreated()), "when the offset is \"0\", the oldest endpoint should have been fetched from the database");
+
+        // When applied the highest offset, the newest endpoint should have
+        // been fetched due to the "order by" clause.
+        final List<Endpoint> newestEndpoint = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(1, regularEndpointsToCreate - 1);
+        Assertions.assertEquals(0, ChronoUnit.DAYS.between(reversedEndpoints.getLast().getCreated(), newestEndpoint.getFirst().getCreated()), "when the offset is the highest one, the newest endpoint should have been fetched from the database");
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationServiceTest.java
@@ -1,0 +1,191 @@
+package com.redhat.cloud.notifications.routers.internal.kessel;
+
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.auth.kessel.ResourceType;
+import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
+import com.redhat.cloud.notifications.config.BackendConfig;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.repositories.StatusRepository;
+import com.redhat.cloud.notifications.models.CurrentStatus;
+import com.redhat.cloud.notifications.models.Status;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.apache.http.HttpStatus;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.project_kessel.api.relations.v1beta1.CreateTuplesRequest;
+import org.project_kessel.api.relations.v1beta1.ObjectReference;
+import org.project_kessel.api.relations.v1beta1.Relationship;
+import org.project_kessel.relations.client.RelationTuplesClient;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+public class KesselAssetsMigrationServiceTest extends DbIsolatedTest {
+    @ConfigProperty(name = "internal.admin-role")
+    String adminRole;
+
+    @InjectMock
+    BackendConfig backendConfig;
+
+    @InjectMock
+    RelationTuplesClient relationTuplesClient;
+
+    @InjectMock
+    StatusRepository statusRepository;
+
+    @InjectMock
+    WorkspaceUtils workspaceUtils;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    /**
+     * Tests that if the application isn't in maintenance mode the migration is
+     * not run, and a "bad request" response is returned.
+     */
+    @Test
+    void testNonMaintenanceModeBadRequest() {
+        // Simulate that the application is operating normally.
+        final CurrentStatus currentStatus = new CurrentStatus();
+        currentStatus.setStatus(Status.UP);
+        Mockito.when(this.statusRepository.getCurrentStatus()).thenReturn(currentStatus);
+
+        given()
+            .when()
+            .header(TestHelpers.createTurnpikeIdentityHeader(DEFAULT_USER, adminRole))
+            .post(API_INTERNAL + "/kessel/migrate-assets")
+            .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    /**
+     * Tests that when the integrations to migrate are less than the batch
+     * size, only one request is sent to Kessel.
+     */
+    @Test
+    void testMigrateLessThanBatchSizeAssetsKessel() {
+        // Simulate that the application is in maintenance mode.
+        final CurrentStatus currentStatus = new CurrentStatus();
+        currentStatus.setStatus(Status.MAINTENANCE);
+        Mockito.when(this.statusRepository.getCurrentStatus()).thenReturn(currentStatus);
+
+        // Simulate that the maximum batch size is 10 endpoints.
+        Mockito.when(this.backendConfig.getKesselMigrationBatchSize()).thenReturn(10);
+        final int integrationsToCreate = this.backendConfig.getKesselMigrationBatchSize() - 1;
+
+        // Mock the response we would get from RBAC when asking for the default
+        // workspace.
+        final UUID workspaceId = UUID.randomUUID();
+        Mockito.when(this.workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)).thenReturn(workspaceId);
+
+        this.resourceHelpers.createTestEndpoints(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, integrationsToCreate);
+
+        given()
+            .when()
+            .header(TestHelpers.createTurnpikeIdentityHeader(DEFAULT_USER, adminRole))
+            .post(API_INTERNAL + "/kessel/migrate-assets")
+            .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // Assert that the correct number of requests was generated for Kessel.
+        final ArgumentCaptor<CreateTuplesRequest> createTuplesRequestArgumentCaptor = ArgumentCaptor.forClass(CreateTuplesRequest.class);
+        Mockito.verify(this.relationTuplesClient, Mockito.times(1)).createTuples(createTuplesRequestArgumentCaptor.capture(), Mockito.any());
+
+        Assertions.assertEquals(
+            1,
+            createTuplesRequestArgumentCaptor.getAllValues().size(),
+            String.format("[maximum_batch_size: %s][calls_to_kessel: %s] Only one request should have been sent to Kessel, since the ", this.backendConfig.getKesselMigrationBatchSize(), createTuplesRequestArgumentCaptor.getAllValues().size())
+        );
+
+        // Assert that the "create request" has the expected data.
+        final CreateTuplesRequest createTuplesRequest = createTuplesRequestArgumentCaptor.getAllValues().getFirst();
+        this.assertCreateRequestIsCorrect(integrationsToCreate, workspaceId, createTuplesRequest);
+    }
+
+    /**
+     * Tests that when the integrations to migrate are more than the batch
+     * size, multiple requests are sent to Kessel.
+     */
+    @Test
+    void testMigrateMoreThanBatchSizeAssetsKessel() {
+        // Simulate that the application is in maintenance mode.
+        final CurrentStatus currentStatus = new CurrentStatus();
+        currentStatus.setStatus(Status.MAINTENANCE);
+        Mockito.when(this.statusRepository.getCurrentStatus()).thenReturn(currentStatus);
+
+        // Simulate that the maximum batch size is 10 endpoints.
+        Mockito.when(this.backendConfig.getKesselMigrationBatchSize()).thenReturn(10);
+        final int integrationsToCreate = this.backendConfig.getKesselMigrationBatchSize() * 3;
+
+        // Mock the response we would get from RBAC when asking for the default
+        // workspace.
+        final UUID workspaceId = UUID.randomUUID();
+        Mockito.when(this.workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)).thenReturn(workspaceId);
+
+        this.resourceHelpers.createTestEndpoints(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, integrationsToCreate);
+
+        given()
+            .when()
+            .header(TestHelpers.createTurnpikeIdentityHeader(DEFAULT_USER, adminRole))
+            .post(API_INTERNAL + "/kessel/migrate-assets")
+            .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // Assert that the correct number of requests was generated for Kessel.
+        final ArgumentCaptor<CreateTuplesRequest> createTuplesRequestArgumentCaptor = ArgumentCaptor.forClass(CreateTuplesRequest.class);
+        Mockito.verify(this.relationTuplesClient, Mockito.times(3)).createTuples(createTuplesRequestArgumentCaptor.capture(), Mockito.any());
+
+        Assertions.assertEquals(
+            3,
+            createTuplesRequestArgumentCaptor.getAllValues().size(),
+            String.format("[maximum_batch_size: %s][calls_to_kessel: %s] Only one request should have been sent to Kessel, since the ", this.backendConfig.getKesselMigrationBatchSize(), createTuplesRequestArgumentCaptor.getAllValues().size())
+        );
+
+        // Assert that the "create request" has the expected data.
+        for (final CreateTuplesRequest createTuplesRequest : createTuplesRequestArgumentCaptor.getAllValues()) {
+            this.assertCreateRequestIsCorrect(this.backendConfig.getKesselMigrationBatchSize(), workspaceId, createTuplesRequest);
+        }
+    }
+
+    /**
+     * Asserts that the given "create request" has the correct data.
+     * @param expectedTuplesToFind expected tuples to find inside the request.
+     * @param createTuplesRequest the request itself which is going to be
+     *                            asserted.
+     */
+    private void assertCreateRequestIsCorrect(final int expectedTuplesToFind, final UUID expectedWorkspaceId, final CreateTuplesRequest createTuplesRequest) {
+        final List<Relationship> relationshipTuples = createTuplesRequest.getTuplesList();
+
+        Assertions.assertEquals(
+            expectedTuplesToFind,
+            relationshipTuples.size(),
+            "Unexpected number of tuples created in the request"
+        );
+
+        for (final Relationship relationship : relationshipTuples) {
+            final ObjectReference objectReference = relationship.getResource();
+            Assertions.assertEquals(ResourceType.INTEGRATION.getKesselObjectType(), objectReference.getType(), "unexpected type set in the tuple");
+            Assertions.assertNotNull(objectReference.getId(), "the ID of the object reference is null, when the endpoint's ID should have been set instead");
+
+            Assertions.assertEquals(KesselAssetsMigrationService.RELATION, relationship.getRelation(), "unexpected relation set in the tuple");
+
+            final ObjectReference subjectReference = relationship.getSubject().getSubject();
+            Assertions.assertEquals("rbac", subjectReference.getType().getNamespace(), "incorrect namespace set for tuple");
+            Assertions.assertEquals("workspace", subjectReference.getType().getName(), "incorrect name set for tuple");
+            Assertions.assertEquals(expectedWorkspaceId.toString(), subjectReference.getId(), "incorrect workspace ID set in tuple");
+        }
+    }
+}


### PR DESCRIPTION
Implements the required migration endpoint so that Kessel can import the
integrations from Notifications.

## Dependency

- https://github.com/RedHatInsights/notifications-backend/pull/3016

## Jira ticket
[[RHCLOUD-35454]](https://issues.redhat.com/browse/RHCLOUD-35454)