### PR TITLE
Introduce pipelinesascode.tekton.dev/pipeline

### DIFF
--- a/.tekton/notifications-aggregator-pull-request.yaml
+++ b/.tekton/notifications-aggregator-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-aggregator-push.yaml
+++ b/.tekton/notifications-aggregator-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-backend-pull-request.yaml
+++ b/.tekton/notifications-backend-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-backend-push.yaml
+++ b/.tekton/notifications-backend-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-drawer-pull-request.yaml
+++ b/.tekton/notifications-connector-drawer-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-drawer-push.yaml
+++ b/.tekton/notifications-connector-drawer-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-email-pull-request.yaml
+++ b/.tekton/notifications-connector-email-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-email-push.yaml
+++ b/.tekton/notifications-connector-email-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-google-chat-pull-request.yaml
+++ b/.tekton/notifications-connector-google-chat-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-google-chat-push.yaml
+++ b/.tekton/notifications-connector-google-chat-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-microsoft-teams-pull-request.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-microsoft-teams-push.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-pagerduty-pull-request.yaml
+++ b/.tekton/notifications-connector-pagerduty-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-pagerduty-push.yaml
+++ b/.tekton/notifications-connector-pagerduty-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-servicenow-pull-request.yaml
+++ b/.tekton/notifications-connector-servicenow-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-servicenow-push.yaml
+++ b/.tekton/notifications-connector-servicenow-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-slack-pull-request.yaml
+++ b/.tekton/notifications-connector-slack-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-slack-push.yaml
+++ b/.tekton/notifications-connector-slack-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-splunk-pull-request.yaml
+++ b/.tekton/notifications-connector-splunk-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-splunk-push.yaml
+++ b/.tekton/notifications-connector-splunk-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-webhook-pull-request.yaml
+++ b/.tekton/notifications-connector-webhook-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-connector-webhook-push.yaml
+++ b/.tekton/notifications-connector-webhook-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-engine-pull-request.yaml
+++ b/.tekton/notifications-engine-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-engine-push.yaml
+++ b/.tekton/notifications-engine-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-recipients-resolver-pull-request.yaml
+++ b/.tekton/notifications-recipients-resolver-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -30,14 +31,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/.tekton/notifications-recipients-resolver-push.yaml
+++ b/.tekton/notifications-recipients-resolver-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.9.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate: {}
   workspaces:
   - name: workspace

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
+  "tekton": {
+    "automerge": true
+  }
+}


### PR DESCRIPTION
This PR introduces 3 changes:

- The `pipelinesascode.tekton.dev/pipeline` annotation which makes the pipeline definitions even shorter.
- A dependency on releases from https://github.com/RedHatInsights/konflux-pipelines instead of depending on `main`. Thanks to this change, we'll catch Konflux build failures that could result from a remote pipeline update.
- Renovate will start creating PRs to update the version of https://github.com/RedHatInsights/konflux-pipelines and automatically merge them as long as the GitHub checks pass.