### PR TITLE
Fix serialization in PagerDuty AuthenticationProcessor

### DIFF
--- a/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/AuthenticationProcessor.java
+++ b/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/AuthenticationProcessor.java
@@ -26,9 +26,9 @@ public class AuthenticationProcessor implements Processor {
                 case BEARER -> throw new IllegalStateException("Unsupported authentication type: BEARER");
                 case SECRET_TOKEN -> {
                     if (secretPassword != null) {
-                        JsonObject message = exchange.getIn().getBody(JsonObject.class);
+                        JsonObject message = new JsonObject(exchange.getIn().getBody(String.class));
                         message.put(ROUTING_KEY, secretPassword);
-                        exchange.getIn().setBody(message);
+                        exchange.getIn().setBody(message.encode());
                     }
                 }
                 default -> throw new IllegalStateException("Unexpected authentication type: " + authType);


### PR DESCRIPTION
The message body is already serialized by PagerDutyTransformer, so it needs to be decoded and then re-encoded.