### PR TITLE
RHCLOUD-35813 | feature: implement Kessel permissions for the NotificationsResource

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/permission/WorkspacePermission.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/permission/WorkspacePermission.java
@@ -1,9 +1,14 @@
 package com.redhat.cloud.notifications.auth.kessel.permission;
 
 public enum WorkspacePermission implements KesselPermission {
+    APPLICATIONS_VIEW("notifications_applications_view"),
+    BUNDLES_VIEW("notifications_bundles_view"),
+    BEHAVIOR_GROUPS_EDIT("notifications_behavior_groups_edit"),
+    BEHAVIOR_GROUPS_VIEW("notifications_behavior_groups_view"),
     CREATE_DRAWER_INTEGRATION("notifications_integration_subscribe_drawer"),
     CREATE_EMAIL_SUBSCRIPTION_INTEGRATION("notifications_integration_subscribe_email"),
     EVENT_LOG_VIEW("notifications_event_log_view"),
+    EVENT_TYPES_VIEW("notifications_event_types_view"),
     INTEGRATIONS_CREATE("notifications_integration_create"),
     DAILY_DIGEST_PREFERENCE_EDIT("notifications_daily_digest_preference_edit"),
     DAILY_DIGEST_PREFERENCE_VIEW("notifications_daily_digest_preference_view");

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointEventTypeRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointEventTypeRepository.java
@@ -36,7 +36,7 @@ public class EndpointEventTypeRepository {
         String query = "SELECT e FROM Endpoint e JOIN e.eventTypes ev WHERE (e.orgId = :orgId OR e.orgId IS NULL) AND ev.id = :eventTypeId";
 
         if (authorizedIds.isPresent()) {
-            query += " AND ev.id in (:authorizedIds)";
+            query += " AND e.id in (:authorizedIds)";
         }
 
         if (limiter != null) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/NotificationResource.java
@@ -3,7 +3,10 @@ package com.redhat.cloud.notifications.routers;
 import com.redhat.cloud.notifications.Constants;
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
 import com.redhat.cloud.notifications.auth.kessel.KesselAuthorization;
+import com.redhat.cloud.notifications.auth.kessel.ResourceType;
 import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
+import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
+import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
@@ -102,19 +105,38 @@ public class NotificationResource {
     @Inject
     BackendConfig backendConfig;
 
+    @Inject
+    WorkspaceUtils workspaceUtils;
+
     @Path(Constants.API_NOTIFICATIONS_V_1_0 + "/notifications")
     public static class V1 extends NotificationResource {
         @GET
         @Path("/eventTypes/{eventTypeId}/behaviorGroups")
         @Produces(APPLICATION_JSON)
         @Operation(summary = "List the behavior groups linked to an event type", description = "Lists the behavior groups that are linked to an event type. Use this endpoint to see which behavior groups will be affected if you delete an event type.")
-        @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
         public List<BehaviorGroup> getLinkedBehaviorGroups(
             @Context SecurityContext sec,
             @PathParam("eventTypeId") UUID eventTypeId,
             @BeanParam @Valid Query query
         ) {
-            String orgId = getOrgId(sec);
+            if (this.backendConfig.isKesselRelationsEnabled()) {
+                final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+                this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+                this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
+                return this.internalGetLinkedBehaviorGroups(sec, eventTypeId, query);
+            } else {
+                return this.legacyRBACGetLinkedBehaviorGroups(sec, eventTypeId, query);
+            }
+        }
+
+        @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+        public List<BehaviorGroup> legacyRBACGetLinkedBehaviorGroups(final SecurityContext securityContext, final UUID eventTypeId, @Valid final Query query) {
+            return this.internalGetLinkedBehaviorGroups(securityContext, eventTypeId, query);
+        }
+
+        public List<BehaviorGroup> internalGetLinkedBehaviorGroups(final SecurityContext securityContext, final UUID eventTypeId, @Valid final Query query) {
+            String orgId = getOrgId(securityContext);
 
             return behaviorGroupRepository.findBehaviorGroupsByEventTypeId(orgId, eventTypeId, query);
         }
@@ -126,14 +148,30 @@ public class NotificationResource {
         @Path("/eventTypes/{eventTypeId}/behaviorGroups")
         @Produces(APPLICATION_JSON)
         @Operation(summary = "Retrieve the behavior groups linked to an event type.")
-        @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
         public Page<BehaviorGroup> getLinkedBehaviorGroups(
             @Context SecurityContext sec,
             @PathParam("eventTypeId") UUID eventTypeId,
             @BeanParam @Valid Query query,
             @Context UriInfo uriInfo
         ) {
-            String orgId = getOrgId(sec);
+            if (this.backendConfig.isKesselRelationsEnabled()) {
+                final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+                this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+                this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
+                return this.internalGetLinkedBehaviorGroups(sec, eventTypeId, query, uriInfo);
+            } else {
+                return this.legacyRBACGetLinkedBehaviorGroups(sec, eventTypeId, query, uriInfo);
+            }
+        }
+
+        @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+        public Page<BehaviorGroup> legacyRBACGetLinkedBehaviorGroups(final SecurityContext securityContext, final UUID eventTypeId, @Valid final Query query, final UriInfo uriInfo) {
+            return this.internalGetLinkedBehaviorGroups(securityContext, eventTypeId, query, uriInfo);
+        }
+
+        public Page<BehaviorGroup> internalGetLinkedBehaviorGroups(final SecurityContext securityContext, final UUID eventTypeId, @Valid final Query query, final UriInfo uriInfo) {
+            String orgId = getOrgId(securityContext);
 
             final List<BehaviorGroup> behaviorGroups = this.behaviorGroupRepository.findBehaviorGroupsByEventTypeId(orgId, eventTypeId, query);
             final long behaviorGroupCount = this.behaviorGroupRepository.countByEventTypeId(orgId, eventTypeId);
@@ -150,11 +188,26 @@ public class NotificationResource {
     @Path("/eventTypes")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List all event types", description = "Lists all event types. You can filter the returned list by bundle, application name, or unmuted types.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public Page<EventType> getEventTypes(
         @Context SecurityContext securityContext, @Context UriInfo uriInfo, @BeanParam @Valid Query query, @QueryParam("applicationIds") Set<UUID> applicationIds,
         @QueryParam("bundleId") UUID bundleId, @QueryParam("eventTypeName") String eventTypeName, @QueryParam("excludeMutedTypes") boolean excludeMutedTypes
     ) {
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalGetEventTypes(securityContext, uriInfo, query, applicationIds, bundleId, eventTypeName, excludeMutedTypes);
+        } else {
+            return this.legacyRBACGetEventTypes(securityContext, uriInfo, query, applicationIds, bundleId, eventTypeName, excludeMutedTypes);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+    public Page<EventType> legacyRBACGetEventTypes(final SecurityContext securityContext, final UriInfo uriInfo, @Valid final Query query, final Set<UUID> applicationIds, final UUID bundleId, final String eventTypeName, final boolean excludeMutedTypes) {
+        return this.internalGetEventTypes(securityContext, uriInfo, query, applicationIds, bundleId, eventTypeName, excludeMutedTypes);
+    }
+
+    public Page<EventType> internalGetEventTypes(final SecurityContext securityContext, final UriInfo uriInfo, @Valid final Query query, final Set<UUID> applicationIds, final UUID bundleId, final String eventTypeName, final boolean excludeMutedTypes) {
         List<UUID> unmutedEventTypeIds = excludeMutedTypes
             ? behaviorGroupRepository.findUnmutedEventTypes(getOrgId(securityContext), bundleId)
             : null;
@@ -172,8 +225,23 @@ public class NotificationResource {
     @Path("/bundles/{bundleName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve a bundle by name", description = "Retrieves the details of a bundle by searching by its name.")
+    public Bundle getBundleByName(@Context final SecurityContext securityContext, @PathParam("bundleName") String bundleName) {
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.BUNDLES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalGetBundleByName(bundleName);
+        } else {
+            return this.legacyRBACGetBundleByName(bundleName);
+        }
+    }
+
     @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public Bundle getBundleByName(@PathParam("bundleName") String bundleName) {
+    public Bundle legacyRBACGetBundleByName(final String bundleName) {
+        return this.internalGetBundleByName(bundleName);
+    }
+
+    public Bundle internalGetBundleByName(final String bundleName) {
         Bundle bundle = bundleRepository.getBundle(bundleName);
         if (bundle == null) {
             throw new NotFoundException();
@@ -186,11 +254,29 @@ public class NotificationResource {
     @Path("/bundles/{bundleName}/applications/{applicationName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve an application by bundle and application names", description = "Retrieves an application by bundle and application names. Use this endpoint to  find an application by searching for the bundle that the application is part of. This is useful if you do not know the UUID of the bundle or application.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+
     public Application getApplicationByNameAndBundleName(
+        @Context SecurityContext securityContext,
         @PathParam("bundleName") String bundleName,
         @PathParam("applicationName") String applicationName
     ) {
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.BUNDLES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.APPLICATIONS_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalGetApplicationByNameAndBundleName(bundleName, applicationName);
+        } else {
+            return this.legacyRBACGetAppliactionByNameAndBundleName(bundleName, applicationName);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+    public Application legacyRBACGetAppliactionByNameAndBundleName(final String bundleName, final String applicationName) {
+        return this.internalGetApplicationByNameAndBundleName(bundleName, applicationName);
+    }
+
+    public Application internalGetApplicationByNameAndBundleName(final String bundleName, final String applicationName) {
         Application application = applicationRepository.getApplication(bundleName, applicationName);
         if (application == null) {
             throw new NotFoundException();
@@ -203,12 +289,31 @@ public class NotificationResource {
     @Path("/bundles/{bundleName}/applications/{applicationName}/eventTypes/{eventTypeName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve an event type by bundle, application and event type names", description = "Retrieves the details of an event type by specifying the bundle name, the application name, and the event type name.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+
     public EventType getEventTypesByNameAndBundleAndApplicationName(
+        @Context SecurityContext securityContext,
         @PathParam("bundleName") String bundleName,
         @PathParam("applicationName") String applicationName,
         @PathParam("eventTypeName") String eventTypeName
     ) {
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.BUNDLES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.APPLICATIONS_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalGetEventTypesByNameAndBundleAndApplicationName(bundleName, applicationName, eventTypeName);
+        } else {
+            return this.legacyRBACGetEventTypesByNameAndBundleAndApplicationName(bundleName, applicationName, eventTypeName);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+    public EventType legacyRBACGetEventTypesByNameAndBundleAndApplicationName(final String bundleName, final String applicationName, final String eventTypeName) {
+        return this.internalGetEventTypesByNameAndBundleAndApplicationName(bundleName, applicationName, eventTypeName);
+    }
+
+    public EventType internalGetEventTypesByNameAndBundleAndApplicationName(final String bundleName, final String applicationName, final String eventTypeName) {
         EventType eventType = applicationRepository.getEventType(bundleName, applicationName, eventTypeName);
         if (eventType == null) {
             throw new NotFoundException();
@@ -226,10 +331,26 @@ public class NotificationResource {
     @Path("/eventTypes/affectedByRemovalOfBehaviorGroup/{behaviorGroupId}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List the event types affected by the removal of a behavior group", description = "Lists the event types that will be affected by the removal of a behavior group. Use this endpoint to see which event types will be removed if you delete a behavior group.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public List<EventType> getEventTypesAffectedByRemovalOfBehaviorGroup(@Context SecurityContext sec,
                                                                          @Parameter(description = "The UUID of the behavior group to check") @PathParam("behaviorGroupId") UUID behaviorGroupId) {
-        String orgId = getOrgId(sec);
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalGetEventTypesAffectedByRemovalOfBehaviorGroup(sec, behaviorGroupId);
+        } else {
+            return this.legacyRBACGetEventTypesAffectedByRemovalOfBehaviorGroup(sec, behaviorGroupId);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+    public List<EventType> legacyRBACGetEventTypesAffectedByRemovalOfBehaviorGroup(final SecurityContext securityContext, final UUID behaviorGroupId) {
+        return this.internalGetEventTypesAffectedByRemovalOfBehaviorGroup(securityContext, behaviorGroupId);
+    }
+
+    public List<EventType> internalGetEventTypesAffectedByRemovalOfBehaviorGroup(final SecurityContext securityContext, final UUID behaviorGroupId) {
+        String orgId = getOrgId(securityContext);
         return behaviorGroupRepository.findEventTypesByBehaviorGroupId(orgId, behaviorGroupId);
     }
 
@@ -241,8 +362,24 @@ public class NotificationResource {
     @Path("/behaviorGroups/affectedByRemovalOfEndpoint/{endpointId}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List the behavior groups affected by the removal of an endpoint", description = "Lists the behavior groups that are affected by the removal of an endpoint. Use this endpoint to understand how removing an endpoint affects existing behavior groups.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
     public List<BehaviorGroup> getBehaviorGroupsAffectedByRemovalOfEndpoint(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+            this.kesselAuthorization.hasPermissionOnResource(sec, IntegrationPermission.VIEW, ResourceType.INTEGRATION, endpointId.toString());
+
+            return this.internalGetBehaviorGroupsAffectedByRemovalOfEndpoint(sec, endpointId);
+        } else {
+            return this.legacyRBACGetBehaviorGroupsAffectedByRemovalOfEndpoint(sec, endpointId);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+    public List<BehaviorGroup> legacyRBACGetBehaviorGroupsAffectedByRemovalOfEndpoint(final SecurityContext securityContext, final UUID endpointId) {
+        return this.internalGetBehaviorGroupsAffectedByRemovalOfEndpoint(securityContext, endpointId);
+    }
+
+    public List<BehaviorGroup> internalGetBehaviorGroupsAffectedByRemovalOfEndpoint(final SecurityContext sec, final UUID endpointId) {
         String orgId = getOrgId(sec);
         return behaviorGroupRepository.findBehaviorGroupsByEndpointId(orgId, endpointId);
     }
@@ -297,14 +434,29 @@ public class NotificationResource {
         @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = CreateBehaviorGroupResponse.class))),
         @APIResponse(responseCode = "400", content = @Content(mediaType = TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING)), description = "Bad or no content passed.")
     })
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @Transactional
     public CreateBehaviorGroupResponse createBehaviorGroup(
         @Context final SecurityContext sec,
-        @RequestBody(required = true) @Valid @NotNull final CreateBehaviorGroupRequest request
+        @RequestBody(required = true) final CreateBehaviorGroupRequest request
     ) {
-        String accountId = getAccountId(sec);
-        String orgId = getOrgId(sec);
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalCreateBehaviorGroup(sec, request);
+        } else {
+            return this.legacyRBACInternalCreateBehaviorGroup(sec, request);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
+    public CreateBehaviorGroupResponse legacyRBACInternalCreateBehaviorGroup(final SecurityContext securityContext, final CreateBehaviorGroupRequest request) {
+        return this.internalCreateBehaviorGroup(securityContext, request);
+    }
+
+    public CreateBehaviorGroupResponse internalCreateBehaviorGroup(final SecurityContext securityContext, @NotNull @Valid CreateBehaviorGroupRequest request) {
+        String accountId = getAccountId(securityContext);
+        String orgId = getOrgId(securityContext);
 
         // We know that either the ID or the name are present because the
         // request gets validated before reaching this point, and therefore it
@@ -358,12 +510,27 @@ public class NotificationResource {
             description = "No behavior group found with the passed id.")
     })
     @Operation(summary = "Update a behavior group", description = "Updates the details of a behavior group. Use this endpoint to update the list of related endpoints and event types associated with this behavior group.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @Transactional
     public Response updateBehaviorGroup(@Context SecurityContext sec,
                                         @Parameter(description = "The UUID of the behavior group to update") @PathParam("id") UUID id,
-                                        @RequestBody(description = "New parameters", required = true) @NotNull @Valid UpdateBehaviorGroupRequest request) {
-        String orgId = getOrgId(sec);
+                                        @RequestBody(description = "New parameters", required = true) UpdateBehaviorGroupRequest request) {
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalUpdateBehaviorGroup(sec, id, request);
+        } else {
+            return this.legacyRBACInternalUpdateBehaviorGroup(sec, id, request);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
+    public Response legacyRBACInternalUpdateBehaviorGroup(final SecurityContext securityContext, final UUID id, UpdateBehaviorGroupRequest request) {
+        return this.internalUpdateBehaviorGroup(securityContext, id, request);
+    }
+
+    public Response internalUpdateBehaviorGroup(final SecurityContext securityContext, final UUID id, @NotNull @Valid UpdateBehaviorGroupRequest request) {
+        String orgId = getOrgId(securityContext);
 
         if (request.displayName != null) {
             UUID bundleId = behaviorGroupRepository.getBundleId(orgId, id);
@@ -394,11 +561,26 @@ public class NotificationResource {
     @Path("/behaviorGroups/{id}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Delete a behavior group", description = "Deletes a behavior group and all of its configured actions. Use this endpoint when you no longer need a behavior group.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @Transactional
     public Boolean deleteBehaviorGroup(@Context SecurityContext sec,
                                        @Parameter(description = "The UUID of the behavior group to delete") @PathParam("id") UUID behaviorGroupId) {
-        String orgId = getOrgId(sec);
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalDeleteBehaviorGroup(sec, behaviorGroupId);
+        } else {
+            return this.legacyRBACDeleteBehaviorGroup(sec, behaviorGroupId);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
+    public Boolean legacyRBACDeleteBehaviorGroup(final SecurityContext securityContext, final UUID behaviorGroupId) {
+        return this.internalDeleteBehaviorGroup(securityContext, behaviorGroupId);
+    }
+
+    public Boolean internalDeleteBehaviorGroup(final SecurityContext securityContext, final UUID behaviorGroupId) {
+        String orgId = getOrgId(securityContext);
         final List<UUID> endpointsLinkedToBgToDelete = endpointEventTypeRepository.findEndpointsByBehaviorGroupId(orgId, Set.of(behaviorGroupId));
         final Boolean response = behaviorGroupRepository.delete(orgId, behaviorGroupId);
         endpointEventTypeRepository.refreshEndpointLinksToEventType(orgId, endpointsLinkedToBgToDelete);
@@ -410,12 +592,27 @@ public class NotificationResource {
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
     @Operation(summary = "Update the list of behavior group actions", description = "Updates the list of actions to be executed in that particular behavior group after an event is received.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
     public Response updateBehaviorGroupActions(@Context SecurityContext sec,
                                                @Parameter(description = "The UUID of the behavior group to update") @PathParam("behaviorGroupId") UUID behaviorGroupId,
                                                @Parameter(description = "List of endpoint ids of the actions") List<UUID> endpointIds) {
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalUpdateBehaviorGroupActions(sec, behaviorGroupId, endpointIds);
+        } else {
+            return this.legacyRBACUpdateBehaviorGroupActions(sec, behaviorGroupId, endpointIds);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
+    public Response legacyRBACUpdateBehaviorGroupActions(final SecurityContext securityContext, final UUID behaviorGroupId, final List<UUID> endpointIds) {
+        return this.internalUpdateBehaviorGroupActions(securityContext, behaviorGroupId, endpointIds);
+    }
+
+    public Response internalUpdateBehaviorGroupActions(final SecurityContext securityContext, final UUID behaviorGroupId, final List<UUID> endpointIds) {
         if (endpointIds == null) {
             throw new BadRequestException("The request body must contain a list (possibly empty) of endpoints identifiers");
         }
@@ -426,7 +623,7 @@ public class NotificationResource {
         if (endpointIds.size() != endpointIds.stream().distinct().count()) {
             throw new BadRequestException("The endpoints identifiers list should not contain duplicates");
         }
-        String orgId = getOrgId(sec);
+        String orgId = getOrgId(securityContext);
         final List<UUID> endpointLinkedToBgBeforeUpdate = endpointEventTypeRepository.findEndpointsByBehaviorGroupId(orgId, Set.of(behaviorGroupId));
         behaviorGroupRepository.updateBehaviorGroupActions(orgId, behaviorGroupId, endpointIds);
         final List<UUID> endpointLinkedToBgAfterUpdate = endpointEventTypeRepository.findEndpointsByBehaviorGroupId(orgId, Set.of(behaviorGroupId));
@@ -441,12 +638,29 @@ public class NotificationResource {
     @Consumes(APPLICATION_JSON)
     @Produces(TEXT_PLAIN)
     @Operation(summary = "Update the list of behavior groups for an event type", description = "Updates the list of behavior groups associated with an event type.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
     public Response updateEventTypeBehaviors(@Context SecurityContext sec,
                                              @Parameter(description = "UUID of the eventType to associate with the behavior group(s)") @PathParam("eventTypeId") UUID eventTypeId,
                                              @Parameter(description = "Set of behavior group ids to associate") Set<UUID> behaviorGroupIds) {
+
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, ResourceType.WORKSPACE, workspaceId.toString());
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalUpdateEventTypeBehaviors(sec, eventTypeId, behaviorGroupIds);
+        } else {
+            return this.legacyRBACUpdateEventTypeBehaviors(sec, eventTypeId, behaviorGroupIds);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
+    public Response legacyRBACUpdateEventTypeBehaviors(final SecurityContext securityContext, final UUID eventTypeId, final Set<UUID> behaviorGroupIds) {
+        return this.internalUpdateEventTypeBehaviors(securityContext, eventTypeId, behaviorGroupIds);
+    }
+
+    public Response internalUpdateEventTypeBehaviors(final SecurityContext securityContext, final UUID eventTypeId, final Set<UUID> behaviorGroupIds) {
         if (behaviorGroupIds == null) {
             throw new BadRequestException("The request body must contain a list (possibly empty) of behavior groups identifiers");
         }
@@ -454,7 +668,7 @@ public class NotificationResource {
         if (behaviorGroupIds.contains(null)) {
             throw new BadRequestException("The behavior groups identifiers list should not contain empty values");
         }
-        String orgId = getOrgId(sec);
+        String orgId = getOrgId(securityContext);
         behaviorGroupRepository.updateEventTypeBehaviors(orgId, eventTypeId, behaviorGroupIds);
 
         // Sync new endpoint to evenType data model
@@ -471,13 +685,29 @@ public class NotificationResource {
     @PUT
     @Path("/eventTypes/{eventTypeUuid}/behaviorGroups/{behaviorGroupUuid}")
     @Operation(summary = "Add a behavior group to the given event type.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "204")
     public void appendBehaviorGroupToEventType(
         @Context final SecurityContext securityContext,
         @RestPath final UUID behaviorGroupUuid,
         @RestPath final UUID eventTypeUuid
     ) {
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, ResourceType.WORKSPACE, workspaceId.toString());
+
+            this.internalAppendBehaviorGroupToEventType(securityContext, behaviorGroupUuid, eventTypeUuid);
+        } else {
+            this.legacyRBACAppendBehaviorGroupToEventType(securityContext, behaviorGroupUuid, eventTypeUuid);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
+    protected void legacyRBACAppendBehaviorGroupToEventType(final SecurityContext securityContext, final UUID behaviorGroupUuid, final UUID eventTypeUuid)  {
+        this.internalAppendBehaviorGroupToEventType(securityContext, behaviorGroupUuid, eventTypeUuid);
+    }
+
+    protected void internalAppendBehaviorGroupToEventType(final SecurityContext securityContext, final UUID behaviorGroupUuid, final UUID eventTypeUuid) {
         final String orgId = getOrgId(securityContext);
 
         this.behaviorGroupRepository.appendBehaviorGroupToEventType(orgId, behaviorGroupUuid, eventTypeUuid);
@@ -489,13 +719,29 @@ public class NotificationResource {
     @DELETE
     @Path("/eventTypes/{eventTypeId}/behaviorGroups/{behaviorGroupId}")
     @Operation(summary = "Delete a behavior group from an event type", description = "Delete a behavior group from the specified event type.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     @APIResponse(responseCode = "204")
     public void deleteBehaviorGroupFromEventType(
         @Context final SecurityContext securityContext,
         @RestPath final UUID eventTypeId,
         @RestPath final UUID behaviorGroupId
     ) {
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+            this.kesselAuthorization.hasPermissionOnResource(securityContext, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, ResourceType.WORKSPACE, workspaceId.toString());
+
+            this.internalDeleteBehaviorGroupFromEventType(securityContext, eventTypeId, behaviorGroupId);
+        } else {
+            this.legacyRBACInternalDeleteBehaviorGroupFromEventType(securityContext, eventTypeId, behaviorGroupId);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
+    protected void legacyRBACInternalDeleteBehaviorGroupFromEventType(final SecurityContext securityContext, final UUID eventTypeId, final UUID behaviorGroupId) {
+        this.internalDeleteBehaviorGroupFromEventType(securityContext, eventTypeId, behaviorGroupId);
+    }
+
+    protected void internalDeleteBehaviorGroupFromEventType(final SecurityContext securityContext, final UUID eventTypeId, final UUID behaviorGroupId) {
         final String orgId = getOrgId(securityContext);
 
         this.behaviorGroupRepository.deleteBehaviorGroupFromEventType(eventTypeId, behaviorGroupId, orgId);
@@ -508,10 +754,27 @@ public class NotificationResource {
     @Path("/bundles/{bundleId}/behaviorGroups")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List behavior groups in a bundle", description = "Lists the behavior groups associated with a bundle. Use this endpoint to see the behavior groups that are configured for a particular bundle for a particular tenant.")
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+
     public List<BehaviorGroup> findBehaviorGroupsByBundleId(@Context SecurityContext sec,
                                                             @Parameter(description = "UUID of the bundle to retrieve the behavior groups for.") @PathParam("bundleId") UUID bundleId) {
-        String orgId = getOrgId(sec);
+        if (this.backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BUNDLES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
+            return this.internalFindBehaviorGroupsByBundleId(sec, bundleId);
+        } else {
+            return this.legacyRBACInternalFindBehaviorGroupsByBundleId(sec, bundleId);
+        }
+    }
+
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
+    protected List<BehaviorGroup> legacyRBACInternalFindBehaviorGroupsByBundleId(final SecurityContext securityContext, final UUID bundleId) {
+        return this.internalFindBehaviorGroupsByBundleId(securityContext, bundleId);
+    }
+
+    protected List<BehaviorGroup> internalFindBehaviorGroupsByBundleId(final SecurityContext securityContext, final UUID bundleId) {
+        String orgId = getOrgId(securityContext);
         List<BehaviorGroup> behaviorGroups = behaviorGroupRepository.findByBundleId(orgId, bundleId);
         endpointRepository.loadProperties(
             behaviorGroups
@@ -537,6 +800,9 @@ public class NotificationResource {
     @Tag(name = OApiFilter.PRIVATE)
     public Page<EndpointDTO> getLinkedEndpoints(@Context final SecurityContext sec, @RestPath("eventTypeId") final UUID eventTypeId, @BeanParam @Valid final Query query, @Context final UriInfo uriInfo) {
         if (backendConfig.isKesselRelationsEnabled()) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
+            this.kesselAuthorization.hasPermissionOnResource(sec, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, workspaceId.toString());
+
             // Fetch the set of integration IDs the user is authorized to view.
             final Set<UUID> authorizedIds = kesselAuthorization.lookupAuthorizedIntegrations(sec, IntegrationPermission.VIEW);
             if (authorizedIds.isEmpty()) {

--- a/common/src/test/java/com/redhat/cloud/notifications/TestConstants.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/TestConstants.java
@@ -5,6 +5,7 @@ package com.redhat.cloud.notifications;
 public class TestConstants {
     public static final String API_INTEGRATIONS_V_1_0 = "/api/integrations/v1.0";
     public static final String API_NOTIFICATIONS_V_1_0 = "/api/notifications/v1.0";
+    public static final String API_NOTIFICATIONS_V_2_0 = "/api/notifications/v2.0";
     public static final String API_NOTIFICATIONS_V_1 = "/api/notifications/v1";
     public static final String API_INTEGRATIONS_V_1 = "/api/integrations/v1";
 


### PR DESCRIPTION
These permissions are needed for when the integration with the Kessel Relations API is enabled. The Kessel permissions are derived from the existing ones, so in theory the old RBAC permissions should be mapped with the new ones we have specified here.

## Jira ticket
[[RHCLOUD-35813]](https://issues.redhat.com/browse/RHCLOUD-35813)