### PR TITLE
[RHCLOUD-37354] add bulk resources for Notifications GW

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -17,8 +17,11 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.NotFoundException;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -187,7 +190,20 @@ public class ApplicationRepository {
         } catch (NoResultException noResultException) {
             return null;
         }
+    }
 
+    public Map<String, Map<String, List<String>>> getBaetList() {
+        final String query = "SELECT application.bundle.name, application.name, name FROM EventType";
+        try {
+            List<String[]> flatBaet = entityManager.createQuery(query, String[].class)
+                .getResultList();
+
+            final Map<String, Map<String, List<String>>> mapBaet = new HashMap<>();
+            flatBaet.stream().forEach(baet -> mapBaet.computeIfAbsent(baet[0], k -> new HashMap<>()).computeIfAbsent(baet[1], k -> new ArrayList<>()).add(baet[2]));
+            return mapBaet;
+        } catch (NoResultException noResultException) {
+            return null;
+        }
     }
 
     public List<EventType> getEventTypes(UUID appId) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -194,16 +194,12 @@ public class ApplicationRepository {
 
     public Map<String, Map<String, List<String>>> getBaetList() {
         final String query = "SELECT application.bundle.name, application.name, name FROM EventType";
-        try {
-            List<String[]> flatBaet = entityManager.createQuery(query, String[].class)
-                .getResultList();
+        final List<String[]> flatBaet = entityManager.createQuery(query, String[].class)
+            .getResultList();
 
-            final Map<String, Map<String, List<String>>> mapBaet = new HashMap<>();
-            flatBaet.stream().forEach(baet -> mapBaet.computeIfAbsent(baet[0], k -> new HashMap<>()).computeIfAbsent(baet[1], k -> new ArrayList<>()).add(baet[2]));
-            return mapBaet;
-        } catch (NoResultException noResultException) {
-            return null;
-        }
+        final Map<String, Map<String, List<String>>> mapBaet = new HashMap<>();
+        flatBaet.stream().forEach(baet -> mapBaet.computeIfAbsent(baet[0], k -> new HashMap<>()).computeIfAbsent(baet[1], k -> new ArrayList<>()).add(baet[2]));
+        return mapBaet;
     }
 
     public List<EventType> getEventTypes(UUID appId) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/X509CertificateRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/X509CertificateRepository.java
@@ -7,6 +7,7 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -42,6 +43,13 @@ public class X509CertificateRepository {
         } catch (NoResultException e) {
             return Optional.empty();
         }
+    }
+
+    public List<X509Certificate> findCertificates() {
+        final String query = "FROM X509Certificate";
+        return this.entityManager
+            .createQuery(query, X509Certificate.class)
+            .getResultList();
     }
 
     @Transactional

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/ValidationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/ValidationResource.java
@@ -23,6 +23,8 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.jboss.resteasy.reactive.RestQuery;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
@@ -59,6 +61,13 @@ public class ValidationResource {
         } else {
             return Response.ok().build();
         }
+    }
+
+    @GET
+    @Path("/baet_list")
+    @Produces(APPLICATION_JSON)
+    public Map<String, Map<String, List<String>>> listBaet() {
+        return applicationRepository.getBaetList();
     }
 
     @POST
@@ -136,5 +145,12 @@ public class ValidationResource {
         } else {
             return gatewayCertificate.get();
         }
+    }
+
+    @GET
+    @Path("/certificates")
+    @Produces(APPLICATION_JSON)
+    public List<X509Certificate> getCertificates() {
+        return x509CertificateRepository.findCertificates();
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/ValidationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/ValidationResourceTest.java
@@ -1,0 +1,73 @@
+package com.redhat.cloud.notifications.routers.internal;
+
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.models.EventType;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.Header;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.CrudTestHelpers.createApp;
+import static com.redhat.cloud.notifications.CrudTestHelpers.createBundle;
+import static com.redhat.cloud.notifications.CrudTestHelpers.createEventType;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.ws.rs.core.Response.Status.OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class ValidationResourceTest extends DbIsolatedTest {
+
+
+    @ConfigProperty(name = "internal.admin-role")
+    String adminRole;
+
+    @Test
+    void testGetBaetList() {
+        Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
+
+        final String bundleName = "bundle-name-baet1";
+        final String applicationName = "application-name-baet1";
+        String bundleId = createBundle(adminIdentity, bundleName, RandomStringUtils.secure().nextAlphanumeric(10), OK.getStatusCode()).get();
+        String applicationId = createApp(adminIdentity, bundleId, applicationName, RandomStringUtils.secure().nextAlphanumeric(10), null, OK.getStatusCode()).get();
+        EventType eventType = new EventType();
+        eventType.setDescription(RandomStringUtils.secure().nextAlphanumeric(10));
+        eventType.setName("event1");
+        eventType.setDisplayName("Event 1");
+        eventType.setApplicationId(UUID.fromString(applicationId));
+        createEventType(adminIdentity, eventType, OK.getStatusCode());
+
+        eventType.setName("event2");
+        eventType.setDisplayName("Event 2");
+        createEventType(adminIdentity, eventType, OK.getStatusCode());
+
+        Map<String, Map<String, List<String>>> baetMap = given()
+            .header(adminIdentity)
+            .contentType(JSON)
+            .when()
+            .get("/internal/validation/baet_list")
+            .then()
+            .statusCode(OK.getStatusCode()).extract().as(new TypeRef<>() { });
+
+        assertEquals(2, baetMap.size());
+        assertEquals(1, baetMap.get("rhel").size());
+        assertEquals(1, baetMap.get("rhel").get("policies").size());
+        assertTrue(baetMap.get("rhel").get("policies").contains("policy-triggered"));
+
+        assertEquals(1, baetMap.get(bundleName).size());
+        assertEquals(2, baetMap.get(bundleName).get(applicationName).size());
+        assertTrue(baetMap.get(bundleName).get(applicationName).contains("event1"));
+        assertTrue(baetMap.get(bundleName).get(applicationName).contains("event2"));
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/ValidationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/ValidationResourceTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
-public class ValidationResourceTest extends DbIsolatedTest {
+class ValidationResourceTest extends DbIsolatedTest {
 
 
     @ConfigProperty(name = "internal.admin-role")


### PR DESCRIPTION
Curently, Notifications GW need to check baet (Bundle + Application + Event Type) existence to valid messages, and also to check certificate CN for tenants who could use their stage environment with Notifications Prod instance.

To get the GW resilient to a database outage/maintenance, we need to cache those data at GW startup, then refresh those periodically when Notifications Backend is available. (If it's not it will have to keep and work with initially loaded  data set)