### PR TITLE
Add severity column

### DIFF
--- a/engine/src/main/resources/templates/Errata/securityEmailBodyV2.html
+++ b/engine/src/main/resources/templates/Errata/securityEmailBodyV2.html
@@ -15,7 +15,8 @@
         <thead>
             <tr>
               <th style="width: 30%">Security update</th>
-              <th style="width: 60%">Synopsis</th>
+              <th style="width: 15%">Severity</th>
+              <th style="width: 45%">Synopsis</th>
             </tr>
         </thead>
         <tbody>
@@ -23,6 +24,7 @@
                 {#each action.events}
                 <tr style="font-size: 14px;">
                     <td><a href="{action.context.base_url}{it.payload.id}" target="_blank">{it.payload.id}</a></td>
+                    <td>{it.payload.severity}</td>
                     <td>{it.payload.synopsis}</td>
                 </tr>
                 {/each}

--- a/engine/src/test/java/com/redhat/cloud/notifications/ErrataTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ErrataTestHelpers.java
@@ -35,7 +35,8 @@ public class ErrataTestHelpers {
                 .withPayload(
                     new Payload.PayloadBuilder()
                         .withAdditionalProperty("id", "RHSA-2024:2106")
-                        .withAdditionalProperty("synopsis", "Moderate: Red Hat build of Quarkus 3.8.4 release")
+                        .withAdditionalProperty("severity", "Moderate")
+                        .withAdditionalProperty("synopsis", "Red Hat build of Quarkus 3.8.4 release")
                         .build()
                 )
                 .build(),
@@ -44,7 +45,8 @@ public class ErrataTestHelpers {
                 .withPayload(
                     new Payload.PayloadBuilder()
                         .withAdditionalProperty("id", "RHSA-2024:3842")
-                        .withAdditionalProperty("synopsis", "Low: c-ares security update")
+                        .withAdditionalProperty("severity", "Important")
+                        .withAdditionalProperty("synopsis", "c-ares security update")
                         .build()
                 )
                 .build(),
@@ -53,7 +55,8 @@ public class ErrataTestHelpers {
                 .withPayload(
                     new Payload.PayloadBuilder()
                         .withAdditionalProperty("id", "RHSA-2024:3843")
-                        .withAdditionalProperty("synopsis", "Moderate: cockpit security update")
+                        .withAdditionalProperty("severity", "Low")
+                        .withAdditionalProperty("synopsis", "cockpit security update")
                         .build()
                 )
                 .build()

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestErrataTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestErrataTemplate.java
@@ -63,6 +63,7 @@ public class TestErrataTemplate extends EmailTemplatesInDbHelper {
         assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
         assertTrue(result.contains("secalert@redhat.com"));
+        assertTrue(result.contains("Moderate"), "Security advisory severity has a dedicated column");
     }
 
     @Test


### PR DESCRIPTION
This change adds a severity column for RHSA email notifications (not for RHEA or RHBAs), per CHAINSAW-6. Please refer to that ticket for a preview of the rendered HTML.

There is a corresponding back-end change to Errata Notifications (hosted on gitlab.cee) which updates the json messages we send to the notifications API. This changes in this MR rely on those back-end changes, so we need to coordinate deployment to production (and preferably stage as well, but that's less important.)

- [x] check this box when errata is dpeloyed

(In one test case I changed the severity from "Low" to "Important" to see how the larger word (and largest of the options) affected layout. This doesn't impact the tests, but I left it in as a convenience for when we inspect the layout in the future.)