### PR TITLE
[RHCLOUD-22813] Handle provided context.host_url in integration templates

### DIFF
--- a/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
+++ b/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.connector.pagerduty;
 
 import io.quarkus.logging.Log;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.apache.camel.Exchange;
@@ -181,9 +182,11 @@ public class PagerDutyTransformer implements Processor {
 
         String inventoryUrl = cloudEventPayload.getString(INVENTORY_URL, "");
         if (!inventoryUrl.isEmpty()) {
-            clientLinks.put(LINKS, JsonObject.of(
-                    HREF, inventoryUrl,
-                    TEXT, "Host"
+            clientLinks.put(LINKS, JsonArray.of(
+                    JsonObject.of(
+                            HREF, inventoryUrl,
+                            TEXT, "Host"
+                    )
             ));
         }
 

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTestUtils.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTestUtils.java
@@ -92,8 +92,7 @@ public class PagerDutyTestUtils {
         payload.put(ENVIRONMENT_URL, "https://console.redhat.com");
         InsightsUrlsBuilder.buildInventoryUrl(payload)
                 .ifPresent(url -> payload.put(INVENTORY_URL, url));
-        InsightsUrlsBuilder.buildApplicationUrl(payload)
-                .ifPresent(url -> payload.put(APPLICATION_URL, url));
+        payload.put(APPLICATION_URL, InsightsUrlsBuilder.buildApplicationUrl(payload));
         payload.put(SEVERITY, PagerDutySeverity.WARNING);
         cloudEventData.put(PAYLOAD, payload);
 
@@ -189,8 +188,9 @@ class InsightsUrlsBuilder {
      * <p>An inventory URL will only be generated if fields from one of these two formats are present:</p>
      *
      * <ul>
-     *     <li>{@code { "context": { "display_name": "non_empty_string" } }}</li>
+     *     <li>{@code { "context": { "host_url": "non_empty_string" }}}</li>
      *     <li>{@code { "context": { "inventory_id": "non_empty_string" }}}</li>
+     *     <li>{@code { "context": { "display_name": "non_empty_string" } }}</li>
      * </ul>
      *
      * <p>If neither field is present, an {@link Optional#empty()} will be returned. If expected fields of
@@ -202,23 +202,34 @@ class InsightsUrlsBuilder {
     static Optional<String> buildInventoryUrl(JsonObject data) {
         String path;
         ArrayList<String> queryParamParts = new ArrayList<>();
+        JsonObject context = data.getJsonObject("context");
+        if (context == null) {
+            return Optional.empty();
+        }
 
-        String displayName = data.getString("display_name", "");
-        String inventoryId = data.getString("inventory_id", "");
+        // A provided host url does not need to be modified
+        String host_url = context.getString("host_url", "");
+        if (!host_url.isEmpty()) {
+            return Optional.of(host_url);
+        }
 
-        if (!displayName.isEmpty()
-                && data.getString("bundle", "").equals("openshift")
-                && data.getString("application", "").equals("advisor")) {
-            path = String.format("/openshift/insights/advisor/clusters/%s", displayName);
-        } else {
-            path = "/insights/inventory/";
-            if (!inventoryId.isEmpty()) {
-                path += inventoryId;
-            } else if (!displayName.isEmpty()) {
-                queryParamParts.add(String.format("hostname_or_id=%s", displayName));
+        String inventoryId = context.getString("inventory_id", "");
+        String displayName = context.getString("display_name", "");
+
+        if (!displayName.isEmpty()) {
+            if (data.getString("bundle", "").equals("openshift")
+                    && data.getString("application", "").equals("advisor")) {
+                path = String.format("/openshift/insights/advisor/clusters/%s", displayName);
             } else {
-                return Optional.empty();
+                path = "/insights/inventory/";
+                if (!inventoryId.isEmpty()) {
+                    path += inventoryId;
+                } else {
+                    queryParamParts.add(String.format("hostname_or_id=%s", displayName));
+                }
             }
+        } else {
+            return Optional.empty();
         }
 
         if (!queryParamParts.isEmpty()) {
@@ -232,34 +243,30 @@ class InsightsUrlsBuilder {
     /**
      * <p>Constructs an Insights URL corresponding to the specific inventory item which generated the notification.</p>
      *
-     * <p>If the required field {@link Action#getApplication()} is not present, an
-     * {@link Optional#empty()} will be returned. If the expected field {@link Action#getBundle()} is not present, an
+     * <p>If the expected fields {@link Action#getApplication()} and {@link Action#getBundle()} are not present, an
      * inaccurate URL may be returned.</p>
      *
      * @param data a payload converted by {@code BaseTransformer#toJsonObject(Event)}
-     * @return URL to the generating application, if required fields are present
+     * @return URL to the generating application
      */
-    static Optional<String> buildApplicationUrl(JsonObject data) {
+    static String buildApplicationUrl(JsonObject data) {
         String path = "";
 
         String bundle = data.getString("bundle", "");
-        String application;
+        String application = data.getString("application", "");
 
-        if (data.containsKey("application") && !data.getString("application", "").isEmpty()) {
-            application = data.getString("application");
-        } else {
-            return Optional.empty();
+        if (bundle.equals("openshift")) {
+            path = "openshift/";
         }
 
-        if (bundle.equals("application-services") && application.equals("rhosak")) {
-            path = "application-services/streams";
+        if (application.equals("integrations")) {
+            path += "settings/";
         } else {
-            if (bundle.equals("openshift")) {
-                path = "openshift/";
-            }
-            path += "insights/" + application;
+            path += "insights/";
         }
 
-        return Optional.of(String.format("%s/%s", PagerDutyTestUtils.DEFAULT_ENVIRONMENT_URL, path));
+        path += application;
+
+        return String.format("%s/%s", PagerDutyTestUtils.DEFAULT_ENVIRONMENT_URL, path);
     }
 }

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
@@ -115,8 +115,7 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
         cloudEventPayload.put("environment_url", "https://console.redhat.com");
         InsightsUrlsBuilder.buildInventoryUrl(cloudEventPayload)
                 .ifPresent(url -> cloudEventPayload.put("inventory_url", url));
-        InsightsUrlsBuilder.buildApplicationUrl(cloudEventPayload)
-                .ifPresent(url -> cloudEventPayload.put("application_url", url));
+        cloudEventPayload.put("application_url", InsightsUrlsBuilder.buildApplicationUrl(cloudEventPayload));
         cloudEventPayload.put("severity", "warning");
         cloudEventData.put(PAYLOAD, cloudEventPayload);
 
@@ -186,6 +185,17 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
                 "inventory_id", "8a4a4f75-5319-4255-9eb5-1ee5a92efd7f"
         ));
         cloudEventData.put(PAYLOAD, cloudPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
+    void testWithHostUrl() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        JsonObject context = cloudPayload.getJsonObject(CONTEXT);
+        context.put("host_url", "https://console.redhat.com/insights/inventory/8a4a4f75-5319-4255-9eb5-1ee5a92efd7f");
 
         JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
         validatePayloadTransform(cloudEventData, expectedPayload);

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
@@ -20,6 +20,7 @@ import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransf
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ENVIRONMENT_URL;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENTS;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENT_TYPE;
+import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.INVENTORY_URL;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.PAYLOAD;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SEVERITY;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.SOURCE;
@@ -28,7 +29,9 @@ import static org.apache.camel.test.junit5.TestSupport.createExchangeWithBody;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/** These test cases are intended to verify that the {@link PagerDutyTransformer} can handle various possible inputs. */
+/**
+ * These test cases are intended to verify that the {@link PagerDutyTransformer} can handle various possible inputs.
+ */
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
 public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
@@ -83,8 +86,10 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
         validatePayloadTransform(cloudEventData, expectedPayload);
     }
 
-    /** This is a real test message generated from the {@code /endpoints/{uuid}/test} integrations endpoint, with the
-     * account and org id replaced. */
+    /**
+     * This is a slightly modified version of a real test message generated from the {@code /endpoints/{uuid}/test}
+     * integrations endpoint, with the account and org id replaced.
+     */
     @Test
     void testSuccessfulTestMessage() {
         JsonObject cloudEventData = createIncomingPayload(TEST_URL);
@@ -108,6 +113,10 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
         );
         cloudEventPayload.put("recipients", JsonArray.of());
         cloudEventPayload.put("environment_url", "https://console.redhat.com");
+        InsightsUrlsBuilder.buildInventoryUrl(cloudEventPayload)
+                .ifPresent(url -> cloudEventPayload.put("inventory_url", url));
+        InsightsUrlsBuilder.buildApplicationUrl(cloudEventPayload)
+                .ifPresent(url -> cloudEventPayload.put("application_url", url));
         cloudEventPayload.put("severity", "warning");
         cloudEventData.put(PAYLOAD, cloudEventPayload);
 
@@ -130,8 +139,7 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
     void testMissingSourceNames() {
         JsonObject cloudEventData = createIncomingPayload(TEST_URL);
         JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
-        cloudEventData.remove(SOURCE);
-        cloudEventData.put(PAYLOAD, cloudPayload);
+        cloudPayload.remove(SOURCE);
 
         JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
         validatePayloadTransform(cloudEventData, expectedPayload);
@@ -142,10 +150,7 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
         JsonObject cloudEventData = createIncomingPayload(TEST_URL);
         JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
         JsonObject sourceNames = cloudPayload.getJsonObject(SOURCE);
-
         sourceNames.remove(APPLICATION);
-        cloudPayload.put(SOURCE, sourceNames);
-        cloudEventData.put(PAYLOAD, cloudPayload);
 
         JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
         validatePayloadTransform(cloudEventData, expectedPayload);
@@ -167,7 +172,6 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
         JsonObject cloudEventData = createIncomingPayload(TEST_URL);
         JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
         cloudPayload.remove(EVENTS);
-        cloudEventData.put(PAYLOAD, cloudPayload);
 
         JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
         validatePayloadTransform(cloudEventData, expectedPayload);
@@ -188,6 +192,17 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    void testWithMissingClientDisplayName() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        JsonObject context = cloudPayload.getJsonObject(CONTEXT);
+        context.remove(DISPLAY_NAME);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
     void testWithClientDisplayNameAndInventoryId() {
         JsonObject cloudEventData = createIncomingPayload(TEST_URL);
         JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
@@ -196,6 +211,14 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
                 "inventory_id", "8a4a4f75-5319-4255-9eb5-1ee5a92efd7f"
         ));
         cloudEventData.put(PAYLOAD, cloudPayload);
+    }
+
+    @Test
+    void testWithMissingInventoryId() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        JsonObject context = cloudPayload.getJsonObject(CONTEXT);
+        context.remove("inventory_id");
 
         JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
         validatePayloadTransform(cloudEventData, expectedPayload);
@@ -211,6 +234,16 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
         validatePayloadTransform(cloudEventData, expectedPayload);
     }
 
+    @Test
+    void testMissingInventoryUrl() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
+        cloudPayload.remove(INVENTORY_URL);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
     void verifyTransformExceptionThrown(JsonObject cloudEventData, Class<? extends Throwable> exceptionType, String exceptionMessage) {
         Exchange exchange = createExchangeWithBody(context, "I am not used!");
 
@@ -219,7 +252,6 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
     }
 
     /**
-     *
      * @param cloudEventData the cloud event, as provided to the connector
      * @param expectedPayload the PagerDuty payload expected to be sent
      */

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
@@ -113,9 +113,8 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
         );
         cloudEventPayload.put("recipients", JsonArray.of());
         cloudEventPayload.put("environment_url", "https://console.redhat.com");
-        InsightsUrlsBuilder.buildInventoryUrl(cloudEventPayload)
-                .ifPresent(url -> cloudEventPayload.put("inventory_url", url));
-        cloudEventPayload.put("application_url", InsightsUrlsBuilder.buildApplicationUrl(cloudEventPayload));
+        // No inventory_url generated
+        cloudEventPayload.put("application_url", "https://console.redhat.com/settings/integrations");
         cloudEventPayload.put("severity", "warning");
         cloudEventData.put(PAYLOAD, cloudEventPayload);
 

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
@@ -123,6 +123,39 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
     }
 
     @Test
+    void testSuccessfulIqeTestMessage() {
+        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
+        JsonObject cloudEventPayload = JsonObject.of(
+                "account_id", "default-account-id",
+                "application", "inventory",
+                "bundle", "rhel",
+                "context", JsonObject.of(
+                    "inventory_id", "85094ed1-1c52-4bc5-8e3e-4ea3869a17ce",
+                    "hostname", "rhiqe.2349fj.notif-test",
+                    "display_name", "rhiqe.2349fj.notif-test",
+                    "rhel_version", "8.0"
+                ),
+                "event_type", "new-system-registered",
+                "events", JsonArray.of(),
+                "org_id", "default-org-id",
+                "timestamp", "2020-10-03T15:22:13.000000025",
+                "source", JsonObject.of(
+                        "application", JsonObject.of("display_name", "Inventory"),
+                        "bundle", JsonObject.of("display_name", "Red Hat Enterprise Linux"),
+                        "event_type", JsonObject.of("display_name", "New system registered")
+                ),
+                "environment_url", "https://localhost"
+        );
+        cloudEventPayload.put("inventory_url", "https://localhost/insights/inventory/85094ed1-1c52-4bc5-8e3e-4ea3869a17ce");
+        cloudEventPayload.put("application_url", "https://localhost/insights/inventory");
+        cloudEventPayload.put("severity", "error");
+        cloudEventData.put("payload", cloudEventPayload);
+
+        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
+        validatePayloadTransform(cloudEventData, expectedPayload);
+    }
+
+    @Test
     void testInvalidTimestampDropped() {
         JsonObject cloudEventData = createIncomingPayload(TEST_URL);
         JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/InsightsUrlsBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/InsightsUrlsBuilder.java
@@ -1,0 +1,65 @@
+package com.redhat.cloud.notifications.processors;
+
+import com.redhat.cloud.notifications.models.Environment;
+import com.redhat.cloud.notifications.models.Event;
+import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+@ApplicationScoped
+public class InsightsUrlsBuilder {
+
+    @Inject
+    Environment environment;
+
+    /**
+     * <p>Constructs an Insights URL corresponding to the specific inventory item which generated the notification.</p>
+     *
+     * <p>In addition to the required fields of {@link com.redhat.cloud.notifications.ingress.Action Action}, an
+     * inventory URL will only be generated if fields from one of these two formats are present:</p>
+     *
+     * <ul>
+     *     <li>{@code { "context": { "display_name": "non_empty_string" } }}</li>
+     *     <li>{@code { "context": { "inventory_id": "non_empty_string" }}}</li>
+     * </ul>
+     *
+     * <p>If neither field is present, an {@link Optional#empty()} will be returned.</p>
+     *
+     * @param data a payload converted by
+     *             {@link com.redhat.cloud.notifications.transformers.BaseTransformer#toJsonObject(Event) BaseTransformer#toJsonObject(Event)}
+     * @return URL to the generating inventory item, if required fields are present
+     */
+    public Optional<String> buildInventoryUrl(JsonObject data) {
+        String path;
+        ArrayList<String> queryParamParts = new ArrayList<>();
+
+        String environmentUrl = environment.url();
+        String displayName = data.getString("display_name", "");
+        String inventoryId = data.getString("inventory_id", "");
+
+        if (!displayName.isEmpty()
+                && data.getString("bundle", "").equals("openshift")
+                && data.getString("application", "").equals("advisor")) {
+            path = "/openshift/insights/advisor/clusters/" + displayName;
+        } else {
+            path = "/insights/inventory/";
+            if (!inventoryId.isEmpty()) {
+                path += inventoryId;
+            } else if (!displayName.isEmpty()) {
+                queryParamParts.add("hostname_or_id=" + displayName);
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        if (!queryParamParts.isEmpty()) {
+            String queryParams = "?" + String.join("&", queryParamParts);
+            path += queryParams;
+        }
+
+        return Optional.of(environmentUrl + path);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/InsightsUrlsBuilder.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/InsightsUrlsBuilder.java
@@ -44,7 +44,7 @@ public class InsightsUrlsBuilder {
 
         // A provided host url does not need to be modified
         String host_url = context.getString("host_url", "");
-        if (!host_url.isEmpty()) {
+        if (!host_url.isBlank()) {
             return Optional.of(host_url);
         }
 
@@ -52,13 +52,13 @@ public class InsightsUrlsBuilder {
         String inventoryId = context.getString("inventory_id", "");
         String displayName = context.getString("display_name", "");
 
-        if (!displayName.isEmpty()) {
+        if (!displayName.isBlank()) {
             if (data.getString("bundle", "").equals("openshift")
                     && data.getString("application", "").equals("advisor")) {
                 path = String.format("/openshift/insights/advisor/clusters/%s", displayName);
             } else {
                 path = "/insights/inventory/";
-                if (!inventoryId.isEmpty()) {
+                if (!inventoryId.isBlank()) {
                     path += inventoryId;
                 } else {
                     queryParamParts.add(String.format("hostname_or_id=%s", displayName));

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
@@ -81,7 +81,7 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
         JsonObject data = baseTransformer.toJsonObject(event);
         data.put("environment_url", environment.url());
         insightsUrlsBuilder.buildInventoryUrl(data).ifPresent(url -> data.put("inventory_url", url));
-        insightsUrlsBuilder.buildApplicationUrl(data).ifPresent(url -> data.put("application_url", url));
+        data.put("application_url", insightsUrlsBuilder.buildApplicationUrl(data));
 
         Map<Object, Object> dataAsMap;
         try {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
@@ -12,6 +12,7 @@ import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.IntegrationTemplate;
 import com.redhat.cloud.notifications.processors.ConnectorSender;
 import com.redhat.cloud.notifications.processors.EndpointTypeProcessor;
+import com.redhat.cloud.notifications.processors.InsightsUrlsBuilder;
 import com.redhat.cloud.notifications.templates.TemplateService;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.quarkus.logging.Log;
@@ -35,6 +36,9 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
 
     @Inject
     Environment environment;
+
+    @Inject
+    InsightsUrlsBuilder insightsUrlsBuilder;
 
     @Inject
     TemplateRepository templateRepository;
@@ -76,6 +80,8 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
     protected String buildNotificationMessage(Event event) {
         JsonObject data = baseTransformer.toJsonObject(event);
         data.put("environment_url", environment.url());
+        insightsUrlsBuilder.buildInventoryUrl(data).ifPresent(url -> data.put("inventory_url", url));
+        insightsUrlsBuilder.buildApplicationUrl(data).ifPresent(url -> data.put("application_url", url));
 
         Map<Object, Object> dataAsMap;
         try {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
@@ -79,7 +79,7 @@ public class PagerDutyProcessor extends EndpointTypeProcessor {
         JsonObject transformedEvent = transformer.toJsonObject(event);
         transformedEvent.put("environment_url", environment.url());
         insightsUrlsBuilder.buildInventoryUrl(transformedEvent).ifPresent(url -> transformedEvent.put("inventory_url", url));
-        insightsUrlsBuilder.buildApplicationUrl(transformedEvent).ifPresent(url -> transformedEvent.put("application_url", url));
+        transformedEvent.put("application_url", insightsUrlsBuilder.buildApplicationUrl(transformedEvent));
         transformedEvent.put("severity", properties.getSeverity());
 
         connectorData.put(PAYLOAD, transformedEvent);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
@@ -8,6 +8,7 @@ import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.PagerDutyProperties;
 import com.redhat.cloud.notifications.processors.ConnectorSender;
 import com.redhat.cloud.notifications.processors.EndpointTypeProcessor;
+import com.redhat.cloud.notifications.processors.InsightsUrlsBuilder;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -36,6 +37,9 @@ public class PagerDutyProcessor extends EndpointTypeProcessor {
 
     @Inject
     Environment environment;
+
+    @Inject
+    InsightsUrlsBuilder insightsUrlsBuilder;
 
     @Inject
     MeterRegistry registry;
@@ -74,6 +78,8 @@ public class PagerDutyProcessor extends EndpointTypeProcessor {
         JsonObject connectorData = new JsonObject();
         JsonObject transformedEvent = transformer.toJsonObject(event);
         transformedEvent.put("environment_url", environment.url());
+        insightsUrlsBuilder.buildInventoryUrl(transformedEvent).ifPresent(url -> transformedEvent.put("inventory_url", url));
+        insightsUrlsBuilder.buildApplicationUrl(transformedEvent).ifPresent(url -> transformedEvent.put("application_url", url));
         transformedEvent.put("severity", properties.getSeverity());
 
         connectorData.put(PAYLOAD, transformedEvent);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatProcessorTest.java
@@ -24,6 +24,9 @@ public class GoogleChatProcessorTest extends CamelProcessorTest {
     private static final String GOOGLE_CHAT_EXPECTED_MSG = "{\"text\":\"<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
             "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>\"}";
 
+    private static final String GOOGLE_CHAT_EXPECTED_MSG_WITH_HOST_URL = "{\"text\":\"<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
+            "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>\"}";
+
     @Inject
     GoogleChatProcessor googleSpacesProcessor;
 
@@ -33,8 +36,8 @@ public class GoogleChatProcessorTest extends CamelProcessorTest {
     }
 
     @Override
-    protected String getExpectedMessage() {
-        return GOOGLE_CHAT_EXPECTED_MSG;
+    protected String getExpectedMessage(boolean withHostUrl) {
+        return withHostUrl ? GOOGLE_CHAT_EXPECTED_MSG_WITH_HOST_URL : GOOGLE_CHAT_EXPECTED_MSG;
     }
 
     @Override

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsProcessorTest.java
@@ -24,6 +24,9 @@ public class TeamsProcessorTest extends CamelProcessorTest {
     private static final String TEAMS_EXPECTED_MSG = "<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
             "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>";
 
+    private static final String TEAMS_EXPECTED_MSG_WITH_HOST_URL = "<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
+            "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>";
+
     @Inject
     TeamsProcessor teamsProcessor;
 
@@ -33,8 +36,8 @@ public class TeamsProcessorTest extends CamelProcessorTest {
     }
 
     @Override
-    protected String getExpectedMessage() {
-        return TEAMS_EXPECTED_MSG;
+    protected String getExpectedMessage(boolean withHostUrl) {
+        return withHostUrl ? TEAMS_EXPECTED_MSG_WITH_HOST_URL : TEAMS_EXPECTED_MSG;
     }
 
     @Override

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessorTest.java
@@ -39,6 +39,7 @@ import org.mockito.ArgumentCaptor;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.processors.ConnectorSender.TOCAMEL_CHANNEL;
 import static com.redhat.cloud.notifications.processors.pagerduty.PagerDutyProcessor.PROCESSED_PAGERDUTY_COUNTER;
@@ -110,6 +111,69 @@ public class PagerDutyProcessorTest {
         eventType.setName("policy-triggered");
         event.setEventType(eventType);
         event.setOrgId(DEFAULT_ORG_ID);
+        Endpoint ep = buildPagerDutyEndpoint();
+
+        pagerDutyProcessor.process(event, List.of(ep));
+        ArgumentCaptor<NotificationHistory> historyArgumentCaptor = ArgumentCaptor.forClass(NotificationHistory.class);
+        verify(notificationHistoryRepository, times(1)).createNotificationHistory(historyArgumentCaptor.capture());
+        NotificationHistory history = historyArgumentCaptor.getAllValues().getFirst();
+        assertFalse(history.isInvocationResult());
+        assertEquals(NotificationStatus.PROCESSING, history.getStatus());
+        // Now let's check the Kafka messages sent to the outgoing channel.
+        // The channel should have received two messages.
+        assertEquals(1, inMemorySink.received().size());
+
+        // We'll only check the payload and metadata of the first Kafka message.
+        Message<JsonObject> message = inMemorySink.received().getFirst();
+        JsonObject payload = message.getPayload();
+
+        final JsonObject payloadToSend = transformer.toJsonObject(event);
+        payloadToSend.put("environment_url", environment.url());
+        insightsUrlsBuilder.buildInventoryUrl(payloadToSend)
+                .ifPresent(url -> payloadToSend.put("inventory_url", url));
+        payloadToSend.put("application_url", insightsUrlsBuilder.buildApplicationUrl(payloadToSend));
+        payloadToSend.put("severity", PagerDutySeverity.ERROR);
+        assertEquals(payloadToSend, payload.getJsonObject("payload"));
+
+        micrometerAssertionHelper.assertCounterIncrement(PROCESSED_PAGERDUTY_COUNTER, 1);
+    }
+
+    @Test
+    void testPagerdutyUsingIqeMessage() {
+        // Make sure that the payload does not get stored in the database.
+        when(engineConfig.getKafkaToCamelMaximumRequestSize()).thenReturn(Integer.MAX_VALUE);
+
+        Action pagerDutyActionMessage = new Action();
+        pagerDutyActionMessage.setBundle("rhel");
+        pagerDutyActionMessage.setApplication("inventory");
+        pagerDutyActionMessage.setTimestamp(LocalDateTime.of(2020, 10, 3, 15, 22, 13, 25));
+        pagerDutyActionMessage.setEventType("new-system-registered");
+        pagerDutyActionMessage.setAccountId(DEFAULT_ACCOUNT_ID);
+        pagerDutyActionMessage.setOrgId(DEFAULT_ORG_ID);
+
+        Context context = new Context.ContextBuilder()
+                .withAdditionalProperty("inventory_id", "85094ed1-1c52-4bc5-8e3e-4ea3869a17ce")
+                .withAdditionalProperty("hostname", "rhiqe.2349fj.notif-test")
+                .withAdditionalProperty("display_name", "rhiqe.2349fj.notif-test")
+                .withAdditionalProperty("rhel_version", "8.0")
+                .build();
+        pagerDutyActionMessage.setContext(context);
+
+        Event event = new Event();
+        event.setEventWrapper(new EventWrapperAction(pagerDutyActionMessage));
+        event.setBundleDisplayName("Red Hat Enterprise Linux");
+        event.setApplicationDisplayName("Inventory");
+        event.setEventTypeDisplayName("New system registered");
+
+        Application application = new Application();
+        application.setName("inventory");
+        application.setDisplayName("Inventory");
+        EventType eventType = new EventType();
+        eventType.setApplication(application);
+        eventType.setName("new-system-registered");
+        eventType.setDisplayName("New system registered");
+        event.setEventType(eventType);
+
         Endpoint ep = buildPagerDutyEndpoint();
 
         pagerDutyProcessor.process(event, List.of(ep));

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessorTest.java
@@ -130,8 +130,7 @@ public class PagerDutyProcessorTest {
         payloadToSend.put("environment_url", environment.url());
         insightsUrlsBuilder.buildInventoryUrl(payloadToSend)
                 .ifPresent(url -> payloadToSend.put("inventory_url", url));
-        insightsUrlsBuilder.buildApplicationUrl(payloadToSend)
-                .ifPresent(url -> payloadToSend.put("application_url", url));
+        payloadToSend.put("application_url", insightsUrlsBuilder.buildApplicationUrl(payloadToSend));
         payloadToSend.put("severity", PagerDutySeverity.ERROR);
         assertEquals(payloadToSend, payload.getJsonObject("payload"));
 


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-22813

## Description

Currently, URLs in PagerDuty and Camel notifications are constructed by the PagerDutyTransformer, or one of three [Qute](https://quarkus.io/guides/qute) templates, respectively. Each one has a slightly different way of handling URLs, and the Camel templates are not the ones currently shown in this repo.

This PR creates a new class, `InsightsUrlsBuilder`, which provides consistent construction of the two URLs for all integrations:

- `data.inventory_url` represents a link to the specific host, cluster, or inventory item in the Console that generated the message. If `data.context.host_url` is provided, it will be used here.
- `data.application_url` links back to the application that generated the event.

The PR will also make it easy to modify the URL format in a followup issue.

## Database migration

~~A new migration file (`V1.110.0`) has been added. It takes the current templates used in the Notifications database, and updates them to use the new URLs.~~

These changes are now part of #3229.

## Testing

- Updated connector-pagerduty tests to emulate the new URL builder on the engine side.
- Updated `CamelProcessorTest` implementers to use the new URLs in their Qute templates
- Added a new test for PagerDuty and Camel to verify that `data.context.host_url` will always be used if present

## Example

Using the following trimmed output from `BaseTransformer`:

```json5
{
  "bundle": "rhel",
  "application": "advisor",
  "event_type": "new-recommendation",
  "timestamp": "2024-12-19T15:21:45.129372",
  // trimmed
  "context": {
    "inventory_id": "6eaaa39c-55f7-4f45-81a9-84c75b1475d6",
    "hostname": "my-computer-jrodri",
    "display_name": "my-computer-jrodri",
    "host_url": "https://console.redhat.com/insights/inventory/some-unique-host-url-path",
    "tags": []
  },
  "events": [
    {
      // one event, trimmed
    },
    {
      // another event, trimmed
    }
  ],
  "source": {
    "application": {"display_name": "Advisor"},
    "bundle": {"display_name": "Red Hat Enterprise Linux"}
  }
  "environment_url": "https://console.redhat.com"
}
```

And the new Microsoft Teams template:

```
{"text":"{#if data.context.display_name??}[{data.context.display_name}]({data.inventory_url}) triggered {data.events.size()} event{#if data.events.size() \u003e 1}s{/if}{#else}{data.events.size()} event{#if data.events.size() \u003e 1}s{/if} triggered{/if} from {data.source.application.display_name} - {data.source.bundle.display_name}. [Open {data.source.application.display_name}]({data.application_url})"}
```

We generate this message:

```markdown
[my-computer-jrodri](https://console.redhat.com/insights/inventory/some-unique-host-url-path) triggered 2 events from Advisor - Red Hat Enterprise Linux. [Open Advisor](https://console.redhat.com/insights/advisor)
```