### PR TITLE
Configure post-deploy tests in Drawer connector

### DIFF
--- a/.rhcicd/clowdapp-connector-drawer.yaml
+++ b/.rhcicd/clowdapp-connector-drawer.yaml
@@ -12,7 +12,11 @@ objects:
     dependencies:
     - notifications-engine
     - notifications-recipients-resolver
+    optionalDependencies:
+    - notifications-backend
     envName: ${ENV_NAME}
+    testing:
+      iqePlugin: notifications
     featureFlags: true
     kafkaTopics:
     - topicName: platform.notifications.tocamel


### PR DESCRIPTION
Configures the iqePlugin so we can run tests in post-deploy jobs
Also adds the backend app as an optional dependency to avoid configuration problems