### PR TITLE
[RHCLOUD-22813] Adjust wording for PD Client title

### DIFF
--- a/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
+++ b/connector-pagerduty/src/main/java/com/redhat/cloud/notifications/connector/pagerduty/PagerDutyTransformer.java
@@ -177,7 +177,7 @@ public class PagerDutyTransformer implements Processor {
     static JsonObject getClientLinks(final JsonObject cloudEventPayload) {
         JsonObject clientLinks = new JsonObject();
 
-        clientLinks.put(CLIENT, String.format("Open %s", cloudEventPayload.getString(APPLICATION)));
+        clientLinks.put(CLIENT, String.format("%s", cloudEventPayload.getString(APPLICATION)));
         clientLinks.put(CLIENT_URL, cloudEventPayload.getString(APPLICATION_URL));
 
         String inventoryUrl = cloudEventPayload.getString(INVENTORY_URL, "");


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-22813

Adjust wording in upcoming PagerDuty messages, removes `"Open "` from the title of the Client (Application) URL.

Example of behaviour to be corrected: 
![Screenshot From 2025-01-29 11-14-07](https://github.com/user-attachments/assets/f67d0eeb-f0c2-4e73-8820-579e5d5d6359)
