### PR TITLE
 RHCLOUD-37680 | feature: bypass the maximum behavior group creation limit with Unleash

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -44,6 +44,7 @@ public class BackendConfig {
     private String kesselInventoryIntegrationsRemovalToggle;
     private String kesselRelationsToggle;
     private String maintenanceModeToggle;
+    private String bypassBehaviorGroupMaxCreationLimitToggle;
 
     private static String toggleName(String feature) {
         return String.format("notifications-backend.%s.enabled", feature);
@@ -112,6 +113,7 @@ public class BackendConfig {
         kesselInventoryIntegrationsRemovalToggle = toggleRegistry.register("kessel-inventory-integrations-removal", true);
         kesselRelationsToggle = toggleRegistry.register("kessel-relations", true);
         maintenanceModeToggle = toggleRegistry.register("notifications-maintenance-mode", true);
+        bypassBehaviorGroupMaxCreationLimitToggle = toggleRegistry.register("bypass-behavior-group-max-creation-limit", true);
     }
 
     void logConfigAtStartup(@Observes Startup event) {
@@ -218,5 +220,26 @@ public class BackendConfig {
             return unleash.isEnabled(maintenanceModeToggle, unleashContext, false);
         }
         return maintenanceModeEnabled;
+    }
+
+    /**
+     * Checks whether the behavior group creation limit is disabled for the
+     * given organization.
+     * @param orgId the organization we want to check the limit for.
+     * @return {@code true} for almost all the organizations. We might disable
+     * this limit on a very specific organization from time to time if we want
+     * to perform some kind of tests, but it is going to be an exception.
+     * @deprecated for removal because once behavior groups go away this
+     * configuration check will not make any sense anymore.
+     */
+    @Deprecated(forRemoval = true)
+    public boolean isBehaviorGroupCreationLimitDisabledForOrgId(final String orgId) {
+        if (unleashEnabled) {
+            final UnleashContext unleashContext = buildUnleashContextWithOrgId(orgId);
+
+            return unleash.isEnabled(bypassBehaviorGroupMaxCreationLimitToggle, unleashContext, false);
+        } else {
+            return false;
+        }
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -777,6 +777,13 @@ public class BehaviorGroupRepository {
      * {@link BehaviorGroupRepository#MAXIMUM_NUMBER_BEHAVIOR_GROUPS}.
      */
     private boolean isAllowedToCreateMoreBehaviorGroups(final String orgId) {
+        // Check with Unleash if we have any overrides for this limit. There
+        // might be some special cases where an organization might require more
+        // than the established limit of behavior groups.
+        if (this.backendConfig.isBehaviorGroupCreationLimitDisabledForOrgId(orgId)) {
+            return true;
+        }
+
         final String countQuery =
             "SELECT " +
                 "COUNT(bg) " +


### PR DESCRIPTION
There are very specific organizations that, for reasons that make sense, might want to have more than the currently established limit of behavior groups.

For that purpose, we are simply adding an Unleash toggle that will be enabled by default for everybody, and that will allow us to selectively disable it for certain organizations.

## Jira ticket
[[RHCLOUD-37680]](https://issues.redhat.com/browse/RHCLOUD-37680)