### PR TITLE
GetGroupUsers adding query param admin_only

### DIFF
--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServices.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServices.java
@@ -312,6 +312,7 @@ public class FetchUsersFromExternalServices {
         } else {
             users = getWithPagination(page -> {
                 Timer.Sample getGroupUsersPageTimer = Timer.start(meterRegistry);
+                // or do i have to add it here 
                 Page<RbacUser> rbacUsers = retryOnError(() ->
                     rbacServiceToService.getGroupUsers(orgId, groupId, page * recipientsResolverConfig.getMaxResultsPerPage(), recipientsResolverConfig.getMaxResultsPerPage()));
                 // Micrometer doesn't like when tags are null and throws a NPE.
@@ -322,6 +323,7 @@ public class FetchUsersFromExternalServices {
 
             // getGroupUsers doesn't have an adminOnly param.
             if (adminOnly) {
+                //users = getGroupUsers(adminOnly)
                 users = users.stream().filter(User::isAdmin).collect(Collectors.toList());
             }
         }

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/rbac/RbacServiceToService.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/rbac/RbacServiceToService.java
@@ -40,6 +40,7 @@ public interface RbacServiceToService {
     Page<RbacUser> getGroupUsers(
             @HeaderParam("x-rh-rbac-org-id") String orgId,
             @PathParam("groupId") UUID groupId,
+            @QueryParam("admin_only") Boolean adminOnly,
             @QueryParam("offset") Integer offset,
             @QueryParam("limit") Integer limit
     );


### PR DESCRIPTION
rbac added a new query parameter for getgroupusers called admin_only. Now we don't have to use our own filtering for adminonly. 