### PR TITLE
RHCLOUD-35479 | refactor: inject the RBAC PSKS in the back end

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -134,6 +134,11 @@ objects:
           value: ${NOTIFICATIONS_KESSEL_RELATIONS_ENABLED}
         - name: NOTIFICATIONS_KESSEL_BACKEND_ENABLED
           value: ${NOTIFICATIONS_KESSEL_BACKEND_ENABLED}
+        - name: NOTIFICATIONS_RBAC_PSKS
+          valueFrom:
+            secretKeyRef:
+              name: rbac-psks
+              key: psks.json
         - name: NOTIFICATIONS_UNLEASH_ENABLED
           value: ${NOTIFICATIONS_UNLEASH_ENABLED}
         - name: QUARKUS_REST_CLIENT_RBAC_AUTHENTICATION_READ_TIMEOUT


### PR DESCRIPTION
I forgot to inject the RBAC PSKS in the back end when I developed the workspaces bit for Kessel, and the RBAC team told us that we were using an invalid PSK.

## Jira ticket
[[RHCLOUD-35479]](https://issues.redhat.com/browse/RHCLOUD-35479)