### PR TITLE
RHCLOUD-35454 | fix: RBAC workspace exceptions stop the bulk import for Kessel

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
@@ -8,7 +8,6 @@ import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.models.Endpoint;
 import io.grpc.stub.StreamObserver;
 import io.quarkus.logging.Log;
-import io.quarkus.security.UnauthorizedException;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import jakarta.annotation.security.RolesAllowed;
@@ -164,7 +163,7 @@ public class KesselAssetsMigrationService {
         for (final Endpoint endpoint : endpoints) {
             try {
                 relations.add(this.mapEndpointToRelationship(endpoint));
-            } catch (final UnauthorizedException e) {
+            } catch (final Exception e) {
                 Log.errorf("[org_id: %s][endpoint_id: %s] Unable to get the default workspace for integration", endpoint.getOrgId(), endpoint.getId());
             }
         }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -197,6 +197,7 @@ public class ResourceHelpers {
     public Stats createTestEndpoints(String accountId, String orgId, int count) {
         final Stats stats = new Stats(count);
 
+        final Random random = new Random();
         for (int i = 0; i < count; i++) {
             // Add new endpoints
             WebhookProperties properties = new WebhookProperties();
@@ -207,7 +208,7 @@ public class ResourceHelpers {
             ep.setType(WEBHOOK);
             ep.setName(String.format("Endpoint %d", count - i));
             ep.setDescription("Automatically generated");
-            boolean enabled = (i % (count / 5)) != 0;
+            boolean enabled = random.nextBoolean();
             if (!enabled) {
                 stats.increaseDisabledCount();
             }


### PR DESCRIPTION
When RBAC returned a non-200 response, and the "RbacService" class threw a "ClientWebApplicationException", the exception was not properly handled by the migration tool and it stopped the migration's execution.

The intended behavior from the beginning was to continue with the migration even when we faced these kind of errors.

## Jira ticket
[[RHCLOUD-35454]](https://issues.redhat.com/browse/RHCLOUD-35454)