### PR TITLE
RHCLOUD-35454 | fix: incorrect logging for the Kessel migration service

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
@@ -147,7 +147,7 @@ public class KesselAssetsMigrationService {
             try {
                 relations.add(this.mapEndpointToRelationship(endpoint));
             } catch (final UnauthorizedException e) {
-                Log.errorf("[org_id: %s][endpoint_id: %s] Unable to get the default workspace");
+                Log.errorf("[org_id: %s][endpoint_id: %s] Unable to get the default workspace for integration", endpoint.getOrgId(), endpoint.getId());
             }
         }
 


### PR DESCRIPTION
The log message is not properly formatted and therefore it doesn't provide the information we intended to provide when things go wrong.

## Jira ticket
[[RHCLOUD-35454]](https://issues.redhat.com/browse/RHCLOUD-35454)