### PR TITLE
RHCLOUD-39238 Lowercase all user_id fields from email_subscriptions table

### DIFF
--- a/database/src/main/resources/db/migration/V1.115.0__RHCLOUD-39238_lowercase_user_id_in_subscriptions.sql
+++ b/database/src/main/resources/db/migration/V1.115.0__RHCLOUD-39238_lowercase_user_id_in_subscriptions.sql
@@ -1,0 +1,14 @@
+UPDATE email_subscriptions es1
+SET user_id = LOWER(user_id)
+WHERE user_id <> LOWER(user_id)
+AND NOT EXISTS (
+    SELECT 1
+    FROM email_subscriptions es2
+    WHERE es2.user_id = LOWER(es1.user_id)
+    AND es2.org_id = es1.org_id
+    AND es2.event_type_id = es1.event_type_id
+    AND es2.subscription_type = es1.subscription_type
+);
+
+DELETE FROM email_subscriptions
+WHERE user_id <> LOWER(user_id);


### PR DESCRIPTION
This PR applies the `LOWER` function to the `user_id` field from the `email_subscriptions` records when:
- the `user_id` field does not exclusively contain lowercase characters
- and there is no existing record in the same table with a `(org_id, LOWER(user_id), event_type_id, subscription_type)` key

In case of conflict, the newer record (user preferences edit from the UI) is kept and the older record (import data) is deleted.