### PR TITLE
RHCLOUD-37430 | fix: integrations are not being returned sometimes

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -134,6 +134,8 @@ objects:
           value: ${NOTIFICATIONS_KESSEL_MIGRATION_BATCH_SIZE}
         - name: NOTIFICATIONS_KESSEL_RELATIONS_ENABLED
           value: ${NOTIFICATIONS_KESSEL_RELATIONS_ENABLED}
+        - name: NOTIFICATIONS_KESSEL_RELATIONS_LOOKUP_RESOURCES_LIMIT
+          value: ${NOTIFICATIONS_KESSEL_RELATIONS_LOOKUP_RESOURCES_LIMIT}
         - name: NOTIFICATIONS_KESSEL_BACKEND_ENABLED
           value: ${NOTIFICATIONS_KESSEL_BACKEND_ENABLED}
         - name: NOTIFICATIONS_RBAC_PSKS
@@ -296,6 +298,9 @@ parameters:
 - name: NOTIFICATIONS_KESSEL_RELATIONS_ENABLED
   description: Is the integration with Kessel's relations enabled?
   value: "false"
+- name: NOTIFICATIONS_KESSEL_RELATIONS_LOOKUP_RESOURCES_LIMIT
+  description: The maximum number of resources that we want Kessel to stream back at us when looking them up.
+  value: "1000"
 - name: NOTIFICATIONS_KESSEL_RELATIONS_SECURE_CLIENTS
   description: Should the inventory gRPC client open channels over TLS?
   value: "false"

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
@@ -22,6 +22,7 @@ import org.project_kessel.api.relations.v1beta1.LookupResourcesRequest;
 import org.project_kessel.api.relations.v1beta1.LookupResourcesResponse;
 import org.project_kessel.api.relations.v1beta1.ObjectReference;
 import org.project_kessel.api.relations.v1beta1.ObjectType;
+import org.project_kessel.api.relations.v1beta1.RequestPagination;
 import org.project_kessel.api.relations.v1beta1.SubjectReference;
 import org.project_kessel.relations.client.CheckClient;
 import org.project_kessel.relations.client.LookupClient;
@@ -137,7 +138,8 @@ public class KesselAuthorization {
 
     /**
      * Looks up the integrations the security context's subject has the given
-     * permission for.
+     * permission for. Useful for when we want to "pre-filter" the integrations
+     * the principal has authorization for.
      * @param securityContext the security context holding the subject's
      *                        identity.
      * @param integrationPermission the integration's permission we want to use
@@ -148,43 +150,66 @@ public class KesselAuthorization {
         // Identify the subject.
         final RhIdentity identity = SecurityContextUtil.extractRhIdentity(securityContext);
 
-        // Build the lookup request for Kessel.
-        final LookupResourcesRequest request = this.buildLookupResourcesRequest(identity, integrationPermission);
-
-        Log.tracef("[identity: %s][permission: %s][resource_type: %s] Payload for the resource lookup: %s", identity, integrationPermission, ResourceType.INTEGRATION, request);
-
         // Measure the time it takes to perform the lookup operation.
         final Timer.Sample lookupTimer = Timer.start(this.meterRegistry);
 
-        // Call Kessel.
-        final Iterator<LookupResourcesResponse> responses;
-        try {
-            responses = this.lookupClient.lookupResources(request);
-        } catch (final Exception e) {
-            Log.errorf(
-                e,
-                "[identity: %s][permission: %s][resource_type: %s] Runtime error when querying Kessel for integration resources with request payload: %s",
-                identity, integrationPermission, ResourceType.INTEGRATION, request
-            );
-            meterRegistry.counter(KESSEL_METRICS_LOOKUP_RESOURCES_COUNTER_NAME, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES)).increment();
-
-            throw e;
-        } finally {
-            // Stop the timer.
-            lookupTimer.stop(this.meterRegistry.timer(KESSEL_METRICS_LOOKUP_RESOURCES_TIMER_NAME, Tags.of(KESSEL_METRICS_TAG_PERMISSION_KEY, integrationPermission.getKesselPermissionName(), Constants.KESSEL_METRICS_TAG_RESOURCE_TYPE_KEY, ResourceType.INTEGRATION.name())));
-        }
-
-        meterRegistry.counter(KESSEL_METRICS_LOOKUP_RESOURCES_COUNTER_NAME, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_SUCCESSES)).increment();
-
-        // Process the incoming responses.
+        // Prepare the set of UUIDs we are going to receive from Kessel.
         final Set<UUID> uuids = new HashSet<>();
-        while (responses.hasNext()) {
-            final LookupResourcesResponse response = responses.next();
 
-            Log.tracef("[identity: %s][permission: %s][resource_type: %s] Received payload for the resource lookup: %s", identity, integrationPermission, ResourceType.INTEGRATION, response);
+        // Every response coming from Kessel has a continuation token. In order
+        // to know when to stop querying for resources, we need to keep track
+        // of the old continuation token and the one from the latest received
+        // element. Once the old one and the new one are the same, we don't
+        // have to keep querying for more resources.
+        String continuationToken;
+        String newContinuationToken = "";
+        do {
+            // Replace the old continuation token with the new one. This way
+            // the token gets used
+            continuationToken = newContinuationToken;
 
-            uuids.add(UUID.fromString(response.getResource().getId()));
-        }
+            // Build the lookup request for Kessel.
+            final LookupResourcesRequest request = this.buildLookupResourcesRequest(identity, integrationPermission, continuationToken);
+
+            Log.tracef("[identity: %s][permission: %s][resource_type: %s] Payload for the resource lookup: %s", identity, integrationPermission, ResourceType.INTEGRATION, request);
+
+            // Make the request to Kessel.
+            final Iterator<LookupResourcesResponse> responses;
+            try {
+                responses = this.lookupClient.lookupResources(request);
+            } catch (final Exception e) {
+                Log.errorf(
+                    e,
+                    "[identity: %s][permission: %s][resource_type: %s] Runtime error when querying Kessel for integration resources with request payload: %s",
+                    identity, integrationPermission, ResourceType.INTEGRATION, request
+                );
+
+                // Increment the errors counter and stop the timer in case of
+                // an error.
+                this.meterRegistry.counter(KESSEL_METRICS_LOOKUP_RESOURCES_COUNTER_NAME, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES)).increment();
+                lookupTimer.stop(this.meterRegistry.timer(KESSEL_METRICS_LOOKUP_RESOURCES_TIMER_NAME, Tags.of(KESSEL_METRICS_TAG_PERMISSION_KEY, integrationPermission.getKesselPermissionName(), Constants.KESSEL_METRICS_TAG_RESOURCE_TYPE_KEY, ResourceType.INTEGRATION.name())));
+
+                throw e;
+            }
+
+            // Iterate over the incoming results.
+            while (responses.hasNext()) {
+                final LookupResourcesResponse response = responses.next();
+
+                Log.tracef("[identity: %s][permission: %s][resource_type: %s] Received payload for the resource lookup: %s", identity, integrationPermission, ResourceType.INTEGRATION, response);
+
+                uuids.add(UUID.fromString(response.getResource().getId()));
+
+                // Update the continuation token every time, to make sure we
+                // grab the last streamed element's continuation token.
+                newContinuationToken = response.getPagination().getContinuationToken();
+            }
+
+            meterRegistry.counter(KESSEL_METRICS_LOOKUP_RESOURCES_COUNTER_NAME, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_SUCCESSES)).increment();
+        } while (!continuationToken.equals(newContinuationToken));
+
+        // Stop the timer.
+        lookupTimer.stop(this.meterRegistry.timer(KESSEL_METRICS_LOOKUP_RESOURCES_TIMER_NAME, Tags.of(KESSEL_METRICS_TAG_PERMISSION_KEY, integrationPermission.getKesselPermissionName(), Constants.KESSEL_METRICS_TAG_RESOURCE_TYPE_KEY, ResourceType.INTEGRATION.name())));
 
         return uuids;
     }
@@ -258,11 +283,14 @@ public class KesselAuthorization {
      * @param identity the subject's identity.
      * @param kesselPermission the permission we want to check against the
      *                         subject's integrations.
+     * @param continuationToken the token that will resume fetching resources
+     *                          from Kessel from the last point we left off.
      * @return a built lookup request that aims at finding integrations for the
      * given subject.
      */
-    protected LookupResourcesRequest buildLookupResourcesRequest(final RhIdentity identity, final KesselPermission kesselPermission) {
-        return LookupResourcesRequest.newBuilder()
+    protected LookupResourcesRequest buildLookupResourcesRequest(final RhIdentity identity, final KesselPermission kesselPermission, final String continuationToken) {
+        // Build the regular query.
+        final LookupResourcesRequest.Builder requestBuilder = LookupResourcesRequest.newBuilder()
             .setSubject(
                 SubjectReference.newBuilder()
                     .setSubject(
@@ -271,8 +299,20 @@ public class KesselAuthorization {
                             .setId(getUserId(identity))
                     ).build()
             ).setRelation(kesselPermission.getKesselPermissionName())
-            .setResourceType(ResourceType.INTEGRATION.getKesselObjectType())
-            .build();
+            .setResourceType(ResourceType.INTEGRATION.getKesselObjectType());
+
+        // Include the continuation token in the request to resume fetching
+        // resources right where we last left off.
+        if (continuationToken != null && !continuationToken.isBlank()) {
+            requestBuilder.setPagination(
+                RequestPagination.newBuilder()
+                    .setContinuationToken(continuationToken)
+                    .setLimit(Integer.MAX_VALUE)
+                    .build()
+            );
+        }
+
+        return requestBuilder.build();
     }
 
     private String getUserId(RhIdentity identity) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselAuthorization.java
@@ -337,7 +337,7 @@ public class KesselAuthorization {
             requestBuilder.setPagination(
                 RequestPagination.newBuilder()
                     .setContinuationToken(continuationToken)
-                    .setLimit(Integer.MAX_VALUE)
+                    .setLimit(this.backendConfig.getKesselRelationsLookupResourceLimit())
                     .build()
             );
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -30,6 +30,7 @@ public class BackendConfig {
     private static final String KESSEL_INVENTORY_ENABLED = "notifications.kessel-inventory.enabled";
     private static final String KESSEL_MIGRATION_BATCH_SIZE = "notifications.kessel.migration.batch.size";
     private static final String KESSEL_RELATIONS_ENABLED = "notifications.kessel-relations.enabled";
+    private static final String KESSEL_RELATIONS_LOOKUP_RESOURCES_LIMIT = "notifications.kessel-relations.lookup-resources.limit";
     private static final String KESSEL_RELATIONS_URL = "relations-api.target-url";
     private static final String KESSEL_DOMAIN = "notifications.kessel.domain";
     private static final String RBAC_PSKS = "notifications.rbac.psks";
@@ -41,7 +42,6 @@ public class BackendConfig {
      */
     private String drawerToggle;
     private String kesselInventoryToggle;
-    private String kesselInventoryIntegrationsRemovalToggle;
     private String kesselRelationsToggle;
     private String maintenanceModeToggle;
 
@@ -81,6 +81,9 @@ public class BackendConfig {
     @ConfigProperty(name = KESSEL_RELATIONS_ENABLED, defaultValue = "false")
     boolean kesselRelationsEnabled;
 
+    @ConfigProperty(name = KESSEL_RELATIONS_LOOKUP_RESOURCES_LIMIT, defaultValue = "1000")
+    int kesselRelationsLookupResourceLimit;
+
     @ConfigProperty(name = ERRATA_MIGRATION_BATCH_SIZE, defaultValue = "1000")
     int errataMigrationBatchSize;
 
@@ -109,7 +112,6 @@ public class BackendConfig {
     void postConstruct() {
         drawerToggle = toggleRegistry.register("drawer", true);
         kesselInventoryToggle = toggleRegistry.register("kessel-inventory", true);
-        kesselInventoryIntegrationsRemovalToggle = toggleRegistry.register("kessel-inventory-integrations-removal", true);
         kesselRelationsToggle = toggleRegistry.register("kessel-relations", true);
         maintenanceModeToggle = toggleRegistry.register("notifications-maintenance-mode", true);
     }
@@ -124,6 +126,7 @@ public class BackendConfig {
         config.put(KESSEL_INVENTORY_ENABLED, isKesselInventoryEnabled(null));
         config.put(KESSEL_INVENTORY_URL, kesselInventoryUrl);
         config.put(KESSEL_RELATIONS_ENABLED, isKesselRelationsEnabled(null));
+        config.put(KESSEL_RELATIONS_LOOKUP_RESOURCES_LIMIT, getKesselRelationsLookupResourceLimit());
         config.put(KESSEL_RELATIONS_URL, kesselRelationsUrl);
         config.put(INSTANT_EMAILS, isInstantEmailsEnabled());
         config.put(KESSEL_DOMAIN, getKesselDomain());
@@ -166,6 +169,15 @@ public class BackendConfig {
         } else {
             return kesselInventoryEnabled;
         }
+    }
+
+    /**
+     * Specifies the maximum number of resources that we will ask Kessel to
+     * stream back at us when we are looking up resources.
+     * @return the maximum number of resources to query for in Kessel.
+     */
+    public int getKesselRelationsLookupResourceLimit() {
+        return this.kesselRelationsLookupResourceLimit;
     }
 
     /**

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/EndpointResource.java
@@ -318,12 +318,7 @@ public class EndpointResource {
             @QueryParam("active")   Boolean activeOnly,
             @QueryParam("name")     String name
         ) {
-            Log.tracef("[org_id: %s] Called V2 \"list endpoints\" endpoint", getOrgId(sec));
-            Log.debugf("[org_id: %s][query: %s][target_type: %s][active_only: %s][name: %s] Received request parameters", getOrgId(sec), query, targetType, activeOnly, name);
-
             if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-                Log.tracef("[org_id: %s] Kessel relations enabled. Looking up authorized integrations", getOrgId(sec));
-
                 // Fetch the set of integration IDs the user is authorized to view.
                 final Set<UUID> authorizedIds = this.kesselAuthorization.lookupAuthorizedIntegrations(sec, IntegrationPermission.VIEW);
                 if (authorizedIds.isEmpty()) {
@@ -334,8 +329,6 @@ public class EndpointResource {
 
                 return internalGetEndpoints(sec, query, targetType, activeOnly, name, authorizedIds, true);
             } else {
-                Log.tracef("[org_id :%s] Legacy RBAC enabled", getOrgId(sec));
-
                 return getEndpointsLegacyRBACRoles(sec, query, targetType, activeOnly, name, true);
             }
         }
@@ -365,12 +358,7 @@ public class EndpointResource {
         @QueryParam("active")   Boolean activeOnly,
         @QueryParam("name")     String name
     ) {
-        Log.tracef("[org_id: %s] Called V1 \"list endpoints\" endpoint", getOrgId(sec));
-        Log.debugf("[org_id: %s][query: %s][target_type: %s][active_only: %s][name: %s] Received request parameters", getOrgId(sec), query, targetType, activeOnly, name);
-
         if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            Log.tracef("[org_id: %s] Kessel relations enabled. Looking up authorized integrations", getOrgId(sec));
-
             // Fetch the set of integration IDs the user is authorized to view.
             final Set<UUID> authorizedIds = this.kesselAuthorization.lookupAuthorizedIntegrations(sec, IntegrationPermission.VIEW);
             if (authorizedIds.isEmpty()) {
@@ -381,8 +369,6 @@ public class EndpointResource {
 
             return this.internalGetEndpoints(sec, query, targetType, activeOnly, name, authorizedIds, false);
         } else {
-            Log.tracef("[org_id :%s] Legacy RBAC enabled", getOrgId(sec));
-
             return this.getEndpointsLegacyRBACRoles(sec, query, targetType, activeOnly, name, false);
         }
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -109,16 +109,16 @@ quarkus.unleash.url=http://localhost:4242
 quarkus.log.category."com.redhat.cloud.notifications.routers.internal.kessel.KesselAssetsMigrationService".min-level=TRACE
 quarkus.log.category."com.redhat.cloud.notifications.auth.kessel".min-level=TRACE
 
-inventory-api.authn.client.id=insights-notifications
+inventory-api.authn.client.id=svc-test
 inventory-api.authn.client.issuer=http://localhost:8084/realms/redhat-external
-inventory-api.authn.client.secret=development-value-123
+inventory-api.authn.client.secret=h91qw8bPiDj9R6VSORsI5TYbceGU5PMH
 inventory-api.authn.mode=oidc-client-credentials
 inventory-api.is-secure-clients=false
 inventory-api.target-url=${clowder.endpoints.kessel-inventory-api:localhost:9081}
 
-relations-api.authn.client.id=insights-notifications
+relations-api.authn.client.id=svc-test
 relations-api.authn.client.issuer=http://localhost:8084/realms/redhat-external
-relations-api.authn.client.secret=development-value-123
+relations-api.authn.client.secret=h91qw8bPiDj9R6VSORsI5TYbceGU5PMH
 relations-api.authn.mode=oidc-client-credentials
 relations-api.is-secure-clients=false
 relations-api.target-url=${clowder.endpoints.kessel-relations-api:localhost:9000}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -122,8 +122,3 @@ relations-api.authn.client.secret=h91qw8bPiDj9R6VSORsI5TYbceGU5PMH
 relations-api.authn.mode=oidc-client-credentials
 relations-api.is-secure-clients=false
 relations-api.target-url=${clowder.endpoints.kessel-relations-api:localhost:9000}
-
-# Enabling "trace" logging level for debugging purposes. Safe to remove these
-# lines after RHCLOUD-37430 has been closed.
-quarkus.log.category."com.redhat.cloud.notifications.db.builder.Parameters".min-level=TRACE
-quarkus.log.category."com.redhat.cloud.notifications.routers.EndpointResource".min-level=TRACE


### PR DESCRIPTION
We were getting reports of integrations not showing up in stage when Kessel Relations was enabled. More specifically, the issue was that after trying to filter integrations by name, some of them did simply not show up in the results even though they were recently created.

After investigating the issue, it turned out that the problem was that we were getting an incomplete set of authorized integration IDs from Kessel, which in turn made us filter the database query results incorrectly, which again, in turn, made us return an inaccurate list of integrations for an organization.

The QE organization which reported the issue had around 2,500 integrations created, and when a request was made to look up for a very specific integration with name "X", Notifications first had to ask Kessel for the principal's authorized integrations. Since Kessel only returned a batch of a 1,000 we would use just those to apply a "integration ID in" filter in the query, so if the specified name in the request was in that batch, the user was lucky and the integration was returned.

These changes introduce a mechanism that keeps firing requests to Kessel whenever there is a continuation token available. That makes sure that we are fetching all the integrations that the user has access to, so that we don't miss any when querying our database.

## Jira ticket
[[RHCLOUD-37430]](https://issues.redhat.com/browse/RHCLOUD-37430)