### PR TITLE
RHCLOUD-38438 | fix: Turnpike requests unauthorized when Kessel is enabled

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleAuthMechanism.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleAuthMechanism.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.auth;
 
 import com.redhat.cloud.notifications.auth.principal.ConsolePrincipal;
 import com.redhat.cloud.notifications.models.InternalRoleAccess;
-import io.quarkus.logging.Log;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -43,9 +42,6 @@ public class ConsoleAuthMechanism implements HttpAuthenticationMechanism {
     @Override
     public Uni<SecurityIdentity> authenticate(RoutingContext routingContext, IdentityProviderManager identityProviderManager) {
         String xRhIdentityHeaderValue = routingContext.request().getHeader(X_RH_IDENTITY_HEADER);
-
-        Log.debugf("Received \"x-rh-identity\" header: %s", xRhIdentityHeaderValue);
-
         String path = routingContext.normalizedPath();
 
         if (path.startsWith(API_INTERNAL) && !isInternalRbacEnabled) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProvider.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/ConsoleIdentityProvider.java
@@ -87,28 +87,36 @@ public class ConsoleIdentityProvider implements IdentityProvider<ConsoleAuthenti
         // if we see that something is not working properly, we can instantly
         // switch back to RBAC by disabling Kessel.
         try {
-            String orgId = "-none-";
             // Build the principal from the incoming "x-rh-identity" header.
-            Optional<Principal> principal = this.buildPrincipalFromIdentityHeader(rhAuthReq);
-            if (principal.get() instanceof RhIdPrincipal rhIdPrincipal) {
-                orgId = rhIdPrincipal.getOrgId();
-            }
-            if (this.backendConfig.isKesselRelationsEnabled(orgId)) {
+            final Optional<Principal> principal = this.buildPrincipalFromIdentityHeader(rhAuthReq);
 
-                final QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
-
-                // Set the principal to the one we decoded from the header,
-                // unless no header was present. In that case we build an empty
-                // principal.
-                builder.setPrincipal(principal.orElse(ConsolePrincipal.noIdentity()));
-
-                // Build the security identity for Quarkus.
-                return Uni.createFrom().item(builder.build());
+            // The incoming "x-rh-identity" header must contain a "user" or
+            // "service account" principal, because those are the ones that
+            // contain the required "user_id" field that is used for Kessel
+            // related queries.
+            if (principal.isPresent() && principal.get() instanceof RhIdPrincipal rhIdPrincipal) {
+                if (this.backendConfig.isKesselRelationsEnabled(rhIdPrincipal.getOrgId())) {
+                    // Build the security identity for Quarkus and return it.
+                    // At this point the principal is authenticated, and the
+                    // pertinent authorization checks will be performed with
+                    // Kessel when appropriate.
+                    return Uni
+                        .createFrom()
+                        .item(
+                            QuarkusSecurityIdentity
+                            .builder()
+                            .setPrincipal(rhIdPrincipal)
+                            .build()
+                        );
+                }
             }
         } catch (final IllegalIdentityHeaderException | IllegalArgumentException e) {
             return Uni.createFrom().failure(() -> new AuthenticationFailedException(e));
         }
 
+        // When both Kessel and RBAC are not enabled that means that we are in
+        // a development context, and therefore we build a security identity
+        // with all the roles available to ease development.
         if (!isRbacEnabled) {
             final Principal principal;
             try {
@@ -134,9 +142,10 @@ public class ConsoleIdentityProvider implements IdentityProvider<ConsoleAuthenti
                     .addRole(adminRole)
                     .build());
         }
+
         // Retrieve the identity header from the authentication request
         return Uni.createFrom().item(() -> (String) rhAuthReq.getAttribute(X_RH_IDENTITY_HEADER))
-                .onItem().transformToUni(xRhIdHeader -> buildQuarkusUni(xRhIdHeader));
+                .onItem().transformToUni(this::buildQuarkusUni);
     }
 
     @CacheResult(cacheName = "rbac-cache")


### PR DESCRIPTION
We realized that when enabling Kessel Relations in stage or production, and when sending Turnpike authenticated requests to the internal endpoints, these would simply return "Forbidden" responses to the caller.

The problem was that for Turnpike requests, for some reason, the Kessel Relations back end was being signaled as "enabled", which ended up building a security identity without the required internal roles for the internal endpoints to work.

Since Kessel only supports "service account" and "user" principals, adding a check for those before proceeding with building a security identity tailored for Kessel solves the issue.

Now the Turnpike authenticated requests will be identified as such when building the security identity, and the proper roles will be added to it.

## Jira ticket
[[RHCLOUD-38438]](https://issues.redhat.com/browse/RHCLOUD-38438)