### PR TITLE
[RHCLOUD-39363] Remove optional account ID from emails

### DIFF
--- a/common-template/src/main/resources/templates/email/Common/insightsDailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Common/insightsDailyEmailBody.html
@@ -470,7 +470,7 @@
                                 <tr>
                                     <td class="rh-masthead__subhead">
                                         <h1>{action.context.title}</h1>
-                                        <h2 style="font-size: 14px">(Org ID: {action.context.orgId}{#if action.context.accountId??} | Account number: {action.context.accountId}{/if})</h2>
+                                        <h2 style="font-size: 14px">(Org ID: {action.context.orgId})</h2>
                                     </td>
                                 </tr>
                                 <tr>

--- a/common-template/src/main/resources/templates/email/Common/insightsEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Common/insightsEmailBody.html
@@ -421,7 +421,7 @@
                                 <tr>
                                     <td class="rh-masthead__subhead">
                                         <h1>{#insert content-title}{/}</h1>
-                                        <h2 style="font-size: 14px">(Org ID: {action.orgId}{#if action.accountId??} | Account number: {action.accountId}{/if})</h2>
+                                        <h2 style="font-size: 14px">(Org ID: {action.orgId})</h2>
                                     </td>
                                 </tr>
                             </table>

--- a/common-template/src/main/resources/templates/email/Secure/Common/insightsDailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/Common/insightsDailyEmailBody.html
@@ -471,7 +471,7 @@
                                 <tr>
                                     <td class="rh-masthead__subhead">
                                         <h1>{action.context.title}</h1>
-                                        <h2 style="font-size: 14px">(Org ID: {action.context.orgId}{#if action.context.accountId??} | Account number: {action.context.accountId}{/if})</h2>
+                                        <h2 style="font-size: 14px">(Org ID: {action.context.orgId})</h2>
                                     </td>
                                 </tr>
                                 <tr>

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
@@ -347,10 +347,6 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
                 TemplateInstance SingleBodyTemplate = templateService.compileTemplate(dailyTemplate.get().getData(), "singleDailyDigest/dailyDigest");
 
                 Map<String, Object> actionContext = new HashMap<>(Map.of("title", emailTitle, "items", result, "orgId", aggregatorEvent.getOrgId()));
-                String accountId = aggregatorEvent.getAccountId();
-                if (accountId != null && !accountId.isBlank()) {
-                    actionContext.put("accountId", accountId);
-                }
                 Map<String, Object> action = Map.of("context", actionContext, "bundle", bundle);
 
                 // build final body

--- a/engine/src/main/resources/templates/Common/insightsDailyEmailBody.html
+++ b/engine/src/main/resources/templates/Common/insightsDailyEmailBody.html
@@ -470,7 +470,7 @@
                                 <tr>
                                     <td class="rh-masthead__subhead">
                                         <h1>{action.context.title}</h1>
-                                        <h2 style="font-size: 14px">(Org ID: {action.context.orgId}{#if action.context.accountId??} | Account number: {action.context.accountId}{/if})</h2>
+                                        <h2 style="font-size: 14px">(Org ID: {action.context.orgId})</h2>
                                     </td>
                                 </tr>
                                 <tr>

--- a/engine/src/main/resources/templates/Common/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Common/insightsEmailBody.html
@@ -421,7 +421,7 @@
                                 <tr>
                                     <td class="rh-masthead__subhead">
                                         <h1>{#insert content-title}{/}</h1>
-                                        <h2 style="font-size: 14px">(Org ID: {action.orgId}{#if action.accountId??} | Account number: {action.accountId}{/if})</h2>
+                                        <h2 style="font-size: 14px">(Org ID: {action.orgId})</h2>
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/main/resources/templates/Secure/Common/insightsDailyEmailBody.html
+++ b/engine/src/main/resources/templates/Secure/Common/insightsDailyEmailBody.html
@@ -471,7 +471,7 @@
                                 <tr>
                                     <td class="rh-masthead__subhead">
                                         <h1>{action.context.title}</h1>
-                                        <h2 style="font-size: 14px">(Org ID: {action.context.orgId}{#if action.context.accountId??} | Account number: {action.context.accountId}{/if})</h2>
+                                        <h2 style="font-size: 14px">(Org ID: {action.context.orgId})</h2>
                                     </td>
                                 </tr>
                                 <tr>

--- a/engine/src/main/resources/templates/Secure/Common/insightsEmailBody.html
+++ b/engine/src/main/resources/templates/Secure/Common/insightsEmailBody.html
@@ -423,7 +423,7 @@
                                 <tr>
                                     <td class="rh-masthead__subhead">
                                         <h1>{#insert content-title}{/}</h1>
-                                        <h2 style="font-size: 14px">(Org ID: {action.orgId}{#if action.accountId??} | Account number: {action.accountId}{/if})</h2>
+                                        <h2 style="font-size: 14px">(Org ID: {action.orgId})</h2>
                                     </td>
                                 </tr>
                             </table>

--- a/engine/src/test/java/com/redhat/cloud/notifications/EmailTemplatesInDbHelper.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/EmailTemplatesInDbHelper.java
@@ -163,19 +163,10 @@ public abstract class EmailTemplatesInDbHelper {
     }
 
     protected String generateAggregatedEmailBody(Map<String, Object> context) {
-        return generateAggregatedEmailBody(context, (EmailPendo) null);
-    }
-
-    /** Additionally specifies an account number that would be included with the email event. */
-    protected String generateAggregatedEmailBody(Map<String, Object> originalContext, String accountId) {
-        return generateAggregatedEmailBody(originalContext, null, accountId);
+        return generateAggregatedEmailBody(context, null);
     }
 
     protected String generateAggregatedEmailBody(Map<String, Object> originalContext, EmailPendo emailPendo) {
-        return generateAggregatedEmailBody(originalContext, emailPendo, null);
-    }
-
-    protected String generateAggregatedEmailBody(Map<String, Object> originalContext, EmailPendo emailPendo, String accountId) {
         Map<String, Object> context = new HashMap<>(originalContext); // to patch immutable maps from individual test cases
         context.put("application", getApp());
         AggregationEmailTemplate emailTemplate = templateRepository.findAggregationEmailTemplate(getBundle(), getApp(), DAILY).get();
@@ -198,10 +189,7 @@ public abstract class EmailTemplatesInDbHelper {
 
         TemplateInstance bodyTemplateGlobalDailyDigest = templateService.compileTemplate(dailyTemplate.get().getData(), "singleDailyDigest/dailyDigest");
 
-        Map<String, Object> mapData = new HashMap<>(Map.of("title", "Daily digest - Red Hat Enterprise Linux", "items", List.of(dailyDigestSection), "orgId", DEFAULT_ORG_ID));
-        if (accountId != null && !accountId.isBlank()) {
-            mapData.put("accountId", accountId);
-        }
+        Map<String, Object> mapData = Map.of("title", "Daily digest - Red Hat Enterprise Linux", "items", List.of(dailyDigestSection), "orgId", DEFAULT_ORG_ID);
         return generateEmailFromContextMap(bodyTemplateGlobalDailyDigest, mapData, emailPendo, bodyTemplate.getTemplate().getId());
     }
 
@@ -209,7 +197,7 @@ public abstract class EmailTemplatesInDbHelper {
         Map<String, Object> contextMap = objectMapper
             .convertValue(action.getContext(), new TypeReference<Map<String, Object>>() { });
 
-        return generateAggregatedEmailBody(contextMap, (EmailPendo) null);
+        return generateAggregatedEmailBody(contextMap, null);
     }
 
     protected String generateEmail(TemplateInstance template, Object actionOrEvent, EmailPendo pendo) {

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestAdvisorTemplate.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.AdvisorTestHelpers.createEmailAggregation;
-import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.DEACTIVATED_RECOMMENDATION;
 import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.NEW_RECOMMENDATION;
@@ -102,9 +101,9 @@ public class TestAdvisorTemplate extends EmailTemplatesInDbHelper {
         context.put("start_time", LocalDateTime.now().toString());
         context.put("end_time", LocalDateTime.now().toString());
 
-        String result = generateAggregatedEmailBody(context, DEFAULT_ACCOUNT_ID);
+        String result = generateAggregatedEmailBody(context);
         assertTrue(result.contains("Resolved Recommendation"));
-        assertTrue(result.contains("(Org ID: " + DEFAULT_ORG_ID + " | Account number: " + DEFAULT_ACCOUNT_ID + ")"));
+        assertTrue(result.contains("(Org ID: " + DEFAULT_ORG_ID + ")"));
         assertTrue(result.contains("/insights/advisor/recommendations/test|Active_rule_2"));
         assertTrue(result.contains("Active rule 2</a>"));
         assertTrue(result.contains("/apps/frontend-assets/email-assets/img_low.png"));

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/secured/TestPendoMessage.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/secured/TestPendoMessage.java
@@ -44,12 +44,12 @@ public class TestPendoMessage extends EmailTemplatesInDbHelper  {
 
         EmailPendo emailPendo = new EmailPendo(GENERAL_PENDO_TITLE, GENERAL_PENDO_MESSAGE);
 
-        String resultBody = generateAggregatedEmailBody(patch, (EmailPendo) null);
+        String resultBody = generateAggregatedEmailBody(patch, null);
         commonValidations(resultBody);
         assertFalse(resultBody.contains(emailPendo.getPendoTitle()));
         assertFalse(resultBody.contains(emailPendo.getPendoMessage()));
 
-        resultBody = generateAggregatedEmailBody(patch, (EmailPendo) emailPendo);
+        resultBody = generateAggregatedEmailBody(patch, emailPendo);
         commonValidations(resultBody);
         assertTrue(resultBody.contains(emailPendo.getPendoTitle()));
         assertTrue(resultBody.contains(emailPendo.getPendoMessage()));


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-39363

## Description

Account ID, if available, will no longer be displayed in the headers of emails. See [Slack discussion](https://redhat-internal.slack.com/archives/C024CDDPRHD/p1747732364382949)

## Compatibility

None, changes have not been deployed to production as of yet.

## Testing

Tests cases have been updated to stop checking for account IDs in email headers.