### PR TITLE
fix(CI): use jq in checkimage

### DIFF
--- a/.github/workflows/base-image-auto-update.yml
+++ b/.github/workflows/base-image-auto-update.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up skopeo
         run: sudo apt-get install -y skopeo
       - name: Check change
-        run: skopeo inspect docker://registry.access.redhat.com/ubi8/openjdk-21-runtime:latest | grep Digest > .baseimage
+        run: skopeo inspect docker://registry.access.redhat.com/ubi8/openjdk-21-runtime:latest | jq .Digest --raw-output > .baseimage
       - name: Do change if the digest changed
         run: |
           git config user.name 'Update-a-Bot'


### PR DESCRIPTION
Use jq to query for image digest to remove the need to rely on skopeo inspect output having json keys in particular order. RHINENG-13679