### PR TITLE
RHCLOUD-32168 | fix: webhook properties can be created with any HTTP method

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/properties/WebhookPropertiesDTO.java
@@ -1,9 +1,11 @@
 package com.redhat.cloud.notifications.models.dto.v1.endpoint.properties;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.dto.v1.endpoint.properties.secrets.BasicAuthenticationDTO;
 import com.redhat.cloud.notifications.models.validation.ValidNonPrivateUrl;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -12,7 +14,7 @@ public final class WebhookPropertiesDTO extends EndpointPropertiesDTO {
     private Boolean disableSslVerification = Boolean.FALSE;
 
     @NotNull
-    private HttpType method;
+    private String method;
 
     @NotNull
     @ValidNonPrivateUrl
@@ -26,6 +28,12 @@ public final class WebhookPropertiesDTO extends EndpointPropertiesDTO {
     @Size(max = 255)
     private String secretToken;
 
+    @JsonIgnore
+    @AssertTrue(message = "Only \"POST\" methods are allowed for the properties of a webhook")
+    private boolean isHttpMethodAllowed() {
+        return HttpType.POST.name().equals(this.method);
+    }
+
     public Boolean getDisableSslVerification() {
         return disableSslVerification;
     }
@@ -34,11 +42,11 @@ public final class WebhookPropertiesDTO extends EndpointPropertiesDTO {
         this.disableSslVerification = disableSslVerification;
     }
 
-    public HttpType getMethod() {
+    public String getMethod() {
         return method;
     }
 
-    public void setMethod(final HttpType method) {
+    public void setMethod(final String method) {
         this.method = method;
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/mappers/v1/endpoint/EndpointMapperTest.java
@@ -243,7 +243,7 @@ public class EndpointMapperTest {
         final WebhookPropertiesDTO webhookPropertiesDTO = (WebhookPropertiesDTO) dto.getProperties();
 
         Assertions.assertTrue(webhookPropertiesDTO.getDisableSslVerification(), "the \"disable SSL verification\" flag was not properly deserialized");
-        Assertions.assertEquals(HttpType.POST, webhookPropertiesDTO.getMethod(), "the method property was not properly deserialized");
+        Assertions.assertEquals(HttpType.POST.name(), webhookPropertiesDTO.getMethod(), "the method property was not properly deserialized");
         Assertions.assertEquals("https://redhat.com", webhookPropertiesDTO.getUrl(), "the url was not properly deserialized");
 
         final BasicAuthenticationDTO basicAuthenticationDTO = webhookPropertiesDTO.getBasicAuthentication();
@@ -270,7 +270,7 @@ public class EndpointMapperTest {
         final WebhookProperties webhookProperties = (WebhookProperties) entity.getProperties();
 
         Assertions.assertTrue(webhookProperties.getDisableSslVerification(), "the \"disable SSL verification\" flag was not properly mapped");
-        Assertions.assertEquals(HttpType.POST, webhookPropertiesDTO.getMethod(), "the method property was not properly mapped");
+        Assertions.assertEquals(HttpType.POST.name(), webhookPropertiesDTO.getMethod(), "the method property was not properly mapped");
         Assertions.assertEquals("https://redhat.com", webhookProperties.getUrl(), "the url was not properly mapped");
 
         final BasicAuthentication basicAuthentication = webhookProperties.getBasicAuthentication();

--- a/database/src/main/resources/db/migration/V1.114.0__RHCLOUD-32168_set_webhook_method_post.sql
+++ b/database/src/main/resources/db/migration/V1.114.0__RHCLOUD-32168_set_webhook_method_post.sql
@@ -1,0 +1,6 @@
+UPDATE
+    endpoint_webhooks
+SET
+    "method" = 'POST'
+WHERE
+    "method" != 'POST';


### PR DESCRIPTION
We only send "POST" requests to clients with the details of the notifications, so it does not make sense to allow customers to create webhook integrations with any other method in their properties.

## Jira ticket
[[RHCLOUD-32168]](https://issues.redhat.com/browse/RHCLOUD-32168)