### PR TITLE
RHCLOUD-37937 | feature: send general notifications to customers

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/engine/GeneralCommunicationsService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/engine/GeneralCommunicationsService.java
@@ -1,0 +1,23 @@
+package com.redhat.cloud.notifications.routers.engine;
+
+import com.redhat.cloud.notifications.Constants;
+import com.redhat.cloud.notifications.routers.general.communication.SendGeneralCommunicationResponse;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "internal-engine")
+public interface GeneralCommunicationsService {
+    /**
+     * Triggers a general communication via email to Red Hat customers.
+     * @return the response body received from the engine.
+     */
+    @Path(Constants.API_INTERNAL + "/general-communications/send")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Retry(maxRetries = 3)
+    SendGeneralCommunicationResponse sendGeneralCommunication();
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -652,7 +652,7 @@ public class InternalResource {
     @Path("/general-communications")
     @POST
     @Produces(APPLICATION_JSON)
-    @RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_USER)
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)
     public SendGeneralCommunicationResponse sendGeneralCommunication(@NotBlank @RestHeader("x-rh-send-general-communication") String safetyHeader, @NotNull @Valid final SendGeneralCommunicationRequest request) {
         if (!"send-communication".equals(safetyHeader)) {
             final JsonObject responseBody = new JsonObject();

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -25,21 +25,26 @@ import com.redhat.cloud.notifications.oapi.OApiFilter;
 import com.redhat.cloud.notifications.routers.SecurityContextUtil;
 import com.redhat.cloud.notifications.routers.dailydigest.TriggerDailyDigestRequest;
 import com.redhat.cloud.notifications.routers.engine.DailyDigestService;
+import com.redhat.cloud.notifications.routers.engine.GeneralCommunicationsService;
 import com.redhat.cloud.notifications.routers.engine.ReplayService;
+import com.redhat.cloud.notifications.routers.general.communication.SendGeneralCommunicationResponse;
 import com.redhat.cloud.notifications.routers.internal.models.AddApplicationRequest;
 import com.redhat.cloud.notifications.routers.internal.models.RequestDefaultBehaviorGroupPropertyList;
 import com.redhat.cloud.notifications.routers.internal.models.ServerInfo;
 import com.redhat.cloud.notifications.routers.internal.models.UpdateApplicationRequest;
 import com.redhat.cloud.notifications.routers.internal.models.dto.ApplicationDTO;
+import com.redhat.cloud.notifications.routers.internal.models.dto.SendGeneralCommunicationRequest;
 import com.redhat.cloud.notifications.routers.internal.models.transformer.ApplicationDTOTransformer;
 import com.redhat.cloud.notifications.routers.replay.EventsReplayRequest;
 import io.quarkus.logging.Log;
 import io.quarkus.narayana.jta.runtime.TransactionConfiguration;
+import io.vertx.core.json.JsonObject;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
@@ -63,6 +68,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestHeader;
 import org.jboss.resteasy.reactive.RestPath;
 
 import java.net.URI;
@@ -110,6 +116,10 @@ public class InternalResource {
 
     @Inject
     Environment environment;
+
+    @Inject
+    @RestClient
+    GeneralCommunicationsService generalCommunicationsService;
 
     @Inject
     InternalRoleAccessRepository internalRoleAccessRepository;
@@ -627,5 +637,37 @@ public class InternalResource {
         }
 
         this.dailyDigestService.triggerDailyDigest(triggerDailyDigestRequest);
+    }
+
+    /**
+     * Sends a "general communication" request to the engine, so that we can
+     * trigger a general communication event.
+     * @param safetyHeader the safety header that is expected to avoid any
+     *                     miscalls to the endpoint.
+     * @param request the safety request body that is expected to avoid any
+     *                miscalls to the endpoint.
+     * @return the received response body from the engine.
+     */
+    @Consumes(APPLICATION_JSON)
+    @Path("/general-communications")
+    @POST
+    @Produces(APPLICATION_JSON)
+    @RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_USER)
+    public SendGeneralCommunicationResponse sendGeneralCommunication(@NotBlank @RestHeader("x-rh-send-general-communication") String safetyHeader, @NotNull @Valid final SendGeneralCommunicationRequest request) {
+        if (!"send-communication".equals(safetyHeader)) {
+            final JsonObject responseBody = new JsonObject();
+            responseBody.put("error", "The safety header does not have the expected value");
+
+            throw new BadRequestException(responseBody.encode());
+        }
+
+        if (!request.sendGeneralCommunication()) {
+            final JsonObject responseBody = new JsonObject();
+            responseBody.put("error", "The request body does not contain the expected safety payload");
+
+            throw new BadRequestException(responseBody.encode());
+        }
+
+        return this.generalCommunicationsService.sendGeneralCommunication();
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/dto/SendGeneralCommunicationRequest.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/models/dto/SendGeneralCommunicationRequest.java
@@ -1,0 +1,14 @@
+package com.redhat.cloud.notifications.routers.internal.models.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Defines the expected payload for the "send general communication" request.
+ * @param sendGeneralCommunication the safety key that must be present in the
+ *                                 payload.
+ */
+public record SendGeneralCommunicationRequest(
+    @JsonProperty("send_general_communication") @NotNull Boolean sendGeneralCommunication
+) {
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/routers/general/communication/SendGeneralCommunicationResponse.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/routers/general/communication/SendGeneralCommunicationResponse.java
@@ -1,0 +1,13 @@
+package com.redhat.cloud.notifications.routers.general.communication;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the response's structure that will come from the engine.
+ * @param info Any information that the engine might have included in the
+ *             response body.
+ */
+public record SendGeneralCommunicationResponse(
+    @JsonProperty("info") String info
+) {
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -350,9 +350,7 @@ public class EndpointRepository {
             "FROM " +
                 "Endpoint AS e " +
             "WHERE " +
-                "e.compositeType = :type " +
-            "ORDER BY " +
-                "orgId";
+                "e.compositeType = :type";
 
         // Fetch the endpoints from the database.
         final List<Endpoint> endpoints = this.entityManager.createQuery(findByTypeQuery, Endpoint.class)

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -360,11 +360,7 @@ public class EndpointRepository {
         // Group the endpoints by org ID.
         final Map<String, List<String>> result = new HashMap<>();
         for (final Endpoint endpoint : endpoints) {
-            final List<String> orgEndpointNames = result.getOrDefault(endpoint.getOrgId(), new ArrayList<>());
-
-            orgEndpointNames.add(endpoint.getName());
-
-            result.putIfAbsent(endpoint.getOrgId(), orgEndpointNames);
+            result.computeIfAbsent(endpoint.getOrgId(), unused -> new ArrayList<>()).add(endpoint.getName());
         }
 
         return result;

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/GeneralCommunicationsHelper.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/GeneralCommunicationsHelper.java
@@ -1,0 +1,70 @@
+package com.redhat.cloud.notifications.events;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.ingress.Recipient;
+import com.redhat.cloud.notifications.models.CompositeEndpointType;
+import com.redhat.cloud.notifications.models.Endpoint;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GeneralCommunicationsHelper {
+    public static final String GENERAL_COMMUNICATION_CONTEXT_INTEGRATION_CATEGORY = "integration_category";
+    public static final String GENERAL_COMMUNICATION_METADATA_KEY = "communication-description";
+    public static final String GENERAL_COMMUNICATION_METADATA_VALUE = "General communication about customers' Microsoft Teams' URLs needing a review";
+    public static final String GENERAL_COMMUNICATION_PAYLOAD_INTEGRATION_NAMES = "integration_names";
+    public static final String GENERAL_COMMUNICATIONS_BUNDLE = "console";
+    public static final String GENERAL_COMMUNICATIONS_APPLICATION = "integrations";
+    public static final String GENERAL_COMMUNICATIONS_EVENT_TYPE = "general-communication";
+
+    private GeneralCommunicationsHelper() { }
+
+    public static Action createGeneralCommunicationAction(final String orgId, final CompositeEndpointType integrationType, final List<String> integrationNames) {
+        // Add the generic data.
+        final Action generalCommunicationAction = new Action();
+        generalCommunicationAction.setBundle(GENERAL_COMMUNICATIONS_BUNDLE);
+        generalCommunicationAction.setApplication(GENERAL_COMMUNICATIONS_APPLICATION);
+        generalCommunicationAction.setEventType(GENERAL_COMMUNICATIONS_EVENT_TYPE);
+        generalCommunicationAction.setOrgId(orgId);
+        generalCommunicationAction.setTimestamp(LocalDateTime.now(Clock.systemUTC()));
+
+        // Override the recipients' settings for this action, since we want
+        // everyone to receive this action.
+        final Recipient recipient = new Recipient();
+        recipient.setIgnoreUserPreferences(true);
+        generalCommunicationAction.setRecipients(List.of(recipient));
+
+        // Add the integration's category in the action so that we can provide
+        // the customers with the proper link to the type of integrations we
+        // are talking about.
+        final Endpoint endpoint = new Endpoint();
+        endpoint.setType(integrationType.getType());
+        endpoint.setSubType(integrationType.getSubType());
+
+        final Context context = new Context();
+        context.setAdditionalProperty(GENERAL_COMMUNICATION_CONTEXT_INTEGRATION_CATEGORY, IntegrationDisabledNotifier.getFrontendCategory(endpoint));
+        generalCommunicationAction.setContext(context);
+
+        // Create a particular event.
+        final Event generalCommunicationEvent = new Event();
+
+        // Specify what the general communication is about in the metadata.
+        final Metadata metadata = new Metadata();
+        metadata.setAdditionalProperty(GENERAL_COMMUNICATION_METADATA_KEY, GENERAL_COMMUNICATION_METADATA_VALUE);
+        generalCommunicationEvent.setMetadata(metadata);
+
+        // Include the payload.
+        final Payload payload = new Payload();
+        payload.setAdditionalProperty(GENERAL_COMMUNICATION_PAYLOAD_INTEGRATION_NAMES, integrationNames);
+        generalCommunicationEvent.setPayload(payload);
+
+        generalCommunicationAction.setEvents(List.of(generalCommunicationEvent));
+
+        return generalCommunicationAction;
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifier.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifier.java
@@ -84,7 +84,7 @@ public class IntegrationDisabledNotifier {
      * - the endpoints subtype no longer makes sense, we should only have the type
      * TODO Let's improve that and fix problems ASAP!
      */
-    private static String getFrontendCategory(Endpoint endpoint) {
+    public static String getFrontendCategory(Endpoint endpoint) {
         return switch (endpoint.getType()) {
             case ANSIBLE -> "Reporting";
             case CAMEL -> {

--- a/engine/src/main/java/com/redhat/cloud/notifications/routers/GeneralCommunicationsResource.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/routers/GeneralCommunicationsResource.java
@@ -1,0 +1,68 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
+import com.redhat.cloud.notifications.events.ConnectorReceiver;
+import com.redhat.cloud.notifications.events.GeneralCommunicationsHelper;
+import com.redhat.cloud.notifications.events.KafkaMessageWithIdBuilder;
+import com.redhat.cloud.notifications.ingress.Parser;
+import com.redhat.cloud.notifications.models.CompositeEndpointType;
+import com.redhat.cloud.notifications.models.EndpointType;
+import com.redhat.cloud.notifications.routers.general.communication.SendGeneralCommunicationResponse;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.Constants.API_INTERNAL;
+
+@Path(API_INTERNAL + "/general-communications")
+public class GeneralCommunicationsResource {
+    /**
+     * Defines the message that will be sent back to the back end when no
+     * general communication was sent.
+     */
+    public static final String NO_OP_RESPONSE_MESSAGE = "No general communication was sent because no results were returned from the database";
+
+    @Channel(ConnectorReceiver.EGRESS_CHANNEL)
+    @Inject
+    Emitter<String> eventEmitter;
+
+    @Inject
+    EndpointRepository endpointRepository;
+
+    /**
+     * Creates a "general communication" action and sends it to the ingress
+     * Kafka channel.
+     */
+    @Path("/send")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public SendGeneralCommunicationResponse sendGeneralCommunication() {
+        // Find all the integration names and group them by organization ID.
+        final CompositeEndpointType compositeEndpointType = new CompositeEndpointType(EndpointType.CAMEL, "teams");
+        final Map<String, List<String>> endpointNamesPerOrg = this.endpointRepository.findIntegrationNamesByTypeGroupedByOrganizationId(compositeEndpointType);
+
+        // Send a "no content" response when there is nothing to do. It is not
+        // an error per se, so that is
+        if (endpointNamesPerOrg.isEmpty()) {
+            return new SendGeneralCommunicationResponse(NO_OP_RESPONSE_MESSAGE);
+        }
+
+        // Encode an event per organization, and send it to Kafka.
+        for (final Map.Entry<String, List<String>> entry : endpointNamesPerOrg.entrySet()) {
+            final String encodedAction = Parser.encode(GeneralCommunicationsHelper.createGeneralCommunicationAction(entry.getKey(), compositeEndpointType, entry.getValue()));
+
+            final Message<String> message = KafkaMessageWithIdBuilder.build(encodedAction);
+            this.eventEmitter.send(message);
+        }
+
+        return new SendGeneralCommunicationResponse(null);
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.templates;
 
 import com.cronutils.utils.StringUtils;
 import com.redhat.cloud.notifications.config.EngineConfig;
+import com.redhat.cloud.notifications.events.GeneralCommunicationsHelper;
 import com.redhat.cloud.notifications.models.AggregationEmailTemplate;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.EventType;
@@ -275,6 +276,12 @@ public class EmailTemplateMigrationService {
                 warnings, "console", "integrations", List.of(INTEGRATION_DISABLED_EVENT_TYPE),
                 "Integrations/integrationDisabledTitle", "txt", "Integrations disabled integration email title",
                 "Integrations/integrationDisabledBody", "html", "Integrations disabled integration email body"
+            );
+
+            createInstantEmailTemplate(
+                warnings, "console", "integrations", List.of(GeneralCommunicationsHelper.GENERAL_COMMUNICATIONS_EVENT_TYPE),
+                "Integrations/generalCommunicationTitle", "txt", "Email title for the general communications sent by Red Hat",
+                "Integrations/generalCommunicationBody", "html", "Email body for the general communications sent by Red Hat"
             );
 
             /*

--- a/engine/src/main/resources/templates/Integrations/generalCommunicationBodyV2.html
+++ b/engine/src/main/resources/templates/Integrations/generalCommunicationBodyV2.html
@@ -1,0 +1,42 @@
+{@boolean renderSection1=true}
+{@boolean renderButtonSection1=true}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Integrations - Console
+{/content-title}
+{#content-title-section1}
+    Your Microsoft Teams integrations need attention
+{/content-title-section1}
+{#content-body-section1}
+    <p>Dear Red Hat customer,</p>
+    <p>We are contacting you because you have the following Microsoft Teams integrations set up for your organization in the <a href="https://console.redhat.com">Red Hat Hybrid Cloud Console</a>:</p>
+    <ul>
+        {#for integrationName in action.events[0].payload.integration_names}
+        <li>{integrationName}</li>
+        {/for}
+    </ul>
+    <p>Microsoft is <a href="https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/">updating the Teams connectors for security reasons</a>, and they are recommending that their customers <a href="https://learn.microsoft.com/en-us/microsoftteams/m365-custom-connectors#update-connectors-url">update any URLs for connectors</a> they have set up. We identified the above Integrations in your account and are asking you to review, and update if needed, to avoid service interruption when Microsoft sunsets the old URLs. <strong>If you have already updated your Integrations URLs, you can safely ignore this email</strong>.</p>
+    <p>To update your Microsoft Teams integrations, complete the following steps:</p>
+    <ol>
+        <li>Generate a new webhook URL from your Microsoft Teams client by following the steps in <a href="https://learn.microsoft.com/en-us/microsoftteams/m365-custom-connectors#update-connectors-url">Update connectors URL</a> in the Microsoft documentation.</li>
+        <li>Copy the URL to your clipboard to use in the Hybrid Cloud Console.</li>
+        <li>To update your integration, log in to the <a href="https://console.redhat.com">Hybrid Cloud Console.</a></li>
+        <li>Navigate to <strong>Settings</strong> (gear icon) > <strong><a href="https://console.redhat.com/settings/integrations">Integrations</a></strong>.</li>
+        <li>Click the <strong>Communications</strong> tab.</li>
+        <li>Locate your Microsoft Teams integration.</li>
+        <li>Next to your integration, click the options icon (⋮) and click <strong>Edit</strong>.</li>
+        <li>Click <strong>Next</strong> to continue past the Integration type step.</li>
+        <li>Paste the incoming webhook URL that you copied from Microsoft Teams into the <strong>Endpoint URL</strong> field.</li>
+        <li>Click <strong>Next</strong>.</li>
+        <li>Review the integration details and click <strong>Submit</strong> to update the integration.</li>
+    </ol>
+    <p>Following the above steps will ensure that you will continue receiving the alerts and notifications in the Microsoft Teams channel that you have configured.</p>
+    <p>For more information about configuring Microsoft Teams integrations, see the <a href="https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/integrating_the_red_hat_hybrid_cloud_console_with_third-party_applications/index#assembly-configuring-integration-with-teams_integrating-communications">Red Hat documentation</a>.</p>
+    <p>Thank you for your attention.</p>
+    <p>Kind regards,</p>
+    <p>Red Hat</p>
+{/content-body-section1}
+{#content-button-section1}
+    <a target="_blank" href="{environment.url}/settings/integrations?category={action.context.integration_category}">Open Integrations</a>
+{/content-button-section1}
+{/include}

--- a/engine/src/main/resources/templates/Integrations/generalCommunicationBodyV2.html
+++ b/engine/src/main/resources/templates/Integrations/generalCommunicationBodyV2.html
@@ -9,19 +9,19 @@
 {/content-title-section1}
 {#content-body-section1}
     <p>Dear Red Hat customer,</p>
-    <p>We are contacting you because you have the following Microsoft Teams integrations set up for your organization in the <a href="https://console.redhat.com">Red Hat Hybrid Cloud Console</a>:</p>
+    <p>We are contacting you because you have the following Microsoft Teams integrations set up for your organization in the <a target="_blank" href="https://console.redhat.com">Red Hat Hybrid Cloud Console</a>:</p>
     <ul>
         {#for integrationName in action.events[0].payload.integration_names}
         <li>{integrationName}</li>
         {/for}
     </ul>
-    <p>Microsoft is <a href="https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/">updating the Teams connectors for security reasons</a>, and they are recommending that their customers <a href="https://learn.microsoft.com/en-us/microsoftteams/m365-custom-connectors#update-connectors-url">update any URLs for connectors</a> they have set up. We identified the above Integrations in your account and are asking you to review, and update if needed, to avoid service interruption when Microsoft sunsets the old URLs. <strong>If you have already updated your Integrations URLs, you can safely ignore this email</strong>.</p>
+    <p>Microsoft is <a target="_blank" href="https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/">updating the Teams connectors for security reasons</a>, and they are recommending that their customers <a target="_blank" href="https://learn.microsoft.com/en-us/microsoftteams/m365-custom-connectors#update-connectors-url">update any URLs for connectors</a> they have set up. We identified the above Integrations in your account and are asking you to review, and update if needed, to avoid service interruption when Microsoft sunsets the old URLs. <strong>If you have already updated your Integrations URLs, you can safely ignore this email</strong>.</p>
     <p>To update your Microsoft Teams integrations, complete the following steps:</p>
     <ol>
-        <li>Generate a new webhook URL from your Microsoft Teams client by following the steps in <a href="https://learn.microsoft.com/en-us/microsoftteams/m365-custom-connectors#update-connectors-url">Update connectors URL</a> in the Microsoft documentation.</li>
+        <li>Generate a new webhook URL from your Microsoft Teams client by following the steps in <a target="_blank" href="https://learn.microsoft.com/en-us/microsoftteams/m365-custom-connectors#update-connectors-url">Update connectors URL</a> in the Microsoft documentation.</li>
         <li>Copy the URL to your clipboard to use in the Hybrid Cloud Console.</li>
-        <li>To update your integration, log in to the <a href="https://console.redhat.com">Hybrid Cloud Console.</a></li>
-        <li>Navigate to <strong>Settings</strong> (gear icon) > <strong><a href="https://console.redhat.com/settings/integrations">Integrations</a></strong>.</li>
+        <li>To update your integration, log in to the <a target="_blank" href="https://console.redhat.com">Hybrid Cloud Console.</a></li>
+        <li>Navigate to <strong>Settings</strong> (gear icon) > <strong><a target="_blank" href="https://console.redhat.com/settings/integrations">Integrations</a></strong>.</li>
         <li>Click the <strong>Communications</strong> tab.</li>
         <li>Locate your Microsoft Teams integration.</li>
         <li>Next to your integration, click the options icon (⋮) and click <strong>Edit</strong>.</li>
@@ -31,7 +31,7 @@
         <li>Review the integration details and click <strong>Submit</strong> to update the integration.</li>
     </ol>
     <p>Following the above steps will ensure that you will continue receiving the alerts and notifications in the Microsoft Teams channel that you have configured.</p>
-    <p>For more information about configuring Microsoft Teams integrations, see the <a href="https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/integrating_the_red_hat_hybrid_cloud_console_with_third-party_applications/index#assembly-configuring-integration-with-teams_integrating-communications">Red Hat documentation</a>.</p>
+    <p>For more information about configuring Microsoft Teams integrations, see the <a target="_blank" href="https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/integrating_the_red_hat_hybrid_cloud_console_with_third-party_applications/index#assembly-configuring-integration-with-teams_integrating-communications">Red Hat documentation</a>.</p>
     <p>Thank you for your attention.</p>
     <p>Kind regards,</p>
     <p>Red Hat</p>

--- a/engine/src/main/resources/templates/Integrations/generalCommunicationTitleV2.txt
+++ b/engine/src/main/resources/templates/Integrations/generalCommunicationTitleV2.txt
@@ -1,0 +1,1 @@
+Your Microsoft Teams integrations need attention

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -162,9 +162,16 @@ public class ResourceHelpers {
         return event;
     }
 
+    public Endpoint createEndpoint(final EndpointType type, final String subType, final boolean enabled, final int serverErrors) {
+        return this.createEndpoint(null, type, subType, enabled, serverErrors);
+    }
+
     @Transactional
-    public Endpoint createEndpoint(EndpointType type, String subType, boolean enabled, int serverErrors) {
+    public Endpoint createEndpoint(final String orgId, final EndpointType type, final String subType, final boolean enabled, final int serverErrors) {
         Endpoint endpoint = new Endpoint();
+        if (orgId != null) {
+            endpoint.setOrgId(orgId);
+        }
         endpoint.setType(type);
         endpoint.setSubType(subType);
         endpoint.setName("endpoint-" + new SecureRandom().nextInt());

--- a/engine/src/test/java/com/redhat/cloud/notifications/routers/GeneralCommunicationsResourceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/routers/GeneralCommunicationsResourceTest.java
@@ -1,0 +1,153 @@
+package com.redhat.cloud.notifications.routers;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.events.GeneralCommunicationsHelper;
+import com.redhat.cloud.notifications.events.IntegrationDisabledNotifier;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Parser;
+import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.ingress.Recipient;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import io.smallrye.reactive.messaging.memory.InMemorySink;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static com.redhat.cloud.notifications.events.ConnectorReceiver.EGRESS_CHANNEL;
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class GeneralCommunicationsResourceTest {
+    @Any
+    @Inject
+    InMemoryConnector inMemoryConnector;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @BeforeEach
+    void beforeEach() {
+        this.inMemoryConnector.sink(EGRESS_CHANNEL).clear();
+    }
+
+    /**
+     * Tests that a "general communication" action is sent to the ingress
+     * channel for the engine to process it.
+     */
+    @Test
+    void testSendGeneralCommunication() {
+        // Create some integrations for an organization.
+        final String orgId = DEFAULT_ORG_ID + "test-send-gen-com";
+        final List<Endpoint> createdEndpoints = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(orgId, EndpointType.CAMEL, "teams", true, 0);
+
+            createdEndpoints.add(createdEndpoint);
+        }
+
+        this.inMemoryConnector.sink(EGRESS_CHANNEL).clear();
+
+        // Call the endpoint under test.
+        given()
+            .when()
+            .post("/internal/general-communications/send")
+            .then()
+            .statusCode(HttpStatus.SC_OK);
+
+        // We should receive the action triggered by the REST call.
+        final InMemorySink<String> actionsOut = this.inMemoryConnector.sink(EGRESS_CHANNEL);
+
+        // Make sure that the message was received before continuing.
+        Awaitility.await().until(
+            () -> !actionsOut.received().isEmpty()
+        );
+
+        // Find the action that was sent on this particular test. When running
+        // this test alone, everything works fine. However, when it is run
+        // along with some other tests from the engine, for some reason the
+        // Kafka sink does not get properly cleared out, so multiple messages
+        // end up getting piled up here. Therefore, in order to avoid that,
+        // since clearing the sink does not work for some reason, we need to
+        // just get the action that belongs to the custom organization ID
+        // we created for this test.
+        final List<? extends Message<String>> actionList = actionsOut.received();
+
+        String kafkaActionRaw = null;
+        for (final Message<String> action : actionList) {
+            final String payload = action.getPayload();
+
+            if (payload.contains(orgId)) {
+                kafkaActionRaw = payload;
+                break;
+            }
+        }
+
+        if (kafkaActionRaw == null) {
+            Assertions.fail(String.format("Unable to find the sent action for organization id \"%s\"", orgId));
+        }
+
+        // Decode the action.
+        final Action kafkaAction = Parser.decode(kafkaActionRaw);
+
+        // Check that the top level values coincide.
+        Assertions.assertEquals(GeneralCommunicationsHelper.GENERAL_COMMUNICATIONS_BUNDLE, kafkaAction.getBundle(), "unexpected bundle in the \"general communications\" action");
+        Assertions.assertEquals(GeneralCommunicationsHelper.GENERAL_COMMUNICATIONS_APPLICATION, kafkaAction.getApplication(), "unexpected application in the \"general communications\" action");
+        Assertions.assertEquals(GeneralCommunicationsHelper.GENERAL_COMMUNICATIONS_EVENT_TYPE, kafkaAction.getEventType(), "unexpected event type in the \"general communications\" action");
+        Assertions.assertEquals(orgId, kafkaAction.getOrgId(), "unexpected org id in the \"general communications\" action");
+
+        // Assert that a recipients' override exists.
+        final List<Recipient> recipients = kafkaAction.getRecipients();
+        Assertions.assertEquals(1, recipients.size(), "there should only be one recipient setting for the \"general communications\" action");
+
+        // Make sure that the user preferences are ignored.
+        final Recipient recipient = recipients.getFirst();
+        Assertions.assertTrue(recipient.getIgnoreUserPreferences());
+
+        final Context context = kafkaAction.getContext();
+        final Map<String, Object> contextProperties = context.getAdditionalProperties();
+        Assertions.assertEquals(IntegrationDisabledNotifier.getFrontendCategory(createdEndpoints.getFirst()), contextProperties.get(GeneralCommunicationsHelper.GENERAL_COMMUNICATION_CONTEXT_INTEGRATION_CATEGORY), "unexpected integration category received in the action's context");
+
+        // Check the events, their metadata and their payload.
+        final List<Event> events = kafkaAction.getEvents();
+        Assertions.assertEquals(1, events.size(), "unexpected number of \"general communications\" action events");
+
+        final Event event = events.getFirst();
+
+        final Metadata metadata = event.getMetadata();
+        Assertions.assertEquals(1, metadata.getAdditionalProperties().size(), "unexpected number of metadata additional properties");
+        Assertions.assertEquals(GeneralCommunicationsHelper.GENERAL_COMMUNICATION_METADATA_VALUE, metadata.getAdditionalProperties().get(GeneralCommunicationsHelper.GENERAL_COMMUNICATION_METADATA_KEY), "unexpected event metadata value");
+
+        final Payload payload = event.getPayload();
+        final Map<String, Object> payloadAdditionalProperties = payload.getAdditionalProperties();
+        Assertions.assertEquals(1, payloadAdditionalProperties.size(), "unexpected number of payload additional properties");
+
+        final List<String> expectedIntegrationNames = createdEndpoints
+            .stream()
+            .map(Endpoint::getName)
+            .toList();
+        final List<String> actionIntegrationNames = (List<String>) payloadAdditionalProperties.get(GeneralCommunicationsHelper.GENERAL_COMMUNICATION_PAYLOAD_INTEGRATION_NAMES);
+
+        for (final String actionIntegrationName : actionIntegrationNames) {
+            Assertions.assertTrue(expectedIntegrationNames.contains(actionIntegrationName), String.format("the event's payload contains an integration name \"%s\" that was not found in the ones created in the database", actionIntegrationName));
+        }
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/IntegrationsTemplatesTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/IntegrationsTemplatesTest.java
@@ -2,7 +2,9 @@ package com.redhat.cloud.notifications.templates;
 
 import com.redhat.cloud.notifications.EmailTemplatesInDbHelper;
 import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.events.GeneralCommunicationsHelper;
 import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.Endpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
@@ -34,7 +36,7 @@ public class IntegrationsTemplatesTest extends EmailTemplatesInDbHelper {
 
     @Override
     protected List<String> getUsedEventTypeNames() {
-        return List.of(INTEGRATION_DISABLED_EVENT_TYPE);
+        return List.of(INTEGRATION_DISABLED_EVENT_TYPE, GeneralCommunicationsHelper.GENERAL_COMMUNICATIONS_EVENT_TYPE);
     }
 
     @Test
@@ -61,6 +63,67 @@ public class IntegrationsTemplatesTest extends EmailTemplatesInDbHelper {
         String rendered = generateEmailBody(INTEGRATION_DISABLED_EVENT_TYPE, action);
         assertTrue(rendered.contains("disabled because the connection couldn't be established with the remote endpoint, or it responded too many times with a server error (HTTP status code 5xx) after 2048 attempts"));
         assertTrue(rendered.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    /**
+     * Tests that the general communication email works as expected.
+     */
+    @Test
+    void testGeneralCommunication() {
+        final String orgId = "12345";
+        final List<String> integrationNames = List.of(
+            "Integration one",
+            "Another integration",
+            "Third integration"
+        );
+
+        final Action action = GeneralCommunicationsHelper.createGeneralCommunicationAction(orgId, new CompositeEndpointType(CAMEL, "teams"), integrationNames);
+        final String rendered = generateEmailBody(GeneralCommunicationsHelper.GENERAL_COMMUNICATIONS_EVENT_TYPE, action);
+        assertTrue(rendered.contains("Dear Red Hat customer,"));
+        assertTrue(rendered.contains("We are contacting you because you have the following Microsoft Teams integrations set up for your organization in the"));
+        assertTrue(rendered.contains("Red Hat Hybrid Cloud Console"));
+        assertTrue(rendered.contains("Integration one"));
+        assertTrue(rendered.contains("Another integration"));
+        assertTrue(rendered.contains("Third integration"));
+        assertTrue(rendered.contains("Microsoft is"));
+        assertTrue(rendered.contains("updating the Teams connectors for security reasons"));
+        assertTrue(rendered.contains(", and they are recommending that their customers"));
+        assertTrue(rendered.contains("update any URLs for connectors"));
+        assertTrue(rendered.contains("they have set up. We identified the above Integrations in your account and are asking you to review, and update if needed, to avoid service interruption when Microsoft sunsets the old URLs."));
+        assertTrue(rendered.contains("If you have already updated your Integrations URLs, you can safely ignore this email"));
+        assertTrue(rendered.contains("To update your Microsoft Teams integrations, complete the following steps:"));
+        assertTrue(rendered.contains("Generate a new webhook URL from your Microsoft Teams client by following the steps in"));
+        assertTrue(rendered.contains("Update connectors URL"));
+        assertTrue(rendered.contains("in the Microsoft documentation"));
+        assertTrue(rendered.contains("Copy the URL to your clipboard to use in the Hybrid Cloud Console."));
+        assertTrue(rendered.contains("To update your integration, log in to the"));
+        assertTrue(rendered.contains("Hybrid Cloud Console"));
+        assertTrue(rendered.contains("Navigate to"));
+        assertTrue(rendered.contains("Settings"));
+        assertTrue(rendered.contains("(gear icon) >"));
+        assertTrue(rendered.contains("Integrations"));
+        assertTrue(rendered.contains("Click the"));
+        assertTrue(rendered.contains("Communications"));
+        assertTrue(rendered.contains("tab"));
+        assertTrue(rendered.contains("Locate your Microsoft Teams integration."));
+        assertTrue(rendered.contains("Next to your integration, click the options icon (⋮) and click"));
+        assertTrue(rendered.contains("Edit"));
+        assertTrue(rendered.contains("Click"));
+        assertTrue(rendered.contains("Next"));
+        assertTrue(rendered.contains("to continue past the Integration type step."));
+        assertTrue(rendered.contains("Paste the incoming webhook URL that you copied from Microsoft Teams into the"));
+        assertTrue(rendered.contains("Endpoint URL"));
+        assertTrue(rendered.contains("field."));
+        assertTrue(rendered.contains("Next"));
+        assertTrue(rendered.contains("Review the integration details and click"));
+        assertTrue(rendered.contains("Submit"));
+        assertTrue(rendered.contains("to update the integration."));
+        assertTrue(rendered.contains("Following the above steps will ensure that you will continue receiving the alerts and notifications in the Microsoft Teams channel that you have configured."));
+        assertTrue(rendered.contains("For more information about configuring Microsoft Teams integrations, see the"));
+        assertTrue(rendered.contains("Red Hat documentation"));
+        assertTrue(rendered.contains("Thank you for your attention."));
+        assertTrue(rendered.contains("Kind regards,"));
+        assertTrue(rendered.contains("Red Hat"));
     }
 
     private static Endpoint buildEndpoint() {


### PR DESCRIPTION
The goal of this feature is to be able to send general communications from Red Hat to the customers. We idea is to have all the parts ready and to just modify the template accordingly whenever it is necessary.

## Implementation details

- An internal REST service is available now in the back end.
- This service calls to another REST service in the engine, which injects an event of the `general-communication` type in the "ingress" Kafka channel.

## Sample email

![image](https://github.com/user-attachments/assets/eef9845c-e007-48d3-aa27-55a0b037202e)

## Jira ticket
[[RHCLOUD-37937]](https://issues.redhat.com/browse/RHCLOUD-37937)