### PR TITLE
Disable quarkus dev services by default

### DIFF
--- a/.rhcicd/sonarqube/scanner/scan_code.bash
+++ b/.rhcicd/sonarqube/scanner/scan_code.bash
@@ -26,6 +26,7 @@ if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "origin/master" ]; then
     -Dsonar.sourceEncoding="UTF-8" \
     -Dsonar.token="${SONARQUBE_TOKEN}" \
     -Dquarkus.devservices.enabled=false \
+    -Dquarkus.datasource.devservices.enabled=false \
     --no-transfer-progress
 else
   ./mvnw clean verify sonar:sonar \
@@ -39,5 +40,6 @@ else
     -Dsonar.sourceEncoding="UTF-8" \
     -Dsonar.token="${SONARQUBE_TOKEN}" \
     -Dquarkus.devservices.enabled=false \
+    -Dquarkus.datasource.devservices.enabled=false \
     --no-transfer-progress
 fi

--- a/aggregator/src/main/resources/application.properties
+++ b/aggregator/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # Kafka bootstrap applies to all topics
 kafka.bootstrap.servers=localhost:9092
 
-%test.quarkus.devservices.enabled=true
+%test.quarkus.datasource.devservices.enabled=true
 
 # configure your datasource
 quarkus.datasource.db-kind=postgresql

--- a/aggregator/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/aggregator/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -22,11 +22,11 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
     public Map<String, String> start() {
 
         System.out.println("++++  TestLifecycleManager start +++");
-        Optional<Boolean> quarkusDevServiceEnabledFlag = ConfigProvider.getConfig().getOptionalValue("quarkus.devservices.enabled", Boolean.class);
+        Optional<Boolean> quarkusDevServiceEnabledFlag = ConfigProvider.getConfig().getOptionalValue("quarkus.datasource.devservices.enabled", Boolean.class);
         if (quarkusDevServiceEnabledFlag.isPresent()) {
             quarkusDevServiceEnabled = quarkusDevServiceEnabledFlag.get();
         }
-        System.out.println(" -- quarkusDevServiceEnabled is " + quarkusDevServiceEnabled);
+        System.out.println(" -- quarkusDatasourceDevServiceEnabled is " + quarkusDevServiceEnabled);
 
         Map<String, String> properties = new HashMap<>();
         try {

--- a/common-template/src/main/resources/application.properties
+++ b/common-template/src/main/resources/application.properties
@@ -6,3 +6,5 @@
 # but we can override the detected content type according its extension
 quarkus.qute.content-types.json=none
 quarkus.qute.content-types.html=none
+
+%test.quarkus.devservices.enabled=false

--- a/common/src/main/resources/application.properties
+++ b/common/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+%test.quarkus.devservices.enabled=false

--- a/connector-common/src/main/resources/application.properties
+++ b/connector-common/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 # The engine's hostname in order to be able to fetch the event's payloads from it.
 quarkus.rest-client.engine.url=${clowder.endpoints.notifications-engine-service.url:http://localhost:8087}
+
+%test.quarkus.devservices.enabled=false

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -8,7 +8,7 @@ quarkus.http.port=8087
 # Change port for tests to avoid messing with local Kafka instance
 %test.quarkus.http.port=9087
 %test.quarkus.http.test-port=9087
-%test.quarkus.devservices.enabled=true
+%test.quarkus.datasource.devservices.enabled=true
 
 # Input queue
 mp.messaging.incoming.ingress.connector=smallrye-kafka

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -32,11 +32,11 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
     @Override
     public Map<String, String> start() {
         System.out.println("++++  TestLifecycleManager start +++");
-        Optional<Boolean> quarkusDevServiceEnabledFlag = ConfigProvider.getConfig().getOptionalValue("quarkus.devservices.enabled", Boolean.class);
+        Optional<Boolean> quarkusDevServiceEnabledFlag = ConfigProvider.getConfig().getOptionalValue("quarkus.datasource.devservices.enabled", Boolean.class);
         if (quarkusDevServiceEnabledFlag.isPresent()) {
             quarkusDevServiceEnabled = quarkusDevServiceEnabledFlag.get();
         }
-        System.out.println(" -- quarkusDevServiceEnabled is " + quarkusDevServiceEnabled);
+        System.out.println(" -- quarkusDatasourceDevServiceEnabled is " + quarkusDevServiceEnabled);
 
         Map<String, String> properties = new HashMap<>();
         if (quarkusDevServiceEnabled) {


### PR DESCRIPTION
With current config, quarkus starts all dev services by default event when not releavant, like starting a postgres container to run connectors unit tests, or staring a default postgres container then stop it and restart a new one with the version specified in `TestLifecycleManager`.