### PR TITLE
RHCLOUD-35924 | fix: name of the Kessel ClowdApps

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -16,8 +16,8 @@ objects:
     - notifications-engine
     - rbac
     optionalDependencies:
-    - inventory-api
-    - relations-api
+    - kessel-inventory
+    - kessel-relations
     - sources-api # https://issues.redhat.com/browse/RHCLOUD-23993
     database:
       name: notifications-backend


### PR DESCRIPTION
The name of the ClowdApps is wrong, and that's why Clowder cannot find them to include them in our configuration files.

## Jira ticket
[[RHCLOUD-35924]](https://issues.redhat.com/browse/RHCLOUD-35924)