### PR TITLE
RHCLOUD-35763 | feature: return proper authorization responses

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/permission/WorkspacePermission.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/permission/WorkspacePermission.java
@@ -10,6 +10,7 @@ public enum WorkspacePermission implements KesselPermission {
     EVENT_LOG_VIEW("notifications_event_log_view"),
     EVENT_TYPES_VIEW("notifications_event_types_view"),
     INTEGRATIONS_CREATE("notifications_integration_create"),
+    INTEGRATIONS_VIEW("notifications_integration_view"),
     DAILY_DIGEST_PREFERENCE_EDIT("notifications_daily_digest_preference_edit"),
     DAILY_DIGEST_PREFERENCE_VIEW("notifications_daily_digest_preference_view");
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -3,7 +3,6 @@ package com.redhat.cloud.notifications.routers;
 import com.redhat.cloud.notifications.Constants;
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
 import com.redhat.cloud.notifications.auth.kessel.KesselAuthorization;
-import com.redhat.cloud.notifications.auth.kessel.ResourceType;
 import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
 import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
 import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
@@ -370,7 +369,7 @@ public class NotificationResource {
         if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
             final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
             this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, workspaceId);
-            this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.VIEW, ResourceType.INTEGRATION, endpointId.toString());
+            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.VIEW, endpointId);
 
             return this.internalGetBehaviorGroupsAffectedByRemovalOfEndpoint(sec, endpointId);
         } else {
@@ -858,7 +857,7 @@ public class NotificationResource {
 
         if (backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
             for (UUID endpointId : endpointsIds) {
-                kesselAuthorization.hasPermissionOnResource(securityContext, IntegrationPermission.EDIT, ResourceType.INTEGRATION, endpointId.toString());
+                kesselAuthorization.hasPermissionOnIntegration(securityContext, IntegrationPermission.EDIT, endpointId);
             }
             return internalUpdateEventTypeEndpoints(securityContext, endpointsIds, eventTypeId);
         } else {

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselTestHelper.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselTestHelper.java
@@ -153,7 +153,7 @@ public class KesselTestHelper {
     }
 
     /**
-     * Mocks the {@link BackendConfig#isKesselRelationsEnabled()} so that it
+     * Mocks the {@link BackendConfig#isKesselRelationsEnabled(String)} so that it
      * returns the given boolean flag when asked, and also makes the {@link CheckClient}
      * return an "allowed" response when the flag is {@code true}.
      * @param isKesselRelationsEnabled is the Kessel relations enabled for the

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/QueryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/QueryTest.java
@@ -270,7 +270,7 @@ public class QueryTest {
             "offset", offsetValuesErrorMessages
         );
 
-        // Create an endpoint that will used in one of the URLs below.
+        // Create an endpoint that will be used in one of the URLs below.
         final UUID endpointId = UUID.randomUUID();
         Mockito.when(this.endpointRepository.existsByUuidAndOrgId(endpointId, DEFAULT_ORG_ID)).thenReturn(true);
 


### PR DESCRIPTION
In order to return consistent responses when an unauthorized principal
calls our APIs, we have decided as a team that we will return "not
found" responses.
    
The reasoning is that many existing services will not let you know
whether the resource exists or not if you are not authorized, so we
thought that following this pattern was a good idea.

## Jira ticket
[[RHCLOUD-35763]](https://issues.redhat.com/browse/RHCLOUd-35763)