### PR TITLE
[RHCLOUD-38675] Currently, high volume topic is usable only for email notifications

### DIFF
--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/ConnectorSenderTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/ConnectorSenderTest.java
@@ -70,7 +70,7 @@ public class ConnectorSenderTest {
         final Application application = this.resourceHelpers.createApp(bundle.getId(), ConnectorSender.HIGH_VOLUME_APPLICATION);
         final EventType eventType = this.resourceHelpers.createEventType(application.getId(), "event-test-high-volume");
         final Event event = this.resourceHelpers.createEvent(eventType);
-        final Endpoint endpoint = this.resourceHelpers.createEndpoint(EndpointType.WEBHOOK, null, true, 0);
+        final Endpoint endpoint = this.resourceHelpers.createEndpoint(EndpointType.EMAIL_SUBSCRIPTION, null, true, 0);
 
         final JsonObject payload = new JsonObject();
         payload.put("Red Hat", "Red Hat Enterprise Linux");


### PR DESCRIPTION
Today, only email connector is listening internal Kafka High volume topic.
This choice could be revisited in the future regarding what kind of integration type could be enabled by default for all users.