### PR TITLE
RHCLOUD-35769 | refactor: remove integration deletion feature flag

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -128,8 +128,6 @@ objects:
               optional: true
         - name: NOTIFICATIONS_KESSEL_INVENTORY_ENABLED
           value: ${NOTIFICATIONS_KESSEL_INVENTORY_ENABLED}
-        - name: NOTIFICATIONS_KESSEL_INVENTORY_INTEGRATIONS_REMOVAL_ENABLED
-          value: ${NOTIFICATIONS_KESSEL_INVENTORY_INTEGRATIONS_REMOVAL_ENABLED}
         - name: NOTIFICATIONS_KESSEL_RELATIONS_ENABLED
           value: ${NOTIFICATIONS_KESSEL_RELATIONS_ENABLED}
         - name: NOTIFICATIONS_KESSEL_BACKEND_ENABLED
@@ -267,9 +265,6 @@ parameters:
   value: "1000"
 - name: NOTIFICATIONS_KESSEL_INVENTORY_ENABLED
   description: Is the integration with Kessel's inventory enabled?
-  value: "false"
-- name: NOTIFICATIONS_KESSEL_INVENTORY_INTEGRATIONS_REMOVAL_ENABLED
-  description: Are integration removals enabled in Kessel?
   value: "false"
 - name: NOTIFICATIONS_KESSEL_INVENTORY_SECURE_CLIENTS
   description: Should the inventory gRPC client open channels over TLS?

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAssets.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAssets.java
@@ -84,10 +84,6 @@ public class KesselAssets {
      *                      our side.
      */
     public void deleteIntegration(final SecurityContext securityContext, final String workspaceId, final String integrationId) {
-        if (!this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled(SecurityContextUtil.getOrgId(securityContext))) {
-            return;
-        }
-
         // Build the request for Kessel's inventory.
         final DeleteNotificationsIntegrationRequest request = this.buildDeleteIntegrationRequest(integrationId);
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -27,7 +27,6 @@ public class BackendConfig {
     private static final String INSTANT_EMAILS = "notifications.instant-emails.enabled";
     private static final String KESSEL_INVENTORY_CLIENT_ID = "inventory-api.authn.client.id";
     private static final String KESSEL_INVENTORY_ENABLED = "notifications.kessel-inventory.enabled";
-    private static final String KESSEL_INVENTORY_INTEGRATIONS_REMOVAL_ENABLED = "notifications.kessel-inventory.integrations-removal.enabled";
     private static final String KESSEL_RELATIONS_ENABLED = "notifications.kessel-relations.enabled";
     private static final String KESSEL_DOMAIN = "notifications.kessel.domain";
     private static final String RBAC_PSKS = "notifications.rbac.psks";
@@ -71,9 +70,6 @@ public class BackendConfig {
     @ConfigProperty(name = KESSEL_INVENTORY_ENABLED, defaultValue = "false")
     boolean kesselInventoryEnabled;
 
-    @ConfigProperty(name = KESSEL_INVENTORY_INTEGRATIONS_REMOVAL_ENABLED, defaultValue = "false")
-    boolean kesselInventoryIntegrationRemovalsEnabled;
-
     @ConfigProperty(name = KESSEL_RELATIONS_ENABLED, defaultValue = "false")
     boolean kesselRelationsEnabled;
 
@@ -108,7 +104,6 @@ public class BackendConfig {
         config.put(EMAILS_ONLY_MODE, isEmailsOnlyModeEnabled());
         config.put(ERRATA_MIGRATION_BATCH_SIZE, getErrataMigrationBatchSize());
         config.put(KESSEL_INVENTORY_ENABLED, isKesselInventoryEnabled(null));
-        config.put(KESSEL_INVENTORY_INTEGRATIONS_REMOVAL_ENABLED, areKesselInventoryIntegrationRemovalsEnabled(null));
         config.put(KESSEL_RELATIONS_ENABLED, isKesselRelationsEnabled(null));
         config.put(INSTANT_EMAILS, isInstantEmailsEnabled());
         config.put(KESSEL_DOMAIN, getKesselDomain());
@@ -142,24 +137,6 @@ public class BackendConfig {
 
     public boolean isInstantEmailsEnabled() {
         return instantEmailsEnabled;
-    }
-
-    /**
-     * In the beginning, only the creation of the integrations was supported in
-     * the Kessel inventory. The removal of them was not implemented nor
-     * supported. There is a <a href="https://issues.redhat.com/browse/RHCLOUD-35755">
-     * bug filed</a> for an issue related to integration removals, so once we
-     * confirm everything works we can simply remove the feature flag.
-     * @return {@code true} if we are allowed to delete integrations from the
-     * Kessel inventory.
-     */
-    public boolean areKesselInventoryIntegrationRemovalsEnabled(String orgId) {
-        if (unleashEnabled) {
-            UnleashContext unleashContext = buildUnleashContextWithOrgId(orgId);
-            return unleash.isEnabled(kesselInventoryIntegrationsRemovalToggle, unleashContext, false);
-        } else {
-            return kesselInventoryIntegrationRemovalsEnabled;
-        }
     }
 
     public boolean isKesselInventoryEnabled(String orgId) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAssetsTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAssetsTest.java
@@ -21,7 +21,6 @@ import org.project_kessel.inventory.client.NotificationsIntegrationClient;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
 
 @QuarkusTest
 public class KesselAssetsTest {
@@ -67,9 +66,6 @@ public class KesselAssetsTest {
      */
     @Test
     void testDeleteIntegration() {
-        // Simulate that removing integrations is enabled.
-        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled(isNull())).thenReturn(true);
-
         // Mock the security context.
         final SecurityContext mockedSecurityContext = Mockito.mock(SecurityContext.class);
 
@@ -89,36 +85,6 @@ public class KesselAssetsTest {
 
         // Verify that the inventory call was made.
         Mockito.verify(this.notificationsIntegrationClient, Mockito.times(1)).DeleteNotificationsIntegration(Mockito.any(DeleteNotificationsIntegrationRequest.class));
-    }
-
-    /**
-     * Test that when the "removing integrations" toggle is disabled, no calls
-     * are made to Kessel to delete the integration from the inventory.
-     */
-    @Test
-    void testDeleteIntegrationDisabled() {
-        // Simulate that removing integrations is enabled.
-        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled(anyString())).thenReturn(false);
-
-        // Mock the security context.
-        final SecurityContext mockedSecurityContext = Mockito.mock(SecurityContext.class);
-
-        // Create a RhIdentity principal and assign it to the mocked security
-        // context.
-        final RhIdentity identity = Mockito.mock(RhIdentity.class);
-        Mockito.when(identity.getName()).thenReturn("Red Hat user");
-
-        final ConsolePrincipal<?> principal = new RhIdPrincipal(identity);
-        Mockito.when(mockedSecurityContext.getUserPrincipal()).thenReturn(principal);
-
-        // Enable the Kessel back end integration for this test.
-        Mockito.when(this.backendConfig.isKesselRelationsEnabled(anyString())).thenReturn(true);
-
-        // Call the function under test.
-        this.kesselAssets.deleteIntegration(mockedSecurityContext, UUID.randomUUID().toString(), UUID.randomUUID().toString());
-
-        // Verify that the inventory call was made.
-        Mockito.verify(this.notificationsIntegrationClient, Mockito.never()).DeleteNotificationsIntegration(Mockito.any(DeleteNotificationsIntegrationRequest.class));
     }
 
     /**

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -4177,9 +4177,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     void testIntegrationCreationRemovalKesselInventory(final boolean isKesselRelationsApiEnabled) {
-        // Enable the Inventory API, and enable the integration removals too so
-        // that Kessel gets notified about them.
-        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled(anyString())).thenReturn(true);
+        // Enable the Inventory API.
         Mockito.when(this.backendConfig.isKesselInventoryEnabled(anyString())).thenReturn(true);
 
         // Conditionally enable the Relations API to test this in both
@@ -4377,9 +4375,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     void testRemoveIntegrationFailInventoryNotNotified(final boolean isKesselRelationsApiEnabled) {
-        // Enable the Inventory API, and enable the integration removals too so
-        // that we can spot whether Kessel gets notified about them or not.
-        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled(anyString())).thenReturn(true);
+        // Enable the Inventory API.
         Mockito.when(this.backendConfig.isKesselInventoryEnabled(anyString())).thenReturn(true);
 
         // Conditionally enable the Relations API to test this in both
@@ -4429,9 +4425,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     void testInventoryDeleteIntegrationFailFailIntegrationNotRemovedFromDatabase(final boolean isKesselRelationsApiEnabled) {
-        // Enable the Inventory API, , and enable the integration removals too so
-        // that we can spot whether Kessel gets notified about them or not.
-        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled(anyString())).thenReturn(true);
+        // Enable the Inventory API.
         Mockito.when(this.backendConfig.isKesselInventoryEnabled(anyString())).thenReturn(true);
 
         // Conditionally enable the Relations API to test this in both
@@ -4467,47 +4461,6 @@ public class EndpointResourceTest extends DbIsolatedTest {
         // Assert that the transaction was rolled back and that the integration
         // was not deleted.
         this.assertIntegrationExists(identityHeader, integration);
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    void testKesselInventoryIntegrationRemovalsDisabled(final boolean isKesselRelationsApiEnabled) {
-        // Enable the Inventory API, and disable integration removals so that
-        // we can test that the toggle works as expected.
-        Mockito.when(this.backendConfig.areKesselInventoryIntegrationRemovalsEnabled(anyString())).thenReturn(false);
-        Mockito.when(this.backendConfig.isKesselInventoryEnabled(anyString())).thenReturn(true);
-
-        // Conditionally enable the Relations API to test this in both
-        // scenarios.
-        Mockito.when(this.backendConfig.isKesselRelationsEnabled(anyString())).thenReturn(isKesselRelationsApiEnabled);
-
-        // Create the integration we are going to attempt to delete.
-        final Endpoint integration = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, WEBHOOK);
-
-        // Create the identity header to be used in the request.
-        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
-        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
-        MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
-
-        // Mock the Kessel permission to be able to delete the integration.
-        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.DELETE, ResourceType.INTEGRATION, integration.getId().toString());
-
-        // Attempt deleting the integration.
-        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
-        given()
-            .header(identityHeader)
-            .pathParam("id", integration.getId())
-            .when()
-            .delete("/endpoints/{id}")
-            .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
-
-        // Assert that the Inventory API never got called.
-        Mockito.verify(this.notificationsIntegrationClient, Mockito.never()).DeleteNotificationsIntegration(Mockito.any(DeleteNotificationsIntegrationRequest.class));
-
-        // Assert that the integration we created no longer exists in the
-        // database.
-        this.assertNoIntegrationsInDatabase(identityHeader);
     }
 
     /**


### PR DESCRIPTION
The issue has been fixed and the integration deletion works with Kessel, so it is safe to remove the feature flag.

## Jira ticket
[[RHCLOUD-35769]](https://issues.redhat.com/browse/RHCLOUD-35769)