### PR TITLE
RHCLOUD-36553 | fix: RBAC requests without headers fail to be logged

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacClientResponseFilter.java
@@ -58,6 +58,10 @@ public class RbacClientResponseFilter implements ClientResponseFilter {
      * {@code {header1=value1, header2=[value2, value3]}}.
      */
     private String headersToString(final MultivaluedMap<String, String> headers) {
+        if (headers == null || headers.isEmpty()) {
+            return "";
+        }
+
         final StringBuilder sb = new StringBuilder();
         for (final Map.Entry<String, List<String>> entry : headers.entrySet()) {
             sb.append(entry.getKey());


### PR DESCRIPTION
There are certain failing RBAC requests which do not have headers, and when we try to log them, the code throws an exception because of course the map of requests is null, and we can't access its elements.

## Jira ticket
[[RHCLOUD-36553]](https://issues.redhat.com/browse/RHCLOUD-36553)