### PR TITLE
RHCLOUD-35479 | feature: handle more failure cases when fetching RBAC workspaces

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
@@ -78,9 +78,15 @@ public class WorkspaceUtils {
 
         // We have been told we are only going to have one workspace per
         // organization.
-        if (workspacePage.getMeta().getCount() > 1) {
-            Log.errorf("[org_id: %s] More than one workspace found for the organization: %s", orgId, workspacePage.getData());
-
+        final Long receivedWorkspaceCount = workspacePage.getMeta().getCount();
+        if (receivedWorkspaceCount == null) {
+            Log.errorf("[org_id: %s] Unable to get the workspace count from the response", orgId);
+            throw new UnauthorizedException();
+        } else if (receivedWorkspaceCount == 0) {
+            Log.errorf("[org_id: %s] No workspace was received in the response", orgId);
+            throw new UnauthorizedException();
+        } else if (receivedWorkspaceCount > 1) {
+            Log.errorf("[org_id: %s][received_workspace_count: %s] More than one workspace received for the organization: %s", orgId, receivedWorkspaceCount, workspacePage.getData());
             throw new UnauthorizedException();
         }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/MockServerConfig.java
@@ -75,6 +75,29 @@ public class MockServerConfig {
 
     /**
      * Adds a path in the MockServer for the {@link com.redhat.cloud.notifications.auth.rbac.RbacServer#getWorkspaces(String, String, String, String, Integer, Integer)}
+     * method, which simulates RBAC returning a response which does not have
+     * the expected "count" JSON key.
+     */
+    public static void addMissingCountFromWorkspacesResponseRbacEndpoint() {
+        getClient()
+            .when(
+                request()
+                    .withHeader("x-rh-rbac-psk", "development-psk-value")
+                    .withHeader("x-rh-rbac-client-id", WorkspaceUtils.APPLICATION_KEY)
+                    .withHeader("x-rh-rbac-org-id", DEFAULT_ORG_ID)
+                    .withQueryStringParameter(Parameter.param("offset", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_OFFSET)))
+                    .withQueryStringParameter(Parameter.param("limit", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_LIMIT)))
+                    .withPath("/api/rbac/v2/workspaces/")
+            ).respond(
+                response()
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                    .withStatusCode(HttpStatus.SC_OK)
+                    .withBody(getFileAsString("rbac-examples/workspaces/missing-count-response.json"))
+            );
+    }
+
+    /**
+     * Adds a path in the MockServer for the {@link com.redhat.cloud.notifications.auth.rbac.RbacServer#getWorkspaces(String, String, String, String, Integer, Integer)}
      * method, which simulates RBAC returning more than one workspace in the
      * response.
      */
@@ -116,6 +139,29 @@ public class MockServerConfig {
                     .withHeader("Content-Type", MediaType.APPLICATION_JSON)
                     .withStatusCode(HttpStatus.SC_OK)
                     .withBody(getFileAsString("rbac-examples/workspaces/single-default-workspace-response.json"))
+            );
+    }
+
+    /**
+     * Adds a path in the MockServer for the {@link com.redhat.cloud.notifications.auth.rbac.RbacServer#getWorkspaces(String, String, String, String, Integer, Integer)}
+     * method, which simulates RBAC returning a response with no workspaces in
+     * it.
+     */
+    public static void addNoReturnedWorkspacesResponseRbacEndpoint() {
+        getClient()
+            .when(
+                request()
+                    .withHeader("x-rh-rbac-psk", "development-psk-value")
+                    .withHeader("x-rh-rbac-client-id", WorkspaceUtils.APPLICATION_KEY)
+                    .withHeader("x-rh-rbac-org-id", DEFAULT_ORG_ID)
+                    .withQueryStringParameter(Parameter.param("offset", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_OFFSET)))
+                    .withQueryStringParameter(Parameter.param("limit", String.valueOf(WorkspaceUtils.REQUEST_DEFAULT_LIMIT)))
+                    .withPath("/api/rbac/v2/workspaces/")
+            ).respond(
+                response()
+                    .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                    .withStatusCode(HttpStatus.SC_OK)
+                    .withBody(getFileAsString("rbac-examples/workspaces/no-workspaces-response.json"))
             );
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtilsTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtilsTest.java
@@ -49,6 +49,22 @@ public class WorkspaceUtilsTest {
      */
     @Test
     void testInvalidNonDefaultWorkspacesReturnedThrowsException() {
+        MockServerConfig.addMissingCountFromWorkspacesResponseRbacEndpoint();
+
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () -> this.workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)
+        );
+
+        MockServerConfig.clearRbacWorkspaces();
+        MockServerConfig.addNoReturnedWorkspacesResponseRbacEndpoint();
+
+        Assertions.assertThrows(
+            UnauthorizedException.class,
+            () -> this.workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)
+        );
+
+        MockServerConfig.clearRbacWorkspaces();
         MockServerConfig.addMultipleReturningMultipleWorkspacesRbacEndpoint();
 
         Assertions.assertThrows(

--- a/backend/src/test/resources/rbac-examples/workspaces/missing-count-response.json
+++ b/backend/src/test/resources/rbac-examples/workspaces/missing-count-response.json
@@ -1,0 +1,9 @@
+{
+  "meta": {
+    "limit": 0,
+    "offset": 0
+  },
+  "links": {
+  },
+  "data": []
+}

--- a/backend/src/test/resources/rbac-examples/workspaces/no-workspaces-response.json
+++ b/backend/src/test/resources/rbac-examples/workspaces/no-workspaces-response.json
@@ -1,0 +1,14 @@
+{
+  "meta": {
+    "count": 0,
+    "limit": 0,
+    "offset": 0
+  },
+  "links": {
+    "first": "/api/rbac/v2/workspaces/?limit=0&offset=0",
+    "next": "/api/rbac/v2/workspaces/?limit=0&offset=0",
+    "previous": "/api/rbac/v2/workspaces/?limit=0&offset=0",
+    "last": "/api/rbac/v2/workspaces/?limit=0&offset=0"
+  },
+  "data": []
+}


### PR DESCRIPTION
Handles a couple more failure cases that we might encounter when fetching the workspaces from RBAC.

## Jira ticket
[[RHCLOUD-35479]](https://issues.redhat.com/browse/RHCLOUD-35479)