### PR TITLE
RHCLOUD-34485 | feature: update API for Kessel Inventory's client

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAssets.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAssets.java
@@ -127,7 +127,7 @@ public class KesselAssets {
                 NotificationsIntegration.newBuilder()
                     .setMetadata(Metadata.newBuilder()
                         .setResourceType(ResourceType.INTEGRATION.getKesselRepresentation())
-                        .setWorkspace(workspaceId)
+                        .setWorkspaceId(workspaceId)
                         .build()
                     ).setReporterData(ReporterData.newBuilder()
                         .setLocalResourceId(integrationId)

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAssetsTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselAssetsTest.java
@@ -102,7 +102,7 @@ public class KesselAssetsTest {
         // Assert that the request was properly built.
         final Metadata metadata = request.getIntegration().getMetadata();
         Assertions.assertEquals(ResourceType.INTEGRATION.getKesselRepresentation(), metadata.getResourceType(), "the \"resource type\" should have been an integration");
-        Assertions.assertEquals(workspaceId, metadata.getWorkspace(), "the workspace ID was incorrectly set");
+        Assertions.assertEquals(workspaceId, metadata.getWorkspaceId(), "the workspace ID was incorrectly set");
 
         final ReporterData reporterData = request.getIntegration().getReporterData();
         Assertions.assertEquals(integrationId, reporterData.getLocalResourceId(), "the \"local resource id\" was incorrectly set");

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/EndpointResourceTest.java
@@ -4227,7 +4227,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
                     NotificationsIntegration.newBuilder()
                         .setMetadata(Metadata.newBuilder()
                             .setResourceType(ResourceType.INTEGRATION.getKesselRepresentation())
-                            .setWorkspace(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString())
+                            .setWorkspaceId(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString())
                             .build()
                         ).setReporterData(ReporterData.newBuilder()
                             .setLocalResourceId(integrationId.toString())

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <mapstruct.version>1.6.2</mapstruct.version>
-        <kessel.inventory-client.version>0.5</kessel.inventory-client.version>
+        <kessel.inventory-client.version>0.7</kessel.inventory-client.version>
         <kessel.oauth-client.version>11.20.1</kessel.oauth-client.version>
         <kessel.relationships-client.version>0.10</kessel.relationships-client.version>
 


### PR DESCRIPTION
The back end requested a "workspace_id" field that was not present in the client's API. It turns out they needed to update the client, and in turn, we needed to update our implementation too.

## Jira ticket
[[RHCLOUD-34485]](https://issues.redhat.com/browse/RHCLOUD-34485)