### PR TITLE
RHCLOUD-35454 | feature: run the Kessel migration in a virtual thread

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
@@ -8,6 +8,7 @@ import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.models.Endpoint;
 import io.grpc.stub.StreamObserver;
 import io.quarkus.logging.Log;
+import io.smallrye.common.annotation.RunOnVirtualThread;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import jakarta.annotation.security.RolesAllowed;
@@ -57,6 +58,7 @@ public class KesselAssetsMigrationService {
 
     @Path("/kessel/migrate-assets")
     @POST
+    @RunOnVirtualThread
     public void migrateAssets() {
         Log.info("Kessel assets' migration begins");
 


### PR DESCRIPTION
We want to avoid blocking Quarkus' event thread, and since the migration uses blocking calls, we want to make sure it does not get killed by Vert.x.

## Jira ticket
[[RHCLOUD-35454]](https://issues.redhat.com/browse/RHCLOUD-35454)