### PR TITLE
[RHCLOUD-37537] Separate SQL upgrades and Engine updates

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Event.java
@@ -71,9 +71,6 @@ public class Event {
     @OneToMany(mappedBy = "event", cascade = REMOVE)
     Set<NotificationHistory> historyEntries;
 
-    @NotNull
-    private boolean hasAuthorizationCriterion = false;
-
     private String payload;
 
     private String renderedDrawerNotification;
@@ -251,15 +248,6 @@ public class Event {
 
     public void setSourceEnvironment(String sourceEnvironment) {
         this.sourceEnvironment = sourceEnvironment;
-    }
-
-    @NotNull
-    public boolean hasAuthorizationCriterion() {
-        return hasAuthorizationCriterion;
-    }
-
-    public void setHasAuthorizationCriterion(@NotNull boolean hasAuthorizationCriterion) {
-        this.hasAuthorizationCriterion = hasAuthorizationCriterion;
     }
 
     @Override

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -11,7 +11,6 @@ import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.NotificationsConsoleCloudEvent;
-import com.redhat.cloud.notifications.processors.RecipientsAuthorizationCriterionExtractor;
 import com.redhat.cloud.notifications.utils.ActionParser;
 import com.redhat.cloud.notifications.utils.ActionParsingException;
 import io.micrometer.core.instrument.Counter;
@@ -84,9 +83,6 @@ public class EventConsumer {
 
     @Inject
     EngineConfig config;
-
-    @Inject
-    RecipientsAuthorizationCriterionExtractor recipientsAuthorizationCriterionExtractor;
 
     ConsoleCloudEventParser cloudEventParser = new ConsoleCloudEventParser();
 
@@ -247,7 +243,6 @@ public class EventConsumer {
                  */
                 Optional<String> sourceEnvironmentHeader = kafkaHeaders.get(SOURCE_ENVIRONMENT_HEADER);
                 Event event = new Event(eventType, payload, eventWrapperToProcess, sourceEnvironmentHeader);
-                event.setHasAuthorizationCriterion(null != recipientsAuthorizationCriterionExtractor.extract(event));
                 if (event.getId() == null) {
                     // NOTIF-499 If there is no ID provided whatsoever we create one.
                     event.setId(Objects.requireNonNullElseGet(messageId, UUID::randomUUID));


### PR DESCRIPTION
Changes introduced by [this PR](https://github.com/RedHatInsights/notifications-backend/pull/3258/files#diff-6bd9650840a80f42278e08cae86b7f1510368200c2114a93a848b62e233cf3a5) breaks message processing during deployment phase, because SQL and java code using updates are not deploy in the same single module. 