### PR TITLE
RHCLOUD-36454 | feature: allow setting resource requests and limits for Floorist

### DIFF
--- a/.rhcicd/floorist/floorplan.yaml
+++ b/.rhcicd/floorist/floorplan.yaml
@@ -13,6 +13,13 @@ objects:
       secretName: ${FLOORIST_DB_SECRET_NAME}
     objectStore:
       secretName: ${FLOORIST_BUCKET_SECRET_NAME}
+    resources:
+      limits:
+        cpu: ${FLOORIST_CPU_LIMIT}
+        memory: ${FLOORIST_MEMORY_LIMIT}
+      requests:
+        cpu: ${FLOORIST_CPU_REQUEST}
+        memory: ${FLOORIST_MEMORY_REQUEST}
     suspend: ${{FLOORIST_SUSPEND}}
     queries:
       # List the behavior groups and the event type they are associated with
@@ -225,6 +232,13 @@ objects:
       secretName: ${FLOORIST_DB_SECRET_NAME}
     objectStore:
       secretName: ${FLOORIST_HMS_BUCKET_SECRET_NAME}
+    resources:
+      limits:
+        cpu: ${FLOORIST_CPU_LIMIT}
+        memory: ${FLOORIST_MEMORY_LIMIT}
+      requests:
+        cpu: ${FLOORIST_CPU_REQUEST}
+        memory: ${FLOORIST_MEMORY_REQUEST}
     logLevel: ${FLOORIST_LOGLEVEL}
     suspend: ${{FLOORIST_SUSPEND}}
     queries:
@@ -271,6 +285,12 @@ parameters:
   description: Floorist's S3 bucket's secret name
   required: true
   value: dummy-secret
+- name: FLOORIST_CPU_REQUEST
+  description: The amount of minimum CPU requested for running the FloorPlan.
+  value: 50m
+- name: FLOORIST_CPU_LIMIT
+  description: The maximum amount of CPU that the FloorPlan is allowed to use before it gets throttled.
+  value: 100m
 - name: FLOORIST_DB_SECRET_NAME
   description: The database's secret name specification for the Floorist operator.
   value: notifications-backend-db
@@ -283,6 +303,10 @@ parameters:
 - name: FLOORIST_LOGLEVEL
   description: Floorist loglevel config
   value: 'INFO'
+- name: FLOORIST_MEMORY_REQUEST
+  description: The amount of minimum memory requested for running the FloorPlan.
+- name: FLOORIST_MEMORY_LIMIT
+  description: The maximum amount of memory that the FloorPlan is allowed to use before getting "out of memory" errors.
 - name: FLOORIST_SUSPEND
   description: Disable Floorist cronjob execution
   required: true

--- a/.rhcicd/floorist/floorplan.yaml
+++ b/.rhcicd/floorist/floorplan.yaml
@@ -305,8 +305,10 @@ parameters:
   value: 'INFO'
 - name: FLOORIST_MEMORY_REQUEST
   description: The amount of minimum memory requested for running the FloorPlan.
+  value: 250Mi
 - name: FLOORIST_MEMORY_LIMIT
   description: The maximum amount of memory that the FloorPlan is allowed to use before getting "out of memory" errors.
+  value: 500Mi
 - name: FLOORIST_SUSPEND
   description: Disable Floorist cronjob execution
   required: true


### PR DESCRIPTION
The pods need a way to be able to adjust their resource requests and limits, in case they run out of resources while running.

## Jira ticket
[[RHCLOUD-36454]](https://issues.redhat.com/browse/RHCLOUD-36454)