### PR TITLE
[RHCLOUD-34488] Fix sync between Behavior group and endpoint to event  types data models

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -669,10 +669,10 @@ public class NotificationResource {
             throw new BadRequestException("The behavior groups identifiers list should not contain empty values");
         }
         String orgId = getOrgId(securityContext);
-        behaviorGroupRepository.updateEventTypeBehaviors(orgId, eventTypeId, behaviorGroupIds);
+        Set<UUID> updatedBgs = behaviorGroupRepository.updateEventTypeBehaviors(orgId, eventTypeId, behaviorGroupIds);
 
         // Sync new endpoint to evenType data model
-        endpointEventTypeRepository.refreshEndpointLinksToEventTypeFromBehaviorGroup(orgId, behaviorGroupIds);
+        endpointEventTypeRepository.refreshEndpointLinksToEventTypeFromBehaviorGroup(orgId, updatedBgs);
         return Response.ok().build();
     }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -669,7 +669,7 @@ public class NotificationResource {
             throw new BadRequestException("The behavior groups identifiers list should not contain empty values");
         }
         String orgId = getOrgId(securityContext);
-        Set<UUID> updatedBgs = behaviorGroupRepository.updateEventTypeBehaviors(orgId, eventTypeId, behaviorGroupIds);
+        final Set<UUID> updatedBgs = behaviorGroupRepository.updateEventTypeBehaviors(orgId, eventTypeId, behaviorGroupIds);
 
         // Sync new endpoint to evenType data model
         endpointEventTypeRepository.refreshEndpointLinksToEventTypeFromBehaviorGroup(orgId, updatedBgs);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/NotificationResourceTest.java
@@ -2101,6 +2101,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
             .put("/notifications/eventTypes/{eventTypeId}/behaviorGroups")
             .then()
             .statusCode(HttpStatus.SC_OK);
+        assertEquals(1, helpers.getEndpoint(endpointId1).getEventTypes().size());
 
         // assign endpoint 2 to behavior group 2
         given()


### PR DESCRIPTION
We didn't handle properly the new data model sync when:
Some event types are removed from existing behavior groups using` /eventTypes/{eventTypeId}/behaviorGroups` api.