### PR TITLE
RHCLOUD-36553 | feature: log RBAC requests and responses

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
@@ -4,9 +4,15 @@ import io.quarkus.logging.Log;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientResponseContext;
 import jakarta.ws.rs.client.ClientResponseFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Filter to look at the response (code) from the Rbac server.
@@ -15,13 +21,64 @@ import java.io.IOException;
 public class RbacClientResponseFilter implements ClientResponseFilter {
 
     @Override
-    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
-        Response.StatusType statusInfo = responseContext.getStatusInfo();
-        int status = statusInfo.getStatusCode();
-        if (status == 0) {
-            Log.infof("Call to the Rbac server failed with code %d, %s", status, statusInfo.getReasonPhrase());
-        } else if (status != 200) {
-            Log.warnf("Call to the Rbac server failed with code %d, %s", status, statusInfo.getReasonPhrase());
+    public void filter(final ClientRequestContext requestContext, final ClientResponseContext responseContext) throws IOException {
+        final int responseStatusCode = responseContext.getStatusInfo().getStatusCode();
+        if (Response.Status.Family.familyOf(responseStatusCode) == Response.Status.Family.SUCCESSFUL) {
+            return;
         }
+
+        Log.warnf("[response_status_code: %s] RBAC responded with a non 2xx status code", responseStatusCode);
+
+        // When the logging level is set to TRACE or lower for this class, log
+        // both the request's and the response's details.
+        final Logger logger = Logger.getLogger(this.getClass().getName());
+        final Level logLevel = logger.getLevel();
+        if (Level.FINEST.equals(logLevel) || Level.FINER.equals(logLevel)) {
+            Log.tracef(
+                "[request_method: %s][request_uri: %s][request_headers: %s] Sent RBAC request",
+                requestContext.getMethod(),
+                requestContext.getUri(),
+                String.format("{%s}", this.headersToString(requestContext.getStringHeaders())),
+                responseStatusCode
+            );
+
+            Log.tracef(
+                "[response_headers: %s][response_status_code: %s][response_body: %s] Received RBAC response",
+                this.headersToString(responseContext.getHeaders()),
+                responseStatusCode,
+                new String(responseContext.getEntityStream().readAllBytes(), StandardCharsets.UTF_8)
+            );
+        }
+    }
+
+    /**
+     * Transforms the incoming headers to a human-readable format.
+     * @param headers the incoming headers to transform.
+     * @return a string containing the headers with the following format:
+     * {@code {header1=value1, header2=[value2, value3]}}.
+     */
+    private String headersToString(final MultivaluedMap<String, String> headers) {
+        final StringBuilder sb = new StringBuilder();
+        for (final Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            sb.append(entry.getKey());
+            sb.append("=");
+
+            // Redact the PSK secret for the headers' value.
+            if (entry.getKey().contains("psk")) {
+                sb.append("REDACTED");
+            } else {
+                // When the headers contain a single value, spare the square
+                // brackets.
+                if (entry.getValue().size() == 1) {
+                    sb.append(entry.getValue().getFirst());
+                } else {
+                    sb.append(entry.getValue());
+                }
+
+                sb.append(",");
+            }
+        }
+
+        return sb.toString();
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -40,6 +40,7 @@ internal-rbac.enabled=false
 
 # RBAC configuration used during user authentication. It is used when a public REST API is called.
 #quarkus.rest-client.rbac-authentication.url=http://ci.foo.redhat.com:1337
+quarkus.log.category."com.redhat.cloud.notifications.auth.rbac.RbacClientResponseFilter".min-level=TRACE
 quarkus.rest-client.rbac-authentication.url=${clowder.endpoints.rbac-service.url:https://ci.cloud.redhat.com}
 quarkus.rest-client.rbac-authentication.trust-store=${clowder.endpoints.rbac-service.trust-store-path}
 quarkus.rest-client.rbac-authentication.trust-store-password=${clowder.endpoints.rbac-service.trust-store-password}


### PR DESCRIPTION
The goal is to be able to log the key requests and responses that we send, so that we can figure out what the problem is when calling RBAC.

The reason for implementing custom logging instead of using the [REST
Client's logging](https://quarkus.io/guides/rest-client#logging-traffic) is that we want to be able to log the requests only
when we receive a non "2xx" response, since otherwise it would produce
too much noise with all the successful requests that we send.
## Jira ticket
[[RHCLOUD-36553]](https://issues.redhat.com/browse/RHCLOUD-36553)