### PR TITLE
 RHCLOUD-35924 | feature: read and intercept the Kessel clients' URLs

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/config/KesselConfigInterceptor.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/KesselConfigInterceptor.java
@@ -1,0 +1,61 @@
+package com.redhat.cloud.notifications.config;
+
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.Priorities;
+import io.smallrye.config.SecretKeys;
+import jakarta.annotation.Priority;
+
+/**
+ * <p>A configuration interceptor which helps overriding the resolved
+ * configuration parameters for Kessel's inventory and relations APIs.</p>
+ *
+ * <p>The <a href="https://github.com/RedHatInsights/clowder-quarkus-config-source">clowder-quarkus-config-source</a>
+ * extension is very helpful to load the Clowder endpoints because it gets both
+ * the {@code hostname} and the {@code port} of the endpoints and returns them
+ * in the following format: {@code ${SCHEME}${HOST}${PORT}}, with the {@code
+ * scheme} being either {@code http} or {@code https}.</p>
+ *
+ * <p>The issue with the Kessel's properties is that the gRPC clients are
+ * expecting just the hostname and the port without any protocol scheme
+ * prepended, so when using the above extension the URLs always get prefixed
+ * with the HTTP protocol's schemes, and therefore the connections cannot be
+ * established with the gRPC servers.</p>
+ *
+ * <p>This class intercepts the resolved values for the specific properties of
+ * the clients and strips the scheme part, so that the Kessel clients are built
+ * with the proper URLs instead.</p>
+ *
+ * <p>The implementation was done following the <a href="https://quarkus.io/guides/config-extending-support#config-interceptors">
+ * Extending Configuration Support Quarkus tutorial</a>.</p>
+ */
+@Priority(Priorities.APPLICATION)
+public class KesselConfigInterceptor implements ConfigSourceInterceptor {
+    /**
+     * Overrides the {@code inventory-api.target-url}'s and
+     * {@code relations-api.target-url}'s URL by removing the "http" or "https"
+     * schemes.
+     * @param configSourceInterceptorContext the configuration source's
+     *                                       interceptor's context.
+     * @param name the name of the configuration property we are loading.
+     * @return the resolved configuration properties without the "http" or
+     * "https" schemes.
+     */
+    @Override
+    public ConfigValue getValue(final ConfigSourceInterceptorContext configSourceInterceptorContext, final String name) {
+        final ConfigValue configValue = SecretKeys.doLocked(() -> configSourceInterceptorContext.proceed(name));
+
+        if ((configValue != null) && (name.equals("inventory-api.target-url") || name.equals("relations-api.target-url"))) {
+            final String kesselUrl = configValue.getValue();
+
+            if (kesselUrl.startsWith("http://")) {
+                return configValue.withValue(kesselUrl.replace("http://", ""));
+            } else {
+                return configValue.withValue(kesselUrl.replace("https://", ""));
+            }
+        }
+
+        return configValue;
+    }
+}

--- a/backend/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/backend/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,0 +1,1 @@
+com.redhat.cloud.notifications.config.KesselConfigInterceptor

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -110,11 +110,11 @@ inventory-api.authn.client.issuer=http://localhost:8084/realms/redhat-external
 inventory-api.authn.client.secret=development-value-123
 inventory-api.authn.mode=oidc-client-credentials
 inventory-api.is-secure-clients=false
-inventory-api.target-url=localhost:9081
+inventory-api.target-url=${clowder.endpoints.kessel-inventory-api:localhost:9081}
 
 relations-api.authn.client.id=insights-notifications
 relations-api.authn.client.issuer=http://localhost:8084/realms/redhat-external
 relations-api.authn.client.secret=development-value-123
 relations-api.authn.mode=oidc-client-credentials
 relations-api.is-secure-clients=false
-relations-api.target-url=localhost:9000
+relations-api.target-url=${clowder.endpoints.kessel-relations-api:localhost:9000}


### PR DESCRIPTION
The previous configuration was pointing to the `localhost` URLs, so we needed to make sure that when using Clowder and the JSON configuration file, the proper URLs were being fed to build the Kessel clients.

However, the `clowder-quarkus-config-source` extension we use to resolve the properties always appends the `http` or `https` schemes to the URLs, and since the gRPC clients are expecting a `${HOSTNAME}:${PORT}` string, we had to implement a configuration interceptor to be able to fed the clients with the proper URLs.

## Jira ticket
[[RHCLOUD-35924]](https://issues.redhat.com/browse/RHCLOUD-35924)