### PR TITLE
RHCLOUD-37536 | refactor: kessel auth handlers

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/annotation/Authorization.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/annotation/Authorization.java
@@ -1,0 +1,40 @@
+package com.redhat.cloud.notifications.auth.annotation;
+
+import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
+import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines the annotation to be able to perform permission checks with Kessel
+ * at the method level.
+ */
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Authorization {
+    /**
+     * The Kessel integration permissions defined by the developer. These
+     * permissions require the method's integration's identifier to be
+     * annotated with the {@link IntegrationId} annotation to work.
+     * @return an array of defined integration permissions.
+     */
+    @Nonbinding IntegrationPermission[] integrationPermissions() default {};
+
+    /**
+     * The legacy RBAC role that will be checked when Kessel is disabled.
+     * @return the legacy RBAC role set for the method.
+     */
+    @Nonbinding String legacyRBACRole();
+
+    /**
+     * The Kessel workspace permissions defined by the developer.
+     * @return an array of defined workspace permissions.
+     */
+    @Nonbinding WorkspacePermission[] workspacePermissions() default {};
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptor.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptor.java
@@ -1,0 +1,157 @@
+package com.redhat.cloud.notifications.auth.annotation;
+
+import com.redhat.cloud.notifications.auth.kessel.KesselAuthorization;
+import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
+import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
+import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
+import com.redhat.cloud.notifications.config.BackendConfig;
+import com.redhat.cloud.notifications.routers.SecurityContextUtil;
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.core.SecurityContext;
+
+import java.lang.reflect.Parameter;
+import java.util.UUID;
+
+/**
+ * The interceptor's implementation for the {@link Authorization} annotaiton.
+ * On any method annotated with the aforementioned annotation, it will perform
+ * authorization checks depending on whether RBAC or Kessel authorization back
+ * ends are enabled.
+ */
+@Interceptor
+@Authorization(legacyRBACRole = "")
+@Priority(Interceptor.Priority.APPLICATION)
+public class AuthorizationInterceptor {
+
+    private final BackendConfig backendConfig;
+    private final KesselAuthorization kesselAuthorization;
+    private final WorkspaceUtils workspaceUtils;
+
+    /**
+     * Constructor for the interceptor. Helps with testing, as otherwise the
+     * interceptor cannot get its dependencies injected.
+     * @param backendConfig the back end's configuration bean.
+     * @param kesselAuthorization the Kessel's authorization bean.
+     * @param workspaceUtils the workspace utils' bean.
+     */
+    public AuthorizationInterceptor(
+        final BackendConfig backendConfig,
+        final KesselAuthorization kesselAuthorization,
+        final WorkspaceUtils workspaceUtils
+    ) {
+        this.backendConfig = backendConfig;
+        this.kesselAuthorization = kesselAuthorization;
+        this.workspaceUtils = workspaceUtils;
+    }
+
+    @AroundInvoke
+    public Object aroundInvoke(final InvocationContext ctx) throws Exception {
+        // Grab the annotation from the method. The annotation will never be
+        // null, because the interceptor only works with those methods that
+        // have been annotated.
+        final Authorization annotation = ctx.getMethod().getDeclaredAnnotation(Authorization.class);
+
+        // Get the parameter indexes from the method's definition. By having
+        // these indexes, we can simply then grab the exact intercepted
+        // parameters from the array of intercepted method parameters.
+        final ParameterIndexes parameterIndexes = this.getParameterIndexes(ctx);
+
+        // When the method doesn't have a "SecurityContext" parameter we cannot
+        // perform the authorization checks, and therefore we cannot continue.
+        if (parameterIndexes.getSecurityContextIndex().isEmpty()) {
+            throw new IllegalStateException(String.format("The security context is not set on the method \"%s\", which is needed for the \"KesselRequiredPermission\" annotation to work", ctx.getMethod().getName()));
+        }
+
+        // Grab the intercepted parameters and make sure that the security
+        // context is present, as otherwise we cannot perform any authorization
+        // checks.
+        final Object[] interceptedParameters = ctx.getParameters();
+
+        // Since we grabbed the parameter index for the "SecurityContext"
+        // parameter, we can safely cast that parameter to that so that we can
+        // use it.
+        final SecurityContext securityContext = (SecurityContext) interceptedParameters[parameterIndexes.getSecurityContextIndex().get()];
+
+        // Perform the legacy RBAC check first. The only reason is to be able
+        // to return early and make the code easier to follow.
+        if (!this.backendConfig.isKesselRelationsEnabled(SecurityContextUtil.getOrgId(securityContext))) {
+            // Legacy RBAC permission checking. The permission will have been
+            // prefetched and processed by the "ConsoleIdentityProvider".
+            if (securityContext.isUserInRole(annotation.legacyRBACRole())) {
+                return ctx.proceed();
+            } else {
+                throw new ForbiddenException();
+            }
+        }
+
+        // When the execution reaches this point we can be sure that the
+        // enabled authorization back end is "Kessel", so we proceed to get the
+        // Kessel permissions.
+        final IntegrationPermission[] integrationPermissions = annotation.integrationPermissions();
+        final WorkspacePermission[] workspacePermissions = annotation.workspacePermissions();
+
+        // Make sure that we have either integration permissions or workspace
+        // permissions to check. If we don't, that probably signals a mistake
+        // on the developer's side.
+        if (integrationPermissions.length == 0 && workspacePermissions.length == 0) {
+            throw new IllegalStateException(String.format("No integration or workspace permissions were set for method \"%s\", and at least one of them is required for the \"KesselRequiredPermission\" annotation to work", ctx.getMethod().getName()));
+        }
+
+        // Check the workspace permissions firs since they are more generic.
+        for (final WorkspacePermission workspacePermission : workspacePermissions) {
+            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(SecurityContextUtil.getOrgId(securityContext));
+
+            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, workspacePermission, workspaceId);
+        }
+
+        // If no integration permissions are specified we can simply skip any
+        // further checks.
+        if (integrationPermissions.length == 0) {
+            return ctx.proceed();
+        }
+
+        // We need to make sure that we spotted the integration's identifier in
+        // the method, as otherwise we will not be able to perform the checks.
+        if (parameterIndexes.getIntegrationIdIndex().isEmpty()) {
+            throw new IllegalStateException(String.format("The integration ID is not annotated on the method \"%s\", which is needed for the \"KesselRequiredPermission\" annotation to work", ctx.getMethod().getName()));
+        }
+
+        // Now it is safe to grab the intercepted integration id...
+        final UUID integrationId = (UUID) interceptedParameters[parameterIndexes.getIntegrationIdIndex().get()];
+        // ... and check the principal's permission.
+        for (final IntegrationPermission integrationPermission : integrationPermissions) {
+            this.kesselAuthorization.hasPermissionOnIntegration(securityContext, integrationPermission, integrationId);
+        }
+
+        return ctx.proceed();
+    }
+
+    /**
+     * Grabs the indexes for the parameters we are interested in.
+     * @param ctx the method's invocation context.
+     * @return a {@link ParameterIndexes} object containing the relevant
+     * indexes we are interested in.
+     */
+    private ParameterIndexes getParameterIndexes(final InvocationContext ctx) {
+        final ParameterIndexes parameterIndexes = new ParameterIndexes();
+
+        final Parameter[] methodParameters = ctx.getMethod().getParameters();
+        for (int i = 0; i < methodParameters.length; i++) {
+            final Parameter parameter = methodParameters[i];
+
+            if (parameter.getType().equals(SecurityContext.class)) {
+                parameterIndexes.setSecurityContextIndex(i);
+                continue;
+            }
+
+            if (parameter.getAnnotation(IntegrationId.class) != null) {
+                parameterIndexes.setIntegrationIdIndex(i);
+            }
+        }
+        return parameterIndexes;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/annotation/IntegrationId.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/annotation/IntegrationId.java
@@ -1,0 +1,15 @@
+package com.redhat.cloud.notifications.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that is simply used to tell the {@link AuthorizationInterceptor}
+ * which parameter contains the received integration identifier.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface IntegrationId {
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/annotation/ParameterIndexes.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/annotation/ParameterIndexes.java
@@ -1,0 +1,30 @@
+package com.redhat.cloud.notifications.auth.annotation;
+
+import java.util.Optional;
+
+/**
+ * Holds the required parameter indexes to be able to perform the proper
+ * authorizations in the {@link AuthorizationInterceptor}.
+ */
+class ParameterIndexes {
+    private Integer securityContextIndex;
+    private Integer integrationIdIndex;
+
+    ParameterIndexes() { }
+
+    public Optional<Integer> getSecurityContextIndex() {
+        return Optional.ofNullable(this.securityContextIndex);
+    }
+
+    public void setSecurityContextIndex(final Integer securityContextIndex) {
+        this.securityContextIndex = securityContextIndex;
+    }
+
+    public Optional<Integer> getIntegrationIdIndex() {
+        return Optional.ofNullable(this.integrationIdIndex);
+    }
+
+    public void setIntegrationIdIndex(final Integer integrationIdIndex) {
+        this.integrationIdIndex = integrationIdIndex;
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
@@ -2,6 +2,8 @@ package com.redhat.cloud.notifications.routers.handlers.endpoint;
 
 import com.redhat.cloud.notifications.Constants;
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
+import com.redhat.cloud.notifications.auth.annotation.Authorization;
+import com.redhat.cloud.notifications.auth.annotation.IntegrationId;
 import com.redhat.cloud.notifications.auth.kessel.KesselAssets;
 import com.redhat.cloud.notifications.auth.kessel.KesselAuthorization;
 import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
@@ -46,7 +48,6 @@ import com.redhat.cloud.notifications.routers.models.RequestSystemSubscriptionPr
 import com.redhat.cloud.notifications.routers.sources.SecretUtils;
 import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonObject;
-import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
@@ -185,28 +186,14 @@ public class EndpointResource {
                 schema = @Schema(type = SchemaType.BOOLEAN)
                 )
         })
-        public List<NotificationHistoryDTO> getEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID id, @QueryParam("includeDetail") Boolean includeDetail, @BeanParam Query query) {
-            if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-                this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.VIEW_HISTORY, id);
-
-                return this.internalGetEndpointHistory(sec, id, includeDetail, query);
-            } else {
-                return this.legacyRBACGetEndpointHistory(sec, id, includeDetail, query);
-            }
-        }
-
-        @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
-        protected List<NotificationHistoryDTO> legacyRBACGetEndpointHistory(final SecurityContext securityContext, final UUID id, final Boolean includeDetail, final Query query) {
-            return this.internalGetEndpointHistory(securityContext, id, includeDetail, query);
-        }
-
-        protected List<NotificationHistoryDTO> internalGetEndpointHistory(final SecurityContext securityContext, final UUID id, final Boolean includeDetail, @Valid final Query query) {
-            if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(securityContext))) {
+        @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.VIEW_HISTORY})
+        public List<NotificationHistoryDTO> getEndpointHistory(@Context SecurityContext sec, @IntegrationId @PathParam("id") UUID id, @QueryParam("includeDetail") Boolean includeDetail, @Valid @BeanParam Query query) {
+            if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(sec))) {
                 throw new NotFoundException("Endpoint not found");
             }
 
             // TODO We need globally limitations (Paging support and limits etc)
-            String orgId = getOrgId(securityContext);
+            String orgId = getOrgId(sec);
             boolean doDetail = includeDetail != null && includeDetail;
             return commonMapper.notificationHistoryListToNotificationHistoryDTOList(notificationRepository.getNotificationHistory(orgId, id, doDetail, query));
         }
@@ -236,34 +223,24 @@ public class EndpointResource {
         @QueryParam("active")   Boolean activeOnly,
         @QueryParam("name")     String name
     ) {
+        Set<UUID> authorizedIds = null;
         if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
             // Fetch the set of integration IDs the user is authorized to view.
-            final Set<UUID> authorizedIds = this.kesselAuthorization.lookupAuthorizedIntegrations(sec, IntegrationPermission.VIEW);
+            authorizedIds = this.kesselAuthorization.lookupAuthorizedIntegrations(sec, IntegrationPermission.VIEW);
             if (authorizedIds.isEmpty()) {
                 Log.infof("[org_id: %s][username: %s] Kessel did not return any integration IDs for the request", getOrgId(sec), getUsername(sec));
 
                 return new EndpointPage(new ArrayList<>(), new HashMap<>(), new Meta(0L));
             }
-
-            return this.internalGetEndpoints(sec, query, targetType, activeOnly, name, authorizedIds, false);
         } else {
-            return this.getEndpointsLegacyRBACRoles(sec, query, targetType, activeOnly, name, false);
+            // Legacy RBAC permission checking. The permission will have been
+            // prefetched and processed by the "ConsoleIdentityProvider".
+            if (!sec.isUserInRole(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)) {
+                throw new ForbiddenException();
+            }
         }
-    }
 
-    /**
-     * Gets the list of endpoints. Checks the principal's authorization by
-     * looking at its roles.
-     * @param securityContext the security context of the request.
-     * @param query the page related query elements.
-     * @param targetType the types of the endpoints to fetch.
-     * @param activeOnly should only the active endpoints be fetched?
-     * @param name filter endpoints by name.
-     * @return a page containing the requested endpoints.
-     */
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
-    protected EndpointPage getEndpointsLegacyRBACRoles(final SecurityContext securityContext, final Query query, final List<String> targetType, final Boolean activeOnly, final String name, final boolean includeLinkedEventTypes) {
-        return this.internalGetEndpoints(securityContext, query, targetType, activeOnly, name, null, includeLinkedEventTypes);
+        return internalGetEndpoints(sec, query, targetType, activeOnly, name, authorizedIds, false);
     }
 
     /**
@@ -335,32 +312,16 @@ public class EndpointResource {
         @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = EndpointDTO.class))),
         @APIResponse(responseCode = "400", description = "Bad data passed, that does not correspond to the definition or Endpoint.properties are empty")
     })
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = {WorkspacePermission.INTEGRATIONS_CREATE})
     public EndpointDTO createEndpoint(
-        @Context                        SecurityContext sec,
-        @RequestBody(required = true)   EndpointDTO endpointDTO
+        @Context                                        final SecurityContext sec,
+        @NotNull @Valid @RequestBody(required = true)   final EndpointDTO endpointDTO
     ) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.INTEGRATIONS_CREATE, workspaceId);
-
-            return this.internalCreateEndpoint(sec, endpointDTO);
-        } else {
-            return this.legacyRBACCreateEndpoint(sec, endpointDTO);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
-    protected EndpointDTO legacyRBACCreateEndpoint(final SecurityContext securityContext, final EndpointDTO endpointDTO) {
-        return this.internalCreateEndpoint(securityContext, endpointDTO);
-    }
-
-    protected EndpointDTO internalCreateEndpoint(final SecurityContext securityContext, @NotNull @Valid final EndpointDTO endpointDTO) {
         final Endpoint endpoint = this.endpointMapper.toEntity(endpointDTO);
 
         try {
             return this.endpointMapper.toDTO(
-                this.internalCreateEndpoint(securityContext, endpoint, endpointDTO.eventTypes)
+                this.internalCreateEndpoint(sec, endpoint, endpointDTO.eventTypes)
             );
         } catch (final Exception e) {
             // Clean up the secrets from Sources if any were created.
@@ -465,21 +426,10 @@ public class EndpointResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Create an email subscription endpoint", description = "Adds the email subscription endpoint into the system and specifies the role-based access control (RBAC) group that will receive email notifications. Use this endpoint in behavior groups to send emails when an action linked to the behavior group is triggered.")
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = {WorkspacePermission.CREATE_EMAIL_SUBSCRIPTION_INTEGRATION})
     @Transactional
-    public EndpointDTO getOrCreateEmailSubscriptionEndpoint(@Context SecurityContext sec, @RequestBody(required = true) RequestSystemSubscriptionProperties requestProps) {
-        final Endpoint endpoint;
-
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, workspaceId);
-
-            endpoint = this.getOrCreateSystemSubscriptionEndpoint(sec, requestProps, EMAIL_SUBSCRIPTION);
-        } else {
-            endpoint = this.legacyRBACGetOrCreateSystemSubscriptionEndpoint(sec, requestProps, EMAIL_SUBSCRIPTION);
-        }
-
-        return this.endpointMapper.toDTO(endpoint);
+    public EndpointDTO getOrCreateEmailSubscriptionEndpoint(@Context SecurityContext sec, @NotNull @Valid @RequestBody(required = true) RequestSystemSubscriptionProperties requestProps) {
+        return this.endpointMapper.toDTO(getOrCreateSystemSubscriptionEndpoint(sec, requestProps, EMAIL_SUBSCRIPTION));
     }
 
     @POST
@@ -487,29 +437,13 @@ public class EndpointResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Add a drawer endpoint", description = "Adds the drawer system endpoint into the system and specifies the role-based access control (RBAC) group that will receive notifications. Use this endpoint to add an animation as a notification in the UI.")
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = {WorkspacePermission.CREATE_DRAWER_INTEGRATION})
     @Transactional
-    public EndpointDTO getOrCreateDrawerSubscriptionEndpoint(@Context SecurityContext sec, @RequestBody(required = true) RequestSystemSubscriptionProperties requestProps) {
-        final Endpoint endpoint;
-
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.CREATE_DRAWER_INTEGRATION, workspaceId);
-
-            endpoint = this.getOrCreateSystemSubscriptionEndpoint(sec, requestProps, DRAWER);
-        } else {
-            endpoint = this.legacyRBACGetOrCreateSystemSubscriptionEndpoint(sec, requestProps, DRAWER);
-        }
-
-        return this.endpointMapper.toDTO(endpoint);
+    public EndpointDTO getOrCreateDrawerSubscriptionEndpoint(@Context SecurityContext sec, @NotNull @Valid @RequestBody(required = true) RequestSystemSubscriptionProperties requestProps) {
+        return this.endpointMapper.toDTO(this.getOrCreateSystemSubscriptionEndpoint(sec, requestProps, DRAWER));
     }
 
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
-    protected Endpoint legacyRBACGetOrCreateSystemSubscriptionEndpoint(final SecurityContext securityContext, final RequestSystemSubscriptionProperties requestProps, final EndpointType endpointType) {
-        return this.getOrCreateSystemSubscriptionEndpoint(securityContext, requestProps, endpointType);
-    }
-
-    protected Endpoint getOrCreateSystemSubscriptionEndpoint(SecurityContext sec, @NotNull @Valid RequestSystemSubscriptionProperties requestProps, EndpointType endpointType) {
+    protected Endpoint getOrCreateSystemSubscriptionEndpoint(SecurityContext sec, RequestSystemSubscriptionProperties requestProps, EndpointType endpointType) {
         RhIdPrincipal principal = (RhIdPrincipal) sec.getUserPrincipal();
         String accountId = getAccountId(sec);
         String orgId = getOrgId(sec);
@@ -541,19 +475,9 @@ public class EndpointResource {
     @Path("/{id}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve an endpoint", description = "Retrieves the public information associated with an endpoint such as its description, name, and properties.")
-    public EndpointDTO getEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.VIEW, id);
-
-            return this.internalGetEndpoint(sec, id, false);
-        } else {
-            return this.legacyGetEndpoint(sec, id, false);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
-    protected EndpointDTO legacyGetEndpoint(final SecurityContext securityContext, final UUID id, final boolean includeLinkedEventTypes) {
-        return this.internalGetEndpoint(securityContext, id, includeLinkedEventTypes);
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.VIEW})
+    public EndpointDTO getEndpoint(@Context SecurityContext sec, @IntegrationId @PathParam("id") UUID id) {
+        return internalGetEndpoint(sec, id, false);
     }
 
     protected EndpointDTO internalGetEndpoint(final SecurityContext securityContext, final UUID id, final boolean includeLinkedEventTypes) {
@@ -580,24 +504,10 @@ public class EndpointResource {
     @Path("/{id}")
     @Operation(summary = "Delete an endpoint", description = "Deletes an endpoint. Use this endpoint to delete an endpoint that is no longer needed. Deleting an endpoint that is already linked to a behavior group will unlink it from the behavior group. You cannot delete system endpoints.")
     @APIResponse(responseCode = "204", description = "The integration has been deleted", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.DELETE})
     @Transactional
-    public Response deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.DELETE, id);
-
-            return this.internalDeleteEndpoint(sec, id);
-        } else {
-            return this.legacyRBACDeleteEndpoint(sec, id);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
-    protected Response legacyRBACDeleteEndpoint(final SecurityContext securityContext, final UUID id) {
-        return this.internalDeleteEndpoint(securityContext, id);
-    }
-
-    private Response internalDeleteEndpoint(final SecurityContext securityContext, final UUID id) {
-        String orgId = getOrgId(securityContext);
+    public Response deleteEndpoint(@Context SecurityContext sec, @IntegrationId @PathParam("id") UUID id) {
+        String orgId = getOrgId(sec);
         EndpointType endpointType = endpointRepository.getEndpointTypeById(orgId, id);
         if (!isEndpointTypeAllowed(endpointType)) {
             throw new BadRequestException(UNSUPPORTED_ENDPOINT_TYPE);
@@ -615,7 +525,7 @@ public class EndpointResource {
             // integration will not be deleted from our database.
             final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(orgId);
 
-            this.kesselAssets.deleteIntegration(securityContext, workspaceId.toString(), id.toString());
+            this.kesselAssets.deleteIntegration(sec, workspaceId.toString(), id.toString());
         }
 
         // Attempt deleting the secrets for the given endpoint. In the case
@@ -632,7 +542,7 @@ public class EndpointResource {
             if (this.backendConfig.isKesselInventoryEnabled(orgId)) {
                 final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(orgId);
 
-                this.kesselAssets.createIntegration(securityContext, workspaceId.toString(), id.toString());
+                this.kesselAssets.createIntegration(sec, workspaceId.toString(), id.toString());
             }
 
             throw e;
@@ -646,24 +556,10 @@ public class EndpointResource {
     @Produces(TEXT_PLAIN)
     @Operation(summary = "Enable an endpoint", description = "Enables an endpoint that is disabled so that the endpoint will be executed on the following operations that use the endpoint. An operation must be restarted to use the enabled endpoint.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.ENABLE})
     @Transactional
-    public Response enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.ENABLE, id);
-
-            return this.internalEnableEndpoint(sec, id);
-        } else {
-            return this.legacyRBACEnableEndpoint(sec, id);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
-    protected Response legacyRBACEnableEndpoint(final SecurityContext securityContext, final UUID id) {
-        return this.internalEnableEndpoint(securityContext, id);
-    }
-
-    private Response internalEnableEndpoint(final SecurityContext securityContext, final UUID id) {
-        String orgId = getOrgId(securityContext);
+    public Response enableEndpoint(@Context SecurityContext sec, @IntegrationId @PathParam("id") UUID id) {
+        String orgId = getOrgId(sec);
         EndpointType endpointType = endpointRepository.getEndpointTypeById(orgId, id);
         if (!isEndpointTypeAllowed(endpointType)) {
             throw new BadRequestException(UNSUPPORTED_ENDPOINT_TYPE);
@@ -678,23 +574,9 @@ public class EndpointResource {
     @Operation(summary = "Disable an endpoint", description = "Disables an endpoint so that the endpoint will not be executed after an operation that uses the endpoint is started. An operation that is already running can still execute the endpoint. Disable an endpoint when you want to stop it from running and might want to re-enable it in the future.")
     @APIResponse(responseCode = "204", description = "The integration has been disabled", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
-    public Response disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.DISABLE, id);
-
-            return this.internalDisableEndpoint(sec, id);
-        } else {
-            return this.legacyRBACDisableEndpoint(sec, id);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
-    protected Response legacyRBACDisableEndpoint(final SecurityContext securityContext, final UUID id) {
-        return this.internalDisableEndpoint(securityContext, id);
-    }
-
-    private Response internalDisableEndpoint(final SecurityContext securityContext, final UUID id) {
-        String orgId = getOrgId(securityContext);
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.DISABLE})
+    public Response disableEndpoint(@Context SecurityContext sec, @IntegrationId @PathParam("id") UUID id) {
+        String orgId = getOrgId(sec);
         EndpointType endpointType = endpointRepository.getEndpointTypeById(orgId, id);
         if (!isEndpointTypeAllowed(endpointType)) {
             throw new BadRequestException(UNSUPPORTED_ENDPOINT_TYPE);
@@ -710,42 +592,13 @@ public class EndpointResource {
     @Path("/{id}")
     @Produces(TEXT_PLAIN)
     @PUT
+    @Transactional
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.EDIT})
     public Response updateEndpoint(
         @Context                                        SecurityContext securityContext,
-        @PathParam("id")                                UUID id,
+        @PathParam("id")              @IntegrationId    UUID id,
         @RequestBody(required = true) @NotNull @Valid   EndpointDTO endpointDTO
     ) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(securityContext, IntegrationPermission.EDIT, id);
-
-            return this.internalUpdateEndpoint(securityContext, id, endpointDTO);
-        }
-
-        return this.updateEndpointLegacyRBACRoles(securityContext, id, endpointDTO);
-    }
-
-    /**
-     * Updates an endpoint. Checks the principal's authorization by looking at
-     * its roles.
-     * @param securityContext the security context of the request.
-     * @param endpointId the ID of the endpoint to be updated.
-     * @param endpointDTO the received request body.
-     * @return a response specifying the outcome of the operation.
-     */
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
-    protected Response updateEndpointLegacyRBACRoles(final SecurityContext securityContext, final UUID endpointId, final EndpointDTO endpointDTO) {
-        return this.internalUpdateEndpoint(securityContext, endpointId, endpointDTO);
-    }
-
-    /**
-     * Updates an endpoint.
-     * @param sec the security context of the request.
-     * @param id the endpoint's identifier.
-     * @param endpointDTO the updated endpoint's body.
-     * @return a response specifying the outcome of the oeration.
-     */
-    @Transactional
-    protected Response internalUpdateEndpoint(final SecurityContext sec, final UUID id, final @NotNull @Valid EndpointDTO endpointDTO) {
         final Endpoint endpoint = this.endpointMapper.toEntity(endpointDTO);
 
         if (!isEndpointTypeAllowed(endpoint.getType())) {
@@ -753,8 +606,8 @@ public class EndpointResource {
         }
         // This prevents from updating an endpoint from whatever EndpointType to a system EndpointType
         checkSystemEndpoint(endpoint.getType());
-        String accountId = getAccountId(sec);
-        String orgId = getOrgId(sec);
+        String accountId = getAccountId(securityContext);
+        String orgId = getOrgId(securityContext);
         endpoint.setAccountId(accountId);
         endpoint.setOrgId(orgId);
         endpoint.setId(id);
@@ -801,7 +654,7 @@ public class EndpointResource {
         }
 
         if (null != endpointDTO.eventTypes) {
-            internalUpdateEventTypesLinkedToEndpoint(sec, id, endpointDTO.eventTypes);
+            internalUpdateEventTypesLinkedToEndpoint(securityContext, id, endpointDTO.eventTypes);
         }
         return Response.ok().build();
     }
@@ -811,23 +664,9 @@ public class EndpointResource {
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve event notification details", description = "Retrieves extended information about the outcome of an event notification related to the specified endpoint. Use this endpoint to learn why an event delivery failed.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    public Response getDetailedEndpointHistory(@Context SecurityContext sec, @PathParam("id") UUID endpointId, @PathParam("history_id") UUID historyId) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.VIEW_HISTORY, endpointId);
-
-            return this.internalGetDetailedEndpointHistory(sec, endpointId, historyId);
-        } else {
-            return this.legacyRBACGetDetailedEndpointHistory(sec, endpointId, historyId);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
-    protected Response legacyRBACGetDetailedEndpointHistory(final SecurityContext securityContext, final UUID endpointId, final UUID historyId) {
-        return this.internalGetDetailedEndpointHistory(securityContext, endpointId, historyId);
-    }
-
-    private Response internalGetDetailedEndpointHistory(final SecurityContext securityContext, final UUID endpointId, final UUID historyId) {
-        String orgId = getOrgId(securityContext);
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.VIEW_HISTORY})
+    public Response getDetailedEndpointHistory(@Context SecurityContext sec, @IntegrationId @PathParam("id") UUID endpointId, @PathParam("history_id") UUID historyId) {
+        String orgId = getOrgId(sec);
         JsonObject json = notificationRepository.getNotificationDetails(orgId, endpointId, historyId);
         if (json == null) {
             // Maybe 404 should only be returned if history_id matches nothing? Otherwise 204
@@ -858,29 +697,15 @@ public class EndpointResource {
                 schema = @Schema(type = SchemaType.STRING)
             )
     })
-    public void testEndpoint(@Context SecurityContext sec, @RestPath UUID uuid, @RequestBody final EndpointTestRequest requestBody) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.TEST, uuid);
-
-            this.internalTestEndpoint(sec, uuid, requestBody);
-        } else {
-            this.legacyRBACTestEndpoint(sec, uuid, requestBody);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS)
-    protected void legacyRBACTestEndpoint(final SecurityContext securityContext, final UUID uuid,  final EndpointTestRequest requestBody) {
-        this.internalTestEndpoint(securityContext, uuid, requestBody);
-    }
-
-    protected void internalTestEndpoint(final SecurityContext securityContext, final UUID uuid, @Valid final EndpointTestRequest requestBody) {
-        if (!this.endpointRepository.existsByUuidAndOrgId(uuid, getOrgId(securityContext))) {
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.TEST})
+    public void testEndpoint(@Context SecurityContext sec, @IntegrationId @RestPath UUID uuid, @Valid @RequestBody final EndpointTestRequest requestBody) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(uuid, getOrgId(sec))) {
             throw new NotFoundException("integration not found");
         }
 
         final InternalEndpointTestRequest internalEndpointTestRequest = new InternalEndpointTestRequest();
         internalEndpointTestRequest.endpointUuid = uuid;
-        internalEndpointTestRequest.orgId = getOrgId(securityContext);
+        internalEndpointTestRequest.orgId = getOrgId(sec);
         if (requestBody != null) {
             internalEndpointTestRequest.message = requestBody.message;
         }
@@ -957,22 +782,8 @@ public class EndpointResource {
     })
     @Tag(name = OApiFilter.PRIVATE)
     @Transactional
-    public void deleteEventTypeFromEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID eventTypeId, @RestPath final UUID endpointId) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(securityContext, IntegrationPermission.EDIT, endpointId);
-
-            internalDeleteEventTypeFromEndpoint(securityContext, eventTypeId, endpointId);
-        } else {
-            legacyRBACDeleteEventTypeFromEndpoint(securityContext, eventTypeId, endpointId);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    protected void legacyRBACDeleteEventTypeFromEndpoint(final SecurityContext securityContext, final UUID eventTypeId, final UUID endpointId) {
-        internalDeleteEventTypeFromEndpoint(securityContext, eventTypeId, endpointId);
-    }
-
-    private void internalDeleteEventTypeFromEndpoint(final SecurityContext securityContext, final UUID eventTypeId, final UUID endpointId) {
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, integrationPermissions = {IntegrationPermission.EDIT})
+    public void deleteEventTypeFromEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID eventTypeId, @IntegrationId @RestPath final UUID endpointId) {
         final String orgId = getOrgId(securityContext);
         endpointEventTypeRepository.deleteEndpointFromEventType(eventTypeId, endpointId, orgId);
 
@@ -999,22 +810,8 @@ public class EndpointResource {
     })
     @Tag(name = OApiFilter.PRIVATE)
     @Transactional
-    public void addEventTypeToEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID eventTypeId, @RestPath final UUID endpointId) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(securityContext, IntegrationPermission.EDIT, endpointId);
-
-            internalAddEventTypeToEndpoint(securityContext, eventTypeId, endpointId);
-        } else {
-            legacyRbacAddEventTypeToEndpoint(securityContext, eventTypeId, endpointId);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    public void legacyRbacAddEventTypeToEndpoint(final SecurityContext securityContext, final UUID eventTypeId, final UUID endpointId) {
-        internalAddEventTypeToEndpoint(securityContext, eventTypeId, endpointId);
-    }
-
-    private void internalAddEventTypeToEndpoint(final SecurityContext securityContext, final UUID eventTypeId, final UUID endpointId) {
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, integrationPermissions = {IntegrationPermission.EDIT})
+    public void addEventTypeToEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID eventTypeId, @IntegrationId @RestPath final UUID endpointId) {
         final String orgId = getOrgId(securityContext);
         final String accountId = getAccountId(securityContext);
 
@@ -1033,18 +830,8 @@ public class EndpointResource {
             description = "No event type or endpoint found with passed ids.")
     })
     @Transactional
-    public void updateEventTypesLinkedToEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID endpointId, @Parameter(description = "Set of event type ids to associate") Set<UUID> eventTypeIds) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(securityContext, IntegrationPermission.EDIT, endpointId);
-
-            internalUpdateEventTypesLinkedToEndpoint(securityContext, endpointId, eventTypeIds);
-        } else {
-            legacyRbacUpdateEventTypesLinkedToEndpoint(securityContext, endpointId, eventTypeIds);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    public void legacyRbacUpdateEventTypesLinkedToEndpoint(final SecurityContext securityContext, final UUID endpointId, final Set<UUID> eventTypeIds) {
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, integrationPermissions = {IntegrationPermission.EDIT})
+    public void updateEventTypesLinkedToEndpoint(@Context final SecurityContext securityContext, @IntegrationId @RestPath final UUID endpointId, @Parameter(description = "Set of event type ids to associate") Set<UUID> eventTypeIds) {
         internalUpdateEventTypesLinkedToEndpoint(securityContext, endpointId, eventTypeIds);
     }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceV2.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceV2.java
@@ -2,6 +2,8 @@ package com.redhat.cloud.notifications.routers.handlers.endpoint;
 
 import com.redhat.cloud.notifications.Constants;
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
+import com.redhat.cloud.notifications.auth.annotation.Authorization;
+import com.redhat.cloud.notifications.auth.annotation.IntegrationId;
 import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.models.NotificationHistory;
@@ -12,9 +14,9 @@ import com.redhat.cloud.notifications.routers.models.Meta;
 import com.redhat.cloud.notifications.routers.models.Page;
 import com.redhat.cloud.notifications.routers.models.PageLinksBuilder;
 import io.quarkus.logging.Log;
-import jakarta.annotation.security.RolesAllowed;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
@@ -68,33 +70,19 @@ public class EndpointResourceV2 extends EndpointResource {
             )
         }
     )
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.VIEW_HISTORY})
     public Page<NotificationHistoryDTO> getEndpointHistory(
         @Context SecurityContext sec,
         @Context UriInfo uriInfo,
-        @PathParam("id") UUID id,
+        @IntegrationId @PathParam("id") UUID id,
         @QueryParam("includeDetail") Boolean includeDetail,
-        @BeanParam Query query
+        @Valid @BeanParam Query query
     ) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.VIEW_HISTORY, id);
-
-            return this.internalGetEndpointHistory(sec, uriInfo, id, includeDetail, query);
-        } else {
-            return this.legacyRBACGetEndpointHistory(sec, uriInfo, id, includeDetail, query);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)
-    protected Page<NotificationHistoryDTO> legacyRBACGetEndpointHistory(final SecurityContext securityContext, final UriInfo uriInfo, final UUID id, final Boolean includeDetail, final Query query) {
-        return this.internalGetEndpointHistory(securityContext, uriInfo, id, includeDetail, query);
-    }
-
-    protected Page<NotificationHistoryDTO> internalGetEndpointHistory(final SecurityContext securityContext, final UriInfo uriInfo, final UUID id, final Boolean includeDetail, @Valid final Query query) {
-        if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(securityContext))) {
+        if (!this.endpointRepository.existsByUuidAndOrgId(id, getOrgId(sec))) {
             throw new NotFoundException("Endpoint not found");
         }
 
-        String orgId = getOrgId(securityContext);
+        String orgId = getOrgId(sec);
         boolean doDetail = includeDetail != null && includeDetail;
 
         final List<NotificationHistory> notificationHistory = this.notificationRepository.getNotificationHistory(orgId, id, doDetail, query);
@@ -111,14 +99,9 @@ public class EndpointResourceV2 extends EndpointResource {
     @Path("/{id}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve an endpoint", description = "Retrieves the public information associated with an endpoint such as its description, name, and properties.")
-    public EndpointDTO getEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.VIEW, id);
-
-            return this.internalGetEndpoint(sec, id, false);
-        } else {
-            return legacyGetEndpoint(sec, id, true);
-        }
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS, integrationPermissions = {IntegrationPermission.VIEW})
+    public EndpointDTO getEndpoint(@Context SecurityContext sec, @IntegrationId @PathParam("id") UUID id) {
+        return internalGetEndpoint(sec, id, true);
     }
 
     @GET
@@ -147,18 +130,23 @@ public class EndpointResourceV2 extends EndpointResource {
         @QueryParam("active")   Boolean activeOnly,
         @QueryParam("name")     String name
     ) {
+        Set<UUID> authorizedIds = null;
         if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
             // Fetch the set of integration IDs the user is authorized to view.
-            final Set<UUID> authorizedIds = this.kesselAuthorization.lookupAuthorizedIntegrations(sec, IntegrationPermission.VIEW);
+            authorizedIds = this.kesselAuthorization.lookupAuthorizedIntegrations(sec, IntegrationPermission.VIEW);
             if (authorizedIds.isEmpty()) {
                 Log.infof("[org_id: %s][username: %s] Kessel did not return any integration IDs for the request", getOrgId(sec), getUsername(sec));
 
                 return new EndpointPage(new ArrayList<>(), new HashMap<>(), new Meta(0L));
             }
-
-            return internalGetEndpoints(sec, query, targetType, activeOnly, name, authorizedIds, true);
+        } else {
+            // Legacy RBAC permission checking. The permission will have been
+            // prefetched and processed by the "ConsoleIdentityProvider".
+            if (!sec.isUserInRole(ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS)) {
+                throw new ForbiddenException();
+            }
         }
 
-        return getEndpointsLegacyRBACRoles(sec, query, targetType, activeOnly, name, true);
+        return internalGetEndpoints(sec, query, targetType, activeOnly, name, authorizedIds, true);
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.routers.handlers.event;
 
+import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
+import com.redhat.cloud.notifications.auth.annotation.Authorization;
 import com.redhat.cloud.notifications.auth.kessel.KesselAuthorization;
 import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
 import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
@@ -17,7 +19,6 @@ import com.redhat.cloud.notifications.routers.models.Meta;
 import com.redhat.cloud.notifications.routers.models.Page;
 import com.redhat.cloud.notifications.routers.models.PageLinksBuilder;
 import io.quarkus.logging.Log;
-import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.BadRequestException;
@@ -43,7 +44,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
-import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -65,6 +65,7 @@ public class EventResource {
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve the event log entries", description = "Retrieves the event log entries. Use this endpoint to review a full history of the events related to the tenant. You can sort by the bundle, application, event, and created fields. You can specify the sort order by appending :asc or :desc to the field, for example bundle:desc. Sorting defaults to desc for the created field and to asc for all other fields."
     )
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS, workspacePermissions = {WorkspacePermission.EVENT_LOG_VIEW})
     public Page<EventLogEntry> getEvents(@Context SecurityContext securityContext, @Context UriInfo uriInfo,
                                          @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
                                          @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
@@ -72,24 +73,6 @@ public class EventResource {
                                          @RestQuery Set<EventLogEntryActionStatus> status,
                                          @BeanParam @Valid Query query,
                                          @RestQuery boolean includeDetails, @RestQuery boolean includePayload, @RestQuery boolean includeActions) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
-
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.EVENT_LOG_VIEW, workspaceId);
-
-            return this.getInternalEvents(securityContext, uriInfo, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults, status, query, includeDetails, includePayload, includeActions);
-        } else {
-            return this.getEventsLegacyRBACRoles(securityContext, uriInfo, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults, status, query, includeDetails, includePayload, includeActions);
-        }
-
-    }
-
-    @RolesAllowed(RBAC_READ_NOTIFICATIONS_EVENTS)
-    public Page<EventLogEntry> getEventsLegacyRBACRoles(final SecurityContext securityContext, final UriInfo uriInfo, final Set<UUID> bundleIds, final Set<UUID> appIds, final String eventTypeDisplayName, final LocalDate startDate, final LocalDate endDate, final Set<String> endpointTypes, final Set<Boolean> invocationResults, final Set<EventLogEntryActionStatus> status, final Query query, final boolean includeDetails, final boolean includePayload, final boolean includeActions) {
-        return this.getInternalEvents(securityContext, uriInfo, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, invocationResults, status, query, includeDetails, includePayload, includeActions);
-    }
-
-    public Page<EventLogEntry> getInternalEvents(final SecurityContext securityContext, final UriInfo uriInfo, final Set<UUID> bundleIds, final Set<UUID> appIds, final String eventTypeDisplayName, final LocalDate startDate, final LocalDate endDate, final Set<String> endpointTypes, final Set<Boolean> invocationResults, final Set<EventLogEntryActionStatus> status, final Query query, final boolean includeDetails, final boolean includePayload, final boolean includeActions) {
         Set<EndpointType> basicTypes = Collections.emptySet();
         Set<CompositeEndpointType> compositeTypes = Collections.emptySet();
         Set<NotificationStatus> notificationStatusSet = status == null ? Set.of() : toNotificationStatus(status);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResource.java
@@ -2,6 +2,8 @@ package com.redhat.cloud.notifications.routers.handlers.notification;
 
 import com.redhat.cloud.notifications.Constants;
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
+import com.redhat.cloud.notifications.auth.annotation.Authorization;
+import com.redhat.cloud.notifications.auth.annotation.IntegrationId;
 import com.redhat.cloud.notifications.auth.kessel.KesselAuthorization;
 import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
 import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
@@ -117,29 +119,13 @@ public class NotificationResource {
         @Path("/eventTypes/{eventTypeId}/behaviorGroups")
         @Produces(APPLICATION_JSON)
         @Operation(summary = "List the behavior groups linked to an event type", description = "Lists the behavior groups that are linked to an event type. Use this endpoint to see which behavior groups will be affected if you delete an event type.")
+        @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_VIEW, WorkspacePermission.EVENT_TYPES_VIEW})
         public List<BehaviorGroup> getLinkedBehaviorGroups(
             @Context SecurityContext sec,
             @PathParam("eventTypeId") UUID eventTypeId,
             @BeanParam @Valid Query query
         ) {
-            if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-                final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-                this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.EVENT_TYPES_VIEW, workspaceId);
-                this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, workspaceId);
-
-                return this.internalGetLinkedBehaviorGroups(sec, eventTypeId, query);
-            } else {
-                return this.legacyRBACGetLinkedBehaviorGroups(sec, eventTypeId, query);
-            }
-        }
-
-        @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-        public List<BehaviorGroup> legacyRBACGetLinkedBehaviorGroups(final SecurityContext securityContext, final UUID eventTypeId, @Valid final Query query) {
-            return this.internalGetLinkedBehaviorGroups(securityContext, eventTypeId, query);
-        }
-
-        public List<BehaviorGroup> internalGetLinkedBehaviorGroups(final SecurityContext securityContext, final UUID eventTypeId, @Valid final Query query) {
-            String orgId = getOrgId(securityContext);
+            final String orgId = getOrgId(sec);
 
             return behaviorGroupRepository.findBehaviorGroupsByEventTypeId(orgId, eventTypeId, query);
         }
@@ -149,26 +135,11 @@ public class NotificationResource {
     @Path("/eventTypes")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List all event types", description = "Lists all event types. You can filter the returned list by bundle, application name, or unmuted types.")
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.EVENT_TYPES_VIEW})
     public Page<EventType> getEventTypes(
         @Context SecurityContext securityContext, @Context UriInfo uriInfo, @BeanParam @Valid Query query, @QueryParam("applicationIds") Set<UUID> applicationIds,
         @QueryParam("bundleId") UUID bundleId, @QueryParam("eventTypeName") String eventTypeName, @QueryParam("excludeMutedTypes") boolean excludeMutedTypes
     ) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.EVENT_TYPES_VIEW, workspaceId);
-
-            return this.internalGetEventTypes(securityContext, uriInfo, query, applicationIds, bundleId, eventTypeName, excludeMutedTypes);
-        } else {
-            return this.legacyRBACGetEventTypes(securityContext, uriInfo, query, applicationIds, bundleId, eventTypeName, excludeMutedTypes);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public Page<EventType> legacyRBACGetEventTypes(final SecurityContext securityContext, final UriInfo uriInfo, @Valid final Query query, final Set<UUID> applicationIds, final UUID bundleId, final String eventTypeName, final boolean excludeMutedTypes) {
-        return this.internalGetEventTypes(securityContext, uriInfo, query, applicationIds, bundleId, eventTypeName, excludeMutedTypes);
-    }
-
-    public Page<EventType> internalGetEventTypes(final SecurityContext securityContext, final UriInfo uriInfo, @Valid final Query query, final Set<UUID> applicationIds, final UUID bundleId, final String eventTypeName, final boolean excludeMutedTypes) {
         List<UUID> unmutedEventTypeIds = excludeMutedTypes
             ? behaviorGroupRepository.findUnmutedEventTypes(getOrgId(securityContext), bundleId)
             : null;
@@ -186,23 +157,8 @@ public class NotificationResource {
     @Path("/bundles/{bundleName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve a bundle by name", description = "Retrieves the details of a bundle by searching by its name.")
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BUNDLES_VIEW})
     public Bundle getBundleByName(@Context final SecurityContext securityContext, @PathParam("bundleName") String bundleName) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.BUNDLES_VIEW, workspaceId);
-
-            return this.internalGetBundleByName(bundleName);
-        } else {
-            return this.legacyRBACGetBundleByName(bundleName);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public Bundle legacyRBACGetBundleByName(final String bundleName) {
-        return this.internalGetBundleByName(bundleName);
-    }
-
-    public Bundle internalGetBundleByName(final String bundleName) {
         Bundle bundle = bundleRepository.getBundle(bundleName);
         if (bundle == null) {
             throw new NotFoundException();
@@ -215,29 +171,12 @@ public class NotificationResource {
     @Path("/bundles/{bundleName}/applications/{applicationName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve an application by bundle and application names", description = "Retrieves an application by bundle and application names. Use this endpoint to  find an application by searching for the bundle that the application is part of. This is useful if you do not know the UUID of the bundle or application.")
-
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BUNDLES_VIEW, WorkspacePermission.APPLICATIONS_VIEW})
     public Application getApplicationByNameAndBundleName(
         @Context SecurityContext securityContext,
         @PathParam("bundleName") String bundleName,
         @PathParam("applicationName") String applicationName
     ) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.BUNDLES_VIEW, workspaceId);
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.APPLICATIONS_VIEW, workspaceId);
-
-            return this.internalGetApplicationByNameAndBundleName(bundleName, applicationName);
-        } else {
-            return this.legacyRBACGetAppliactionByNameAndBundleName(bundleName, applicationName);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public Application legacyRBACGetAppliactionByNameAndBundleName(final String bundleName, final String applicationName) {
-        return this.internalGetApplicationByNameAndBundleName(bundleName, applicationName);
-    }
-
-    public Application internalGetApplicationByNameAndBundleName(final String bundleName, final String applicationName) {
         Application application = applicationRepository.getApplication(bundleName, applicationName);
         if (application == null) {
             throw new NotFoundException();
@@ -250,31 +189,13 @@ public class NotificationResource {
     @Path("/bundles/{bundleName}/applications/{applicationName}/eventTypes/{eventTypeName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve an event type by bundle, application and event type names", description = "Retrieves the details of an event type by specifying the bundle name, the application name, and the event type name.")
-
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BUNDLES_VIEW, WorkspacePermission.APPLICATIONS_VIEW, WorkspacePermission.EVENT_TYPES_VIEW})
     public EventType getEventTypesByNameAndBundleAndApplicationName(
         @Context SecurityContext securityContext,
         @PathParam("bundleName") String bundleName,
         @PathParam("applicationName") String applicationName,
         @PathParam("eventTypeName") String eventTypeName
     ) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.BUNDLES_VIEW, workspaceId);
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.APPLICATIONS_VIEW, workspaceId);
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.EVENT_TYPES_VIEW, workspaceId);
-
-            return this.internalGetEventTypesByNameAndBundleAndApplicationName(bundleName, applicationName, eventTypeName);
-        } else {
-            return this.legacyRBACGetEventTypesByNameAndBundleAndApplicationName(bundleName, applicationName, eventTypeName);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public EventType legacyRBACGetEventTypesByNameAndBundleAndApplicationName(final String bundleName, final String applicationName, final String eventTypeName) {
-        return this.internalGetEventTypesByNameAndBundleAndApplicationName(bundleName, applicationName, eventTypeName);
-    }
-
-    public EventType internalGetEventTypesByNameAndBundleAndApplicationName(final String bundleName, final String applicationName, final String eventTypeName) {
         EventType eventType = applicationRepository.getEventType(bundleName, applicationName, eventTypeName);
         if (eventType == null) {
             throw new NotFoundException();
@@ -292,26 +213,10 @@ public class NotificationResource {
     @Path("/eventTypes/affectedByRemovalOfBehaviorGroup/{behaviorGroupId}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List the event types affected by the removal of a behavior group", description = "Lists the event types that will be affected by the removal of a behavior group. Use this endpoint to see which event types will be removed if you delete a behavior group.")
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_VIEW, WorkspacePermission.EVENT_TYPES_VIEW})
     public List<EventType> getEventTypesAffectedByRemovalOfBehaviorGroup(@Context SecurityContext sec,
                                                                          @Parameter(description = "The UUID of the behavior group to check") @PathParam("behaviorGroupId") UUID behaviorGroupId) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, workspaceId);
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.EVENT_TYPES_VIEW, workspaceId);
-
-            return this.internalGetEventTypesAffectedByRemovalOfBehaviorGroup(sec, behaviorGroupId);
-        } else {
-            return this.legacyRBACGetEventTypesAffectedByRemovalOfBehaviorGroup(sec, behaviorGroupId);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public List<EventType> legacyRBACGetEventTypesAffectedByRemovalOfBehaviorGroup(final SecurityContext securityContext, final UUID behaviorGroupId) {
-        return this.internalGetEventTypesAffectedByRemovalOfBehaviorGroup(securityContext, behaviorGroupId);
-    }
-
-    public List<EventType> internalGetEventTypesAffectedByRemovalOfBehaviorGroup(final SecurityContext securityContext, final UUID behaviorGroupId) {
-        String orgId = getOrgId(securityContext);
+        String orgId = getOrgId(sec);
         return behaviorGroupRepository.findEventTypesByBehaviorGroupId(orgId, behaviorGroupId);
     }
 
@@ -323,24 +228,8 @@ public class NotificationResource {
     @Path("/behaviorGroups/affectedByRemovalOfEndpoint/{endpointId}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List the behavior groups affected by the removal of an endpoint", description = "Lists the behavior groups that are affected by the removal of an endpoint. Use this endpoint to understand how removing an endpoint affects existing behavior groups.")
-    public List<BehaviorGroup> getBehaviorGroupsAffectedByRemovalOfEndpoint(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, workspaceId);
-            this.kesselAuthorization.hasPermissionOnIntegration(sec, IntegrationPermission.VIEW, endpointId);
-
-            return this.internalGetBehaviorGroupsAffectedByRemovalOfEndpoint(sec, endpointId);
-        } else {
-            return this.legacyRBACGetBehaviorGroupsAffectedByRemovalOfEndpoint(sec, endpointId);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    public List<BehaviorGroup> legacyRBACGetBehaviorGroupsAffectedByRemovalOfEndpoint(final SecurityContext securityContext, final UUID endpointId) {
-        return this.internalGetBehaviorGroupsAffectedByRemovalOfEndpoint(securityContext, endpointId);
-    }
-
-    public List<BehaviorGroup> internalGetBehaviorGroupsAffectedByRemovalOfEndpoint(final SecurityContext sec, final UUID endpointId) {
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, integrationPermissions = {IntegrationPermission.VIEW}, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_VIEW})
+    public List<BehaviorGroup> getBehaviorGroupsAffectedByRemovalOfEndpoint(@Context SecurityContext sec, @IntegrationId @PathParam("endpointId") UUID endpointId) {
         String orgId = getOrgId(sec);
         return behaviorGroupRepository.findBehaviorGroupsByEndpointId(orgId, endpointId);
     }
@@ -396,28 +285,13 @@ public class NotificationResource {
         @APIResponse(responseCode = "400", content = @Content(mediaType = TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING)), description = "Bad or no content passed.")
     })
     @Transactional
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_EDIT})
     public CreateBehaviorGroupResponse createBehaviorGroup(
         @Context final SecurityContext sec,
-        @RequestBody(required = true) final CreateBehaviorGroupRequest request
+        @NotNull @Valid @RequestBody(required = true) final CreateBehaviorGroupRequest request
     ) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, workspaceId);
-
-            return this.internalCreateBehaviorGroup(sec, request);
-        } else {
-            return this.legacyRBACInternalCreateBehaviorGroup(sec, request);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    public CreateBehaviorGroupResponse legacyRBACInternalCreateBehaviorGroup(final SecurityContext securityContext, final CreateBehaviorGroupRequest request) {
-        return this.internalCreateBehaviorGroup(securityContext, request);
-    }
-
-    public CreateBehaviorGroupResponse internalCreateBehaviorGroup(final SecurityContext securityContext, @NotNull @Valid CreateBehaviorGroupRequest request) {
-        String accountId = getAccountId(securityContext);
-        String orgId = getOrgId(securityContext);
+        String accountId = getAccountId(sec);
+        String orgId = getOrgId(sec);
 
         // We know that either the ID or the name are present because the
         // request gets validated before reaching this point, and therefore it
@@ -472,26 +346,11 @@ public class NotificationResource {
     })
     @Operation(summary = "Update a behavior group", description = "Updates the details of a behavior group. Use this endpoint to update the list of related endpoints and event types associated with this behavior group.")
     @Transactional
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_EDIT})
     public Response updateBehaviorGroup(@Context SecurityContext sec,
                                         @Parameter(description = "The UUID of the behavior group to update") @PathParam("id") UUID id,
-                                        @RequestBody(description = "New parameters", required = true) UpdateBehaviorGroupRequest request) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, workspaceId);
-
-            return this.internalUpdateBehaviorGroup(sec, id, request);
-        } else {
-            return this.legacyRBACInternalUpdateBehaviorGroup(sec, id, request);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    public Response legacyRBACInternalUpdateBehaviorGroup(final SecurityContext securityContext, final UUID id, UpdateBehaviorGroupRequest request) {
-        return this.internalUpdateBehaviorGroup(securityContext, id, request);
-    }
-
-    public Response internalUpdateBehaviorGroup(final SecurityContext securityContext, final UUID id, @NotNull @Valid UpdateBehaviorGroupRequest request) {
-        String orgId = getOrgId(securityContext);
+                                        @NotNull @RequestBody(description = "New parameters", required = true) @Valid UpdateBehaviorGroupRequest request) {
+        String orgId = getOrgId(sec);
 
         if (request.displayName != null) {
             UUID bundleId = behaviorGroupRepository.getBundleId(orgId, id);
@@ -523,25 +382,10 @@ public class NotificationResource {
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Delete a behavior group", description = "Deletes a behavior group and all of its configured actions. Use this endpoint when you no longer need a behavior group.")
     @Transactional
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_EDIT})
     public Boolean deleteBehaviorGroup(@Context SecurityContext sec,
                                        @Parameter(description = "The UUID of the behavior group to delete") @PathParam("id") UUID behaviorGroupId) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, workspaceId);
-
-            return this.internalDeleteBehaviorGroup(sec, behaviorGroupId);
-        } else {
-            return this.legacyRBACDeleteBehaviorGroup(sec, behaviorGroupId);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    public Boolean legacyRBACDeleteBehaviorGroup(final SecurityContext securityContext, final UUID behaviorGroupId) {
-        return this.internalDeleteBehaviorGroup(securityContext, behaviorGroupId);
-    }
-
-    public Boolean internalDeleteBehaviorGroup(final SecurityContext securityContext, final UUID behaviorGroupId) {
-        String orgId = getOrgId(securityContext);
+        String orgId = getOrgId(sec);
         final List<UUID> endpointsLinkedToBgToDelete = endpointEventTypeRepository.findEndpointsByBehaviorGroupId(orgId, Set.of(behaviorGroupId));
         final Boolean response = behaviorGroupRepository.delete(orgId, behaviorGroupId);
         endpointEventTypeRepository.refreshEndpointLinksToEventType(orgId, endpointsLinkedToBgToDelete);
@@ -555,25 +399,10 @@ public class NotificationResource {
     @Operation(summary = "Update the list of behavior group actions", description = "Updates the list of actions to be executed in that particular behavior group after an event is received.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_EDIT})
     public Response updateBehaviorGroupActions(@Context SecurityContext sec,
                                                @Parameter(description = "The UUID of the behavior group to update") @PathParam("behaviorGroupId") UUID behaviorGroupId,
                                                @Parameter(description = "List of endpoint ids of the actions") List<UUID> endpointIds) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, workspaceId);
-
-            return this.internalUpdateBehaviorGroupActions(sec, behaviorGroupId, endpointIds);
-        } else {
-            return this.legacyRBACUpdateBehaviorGroupActions(sec, behaviorGroupId, endpointIds);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    public Response legacyRBACUpdateBehaviorGroupActions(final SecurityContext securityContext, final UUID behaviorGroupId, final List<UUID> endpointIds) {
-        return this.internalUpdateBehaviorGroupActions(securityContext, behaviorGroupId, endpointIds);
-    }
-
-    public Response internalUpdateBehaviorGroupActions(final SecurityContext securityContext, final UUID behaviorGroupId, final List<UUID> endpointIds) {
         if (endpointIds == null) {
             throw new BadRequestException("The request body must contain a list (possibly empty) of endpoints identifiers");
         }
@@ -584,7 +413,7 @@ public class NotificationResource {
         if (endpointIds.size() != endpointIds.stream().distinct().count()) {
             throw new BadRequestException("The endpoints identifiers list should not contain duplicates");
         }
-        String orgId = getOrgId(securityContext);
+        String orgId = getOrgId(sec);
         final List<UUID> endpointLinkedToBgBeforeUpdate = endpointEventTypeRepository.findEndpointsByBehaviorGroupId(orgId, Set.of(behaviorGroupId));
         behaviorGroupRepository.updateBehaviorGroupActions(orgId, behaviorGroupId, endpointIds);
         final List<UUID> endpointLinkedToBgAfterUpdate = endpointEventTypeRepository.findEndpointsByBehaviorGroupId(orgId, Set.of(behaviorGroupId));
@@ -601,27 +430,10 @@ public class NotificationResource {
     @Operation(summary = "Update the list of behavior groups for an event type", description = "Updates the list of behavior groups associated with an event type.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_EDIT, WorkspacePermission.EVENT_TYPES_VIEW})
     public Response updateEventTypeBehaviors(@Context SecurityContext sec,
                                              @Parameter(description = "UUID of the eventType to associate with the behavior group(s)") @PathParam("eventTypeId") UUID eventTypeId,
                                              @Parameter(description = "Set of behavior group ids to associate") Set<UUID> behaviorGroupIds) {
-
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, workspaceId);
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.EVENT_TYPES_VIEW, workspaceId);
-
-            return this.internalUpdateEventTypeBehaviors(sec, eventTypeId, behaviorGroupIds);
-        } else {
-            return this.legacyRBACUpdateEventTypeBehaviors(sec, eventTypeId, behaviorGroupIds);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    public Response legacyRBACUpdateEventTypeBehaviors(final SecurityContext securityContext, final UUID eventTypeId, final Set<UUID> behaviorGroupIds) {
-        return this.internalUpdateEventTypeBehaviors(securityContext, eventTypeId, behaviorGroupIds);
-    }
-
-    public Response internalUpdateEventTypeBehaviors(final SecurityContext securityContext, final UUID eventTypeId, final Set<UUID> behaviorGroupIds) {
         if (behaviorGroupIds == null) {
             throw new BadRequestException("The request body must contain a list (possibly empty) of behavior groups identifiers");
         }
@@ -629,7 +441,7 @@ public class NotificationResource {
         if (behaviorGroupIds.contains(null)) {
             throw new BadRequestException("The behavior groups identifiers list should not contain empty values");
         }
-        String orgId = getOrgId(securityContext);
+        String orgId = getOrgId(sec);
         final Set<UUID> updatedBgs = behaviorGroupRepository.updateEventTypeBehaviors(orgId, eventTypeId, behaviorGroupIds);
 
         // Sync new endpoint to evenType data model
@@ -647,28 +459,12 @@ public class NotificationResource {
     @Path("/eventTypes/{eventTypeUuid}/behaviorGroups/{behaviorGroupUuid}")
     @Operation(summary = "Add a behavior group to the given event type.")
     @APIResponse(responseCode = "204")
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_EDIT, WorkspacePermission.EVENT_TYPES_VIEW})
     public void appendBehaviorGroupToEventType(
         @Context final SecurityContext securityContext,
         @RestPath final UUID behaviorGroupUuid,
         @RestPath final UUID eventTypeUuid
     ) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.EVENT_TYPES_VIEW, workspaceId);
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, workspaceId);
-
-            this.internalAppendBehaviorGroupToEventType(securityContext, behaviorGroupUuid, eventTypeUuid);
-        } else {
-            this.legacyRBACAppendBehaviorGroupToEventType(securityContext, behaviorGroupUuid, eventTypeUuid);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    protected void legacyRBACAppendBehaviorGroupToEventType(final SecurityContext securityContext, final UUID behaviorGroupUuid, final UUID eventTypeUuid)  {
-        this.internalAppendBehaviorGroupToEventType(securityContext, behaviorGroupUuid, eventTypeUuid);
-    }
-
-    protected void internalAppendBehaviorGroupToEventType(final SecurityContext securityContext, final UUID behaviorGroupUuid, final UUID eventTypeUuid) {
         final String orgId = getOrgId(securityContext);
 
         this.behaviorGroupRepository.appendBehaviorGroupToEventType(orgId, behaviorGroupUuid, eventTypeUuid);
@@ -681,28 +477,12 @@ public class NotificationResource {
     @Path("/eventTypes/{eventTypeId}/behaviorGroups/{behaviorGroupId}")
     @Operation(summary = "Delete a behavior group from an event type", description = "Delete a behavior group from the specified event type.")
     @APIResponse(responseCode = "204")
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_EDIT, WorkspacePermission.EVENT_TYPES_VIEW})
     public void deleteBehaviorGroupFromEventType(
         @Context final SecurityContext securityContext,
         @RestPath final UUID eventTypeId,
         @RestPath final UUID behaviorGroupId
     ) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.EVENT_TYPES_VIEW, workspaceId);
-            this.kesselAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.BEHAVIOR_GROUPS_EDIT, workspaceId);
-
-            this.internalDeleteBehaviorGroupFromEventType(securityContext, eventTypeId, behaviorGroupId);
-        } else {
-            this.legacyRBACInternalDeleteBehaviorGroupFromEventType(securityContext, eventTypeId, behaviorGroupId);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    protected void legacyRBACInternalDeleteBehaviorGroupFromEventType(final SecurityContext securityContext, final UUID eventTypeId, final UUID behaviorGroupId) {
-        this.internalDeleteBehaviorGroupFromEventType(securityContext, eventTypeId, behaviorGroupId);
-    }
-
-    protected void internalDeleteBehaviorGroupFromEventType(final SecurityContext securityContext, final UUID eventTypeId, final UUID behaviorGroupId) {
         final String orgId = getOrgId(securityContext);
 
         this.behaviorGroupRepository.deleteBehaviorGroupFromEventType(eventTypeId, behaviorGroupId, orgId);
@@ -715,27 +495,10 @@ public class NotificationResource {
     @Path("/bundles/{bundleId}/behaviorGroups")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List behavior groups in a bundle", description = "Lists the behavior groups associated with a bundle. Use this endpoint to see the behavior groups that are configured for a particular bundle for a particular tenant.")
-
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BUNDLES_VIEW, WorkspacePermission.BEHAVIOR_GROUPS_VIEW})
     public List<BehaviorGroup> findBehaviorGroupsByBundleId(@Context SecurityContext sec,
                                                             @Parameter(description = "UUID of the bundle to retrieve the behavior groups for.") @PathParam("bundleId") UUID bundleId) {
-        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(sec))) {
-            final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(sec));
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BUNDLES_VIEW, workspaceId);
-            this.kesselAuthorization.hasPermissionOnWorkspace(sec, WorkspacePermission.BEHAVIOR_GROUPS_VIEW, workspaceId);
-
-            return this.internalFindBehaviorGroupsByBundleId(sec, bundleId);
-        } else {
-            return this.legacyRBACInternalFindBehaviorGroupsByBundleId(sec, bundleId);
-        }
-    }
-
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS)
-    protected List<BehaviorGroup> legacyRBACInternalFindBehaviorGroupsByBundleId(final SecurityContext securityContext, final UUID bundleId) {
-        return this.internalFindBehaviorGroupsByBundleId(securityContext, bundleId);
-    }
-
-    protected List<BehaviorGroup> internalFindBehaviorGroupsByBundleId(final SecurityContext securityContext, final UUID bundleId) {
-        String orgId = getOrgId(securityContext);
+        String orgId = getOrgId(sec);
         List<BehaviorGroup> behaviorGroups = behaviorGroupRepository.findByBundleId(orgId, bundleId);
         endpointRepository.loadProperties(
             behaviorGroups
@@ -802,6 +565,7 @@ public class NotificationResource {
     @Operation(summary = "Update the list of endpoints for an event type", description = "Updates the list of endpoints associated with an event type.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
     public Response updateEventTypeEndpoints(@Context SecurityContext securityContext,
                                              @Parameter(description = "UUID of the eventType to associate with the endpoint(s)") @PathParam("eventTypeId") UUID eventTypeId,
                                              @Parameter(description = "Set of endpoint ids to associate") Set<UUID> endpointsIds) {
@@ -813,22 +577,14 @@ public class NotificationResource {
             throw new BadRequestException("The endpoints identifiers list should not contain empty values");
         }
 
-        if (backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
-            for (UUID endpointId : endpointsIds) {
+        // When Kessel is enabled we need to make sure that the principal has
+        // edit access to all the integrations.
+        if (this.backendConfig.isKesselRelationsEnabled(getOrgId(securityContext))) {
+            for (final UUID endpointId : endpointsIds) {
                 kesselAuthorization.hasPermissionOnIntegration(securityContext, IntegrationPermission.EDIT, endpointId);
             }
-            return internalUpdateEventTypeEndpoints(securityContext, endpointsIds, eventTypeId);
-        } else {
-            return legacyRbacUpdateEventTypeEndpoints(securityContext, endpointsIds, eventTypeId);
         }
-    }
 
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS)
-    public Response legacyRbacUpdateEventTypeEndpoints(SecurityContext securityContext, Set<UUID> endpointsIds, UUID eventTypeId) {
-        return internalUpdateEventTypeEndpoints(securityContext, endpointsIds, eventTypeId);
-    }
-
-    public Response internalUpdateEventTypeEndpoints(SecurityContext securityContext, Set<UUID> endpointsIds, UUID eventTypeId) {
         String orgId = getOrgId(securityContext);
         String accountId = getAccountId(securityContext);
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptorHelper.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptorHelper.java
@@ -1,0 +1,42 @@
+package com.redhat.cloud.notifications.auth.annotation;
+
+import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
+import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
+import jakarta.ws.rs.core.SecurityContext;
+
+import java.util.UUID;
+
+/**
+ * A simple helper class which defines a few methods for the {@link AuthorizationInterceptorTest}
+ * class. For some reason, defining them there made the method's annotations
+ * disappear when trying to use reflection to get them.
+ */
+public class AuthorizationInterceptorHelper {
+
+    @Authorization(legacyRBACRole = AuthorizationInterceptorTest.LEGACY_RBAC_ROLE)
+    public void testMethodWithoutSecurityContext(final String ignored, final UUID ignoredTwo) { }
+
+    @Authorization(legacyRBACRole = AuthorizationInterceptorTest.LEGACY_RBAC_ROLE)
+    public void testMethodWithRBACRole(final SecurityContext ignored, final String ignoredTwo, final UUID ignoredThree) { }
+
+    @Authorization(
+        legacyRBACRole = AuthorizationInterceptorTest.LEGACY_RBAC_ROLE,
+        workspacePermissions = {WorkspacePermission.BUNDLES_VIEW, WorkspacePermission.APPLICATIONS_VIEW, WorkspacePermission.EVENT_TYPES_VIEW}
+    )
+    public void testMethodWithWorkspacePermissions(final SecurityContext ignored, final String ignoredTwo, final UUID ignoredThree) { }
+
+    @Authorization(
+        legacyRBACRole = AuthorizationInterceptorTest.LEGACY_RBAC_ROLE,
+        workspacePermissions = {WorkspacePermission.BUNDLES_VIEW, WorkspacePermission.APPLICATIONS_VIEW, WorkspacePermission.EVENT_TYPES_VIEW},
+        integrationPermissions = {IntegrationPermission.VIEW, IntegrationPermission.VIEW_HISTORY}
+    )
+    public void testMethodWithWorkspaceAndIntegrationPermissionsMissingIntegrationId(final SecurityContext ignored, final String ignoredTwo, final UUID ignoredThree) { }
+
+    @Authorization(
+        legacyRBACRole = AuthorizationInterceptorTest.LEGACY_RBAC_ROLE,
+        workspacePermissions = {WorkspacePermission.BUNDLES_VIEW, WorkspacePermission.APPLICATIONS_VIEW, WorkspacePermission.EVENT_TYPES_VIEW},
+        integrationPermissions = {IntegrationPermission.VIEW, IntegrationPermission.VIEW_HISTORY}
+    )
+    public void testMethodWithWorkspaceAndIntegrationPermissions(final SecurityContext ignored, final String ignoredTwo, @IntegrationId final UUID ignoredThree) { }
+
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptorTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptorTest.java
@@ -1,0 +1,453 @@
+package com.redhat.cloud.notifications.auth.annotation;
+
+import com.redhat.cloud.notifications.auth.kessel.KesselAuthorization;
+import com.redhat.cloud.notifications.auth.kessel.KesselTestHelper;
+import com.redhat.cloud.notifications.auth.kessel.ResourceType;
+import com.redhat.cloud.notifications.auth.kessel.permission.IntegrationPermission;
+import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
+import com.redhat.cloud.notifications.auth.principal.ConsolePrincipal;
+import com.redhat.cloud.notifications.auth.principal.rhid.RhIdPrincipal;
+import com.redhat.cloud.notifications.auth.principal.rhid.RhIdentity;
+import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
+import com.redhat.cloud.notifications.config.BackendConfig;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.interceptor.InvocationContext;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.SecurityContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.project_kessel.api.relations.v1beta1.CheckResponse;
+import org.project_kessel.relations.client.CheckClient;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
+
+@QuarkusTest
+public class AuthorizationInterceptorTest {
+    @Inject
+    KesselTestHelper kesselTestHelper;
+
+    @Inject
+    KesselAuthorization kesselAuthorization;
+
+    @InjectMock
+    BackendConfig backendConfig;
+
+    /**
+     * Required for the {@link KesselTestHelper}.
+     */
+    @InjectMock
+    CheckClient checkClient;
+
+    @InjectMock
+    WorkspaceUtils workspaceUtils;
+
+    public static final String LEGACY_RBAC_ROLE = "legacy-rbac-role";
+
+    private AuthorizationInterceptor authorizationInterceptor;
+
+    /**
+     * Mocks the security context with a {@link RhIdentity} as the principal.
+     * @return the mocked security context.
+     */
+    private SecurityContext mockSecurityContext() {
+        return this.mockSecurityContext(null);
+    }
+
+    /**
+     * Mocks the security context with a {@link RhIdentity} as the principal.
+     * @param authorizedRbacRole the RBAC role the principal will be authorized
+     *                           for. When the parameter is {@code null}, then
+     *                           the principal will not be authorized.
+     * @return the mocked security context.
+     */
+    private SecurityContext mockSecurityContext(final String authorizedRbacRole) {
+        // Mock the security context.
+        final SecurityContext mockedSecurityContext = Mockito.mock(SecurityContext.class);
+
+        // Authorize the user on the given RBAC role, if any.
+        Mockito.when(mockedSecurityContext.isUserInRole(authorizedRbacRole)).thenReturn(authorizedRbacRole != null && !authorizedRbacRole.isBlank());
+
+        // Create a RhIdentity principal and assign it to the mocked security
+        // context.
+        final RhIdentity identity = Mockito.mock(RhIdentity.class);
+        Mockito.when(identity.getName()).thenReturn("Red Hat user");
+        Mockito.when(identity.getOrgId()).thenReturn(DEFAULT_ORG_ID);
+        Mockito.when(identity.getUserId()).thenReturn(DEFAULT_USER);
+
+        final ConsolePrincipal<?> principal = new RhIdPrincipal(identity);
+        Mockito.when(mockedSecurityContext.getUserPrincipal()).thenReturn(principal);
+
+        return mockedSecurityContext;
+    }
+
+    /**
+     * Manually set up the authorization interceptor, as using CDI injections
+     * does not work.
+     */
+    @BeforeEach
+    public void setUp() {
+        this.authorizationInterceptor = new AuthorizationInterceptor(this.backendConfig, this.kesselAuthorization, this.workspaceUtils);
+    }
+
+    /**
+     * Tests that when the method does not have a {@link jakarta.ws.rs.core.SecurityContext}
+     * parameter, then the function under test throws an exception.
+     *
+     * @throws NoSuchMethodException when the method's specification is not
+     * properly defined, and therefore we cannot get it to perform the tests.
+     */
+    @Test
+    void testMissingSecurityContextThrowsException() throws NoSuchMethodException {
+        // Mock the invocation context and make it return one of our defined
+        // methods in this class, for simplicity.
+        final InvocationContext invocationContext = Mockito.mock(InvocationContext.class);
+
+        final Method methodUnderTest = AuthorizationInterceptorHelper.class.getMethod("testMethodWithoutSecurityContext", String.class, UUID.class);
+        Mockito.when(invocationContext.getMethod()).thenReturn(methodUnderTest);
+
+        // Call the function under test which should throw an exception that
+        // signals that the security context is required in the annotated
+        // method's signature.
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.authorizationInterceptor.aroundInvoke(invocationContext)
+        );
+
+        // Assert that the expected exception was thrown.
+        Assertions.assertEquals(
+            String.format("The security context is not set on the method \"%s\", which is needed for the \"KesselRequiredPermission\" annotation to work", methodUnderTest.getName()),
+            exception.getMessage()
+        );
+    }
+
+    /**
+     * Tests that the function under test does not throw an exception when the
+     * principal has the expected legacy RBAC role.
+     *
+     * @throws Exception when an unexpected error occurs.
+     * @throws NoSuchMethodException when the method's specification is not
+     * properly defined, and therefore we cannot get it to perform the tests.
+     */
+    @Test
+    void testRBACPermissionGranted() throws Exception, NoSuchMethodException {
+        // Mock the invocation context and make it return one of our defined
+        // methods in this class, for simplicity.
+        final InvocationContext invocationContext = Mockito.mock(InvocationContext.class);
+
+        final Method methodUnderTest = AuthorizationInterceptorHelper.class.getMethod("testMethodWithRBACRole", SecurityContext.class, String.class, UUID.class);
+        Mockito.when(invocationContext.getMethod()).thenReturn(methodUnderTest);
+
+        // Mock the returned parameters by the context, to be able to provide
+        // whichever security context we want to the interceptor.
+        final SecurityContext securityContext = this.mockSecurityContext(LEGACY_RBAC_ROLE);
+        Mockito.when(invocationContext.getParameters()).thenReturn(new Object[]{securityContext});
+
+        // Call the function under test which should not throw any exceptions.
+        this.authorizationInterceptor.aroundInvoke(invocationContext);
+    }
+
+    /**
+     * Tests that the function under test throws a {@link ForbiddenException}
+     * when the principal does hot havethe expected legacy RBAC role.
+     *
+     * @throws NoSuchMethodException when the method's specification is not
+     * properly defined, and therefore we cannot get it to perform the tests.
+     */
+    @Test
+    void testRBACPermissionDenied() throws NoSuchMethodException {
+        // Mock the invocation context and make it return one of our defined
+        // methods in this class, for simplicity.
+        final InvocationContext invocationContext = Mockito.mock(InvocationContext.class);
+
+        final Method methodUnderTest = AuthorizationInterceptorHelper.class.getMethod("testMethodWithRBACRole", SecurityContext.class, String.class, UUID.class);
+        Mockito.when(invocationContext.getMethod()).thenReturn(methodUnderTest);
+
+        // Make sure that Kessel relations is disabled for this test.
+        this.kesselTestHelper.mockKesselRelations(false);
+
+        // Mock the returned parameters by the context, to be able to provide
+        // whichever security context we want to the interceptor.
+        final SecurityContext securityContext = this.mockSecurityContext();
+        Mockito.when(invocationContext.getParameters()).thenReturn(new Object[]{securityContext});
+
+        // Call the function under test which should throw a ForbiddenException.
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () -> this.authorizationInterceptor.aroundInvoke(invocationContext)
+        );
+    }
+
+    /**
+     * Tests that the function under test throws an exception when Kessel is
+     * enabled as the authorization back end, and no {@link IntegrationPermission}
+     * or {@link WorkspacePermission} elements were defined in the annotation.
+     *
+     * @throws NoSuchMethodException when the method's specification is not
+     * properly defined, and therefore we cannot get it to perform the tests.
+     */
+    @Test
+    void testMissingIntegrationWorkspacePermissions() throws NoSuchMethodException {
+        // Mock the invocation context and make it return one of our defined
+        // methods in this class, for simplicity.
+        final InvocationContext invocationContext = Mockito.mock(InvocationContext.class);
+
+        final Method methodUnderTest = AuthorizationInterceptorHelper.class.getMethod("testMethodWithRBACRole", SecurityContext.class, String.class, UUID.class);
+        Mockito.when(invocationContext.getMethod()).thenReturn(methodUnderTest);
+
+        // Make sure that Kessel relations is enabled for this test.
+        this.kesselTestHelper.mockKesselRelations(true);
+
+        // Mock the returned parameters by the context, to be able to provide
+        // whichever security context we want to the interceptor.
+        final SecurityContext securityContext = this.mockSecurityContext();
+        Mockito.when(invocationContext.getParameters()).thenReturn(new Object[]{securityContext});
+
+        // Call the function under test which should throw an exception that
+        // signals that the required permissions are not defined in the
+        // annotation.
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.authorizationInterceptor.aroundInvoke(invocationContext)
+        );
+
+        // Assert that the expected exception was thrown.
+        Assertions.assertEquals(
+            String.format("No integration or workspace permissions were set for method \"%s\", and at least one of them is required for the \"KesselRequiredPermission\" annotation to work", methodUnderTest.getName()),
+            exception.getMessage()
+        );
+    }
+
+    /**
+     * Tests that the function under test does not throw an exception and runs
+     * normally when the principal is authorized for the specified workspace
+     * permissions in the annotation.
+     *
+     * @throws Exception when an unexpected error occurs.
+     * @throws NoSuchMethodException when the method's specification is not
+     * properly defined, and therefore we cannot get it to perform the tests.
+     */
+    @Test
+    void testWorkspacePermissionGranted() throws Exception, NoSuchMethodException {
+        // Mock the invocation context and make it return one of our defined
+        // methods in this class, for simplicity.
+        final InvocationContext invocationContext = Mockito.mock(InvocationContext.class);
+
+        final Method methodUnderTest = AuthorizationInterceptorHelper.class.getMethod("testMethodWithWorkspacePermissions", SecurityContext.class, String.class, UUID.class);
+        Mockito.when(invocationContext.getMethod()).thenReturn(methodUnderTest);
+
+        // Make sure that Kessel relations is enabled for this test.
+        this.kesselTestHelper.mockKesselRelations(true);
+
+        // Mock the returned parameters by the context, to be able to provide
+        // whichever security context we want to the interceptor.
+        final SecurityContext securityContext = this.mockSecurityContext();
+        Mockito.when(invocationContext.getParameters()).thenReturn(new Object[]{securityContext});
+
+        // Mock the Kessel checks to simulate that the principal has the
+        // required workspace permissions.
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.BUNDLES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.APPLICATIONS_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+
+        // Call the function under test which should not throw any exceptions.
+        this.authorizationInterceptor.aroundInvoke(invocationContext);
+    }
+
+    /**
+     * Tests that the function under test does not throw an exception and runs
+     * normally when the principal is authorized for the specified workspace
+     * permissions in the annotation.
+     *
+     * @throws Exception when an unexpected error occurs.
+     * @throws NoSuchMethodException when the method's specification is not
+     * properly defined, and therefore we cannot get it to perform the tests.
+     */
+    @Test
+    void testWorkspacePermissionDenied() throws Exception, NoSuchMethodException {
+        // Mock the invocation context and make it return one of our defined
+        // methods in this class, for simplicity.
+        final InvocationContext invocationContext = Mockito.mock(InvocationContext.class);
+
+        final Method methodUnderTest = AuthorizationInterceptorHelper.class.getMethod("testMethodWithWorkspacePermissions", SecurityContext.class, String.class, UUID.class);
+        Mockito.when(invocationContext.getMethod()).thenReturn(methodUnderTest);
+
+        // Make sure that Kessel relations is enabled for this test.
+        this.kesselTestHelper.mockKesselRelations(true);
+
+        // Mock the returned parameters by the context, to be able to provide
+        // whichever security context we want to the interceptor.
+        final SecurityContext securityContext = this.mockSecurityContext();
+        Mockito.when(invocationContext.getParameters()).thenReturn(new Object[]{securityContext});
+
+        // Mock the Kessel checks to simulate that the principal has the
+        // required workspace permissions.
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.BUNDLES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.APPLICATIONS_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString(), CheckResponse.Allowed.ALLOWED_FALSE);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+
+        // Call the function under test which should throw a ForbiddenException.
+        Assertions.assertThrows(
+            ForbiddenException.class,
+            () -> this.authorizationInterceptor.aroundInvoke(invocationContext)
+        );
+    }
+
+    /**
+     * Tests that the function under test throws an exception when an
+     * {@link IntegrationPermission} is specified, but the {@link IntegrationId}
+     * annotation has not been set in the method.
+     *
+     * @throws Exception when an unexpected error occurs.
+     * @throws NoSuchMethodException when the method's specification is not
+     * properly defined, and therefore we cannot get it to perform the tests.
+     */
+    @Test
+    void testMissingIntegrationIdAnnotation() throws Exception, NoSuchMethodException {
+        // Mock the invocation context and make it return one of our defined
+        // methods in this class, for simplicity.
+        final InvocationContext invocationContext = Mockito.mock(InvocationContext.class);
+
+        final Method methodUnderTest = AuthorizationInterceptorHelper.class.getMethod("testMethodWithWorkspaceAndIntegrationPermissionsMissingIntegrationId", SecurityContext.class, String.class, UUID.class);
+        Mockito.when(invocationContext.getMethod()).thenReturn(methodUnderTest);
+
+        // Make sure that Kessel relations is enabled for this test.
+        this.kesselTestHelper.mockKesselRelations(true);
+
+        // Mock the returned parameters by the context, to be able to provide
+        // whichever security context and integration ID we want to the
+        // interceptor.
+        final SecurityContext securityContext = this.mockSecurityContext();
+        final String secondIgnoredParameter = "second-ignored-parameter";
+        final UUID integrationId = UUID.randomUUID();
+        Mockito.when(invocationContext.getParameters()).thenReturn(new Object[]{securityContext, secondIgnoredParameter, integrationId});
+
+        // Mock the Kessel checks to simulate that the principal has the
+        // required workspace permissions.
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.BUNDLES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.APPLICATIONS_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+
+        // Mock the Kessel checks to simulate that the principal has the
+        // required integration permissions.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.VIEW, ResourceType.INTEGRATION, integrationId.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.VIEW_HISTORY, ResourceType.INTEGRATION, integrationId.toString());
+
+        // Call the function under test which should throw an exception that
+        // signals that the method is missing a parameter annotated with the
+        // "IntegrationId" annotation.
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> this.authorizationInterceptor.aroundInvoke(invocationContext)
+        );
+
+        // Assert that the expected exception was thrown.
+        Assertions.assertEquals(
+            String.format("The integration ID is not annotated on the method \"%s\", which is needed for the \"KesselRequiredPermission\" annotation to work", methodUnderTest.getName()),
+            exception.getMessage()
+        );
+    }
+
+    /**
+     * Tests that the function under test throws a {@link jakarta.ws.rs.NotFoundException}
+     * when the principal does not have authorization with one of the
+     * {@link IntegrationPermission}s.
+     *
+     * @throws Exception when an unexpected error occurs.
+     * @throws NoSuchMethodException when the method's specification is not
+     * properly defined, and therefore we cannot get it to perform the tests.
+     */
+    @Test
+    void testIntegrationPermissionDenied() throws Exception, NoSuchMethodException {
+        // Mock the invocation context and make it return one of our defined
+        // methods in this class, for simplicity.
+        final InvocationContext invocationContext = Mockito.mock(InvocationContext.class);
+
+        final Method methodUnderTest = AuthorizationInterceptorHelper.class.getMethod("testMethodWithWorkspaceAndIntegrationPermissions", SecurityContext.class, String.class, UUID.class);
+        Mockito.when(invocationContext.getMethod()).thenReturn(methodUnderTest);
+
+        // Make sure that Kessel relations is enabled for this test.
+        this.kesselTestHelper.mockKesselRelations(true);
+
+        // Mock the returned parameters by the context, to be able to provide
+        // whichever security context and integration ID we want to the
+        // interceptor.
+        final SecurityContext securityContext = this.mockSecurityContext();
+        final String secondIgnoredParameter = "second-ignored-parameter";
+        final UUID integrationId = UUID.randomUUID();
+        Mockito.when(invocationContext.getParameters()).thenReturn(new Object[]{securityContext, secondIgnoredParameter, integrationId});
+
+        // Mock the Kessel checks to simulate that the principal has the
+        // required workspace permissions.
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.BUNDLES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.APPLICATIONS_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+
+        // Mock the Kessel checks to simulate that the principal does not have
+        // all the required integration permissions.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.VIEW, ResourceType.INTEGRATION, integrationId.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.VIEW_HISTORY, ResourceType.INTEGRATION, integrationId.toString(), CheckResponse.Allowed.ALLOWED_FALSE);
+
+        // Call the function under test which should throw a ForbiddenException.
+        Assertions.assertThrows(
+            NotFoundException.class,
+            () -> this.authorizationInterceptor.aroundInvoke(invocationContext)
+        );
+    }
+
+    /**
+     * Tests that the function under test does not throw an exception when
+     * the principal has the specified {@link WorkspacePermission} and {@link IntegrationPermission}.
+     *
+     * @throws Exception when an unexpected error occurs.
+     * @throws NoSuchMethodException when the method's specification is not
+     * properly defined, and therefore we cannot get it to perform the tests.
+     */
+    @Test
+    void testIntegrationPermissionGranted() throws Exception, NoSuchMethodException {
+        // Mock the invocation context and make it return one of our defined
+        // methods in this class, for simplicity.
+        final InvocationContext invocationContext = Mockito.mock(InvocationContext.class);
+
+        final Method methodUnderTest = AuthorizationInterceptorHelper.class.getMethod("testMethodWithWorkspaceAndIntegrationPermissions", SecurityContext.class, String.class, UUID.class);
+        Mockito.when(invocationContext.getMethod()).thenReturn(methodUnderTest);
+
+        // Make sure that Kessel relations is enabled for this test.
+        this.kesselTestHelper.mockKesselRelations(true);
+
+        // Mock the returned parameters by the context, to be able to provide
+        // whichever security context and integration ID we want to the
+        // interceptor.
+        final SecurityContext securityContext = this.mockSecurityContext();
+        final String secondIgnoredParameter = "second-ignored-parameter";
+        final UUID integrationId = UUID.randomUUID();
+        Mockito.when(invocationContext.getParameters()).thenReturn(new Object[]{securityContext, secondIgnoredParameter, integrationId});
+
+        // Mock the Kessel checks to simulate that the principal has the
+        // required workspace permissions.
+        this.kesselTestHelper.mockDefaultWorkspaceId(DEFAULT_ORG_ID);
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.BUNDLES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.APPLICATIONS_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, WorkspacePermission.EVENT_TYPES_VIEW, ResourceType.WORKSPACE, KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID.toString());
+
+        // Mock the Kessel checks to simulate that the principal has the
+        // required integration permissions.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.VIEW, ResourceType.INTEGRATION, integrationId.toString());
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.VIEW_HISTORY, ResourceType.INTEGRATION, integrationId.toString());
+
+        // Call the function under test which should not throw any exceptions.
+        this.authorizationInterceptor.aroundInvoke(invocationContext);
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselTestHelper.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselTestHelper.java
@@ -51,6 +51,12 @@ public class KesselTestHelper {
     public static final UUID RBAC_DEFAULT_WORKSPACE_ID = UUID.randomUUID();
 
     /**
+     * Defines a default Kessel domain that will get returned every time
+     * that the {@link BackendConfig#getKesselDomain()} method is called.
+     */
+    public static final String DEFAULT_KESSEL_DOMAIN = "redhat";
+
+    /**
      * Mocks the {@link LookupClient} so that it simulates that no authorized
      * integrations were fetched from Kessel.
      * @deprecated In favor of "post-filtering". Looking up integrations makes
@@ -198,6 +204,11 @@ public class KesselTestHelper {
         if (!this.backendConfig.isKesselRelationsEnabled(anyString())) {
             return;
         }
+
+        // Return a default domain for Kessel.
+        Mockito
+            .when(this.backendConfig.getKesselDomain())
+            .thenReturn(DEFAULT_KESSEL_DOMAIN);
 
         // Default to an unauthorized response.
         Mockito

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
@@ -1237,6 +1237,9 @@ public class EndpointResourceTest extends DbIsolatedTest {
         attrSingle.mapTo(WebhookProperties.class);
         attrSingle.put("secret_token", "not-so-secret-anymore");
 
+        // Give the Kessel permissions to see the endpoint.
+        this.kesselTestHelper.mockKesselPermission(DEFAULT_USER, IntegrationPermission.EDIT, ResourceType.INTEGRATION, responsePointSingle.getString("id"));
+
         // Update without payload
         given()
                 .header(identityHeader)
@@ -2832,7 +2835,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         final JsonObject constraintViolation = constraintViolations.getJsonObject(0);
 
-        Assertions.assertEquals("internalTestEndpoint.requestBody.message", constraintViolation.getString("field"), "unexpected field validated when sending a blank test message");
+        Assertions.assertEquals("testEndpoint.requestBody.message", constraintViolation.getString("field"), "unexpected field validated when sending a blank test message");
         Assertions.assertEquals("must not be blank", constraintViolation.getString("message"), "unexpected error message received when sending a blank custom message for testing the endpoint");
     }
 


### PR DESCRIPTION
The changes make use of the new "Authorization" annotation to simplify
the code and improve maintainability.

> [!NOTE]
> Depends on https://github.com/RedHatInsights/notifications-backend/pull/3293

## Jira ticket
[[RHCLOUD-37536]](https://issues.redhat.com/browse/RHCLOUD-37536)