### PR TITLE
RHCLOUD-37782 | feature: restrict Kessel Assets' migration to a specific org

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationRequest.java
@@ -1,0 +1,13 @@
+package com.redhat.cloud.notifications.routers.internal.kessel;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the expected request's structure when requesting a migration for
+ * the Kessel's assets.
+ * @param orgId the organization ID for which the assets want to be migrated.
+ */
+public record KesselAssetsMigrationRequest(
+    @JsonProperty("org_id") String orgId
+) {
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
@@ -11,11 +11,14 @@ import io.quarkus.logging.Log;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import jakarta.annotation.Nullable;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
 import org.project_kessel.api.relations.v1beta1.CreateTuplesRequest;
 import org.project_kessel.api.relations.v1beta1.CreateTuplesResponse;
 import org.project_kessel.api.relations.v1beta1.ImportBulkTuplesRequest;
@@ -28,6 +31,7 @@ import org.project_kessel.relations.client.RelationTuplesClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -56,11 +60,15 @@ public class KesselAssetsMigrationService {
     @Inject
     WorkspaceUtils workspaceUtils;
 
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/kessel/migrate-assets")
     @POST
     @RunOnVirtualThread
-    public void migrateAssets() {
+    public void migrateAssets(@Nullable final KesselAssetsMigrationRequest kamRequest) {
         Log.info("Kessel assets' migration begins");
+
+        // Grab the organization ID specified in the request.
+        final Optional<String> orgId = (kamRequest == null) ? Optional.empty() : Optional.of(kamRequest.orgId());
 
         int fetchedEndpointsSize = 0;
         int offset = 0;
@@ -68,7 +76,7 @@ public class KesselAssetsMigrationService {
         do {
             Log.debugf("[loops: %s] Loops", traceLoops);
 
-            final List<Endpoint> fetchedEndpoints = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(this.backendConfig.getKesselMigrationBatchSize(), offset);
+            final List<Endpoint> fetchedEndpoints = this.endpointRepository.getNonSystemEndpointsByOrgIdWithLimitAndOffset(orgId, this.backendConfig.getKesselMigrationBatchSize(), offset);
             Log.debugf("[offset: %s][first_integration: %s][last_integration: %s] Fetched batch of %s integrations", offset, (fetchedEndpoints.isEmpty()) ? "none" : fetchedEndpoints.getFirst().getId(), (fetchedEndpoints.isEmpty()) ? "none" : fetchedEndpoints.getLast().getId(), fetchedEndpoints.size());
 
             // If for some reason we have fetched full pages from the database
@@ -115,7 +123,7 @@ public class KesselAssetsMigrationService {
 
     @Path("/kessel/migrate-assets/async")
     @POST
-    public void migrateAssetsAsync() {
+    public void migrateAssetsAsync(final Optional<String> orgId) {
         Log.info("Kessel assets' migration begins");
 
         final int limit = this.backendConfig.getKesselMigrationBatchSize();
@@ -127,7 +135,7 @@ public class KesselAssetsMigrationService {
             .supplier(
                 () -> offsetContainer.addAndGet(limit),
                 offset -> {
-                    final List<Endpoint> endpoints = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(limit, offset);
+                    final List<Endpoint> endpoints = this.endpointRepository.getNonSystemEndpointsByOrgIdWithLimitAndOffset(orgId, limit, offset);
                     Log.infof("[limit: %s][offset: %s] Fetched endpoint batch from the database", limit, offset);
 
                     return endpoints;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/kessel/KesselAssetsMigrationService.java
@@ -121,10 +121,14 @@ public class KesselAssetsMigrationService {
         Log.info("Finished migrating integrations to the Kessel inventory");
     }
 
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/kessel/migrate-assets/async")
     @POST
-    public void migrateAssetsAsync(final Optional<String> orgId) {
+    public void migrateAssetsAsync(@Nullable final KesselAssetsMigrationRequest kamRequest) {
         Log.info("Kessel assets' migration begins");
+
+        // Grab the organization ID specified in the request.
+        final Optional<String> orgId = (kamRequest == null) ? Optional.empty() : Optional.of(kamRequest.orgId());
 
         final int limit = this.backendConfig.getKesselMigrationBatchSize();
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -299,7 +300,7 @@ public class EndpointRepositoryTest {
     }
 
     /**
-     * Tests that the {@link EndpointRepository#getNonSystemEndpointsWithLimitAndOffset(int, int)}
+     * Tests that the {@link EndpointRepository#getNonSystemEndpointsByOrgIdWithLimitAndOffset(Optional, int, int)}
      * function only fetches regular endpoints, and that it respects the
      * "limit" and "offset" values.
      */
@@ -318,6 +319,28 @@ public class EndpointRepositoryTest {
             final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(
                 DEFAULT_ACCOUNT_ID,
                 DEFAULT_ORG_ID,
+                EndpointType.WEBHOOK,
+                null,
+                String.format("Webhook integration %s", i),
+                String.format("Webhook integration %s", i),
+                webhookProperties,
+                true,
+                LocalDateTime.now(ZoneOffset.UTC).minusDays(i)
+            );
+
+            createdEndpoints.add(createdEndpoint);
+        }
+
+        // Create some integrations in a different organization.
+        for (int i = 0; i < regularEndpointsToCreate; i++) {
+            final WebhookProperties webhookProperties = new WebhookProperties();
+            webhookProperties.setDisableSslVerification(random.nextBoolean());
+            webhookProperties.setMethod(HttpType.GET);
+            webhookProperties.setUrl("https://redhat.com");
+
+            final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(
+                DEFAULT_ACCOUNT_ID + "other",
+                DEFAULT_ORG_ID + "other",
                 EndpointType.WEBHOOK,
                 null,
                 String.format("Webhook integration %s", i),
@@ -349,7 +372,7 @@ public class EndpointRepositoryTest {
         }
 
         // Call the function under test.
-        final List<Endpoint> fetchedEndpoints = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(50, 0);
+        final List<Endpoint> fetchedEndpoints = this.endpointRepository.getNonSystemEndpointsByOrgIdWithLimitAndOffset(Optional.of(DEFAULT_ORG_ID), 50, 0);
         Assertions.assertEquals(regularEndpointsToCreate, fetchedEndpoints.size(), "unexpected number of endpoints fetched");
 
         // Make sure all the endpoints are non system endpoints.
@@ -361,7 +384,7 @@ public class EndpointRepositoryTest {
         );
 
         // Call the function under test with a limit.
-        final List<Endpoint> limitedEndpoints = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(1, 0);
+        final List<Endpoint> limitedEndpoints = this.endpointRepository.getNonSystemEndpointsByOrgIdWithLimitAndOffset(Optional.of(DEFAULT_ORG_ID), 1, 0);
         Assertions.assertEquals(1, limitedEndpoints.size(), "only one endpoint should have been fetched. The limit option has not been respected");
 
         // Call the function under test with an offset. Reverse the created
@@ -369,7 +392,7 @@ public class EndpointRepositoryTest {
         final List<Endpoint> reversedEndpoints = createdEndpoints.reversed();
         final Iterator<Endpoint> expectedEndpoints = reversedEndpoints.iterator();
         for (int i = 0; i < regularEndpointsToCreate; i++) {
-            final List<Endpoint> offsetedEndpoint = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(1, i);
+            final List<Endpoint> offsetedEndpoint = this.endpointRepository.getNonSystemEndpointsByOrgIdWithLimitAndOffset(Optional.of(DEFAULT_ORG_ID), 1, i);
             Assertions.assertEquals(1, offsetedEndpoint.size(), "only a single endpoint should hav been fetched since the limit is set to \"1\"");
 
             // Compare the fetched endpoint from the database with the one we
@@ -382,12 +405,12 @@ public class EndpointRepositoryTest {
 
         // When applied the offset "0", we should get the oldest integration by
         // default due to the "order by" clause.
-        final List<Endpoint> oldestEndpoint = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(1, 0);
+        final List<Endpoint> oldestEndpoint = this.endpointRepository.getNonSystemEndpointsByOrgIdWithLimitAndOffset(Optional.of(DEFAULT_ORG_ID), 1, 0);
         Assertions.assertEquals(0, ChronoUnit.DAYS.between(reversedEndpoints.getFirst().getCreated(), oldestEndpoint.getFirst().getCreated()), "when the offset is \"0\", the oldest endpoint should have been fetched from the database");
 
         // When applied the highest offset, the newest endpoint should have
         // been fetched due to the "order by" clause.
-        final List<Endpoint> newestEndpoint = this.endpointRepository.getNonSystemEndpointsWithLimitAndOffset(1, regularEndpointsToCreate - 1);
+        final List<Endpoint> newestEndpoint = this.endpointRepository.getNonSystemEndpointsByOrgIdWithLimitAndOffset(Optional.of(DEFAULT_ORG_ID), 1, regularEndpointsToCreate - 1);
         Assertions.assertEquals(0, ChronoUnit.DAYS.between(reversedEndpoints.getLast().getCreated(), newestEndpoint.getFirst().getCreated()), "when the offset is the highest one, the newest endpoint should have been fetched from the database");
     }
 }


### PR DESCRIPTION
The feature allows the requester to specify an organization ID if they want to just migrate that organization, or to leave it empty to migrate the whole database.

## Jira ticket
[[RHCLOUD-37782]](https://issues.redhat.com/browse/RHCLOUD-37782)