### PR TITLE
Update Kessel format url

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -114,11 +114,11 @@ inventory-api.authn.client.issuer=http://localhost:8084/realms/redhat-external
 inventory-api.authn.client.secret=h91qw8bPiDj9R6VSORsI5TYbceGU5PMH
 inventory-api.authn.mode=oidc-client-credentials
 inventory-api.is-secure-clients=false
-inventory-api.target-url=${clowder.endpoints.kessel-inventory-api:localhost:9081}
+inventory-api.target-url=${clowder.endpoints.kessel-inventory-api.url:localhost:9081}
 
 relations-api.authn.client.id=svc-test
 relations-api.authn.client.issuer=http://localhost:8084/realms/redhat-external
 relations-api.authn.client.secret=h91qw8bPiDj9R6VSORsI5TYbceGU5PMH
 relations-api.authn.mode=oidc-client-credentials
 relations-api.is-secure-clients=false
-relations-api.target-url=${clowder.endpoints.kessel-relations-api:localhost:9000}
+relations-api.target-url=${clowder.endpoints.kessel-relations-api.url:localhost:9000}

--- a/recipients-resolver/src/main/resources/application.properties
+++ b/recipients-resolver/src/main/resources/application.properties
@@ -61,7 +61,7 @@ quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242
 
 # Kessel relations integration
-notifications.recipients-resolver.kessel.target-url=${clowder.endpoints.kessel-relations-api:localhost:9000}
+notifications.recipients-resolver.kessel.target-url=${clowder.endpoints.kessel-relations-api.url:localhost:9000}
 relations-api.is-secure-clients=false
 relations-api.authn.client.id=insights-notifications
 relations-api.authn.client.issuer=http://localhost:8084/realms/redhat-external


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Modify configuration properties to consistently use `.url` suffix when referencing Kessel API endpoints