### PR TITLE
RHCLOUD-34485 | feature: let the Kessel log levels go down to "trace"

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
@@ -97,8 +97,8 @@ public class KesselAuthorization {
         } catch (final Exception e) {
             Log.errorf(
                 e,
-                "[identity: %s][permission: %s][resource_type: %s][resource_id: %s] Runtime error when querying Kessel for a permission check with request payload: %s",
-                identity, permission, resourceType, resourceId, permissionCheckRequest
+                "[identity: %s][permission: %s][resource_type: %s][resource_id: %s] Unable to query Kessel for a permission on a resource",
+                identity, permission, resourceType, resourceId
             );
 
             throw e;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -105,6 +105,8 @@ quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242
 
 # Kessel
+quarkus.log.category."com.redhat.cloud.notifications.auth.kessel".min-level=TRACE
+
 inventory-api.authn.client.id=insights-notifications
 inventory-api.authn.client.issuer=http://localhost:8084/realms/redhat-external
 inventory-api.authn.client.secret=development-value-123


### PR DESCRIPTION
Unless the "min-level" setting is set to "trace" for the Kessel package, we will not be able to set the logging level to that level using Unleash.

## Jira ticket
[[RHCLOUD-34485]](https://issues.redhat.com/browse/RHCLOUD-34485)