### PR TITLE
Reduce alert noise clowdwatch exception: remove excessive log

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -215,7 +215,6 @@ public class EmailAggregator {
                 aggregation.setEventWrapper(getEventWrapper(aggregation.getPayload()));
                 RecipientsAuthorizationCriterion externalAuthorizationCriterion = recipientsAuthorizationCriterionExtractor.extract(aggregation);
 
-                Log.info("Start calling external resolver service ");
                 Set<User> recipients = externalRecipientsResolver.recipientUsers(
                     aggregation.getOrgId(),
                     Stream.concat(


### PR DESCRIPTION
Remove exessive useless log entry.
It also generate some clowdwatch exception because its volume could be higher than CW batch limit.