### PR TITLE
[RHCLOUD-39099] New Aggregation logic can't parse misformated payloads

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -27,6 +27,7 @@ import com.redhat.cloud.notifications.recipients.User;
 import com.redhat.cloud.notifications.recipients.recipientsresolver.ExternalRecipientsResolver;
 import com.redhat.cloud.notifications.recipients.request.ActionRecipientSettings;
 import com.redhat.cloud.notifications.recipients.request.EndpointRecipientSettings;
+import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import com.redhat.cloud.notifications.utils.ActionParser;
 import com.redhat.cloud.notifications.utils.ActionParsingException;
 import com.redhat.cloud.notifications.utils.RecipientsAuthorizationCriterionExtractor;
@@ -74,6 +75,9 @@ public class EmailAggregator {
 
     @Inject
     EngineConfig engineConfig;
+
+    @Inject
+    BaseTransformer baseTransformer;
 
     ConsoleCloudEventParser cloudEventParser = new ConsoleCloudEventParser();
 
@@ -235,7 +239,7 @@ public class EmailAggregator {
                     AbstractEmailPayloadAggregator aggregator = aggregated
                         .computeIfAbsent(recipient, ignored -> EmailPayloadAggregatorFactory.by(eventAggregationCriteria, start, end));
                     // It's aggregation time!
-                    EmailAggregation eventDataToAggregate = new EmailAggregation(aggregation.getOrgId(), eventAggregationCriteria.getBundle(), eventAggregationCriteria.getApplication(), new JsonObject(aggregation.getPayload()));
+                    EmailAggregation eventDataToAggregate = new EmailAggregation(aggregation.getOrgId(), eventAggregationCriteria.getBundle(), eventAggregationCriteria.getApplication(), baseTransformer.toJsonObject(aggregation));
                     aggregator.aggregate(eventDataToAggregate);
                 });
             }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
@@ -178,6 +178,21 @@ class EmailAggregatorTest {
             JsonObject payload = TestHelpers.createEmailAggregation("org-1", "rhel", "policies", RandomStringUtils.random(10), RandomStringUtils.random(10)).getPayload();
             // the base transformer adds a "source" element which should not be present in an original event payload
             payload.remove(BaseTransformer.SOURCE);
+
+            // some tenants send their events/payload and events/context as string instead of Json
+            // at least one test event must cover this case
+            if (i == 0) {
+                String contextAsString = payload.getString("context");
+
+                JsonObject event = payload.getJsonArray("events").getJsonObject(0);
+                String payloadAsString = event.getString("payload");
+                JsonObject jso2 = event.copy()
+                    .put("payload", payloadAsString);
+
+                payload.getJsonArray("events").clear();
+                payload.getJsonArray("events").add(jso2);
+                payload.put("context", contextAsString);
+            }
             resourceHelpers.addEventEmailAggregation("org-1", "rhel", "policies", payload, false);
         }
         JsonObject payload = TestHelpers.createEmailAggregation("org-2", "rhel", "policies", RandomStringUtils.random(10), RandomStringUtils.random(10)).getPayload();


### PR DESCRIPTION
Some tenants send `context` and `events[].payload` data as Json string instead of Json object.
Json transformer used by new aggregation logic must be more permissive to support this format.