### PR TITLE
RHCLOUD-38452 | fix: template rendering errors are not returned in the response

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineResource.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/TemplateEngineResource.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateRequest;
 import com.redhat.cloud.notifications.routers.models.RenderEmailTemplateResponse;
 import com.redhat.cloud.notifications.utils.ActionParser;
+import io.quarkus.qute.TemplateException;
 import io.quarkus.qute.TemplateInstance;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
@@ -46,7 +47,17 @@ public class TemplateEngineResource {
 
             return Response.ok(new RenderEmailTemplateResponse.Success(renderedTemplate)).build();
         } catch (Exception e) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(new RenderEmailTemplateResponse.Error(e.getMessage())).build();
+            final String errorMessage;
+
+            // For some reason the error message is in the nested exception of
+            // the thrown exception.
+            if (e.getCause() instanceof TemplateException templateException) {
+                errorMessage = templateException.getMessage();
+            } else {
+                errorMessage = e.getMessage();
+            }
+
+            return Response.status(Response.Status.BAD_REQUEST).entity(new RenderEmailTemplateResponse.Error(errorMessage)).build();
         }
     }
 }


### PR DESCRIPTION
Apparently the exception that gets thrown does not contain the useful error message that gets returned back to the back end, so we needed to go one level deeper to get it.

## Jira ticket
[[RHCLOUD-38452]](https://issues.redhat.com/browse/RHCLOUD-38452)