### PR TITLE
RHCLOUD-35769 | feature: Kessel inventory tests

### DIFF
--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EmailsOnlyModeTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EmailsOnlyModeTest.java
@@ -82,8 +82,8 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
     @MethodSource("argumentsProvider")
     @ParameterizedTest
-    void testCreateUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testCreateUnsupportedEndpointType(final String apiPath, final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 
@@ -112,8 +112,8 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
     @MethodSource("argumentsProvider")
     @ParameterizedTest
-    void testUpdateUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testUpdateUnsupportedEndpointType(final String apiPath, final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 
@@ -146,8 +146,8 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
     @MethodSource("argumentsProvider")
     @ParameterizedTest
-    void testDeleteUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testDeleteUnsupportedEndpointType(final String apiPath, final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 
@@ -175,8 +175,8 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
     @MethodSource("argumentsProvider")
     @ParameterizedTest
-    void testEnableUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEnableUnsupportedEndpointType(final String apiPath, final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 
@@ -204,8 +204,8 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
     @MethodSource("argumentsProvider")
     @ParameterizedTest
-    void testDisableUnsupportedEndpointType(final String apiPath, final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testDisableUnsupportedEndpointType(final String apiPath, final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -44,6 +44,8 @@ import com.redhat.cloud.notifications.routers.models.EndpointPage;
 import com.redhat.cloud.notifications.routers.models.RequestSystemSubscriptionProperties;
 import com.redhat.cloud.notifications.routers.sources.Secret;
 import com.redhat.cloud.notifications.routers.sources.SourcesService;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.test.InjectMock;
@@ -72,6 +74,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.project_kessel.api.inventory.v1beta1.resources.CreateNotificationsIntegrationRequest;
+import org.project_kessel.api.inventory.v1beta1.resources.DeleteNotificationsIntegrationRequest;
+import org.project_kessel.api.inventory.v1beta1.resources.Metadata;
+import org.project_kessel.api.inventory.v1beta1.resources.NotificationsIntegration;
+import org.project_kessel.api.inventory.v1beta1.resources.ReporterData;
+import org.project_kessel.inventory.client.NotificationsIntegrationClient;
 import org.project_kessel.relations.client.CheckClient;
 import org.project_kessel.relations.client.LookupClient;
 
@@ -176,6 +184,13 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @InjectMock
     LookupClient lookupClient;
+
+    /**
+     * Mocked Kessel's inventory client so that the {@link KesselTestHelper}
+     * can be used.
+     */
+    @InjectMock
+    NotificationsIntegrationClient notificationsIntegrationClient;
 
     /**
      * We mock the sources service's REST client because there are a few tests
@@ -4114,5 +4129,407 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .put("/endpoints/{endpointId}/eventTypes")
             .then()
             .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    /**
+     * Tests that when the Kessel inventory back end's toggle is enabled, the
+     * integration creations and removals are notified to Kessel's Inventory
+     * API. We need to test for both cases when the Relations API is enabled or
+     * not, because we might enable the Inventory API way before we start using
+     * the Relations API.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testIntegrationCreationRemovalKesselInventory(final boolean isKesselRelationsApiEnabled) {
+        // Enable the Inventory API, and enable the integration removals too so
+        // that Kessel gets notified about them.
+        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled()).thenReturn(true);
+        Mockito.when(this.backendConfig.isKesselInventoryEnabled()).thenReturn(true);
+
+        // Conditionally enable the Relations API to test this in both
+        // scenarios.
+        Mockito.when(this.backendConfig.isKesselRelationsEnabled()).thenReturn(isKesselRelationsApiEnabled);
+
+        // Mock the reporter instance id.
+        Mockito.when(this.backendConfig.getKesselInventoryReporterInstanceId()).thenReturn("service-account-notifications");
+
+        // Create the identity header to be used in the requests.
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+
+        // Add full RBAC access for when the Relations API is disabled.
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
+
+        // Give the principal the "create endpoints" permission.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+
+        // Create the integration.
+        final Set<UUID> createdIntegration = this.addEndpoints(1, identityHeader);
+        Assertions.assertEquals(1, createdIntegration.size(), "only a single integration should have been created");
+
+        final UUID integrationId = createdIntegration.iterator().next();
+
+        // Verify that the integration's creation was communicated to the
+        // Inventory API.
+        Mockito.verify(this.notificationsIntegrationClient, Mockito.times(1)).CreateNotificationsIntegration(
+            CreateNotificationsIntegrationRequest.newBuilder()
+                .setIntegration(
+                    NotificationsIntegration.newBuilder()
+                        .setMetadata(Metadata.newBuilder()
+                            .setResourceType(ResourceType.INTEGRATION.getKesselRepresentation())
+                            .setWorkspace(WORKSPACE_ID_PLACEHOLDER)
+                            .build()
+                        ).setReporterData(ReporterData.newBuilder()
+                            .setLocalResourceId(integrationId.toString())
+                            .setReporterInstanceId(this.backendConfig.getKesselInventoryReporterInstanceId())
+                            .setReporterType(ReporterData.ReporterType.NOTIFICATIONS)
+                            .build()
+                        ).build()
+                ).build()
+        );
+
+        // Give the principal the permission to delete the integration.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.DELETE, ResourceType.INTEGRATION, integrationId.toString());
+
+        // Delete the integration.
+        given()
+            .header(identityHeader)
+            .when()
+            .contentType(JSON)
+            .pathParam("endpointId", integrationId)
+            .delete("/endpoints/{endpointId}")
+            .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // Verify that the integration's removal was communicated to the
+        // Inventory API.
+        Mockito.verify(this.notificationsIntegrationClient, Mockito.times(1)).DeleteNotificationsIntegration(
+            DeleteNotificationsIntegrationRequest.newBuilder()
+                .setReporterData(
+                    ReporterData.newBuilder()
+                        .setLocalResourceId(integrationId.toString())
+                        .setReporterInstanceId(this.backendConfig.getKesselInventoryReporterInstanceId())
+                        .setReporterType(ReporterData.ReporterType.NOTIFICATIONS)
+                ).build()
+        );
+    }
+
+    /**
+     * Tests that when we fail to save an integration in our database for some
+     * reason, the Inventory API does not get called to create an integration
+     * there.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testCreateIntegrationFailInventoryNotNotified(final boolean isKesselRelationsApiEnabled) {
+        // Enable the Inventory API.
+        Mockito.when(this.backendConfig.isKesselInventoryEnabled()).thenReturn(true);
+
+        // Conditionally enable the Relations API to test this in both
+        // scenarios.
+        Mockito.when(this.backendConfig.isKesselRelationsEnabled()).thenReturn(isKesselRelationsApiEnabled);
+
+        // Create the identity header to be used in the request.
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
+
+        // Mock the Kessel permission to be able to create the integration.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+
+        // Simulate an error when saving the integration in our database.
+        Mockito.doThrow(IllegalStateException.class).when(this.endpointRepository).createEndpoint(Mockito.any());
+
+        // Create the integration.
+        final CamelProperties slackProperties = new CamelProperties();
+        slackProperties.setDisableSslVerification(false);
+        slackProperties.setUrl(getMockServerUrl());
+
+        final Endpoint slackIntegration = new Endpoint();
+        slackIntegration.setDescription("I guess the camel is slacking");
+        slackIntegration.setEnabled(true);
+        slackIntegration.setName("Push the camel through the needle's ear");
+        slackIntegration.setProperties(slackProperties);
+        slackIntegration.setStatus(EndpointStatus.PROVISIONING);
+        slackIntegration.setSubType("slack");
+        slackIntegration.setType(EndpointType.CAMEL);
+
+        given()
+            .header(identityHeader)
+            .when()
+            .contentType(JSON)
+            .body(Json.encode(this.endpointMapper.toDTO(slackIntegration)))
+            .post("/endpoints")
+            .then()
+            .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+            .contentType(JSON);
+
+        // Assert that the Inventory API never got called.
+        Mockito.verify(this.notificationsIntegrationClient, Mockito.never()).CreateNotificationsIntegration(Mockito.any(CreateNotificationsIntegrationRequest.class));
+
+        // Assert that the transaction was rolled back and that the integration
+        // was not created.
+        this.assertNoIntegrationsInDatabase(identityHeader);
+    }
+
+    /**
+     * Tests that when the Inventory API returns any kind of error when
+     * attempting to create an integration, we also do not save it in our
+     * database.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testInventoryCreateIntegrationFailNotSavedInDatabase(final boolean isKesselRelationsApiEnabled) {
+        // Enable the Inventory API.
+        Mockito.when(this.backendConfig.isKesselInventoryEnabled()).thenReturn(true);
+
+        // Conditionally enable the Relations API to test this in both
+        // scenarios.
+        Mockito.when(this.backendConfig.isKesselRelationsEnabled()).thenReturn(isKesselRelationsApiEnabled);
+
+        // Create the identity header to be used in the request.
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
+
+        // Mock the Kessel permission to be able to create the integration.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.INTEGRATIONS_CREATE, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
+
+        // Simulate an error when saving the integration in the Inventory API.
+        Mockito.when(this.notificationsIntegrationClient.CreateNotificationsIntegration(Mockito.any(CreateNotificationsIntegrationRequest.class))).thenThrow(StatusRuntimeException.class);
+
+        // Create the integration.
+        final CamelProperties slackProperties = new CamelProperties();
+        slackProperties.setDisableSslVerification(false);
+        slackProperties.setUrl(getMockServerUrl());
+
+        final Endpoint slackIntegration = new Endpoint();
+        slackIntegration.setDescription("I guess the camel is slacking");
+        slackIntegration.setEnabled(true);
+        slackIntegration.setName("Push the camel through the needle's ear");
+        slackIntegration.setProperties(slackProperties);
+        slackIntegration.setStatus(EndpointStatus.PROVISIONING);
+        slackIntegration.setSubType("slack");
+        slackIntegration.setType(EndpointType.CAMEL);
+
+        given()
+            .header(identityHeader)
+            .when()
+            .contentType(JSON)
+            .body(Json.encode(this.endpointMapper.toDTO(slackIntegration)))
+            .post("/endpoints")
+            .then()
+            .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+            .contentType(JSON);
+
+        // Assert that the Inventory API never got called.
+        Mockito.verify(this.notificationsIntegrationClient, Mockito.never()).CreateNotificationsIntegration(Mockito.any(CreateNotificationsIntegrationRequest.class));
+
+        // Assert that the transaction was rolled back and that the integration
+        // was not created.
+        this.assertNoIntegrationsInDatabase(identityHeader);
+    }
+
+    /**
+     * Tests that when we fail to delete an integration from our database for
+     * some reason, the Inventory API does not get called to delete an
+     * integration from there.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testRemoveIntegrationFailInventoryNotNotified(final boolean isKesselRelationsApiEnabled) {
+        // Enable the Inventory API, and enable the integration removals too so
+        // that we can spot whether Kessel gets notified about them or not.
+        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled()).thenReturn(true);
+        Mockito.when(this.backendConfig.isKesselInventoryEnabled()).thenReturn(true);
+
+        // Conditionally enable the Relations API to test this in both
+        // scenarios.
+        Mockito.when(this.backendConfig.isKesselRelationsEnabled()).thenReturn(isKesselRelationsApiEnabled);
+
+        // Mock the reporter instance id.
+        Mockito.when(this.backendConfig.getKesselInventoryReporterInstanceId()).thenReturn("service-account-notifications");
+
+        // Create the integration we are going to attempt to delete.
+        final Endpoint integration = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, WEBHOOK);
+
+        // Simulate that removing the integration from our database throws an
+        // exception.
+        Mockito.doThrow(IllegalStateException.class).when(this.endpointRepository).deleteEndpoint(DEFAULT_ORG_ID, integration.getId());
+
+        // Create the identity header to be used in the request.
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
+
+        // Mock the Kessel permission to be able to delete the integration.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.DELETE, ResourceType.INTEGRATION, integration.getId().toString());
+
+        // Attempt deleting the integration.
+        given()
+            .header(identityHeader)
+            .pathParam("id", integration.getId())
+            .when()
+            .delete("/endpoints/{id}")
+            .then()
+            .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+
+        // Assert that the Inventory API never got called.
+        Mockito.verify(this.notificationsIntegrationClient, Mockito.never()).DeleteNotificationsIntegration(Mockito.any(DeleteNotificationsIntegrationRequest.class));
+
+        // Assert that the transaction was rolled back and that the integration
+        // was not deleted.
+        this.assertIntegrationExists(identityHeader, integration);
+    }
+
+    /**
+     * Tests that when we attempt to remove an integration from our database,
+     * if the Inventory API throws an exception, the whole transaction is
+     * rolled back and the integration does not get deleted from our database.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testInventoryDeleteIntegrationFailFailIntegrationNotRemovedFromDatabase(final boolean isKesselRelationsApiEnabled) {
+        // Enable the Inventory API, , and enable the integration removals too so
+        // that we can spot whether Kessel gets notified about them or not.
+        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled()).thenReturn(true);
+        Mockito.when(this.backendConfig.isKesselInventoryEnabled()).thenReturn(true);
+
+        // Conditionally enable the Relations API to test this in both
+        // scenarios.
+        Mockito.when(this.backendConfig.isKesselRelationsEnabled()).thenReturn(isKesselRelationsApiEnabled);
+
+        // Mock the reporter instance id.
+        Mockito.when(this.backendConfig.getKesselInventoryReporterInstanceId()).thenReturn("service-account-notifications");
+
+        // Create the integration we are going to attempt to delete.
+        final Endpoint integration = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, WEBHOOK);
+
+        // Simulate that the Kessel Inventory throws an exception.
+        Mockito.when(this.notificationsIntegrationClient.DeleteNotificationsIntegration(Mockito.any())).thenThrow(new StatusRuntimeException(Status.NOT_FOUND));
+
+        // Create the identity header to be used in the request.
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
+
+        // Mock the Kessel permission to be able to delete the integration.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.DELETE, ResourceType.INTEGRATION, integration.getId().toString());
+
+        // Attempt deleting the integration.
+        given()
+            .header(identityHeader)
+            .pathParam("id", integration.getId())
+            .when()
+            .delete("/endpoints/{id}")
+            .then()
+            .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+
+        // Assert that the transaction was rolled back and that the integration
+        // was not deleted.
+        this.assertIntegrationExists(identityHeader, integration);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testKesselInventoryIntegrationRemovalsDisabled(final boolean isKesselRelationsApiEnabled) {
+        // Enable the Inventory API, and disable integration removals so that
+        // we can test that the toggle works as expected.
+        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled()).thenReturn(false);
+        Mockito.when(this.backendConfig.isKesselInventoryEnabled()).thenReturn(true);
+
+        // Conditionally enable the Relations API to test this in both
+        // scenarios.
+        Mockito.when(this.backendConfig.isKesselRelationsEnabled()).thenReturn(isKesselRelationsApiEnabled);
+
+        // Create the integration we are going to attempt to delete.
+        final Endpoint integration = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, WEBHOOK);
+
+        // Create the identity header to be used in the request.
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
+
+        // Mock the Kessel permission to be able to delete the integration.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.DELETE, ResourceType.INTEGRATION, integration.getId().toString());
+
+        // Attempt deleting the integration.
+        given()
+            .header(identityHeader)
+            .pathParam("id", integration.getId())
+            .when()
+            .delete("/endpoints/{id}")
+            .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // Assert that the Inventory API never got called.
+        Mockito.verify(this.notificationsIntegrationClient, Mockito.never()).DeleteNotificationsIntegration(Mockito.any(DeleteNotificationsIntegrationRequest.class));
+
+        // Assert that the integration we created no longer exists in the
+        // database.
+        this.assertNoIntegrationsInDatabase(identityHeader);
+    }
+
+    /**
+     * Asserts that no integrations are present in the database by issuing a
+     * query directly and by calling the "/endpoints" REST endpoint.
+     * @param identityHeader the identity header to be used when fetching the
+     *                       list of integrations via the REST endpoint.
+     */
+    void assertNoIntegrationsInDatabase(final Header identityHeader) {
+        Assertions.assertTrue(this.entityManager.createQuery("FROM Endpoint").getResultList().isEmpty(), "when fetching all the integrations from the database, the list was not empty");
+
+        // It does not make sense to attempt fetching all the integrations from
+        // the back end when using the Relations API, because we would need to
+        // mock which integrations the principal is authorized to list, and
+        // since we are just trying to fetch them all to verify that none got
+        // created, it kind of defeats the purpose. We also do not have an ID
+        // we could use to even mock the Relations API, because the integration
+        // does not get created in the database.
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            return;
+        }
+
+        given()
+            .header(identityHeader)
+            .when()
+            .get("/endpoints")
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .body("data", Matchers.hasSize(0))
+            .body("links", Matchers.anEmptyMap())
+            .body("meta.count", Matchers.is(0));
+    }
+
+    /**
+     * Assert that the given integration is present in the database by issuing
+     * a query directly and by calling the "/endpoints/{id}" REST endpoint.
+     * @param identityHeader the identity header to be used when fetching the
+     *                       integration.
+     * @param endpoint the integration that we want to make sure that still
+     *                 exists on our end.
+     */
+    void assertIntegrationExists(final Header identityHeader, final Endpoint endpoint) {
+        Assertions.assertEquals(1, this.entityManager.createQuery("FROM Endpoint WHERE id=:id").setParameter("id", endpoint.getId()).getResultList().size(), "the integration was unexpectedly deleted from the database");
+
+        // Mock the Kessel permission to be able to fetch the endpoint. Also,
+        // simulate that the principal has edit permissions so that the Sources
+        // secrets are not redacted. We are not interested in testing any
+        // Sources' stuff in this assertion, but we need to give the principal
+        // this permission so that the check evaluates to something instead of
+        // throwing a "null pointer" exception.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.VIEW, ResourceType.INTEGRATION, endpoint.getId().toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.EDIT, ResourceType.INTEGRATION, endpoint.getId().toString());
+
+        given()
+            .header(identityHeader)
+            .when()
+            .pathParam("id", endpoint.getId())
+            .get("/endpoints/{id}")
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .contentType(JSON)
+            .body("id", Matchers.is(endpoint.getId().toString()));
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -231,8 +231,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointAdding(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointAdding(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -443,8 +443,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testRepeatedEndpointName(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testRepeatedEndpointName(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -584,8 +584,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointValidation(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointValidation(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -655,8 +655,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void addCamelEndpoint(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void addCamelEndpoint(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -745,8 +745,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void addBogusCamelEndpoint(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void addBogusCamelEndpoint(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -792,8 +792,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testForbidSlackChannelUsage(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testForbidSlackChannelUsage(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("account-id", "org-id", DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -888,8 +888,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testRequireHttpsSchemeServiceNow(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testRequireHttpsSchemeServiceNow(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         URI sNowUri = URI.create("http://redhat.com");
         testRequireHttpsScheme("servicenow", sNowUri);
@@ -897,8 +897,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testRequireHttpsSchemeSplunk(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testRequireHttpsSchemeSplunk(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         URI splunkUri = URI.create("http://redhat.com");
         testRequireHttpsScheme("splunk", splunkUri);
@@ -1003,8 +1003,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void addSlackEndpoint(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void addSlackEndpoint(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         final ConsoleIdentity ide = TestHelpers.decodeRhIdentityHeader(identityHeaderValue);
@@ -1094,8 +1094,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointUpdates(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointUpdates(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -1243,8 +1243,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @MethodSource
-    void testEndpointTypeQuery(final boolean isKesselEnabled, final Set<EndpointType> types) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointTypeQuery(final boolean isKesselRelationsApiEnabled, final Set<EndpointType> types) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -1369,8 +1369,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointLimiter(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointLimiter(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -1436,8 +1436,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testSortingOrder(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testSortingOrder(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -1530,8 +1530,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testWebhookAttributes(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testWebhookAttributes(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -1619,8 +1619,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testAddEndpointEmailSubscription(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testAddEndpointEmailSubscription(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -1797,8 +1797,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testAddEndpointDrawerSubscription(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testAddEndpointDrawerSubscription(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -1975,8 +1975,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testAddEndpointEmailSubscriptionRbac(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testAddEndpointEmailSubscriptionRbac(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String validGroupId = "f85517d0-063b-4eed-a501-e79ffc1f5ad3";
         String unknownGroupId = "f44f50d5-acab-482c-a3cf-087faf2c709c";
@@ -2056,8 +2056,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testUnknownEndpointTypes(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testUnknownEndpointTypes(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo("test-tenant", "test-orgid", "test-user");
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -2091,8 +2091,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testConnectionCount(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testConnectionCount(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -2161,8 +2161,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testActive(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testActive(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -2224,8 +2224,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testSearch(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testSearch(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -2273,8 +2273,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testSearchWithType(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testSearchWithType(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -2329,8 +2329,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointInvalidUrls(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointInvalidUrls(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         // Set up the RBAC access for the test.
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -2460,8 +2460,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointValidUrls(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointValidUrls(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         // Set up the RBAC access for the test.
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -2549,8 +2549,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void testEndpointSubtypeIsOnlyAllowedWhenRequired(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    public void testEndpointSubtypeIsOnlyAllowedWhenRequired(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String EMPTY = "empty";
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(EMPTY, EMPTY, DEFAULT_USER);
@@ -2615,8 +2615,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointTest(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointTest(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, EndpointType.CAMEL);
 
@@ -2654,8 +2654,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointTestNotFound(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointTestNotFound(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -2687,8 +2687,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointTestCustomMessage(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointTestCustomMessage(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, EndpointType.CAMEL);
 
@@ -2730,8 +2730,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testEndpointTestBlankMessageReturnsBadRequest(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testEndpointTestBlankMessageReturnsBadRequest(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, EndpointType.CAMEL);
 
@@ -2774,8 +2774,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
     */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void testUpdateEndpointCreateSecrets(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    public void testUpdateEndpointCreateSecrets(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -2878,8 +2878,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void testUpdateEndpointDeleteSecrets(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    public void testUpdateEndpointDeleteSecrets(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -2986,8 +2986,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void testUpdateEndpointUpdateSecrets(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    public void testUpdateEndpointUpdateSecrets(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -3114,8 +3114,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testAnsibleEndpointCRUD(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testAnsibleEndpointCRUD(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -3198,8 +3198,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void addPagerDutyEndpoint(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void addPagerDutyEndpoint(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
@@ -3278,8 +3278,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testSourcesSecretsDeletedWhenEndpointCreationFails(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testSourcesSecretsDeletedWhenEndpointCreationFails(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         WebhookProperties properties = new WebhookProperties();
         properties.setBasicAuthentication(new BasicAuthentication("username", "password"));
@@ -3973,8 +3973,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testNotFoundResponsesUnknownEndpointId(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testNotFoundResponsesUnknownEndpointId(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         // Add RBAC access.
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EventResourceTest.java
@@ -122,8 +122,8 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void shouldNotBeAllowedTogetEventLogsWhenUserHasNotificationsAccessRightsOnly(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "user2", NOTIFICATIONS_ACCESS_ONLY);
         given()
@@ -135,8 +135,8 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testAllQueryParams(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testAllQueryParams(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
         /*
          * This method is very long, but splitting it into several smaller ones would mean we have to recreate lots of
          * database records for each test. To avoid doing that, the data is only persisted once and many tests are run
@@ -641,8 +641,8 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testInsufficientPrivileges(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testInsufficientPrivileges(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         Header noAccessIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER + "no-access", NO_ACCESS);
         given()
@@ -654,8 +654,8 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testInvalidSortBy(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testInvalidSortBy(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
         this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.EVENT_LOG_VIEW, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
@@ -671,8 +671,8 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testInvalidLimit(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testInvalidLimit(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
         this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.EVENT_LOG_VIEW, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
@@ -695,8 +695,8 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void shouldBeAllowedToGetEventLogs(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void shouldBeAllowedToGetEventLogs(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         Header readAccessIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, NOTIFICATIONS_READ_ACCESS_ONLY);
         this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.EVENT_LOG_VIEW, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/OrgConfigResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/OrgConfigResourceTest.java
@@ -93,8 +93,8 @@ class OrgConfigResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testSaveDailyDigestTimePreference(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testSaveDailyDigestTimePreference(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         // check regular parameter
         this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.DAILY_DIGEST_PREFERENCE_EDIT, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
@@ -113,8 +113,8 @@ class OrgConfigResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testMinuteFilter(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testMinuteFilter(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
 
         final String ERROR_MESSAGE_WRONG_MINUTE_VALUE = "Accepted minute values are: 00, 15, 30, 45.";
 
@@ -132,8 +132,8 @@ class OrgConfigResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testGetDailyDigestTimePreference(final boolean isKesselEnabled) {
-        this.kesselTestHelper.mockKesselRelations(isKesselEnabled);
+    void testGetDailyDigestTimePreference(final boolean isKesselRelationsApiEnabled) {
+        this.kesselTestHelper.mockKesselRelations(isKesselRelationsApiEnabled);
         this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.DAILY_DIGEST_PREFERENCE_VIEW, ResourceType.WORKSPACE, WORKSPACE_ID_PLACEHOLDER);
 
         LocalTime foundedPreference = given()


### PR DESCRIPTION
feature: tests for the Kessel Inventory integration

Tests that creating and deleting integrations also notifies Kessel
Inventory about it. We also test if the "@Transactional" methods work as
expected and that we will not be creating a desynchronization between
our database and the Kessel Inventory if we suffer from any kind of
errors. More precisely:

- When saving the integration in our database fails, we check that
  Kessel does not get an "integration created" request.
- When we succesfully save an integration in our database but sending
  the "integration created" request to Kessel fails, we check that the
  whole transaction gets rolled back and no integration gets saved in
  our database.
- When deleting the integration in our database fails, we check that
  Kessel does not get an "integration deleted" request.
- Finally, when we successfully save the integration in our database but
  sending the "integration deleted" request to Kessel fails, we check
  that the whole transaction gets rolled back and that the integration
  does not get deleted from our database.

## Dependency

- https://github.com/RedHatInsights/notifications-backend/pull/3045

## Jira ticket
[[RHCLOUD-35769]](https://issues.redhat.com/browse/RHCLOUD-35769)