### PR TITLE
[RHCLOUD-22813] Message link migration

### DIFF
--- a/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
+++ b/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
@@ -33,7 +33,6 @@ public class PagerDutyTransformer implements Processor {
     public static final String CONTEXT = "context";
     public static final String CUSTOM_DETAILS = "custom_details";
     public static final String DISPLAY_NAME = "display_name";
-    public static final String ENVIRONMENT_URL = "environment_url";
     public static final String EVENT_ACTION = "event_action";
     public static final String EVENT_TYPE = "event_type";
     public static final String EVENTS = "events";
@@ -58,7 +57,6 @@ public class PagerDutyTransformer implements Processor {
 
         JsonObject message = new JsonObject();
         message.put(EVENT_ACTION, PagerDutyEventAction.TRIGGER);
-        message.mergeIn(getClientLink(cloudEventPayload, cloudEventPayload.getString(ENVIRONMENT_URL)));
         message.mergeIn(getClientLinks(cloudEventPayload));
 
         JsonObject messagePayload = new JsonObject();
@@ -123,45 +121,6 @@ public class PagerDutyTransformer implements Processor {
                 throw new IllegalArgumentException("Invalid severity value provided for PagerDuty payload: " + severity);
             }
         }
-    }
-
-    /**
-     * Adapted from CamelProcessor template for Teams, with some changes to more gracefully handle missing fields
-     * <br>
-     * TODO update to work more consistently and with other platforms
-     *
-     * @return {@link #CLIENT} and {@link #CLIENT_URL}
-     */
-    private JsonObject getClientLink(final JsonObject cloudEventPayload, String environmentUrl) {
-        JsonObject clientLink = new JsonObject();
-
-        String contextName = cloudEventPayload.containsKey(CONTEXT)
-                ? cloudEventPayload.getJsonObject(CONTEXT).getString(DISPLAY_NAME)
-                : null;
-
-        if (contextName != null) {
-            clientLink.put(CLIENT, contextName);
-
-            String inventoryId = cloudEventPayload.getJsonObject(CONTEXT).getString("inventory_id");
-            if (environmentUrl != null && !environmentUrl.isEmpty() && inventoryId != null && !inventoryId.isEmpty()) {
-                clientLink.put(CLIENT_URL, String.format("%s/insights/inventory/%s",
-                        environmentUrl,
-                        cloudEventPayload.getJsonObject(CONTEXT).getString("inventory_id")
-                ));
-            }
-        } else {
-            if (environmentUrl != null && !environmentUrl.isEmpty()) {
-                clientLink.put(CLIENT, String.format("Open %s", cloudEventPayload.getString(APPLICATION)));
-                clientLink.put(CLIENT_URL, String.format("%s/insights/%s",
-                        environmentUrl,
-                        cloudEventPayload.getString(APPLICATION)
-                ));
-            } else {
-                clientLink.put(CLIENT, cloudEventPayload.getString(APPLICATION));
-            }
-        }
-
-        return clientLink;
     }
 
     /**

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTestUtils.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTestUtils.java
@@ -14,12 +14,9 @@ import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransf
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.APPLICATION;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.APPLICATION_URL;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.BUNDLE;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CLIENT;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CLIENT_URL;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CONTEXT;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CUSTOM_DETAILS;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.DISPLAY_NAME;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ENVIRONMENT_URL;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENTS;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENT_ACTION;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENT_TYPE;
@@ -86,7 +83,6 @@ public class PagerDutyTestUtils {
         );
 
         payload.put(SOURCE, source);
-        payload.put(ENVIRONMENT_URL, "https://console.redhat.com");
         payload.put(INVENTORY_URL, "https://console.redhat.com/insights/inventory/8a4a4f75-5319-4255-9eb5-1ee5a92efd7f");
         payload.put(APPLICATION_URL, "https://console.redhat.com/insights/default-application");
         payload.put(SEVERITY, PagerDutySeverity.WARNING);
@@ -102,7 +98,6 @@ public class PagerDutyTestUtils {
 
         JsonObject oldInnerPayload = expected.getJsonObject(PAYLOAD);
         expected.put(EVENT_ACTION, PagerDutyEventAction.TRIGGER);
-        expected.mergeIn(getClientLink(oldInnerPayload, oldInnerPayload.getString(ENVIRONMENT_URL)));
         expected.mergeIn(getClientLinks(oldInnerPayload));
 
         JsonObject newInnerPayload = new JsonObject();
@@ -139,37 +134,5 @@ public class PagerDutyTestUtils {
         expected.remove(PAYLOAD);
         expected.put(PAYLOAD, newInnerPayload);
         return expected;
-    }
-
-    private static JsonObject getClientLink(final JsonObject oldInnerPayload, String environmentUrl) {
-        JsonObject clientLink = new JsonObject();
-
-        String contextName = oldInnerPayload.containsKey(CONTEXT)
-                ? oldInnerPayload.getJsonObject(CONTEXT).getString(DISPLAY_NAME)
-                : null;
-
-        if (contextName != null) {
-            clientLink.put(CLIENT, contextName);
-
-            String inventoryId = oldInnerPayload.getJsonObject(CONTEXT).getString("inventory_id");
-            if (environmentUrl != null && !environmentUrl.isEmpty() && inventoryId != null && !inventoryId.isEmpty()) {
-                clientLink.put(CLIENT_URL, String.format("%s/insights/inventory/%s",
-                        environmentUrl,
-                        oldInnerPayload.getJsonObject(CONTEXT).getString("inventory_id")
-                ));
-            }
-        } else {
-            if (environmentUrl != null && !environmentUrl.isEmpty()) {
-                clientLink.put(CLIENT, String.format("Open %s", oldInnerPayload.getString(APPLICATION)));
-                clientLink.put(CLIENT_URL, String.format("%s/insights/%s",
-                        environmentUrl,
-                        oldInnerPayload.getString(APPLICATION)
-                ));
-            } else {
-                clientLink.put(CLIENT, oldInnerPayload.getString(APPLICATION));
-            }
-        }
-
-        return clientLink;
     }
 }

--- a/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
+++ b/connector-pagerduty/src/test/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformerTest.java
@@ -17,7 +17,6 @@ import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTestUt
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.APPLICATION;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.CONTEXT;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.DISPLAY_NAME;
-import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.ENVIRONMENT_URL;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENTS;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.EVENT_TYPE;
 import static com.redhat.cloud.notifications.connector.pagerduty.PagerDutyTransformer.INVENTORY_URL;
@@ -112,7 +111,6 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
                 )
         );
         cloudEventPayload.put("recipients", JsonArray.of());
-        cloudEventPayload.put("environment_url", "https://console.redhat.com");
         // No inventory_url generated
         cloudEventPayload.put("application_url", "https://console.redhat.com/settings/integrations");
         cloudEventPayload.put("severity", "warning");
@@ -209,20 +207,6 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
     }
 
     @Test
-    void testWithClientDisplayName() {
-        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
-        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
-        cloudPayload.put(CONTEXT, JsonObject.of(
-                DISPLAY_NAME, "console",
-                "inventory_id", "8a4a4f75-5319-4255-9eb5-1ee5a92efd7f"
-        ));
-        cloudEventData.put(PAYLOAD, cloudPayload);
-
-        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
-        validatePayloadTransform(cloudEventData, expectedPayload);
-    }
-
-    @Test
     void testWithHostUrl() {
         JsonObject cloudEventData = createIncomingPayload(TEST_URL);
         JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
@@ -245,32 +229,11 @@ public class PagerDutyTransformerTest extends CamelQuarkusTestSupport {
     }
 
     @Test
-    void testWithClientDisplayNameAndInventoryId() {
-        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
-        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
-        cloudPayload.put(CONTEXT, JsonObject.of(
-                DISPLAY_NAME, "console",
-                "inventory_id", "8a4a4f75-5319-4255-9eb5-1ee5a92efd7f"
-        ));
-        cloudEventData.put(PAYLOAD, cloudPayload);
-    }
-
-    @Test
     void testWithMissingInventoryId() {
         JsonObject cloudEventData = createIncomingPayload(TEST_URL);
         JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
         JsonObject context = cloudPayload.getJsonObject(CONTEXT);
         context.remove("inventory_id");
-
-        JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
-        validatePayloadTransform(cloudEventData, expectedPayload);
-    }
-
-    @Test
-    void testMissingEnvironmentUrl() {
-        JsonObject cloudEventData = createIncomingPayload(TEST_URL);
-        JsonObject cloudPayload = cloudEventData.getJsonObject(PAYLOAD);
-        cloudPayload.remove(ENVIRONMENT_URL);
 
         JsonObject expectedPayload = buildExpectedOutgoingPayload(cloudEventData);
         validatePayloadTransform(cloudEventData, expectedPayload);

--- a/database/src/main/resources/db/migration/V1.111.0__RHCLOUD-22813_update_template_host_app_urls.sql
+++ b/database/src/main/resources/db/migration/V1.111.0__RHCLOUD-22813_update_template_host_app_urls.sql
@@ -1,0 +1,11 @@
+UPDATE template
+SET data = '{#if data.context.display_name??}<{data.inventory_url}|{data.context.display_name}> triggered {data.events.size()} event{#if data.events.size() > 1}s{/if}{#else}{data.events.size()} event{#if data.events.size() > 1}s{/if} triggered{/if} from {data.source.application.display_name} - {data.source.bundle.display_name}. <{data.application_url}|Open {data.source.application.display_name}>'
+WHERE name = 'generic-slack';
+
+UPDATE template
+SET data = '{"text":"{#if data.context.display_name??}[{data.context.display_name}]({data.inventory_url}) triggered {data.events.size()} event{#if data.events.size() > 1}s{/if}{#else}{data.events.size()} event{#if data.events.size() > 1}s{/if} triggered{/if} from {data.source.application.display_name} - {data.source.bundle.display_name}. [Open {data.source.application.display_name}]({data.application_url})"}'
+WHERE name = 'generic-teams';
+
+UPDATE template
+SET data = '{"text":"{#if data.context.display_name??}<{data.inventory_url}|{data.context.display_name}> triggered {data.events.size()} event{#if data.events.size() > 1}s{/if}{#else}{data.events.size()} event{#if data.events.size() > 1}s{/if} triggered{/if} from {data.source.application.display_name} - {data.source.bundle.display_name}. <{data.application_url}|Open {data.source.application.display_name}>"}'
+WHERE name = 'generic-google-chat';

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
@@ -7,7 +7,6 @@ import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.db.repositories.TemplateRepository;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.Endpoint;
-import com.redhat.cloud.notifications.models.Environment;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.IntegrationTemplate;
 import com.redhat.cloud.notifications.processors.ConnectorSender;
@@ -33,9 +32,6 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
 
     @Inject
     BaseTransformer baseTransformer;
-
-    @Inject
-    Environment environment;
 
     @Inject
     InsightsUrlsBuilder insightsUrlsBuilder;
@@ -79,7 +75,6 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
 
     protected String buildNotificationMessage(Event event) {
         JsonObject data = baseTransformer.toJsonObject(event);
-        data.put("environment_url", environment.url());
         insightsUrlsBuilder.buildInventoryUrl(data).ifPresent(url -> data.put("inventory_url", url));
         data.put("application_url", insightsUrlsBuilder.buildApplicationUrl(data));
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
@@ -3,7 +3,6 @@ package com.redhat.cloud.notifications.processors.pagerduty;
 import com.redhat.cloud.notifications.DelayedThrower;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.models.Endpoint;
-import com.redhat.cloud.notifications.models.Environment;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.PagerDutyProperties;
 import com.redhat.cloud.notifications.processors.ConnectorSender;
@@ -34,9 +33,6 @@ public class PagerDutyProcessor extends EndpointTypeProcessor {
 
     @Inject
     EngineConfig engineConfig;
-
-    @Inject
-    Environment environment;
 
     @Inject
     InsightsUrlsBuilder insightsUrlsBuilder;
@@ -77,7 +73,6 @@ public class PagerDutyProcessor extends EndpointTypeProcessor {
 
         JsonObject connectorData = new JsonObject();
         JsonObject transformedEvent = transformer.toJsonObject(event);
-        transformedEvent.put("environment_url", environment.url());
         insightsUrlsBuilder.buildInventoryUrl(transformedEvent).ifPresent(url -> transformedEvent.put("inventory_url", url));
         transformedEvent.put("application_url", insightsUrlsBuilder.buildApplicationUrl(transformedEvent));
         transformedEvent.put("severity", properties.getSeverity());

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
@@ -182,7 +182,8 @@ public abstract class CamelProcessorTest {
         event.setId(UUID.randomUUID());
         event.setOrgId(DEFAULT_ORG_ID);
         event.setEventWrapper(new EventWrapperAction(action));
-        event.setApplicationDisplayName("policies");
+        event.setBundleDisplayName("Red Hat Enterprise Linux");
+        event.setApplicationDisplayName("Policies");
         Application application = new Application();
         application.setName("policies");
         EventType eventType = new EventType();

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/google/chat/GoogleChatProcessorTest.java
@@ -15,17 +15,17 @@ import static com.redhat.cloud.notifications.events.EndpointProcessor.GOOGLE_CHA
 public class GoogleChatProcessorTest extends CamelProcessorTest {
 
     private static final String GOOGLE_CHAT_TEMPLATE = "{\"text\":\"{#if data.context.display_name??}" +
-            "<{data.environment_url}/insights/inventory/{data.context.inventory_id}|{data.context.display_name}> " +
+            "<{data.inventory_url}|{data.context.display_name}> " +
             "triggered {data.events.size()} event{#if data.events.size() > 1}s{/if}" +
-            "{#else}{data.events.size()} event{#if data.events.size() > 1}s{/if} triggered{/if} " +
-            "from {data.bundle}/{data.application}. " +
-            "<{data.environment_url}/insights/{data.application}|Open {data.application}>\"}";
+            "{#else}{data.events.size()} event{#if data.events.size() > 1}s{/if} " +
+            "triggered{/if} from {data.source.application.display_name} - {data.source.bundle.display_name}. " +
+            "<{data.application_url}|Open {data.source.application.display_name}>\"}";
 
     private static final String GOOGLE_CHAT_EXPECTED_MSG = "{\"text\":\"<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
-            "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>\"}";
+            "triggered 1 event from Policies - Red Hat Enterprise Linux. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open Policies>\"}";
 
-    private static final String GOOGLE_CHAT_EXPECTED_MSG_WITH_HOST_URL = "{\"text\":\"<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
-            "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>\"}";
+    private static final String GOOGLE_CHAT_EXPECTED_MSG_WITH_HOST_URL = "{\"text\":\"<" + CONTEXT_HOST_URL + "|my-computer> " +
+            "triggered 1 event from Policies - Red Hat Enterprise Linux. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open Policies>\"}";
 
     @Inject
     GoogleChatProcessor googleSpacesProcessor;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/slack/SlackProcessorTest.java
@@ -29,15 +29,15 @@ public class SlackProcessorTest extends CamelProcessorTest {
     private static final String WEBHOOK_URL = "https://foo.bar";
     private static final String CHANNEL = "#notifications";
     private static final String SLACK_TEMPLATE = "{#if data.context.display_name??}" +
-            "<{data.environment_url}/insights/inventory/{data.context.inventory_id}|{data.context.display_name}> " +
+            "<{data.inventory_url}|{data.context.display_name}> " +
             "triggered {data.events.size()} event{#if data.events.size() > 1}s{/if}" +
             "{#else}{data.events.size()} event{#if data.events.size() > 1}s{/if} triggered{/if} " +
-            "from {data.bundle}/{data.application}. " +
-            "<{data.environment_url}/insights/{data.application}|Open {data.application}>";
+            "from {data.source.application.display_name} - {data.source.bundle.display_name}. " +
+            "<{data.application_url}|Open {data.source.application.display_name}>";
     private static final String SLACK_EXPECTED_MSG = "<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
-            "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>";
-    private static final String SLACK_EXPECTED_MSG_WITH_HOST_URL = "<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
-            "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>";
+            "triggered 1 event from Policies - Red Hat Enterprise Linux. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open Policies>";
+    private static final String SLACK_EXPECTED_MSG_WITH_HOST_URL = "<" + CONTEXT_HOST_URL + "|my-computer> " +
+            "triggered 1 event from Policies - Red Hat Enterprise Linux. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open Policies>";
 
     @Inject
     SlackProcessor slackProcessor;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/teams/TeamsProcessorTest.java
@@ -14,18 +14,18 @@ import static com.redhat.cloud.notifications.events.EndpointProcessor.TEAMS_ENDP
 @QuarkusTestResource(TestLifecycleManager.class)
 public class TeamsProcessorTest extends CamelProcessorTest {
 
-    private static final String TEAMS_TEMPLATE = "{#if data.context.display_name??}" +
-            "<{data.environment_url}/insights/inventory/{data.context.inventory_id}|{data.context.display_name}> " +
+    private static final String TEAMS_TEMPLATE = "{\"text\":\"{#if data.context.display_name??}" +
+            "[{data.context.display_name}]({data.inventory_url}) " +
             "triggered {data.events.size()} event{#if data.events.size() > 1}s{/if}" +
             "{#else}{data.events.size()} event{#if data.events.size() > 1}s{/if} triggered{/if} " +
-            "from {data.bundle}/{data.application}. " +
-            "<{data.environment_url}/insights/{data.application}|Open {data.application}>";
+            "from {data.source.application.display_name} - {data.source.bundle.display_name}. " +
+            "[Open {data.source.application.display_name}]({data.application_url})\"}";
 
-    private static final String TEAMS_EXPECTED_MSG = "<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
-            "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>";
+    private static final String TEAMS_EXPECTED_MSG = "{\"text\":\"[my-computer](" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f) " +
+            "triggered 1 event from Policies - Red Hat Enterprise Linux. [Open Policies](" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies)\"}";
 
-    private static final String TEAMS_EXPECTED_MSG_WITH_HOST_URL = "<" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/inventory/6ad30f3e-0497-4e74-99f1-b3f9a6120a6f|my-computer> " +
-            "triggered 1 event from rhel/policies. <" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies|Open policies>";
+    private static final String TEAMS_EXPECTED_MSG_WITH_HOST_URL = "{\"text\":\"[my-computer](" + CONTEXT_HOST_URL + ") " +
+            "triggered 1 event from Policies - Red Hat Enterprise Linux. [Open Policies](" + EnvironmentTest.expectedTestEnvUrlValue + "/insights/policies)\"}";
 
     @Inject
     TeamsProcessor teamsProcessor;

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessorTest.java
@@ -12,7 +12,6 @@ import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
-import com.redhat.cloud.notifications.models.Environment;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
@@ -73,9 +72,6 @@ public class PagerDutyProcessorTest {
     BaseTransformer transformer;
 
     @Inject
-    Environment environment;
-
-    @Inject
     InsightsUrlsBuilder insightsUrlsBuilder;
 
     @PostConstruct
@@ -128,7 +124,6 @@ public class PagerDutyProcessorTest {
         JsonObject payload = message.getPayload();
 
         final JsonObject payloadToSend = transformer.toJsonObject(event);
-        payloadToSend.put("environment_url", environment.url());
         insightsUrlsBuilder.buildInventoryUrl(payloadToSend)
                 .ifPresent(url -> payloadToSend.put("inventory_url", url));
         payloadToSend.put("application_url", insightsUrlsBuilder.buildApplicationUrl(payloadToSend));
@@ -191,7 +186,6 @@ public class PagerDutyProcessorTest {
         JsonObject payload = message.getPayload();
 
         final JsonObject payloadToSend = transformer.toJsonObject(event);
-        payloadToSend.put("environment_url", environment.url());
         insightsUrlsBuilder.buildInventoryUrl(payloadToSend)
                 .ifPresent(url -> payloadToSend.put("inventory_url", url));
         payloadToSend.put("application_url", insightsUrlsBuilder.buildApplicationUrl(payloadToSend));


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-22813

## Breaking changes

This is the second part of #3221, splitting the two breaking changes into a separate PR:

- The removal of `data.environment_url` from `EngineToConnector` messages for PagerDuty and CamelProcessor (Google Chat, Slack, Microsoft Teams)
- Updating the Qute template to the new format described in the other PR, in database migration `V1.111.0`

> [!NOTE]
>
> **One change has been made to the existing format:** Camel messages no longer contain a leading `\n`. This caused unexpected failures while testing the Slack processor, and weirdly did not fail with the Teams processor when it should have.