### PR TITLE
Try to fix MSTeams post-deploy CJI as its name could be longer than permitted

### DIFF
--- a/.rhcicd/stage-microsoft-teams-post-deployment-tests.yaml
+++ b/.rhcicd/stage-microsoft-teams-post-deployment-tests.yaml
@@ -7,7 +7,7 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: notifications-connector-microsoft-teams-tests-${UID}
+    name: notifications-connector-ms-teams-tests-${UID}
   spec:
     appName: notifications-connector-microsoft-teams
     testing:


### PR DESCRIPTION
There is a limitation on CJI names that they need to be shorter than 64 characters. 
Based on how CJI names are created, the Teams one gets up to 65 characters