### PR TITLE
refactor: remove unnecessary log

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/builder/QueryBuilder.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/builder/QueryBuilder.java
@@ -1,7 +1,6 @@
 package com.redhat.cloud.notifications.db.builder;
 
 import com.redhat.cloud.notifications.db.Query;
-import io.quarkus.logging.Log;
 import jakarta.persistence.TypedQuery;
 
 import java.util.Map;
@@ -109,8 +108,6 @@ public class QueryBuilder<T> {
         }
 
         appendRemaining(rawQuery);
-
-        Log.debugf("Built query: %s", rawQuery.toString());
 
         return rawQuery.toString();
     }


### PR DESCRIPTION
The log statement was part of an old debug session and it is not used anymore.