### PR TITLE
refactor: log the "x-rh-identity" header

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleAuthMechanism.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleAuthMechanism.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.auth;
 
 import com.redhat.cloud.notifications.auth.principal.ConsolePrincipal;
 import com.redhat.cloud.notifications.models.InternalRoleAccess;
+import io.quarkus.logging.Log;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -42,6 +43,9 @@ public class ConsoleAuthMechanism implements HttpAuthenticationMechanism {
     @Override
     public Uni<SecurityIdentity> authenticate(RoutingContext routingContext, IdentityProviderManager identityProviderManager) {
         String xRhIdentityHeaderValue = routingContext.request().getHeader(X_RH_IDENTITY_HEADER);
+
+        Log.debugf("Received \"x-rh-identity\" header: %s", xRhIdentityHeaderValue);
+
         String path = routingContext.normalizedPath();
 
         if (path.startsWith(API_INTERNAL) && !isInternalRbacEnabled) {


### PR DESCRIPTION
When Kessel is enabled, the requests that were authenticated with
Turnpike end up being "unauthorized". In order to help with the
debugging, we are adding a log statement to debug how the incoming
identity headers look like, so that we can adapt our code to them.