### PR TITLE
[RHCLOUD-40121] Allow Slack connector to send "Blocks" format notifications

### DIFF
--- a/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackCloudEventDataExtractor.java
+++ b/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackCloudEventDataExtractor.java
@@ -1,8 +1,10 @@
 package com.redhat.cloud.notifications.connector.slack;
 
 import com.redhat.cloud.notifications.connector.CloudEventDataExtractor;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.JsonException;
 import org.apache.camel.Exchange;
 
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.TARGET_URL;
@@ -14,7 +16,12 @@ public class SlackCloudEventDataExtractor extends CloudEventDataExtractor {
     public void extract(Exchange exchange, JsonObject cloudEventData) {
         exchange.setProperty(TARGET_URL, cloudEventData.getString("webhookUrl"));
         JsonObject message = new JsonObject();
-        message.put("text", cloudEventData.getString("message"));
+        try {
+            message = new JsonObject(cloudEventData.getString("message"));
+        } catch (DecodeException e) {
+            message.put("text", cloudEventData.getString("message"));
+        }
+
         if (cloudEventData.getValue("channel") != null) {
             message.put("channel", cloudEventData.getString("channel"));
         }

--- a/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackCloudEventDataExtractor.java
+++ b/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackCloudEventDataExtractor.java
@@ -4,7 +4,6 @@ import com.redhat.cloud.notifications.connector.CloudEventDataExtractor;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.json.JsonException;
 import org.apache.camel.Exchange;
 
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.TARGET_URL;

--- a/connector-slack/src/test/java/com/redhat/cloud/notifications/connector/slack/SlackConnectorRoutesMessageBlocksFormatTest.java
+++ b/connector-slack/src/test/java/com/redhat/cloud/notifications/connector/slack/SlackConnectorRoutesMessageBlocksFormatTest.java
@@ -1,0 +1,72 @@
+package com.redhat.cloud.notifications.connector.slack;
+
+import com.redhat.cloud.notifications.connector.ConnectorRoutesTest;
+import com.redhat.cloud.notifications.connector.TestLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.json.JsonObject;
+import org.apache.camel.Predicate;
+import org.junit.jupiter.api.Test;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class SlackConnectorRoutesMessageBlocksFormatTest extends ConnectorRoutesTest {
+
+    // The randomness of this field helps avoid side-effects between tests.
+    private String SLACK_CHANNEL = "#notifications-" + UUID.randomUUID();
+
+    @Override
+    protected String getMockEndpointPattern() {
+        return "https://foo.bar";
+    }
+
+    @Override
+    protected String getMockEndpointUri() {
+        return "mock:https:foo.bar";
+    }
+
+    private boolean testWithoutChannel = false;
+
+    private final String EXPECTED_MESSAGE = "{\"blocks\": [{\"type\": \"section\",\"text\": {\"type\": \"mrkdwn\",\"text\": \"*Bug Fixes - Errata - Subscription Services*\"}}]}";
+
+    @Override
+    protected JsonObject buildIncomingPayload(String targetUrl) {
+        JsonObject payload = new JsonObject();
+        payload.put("orgId", DEFAULT_ORG_ID);
+        payload.put("webhookUrl", targetUrl);
+        if (!testWithoutChannel) {
+            payload.put("channel", SLACK_CHANNEL);
+        } else {
+            payload.put("channel", null);
+        }
+        payload.put("message", EXPECTED_MESSAGE);
+        return payload;
+    }
+
+    @Override
+    protected Predicate checkOutgoingPayload(JsonObject incomingPayload) {
+        return exchange -> {
+            JsonObject outgoingPayload = new JsonObject(exchange.getIn().getBody(String.class));
+            System.out.println(outgoingPayload);
+            boolean textMessageMatch = outgoingPayload.getString("blocks").equals(new JsonObject(EXPECTED_MESSAGE).getString("blocks"));
+            if (!testWithoutChannel) {
+                return textMessageMatch && outgoingPayload.getString(ExchangeProperty.CHANNEL).equals(incomingPayload.getString(ExchangeProperty.CHANNEL));
+            }
+            return textMessageMatch && !outgoingPayload.containsKey(ExchangeProperty.CHANNEL);
+        };
+    }
+
+    @Test
+    protected void testSuccessfulNotificationWithoutChannel() throws Exception {
+        try {
+            testWithoutChannel = true;
+            testSuccessfulNotification();
+        } finally {
+            testWithoutChannel = false;
+        }
+
+    }
+}

--- a/connector-slack/src/test/java/com/redhat/cloud/notifications/connector/slack/SlackConnectorRoutesMessageBlocksFormatTest.java
+++ b/connector-slack/src/test/java/com/redhat/cloud/notifications/connector/slack/SlackConnectorRoutesMessageBlocksFormatTest.java
@@ -50,7 +50,6 @@ public class SlackConnectorRoutesMessageBlocksFormatTest extends ConnectorRoutes
     protected Predicate checkOutgoingPayload(JsonObject incomingPayload) {
         return exchange -> {
             JsonObject outgoingPayload = new JsonObject(exchange.getIn().getBody(String.class));
-            System.out.println(outgoingPayload);
             boolean textMessageMatch = outgoingPayload.getString("blocks").equals(new JsonObject(EXPECTED_MESSAGE).getString("blocks"));
             if (!testWithoutChannel) {
                 return textMessageMatch && outgoingPayload.getString(ExchangeProperty.CHANNEL).equals(incomingPayload.getString(ExchangeProperty.CHANNEL));


### PR DESCRIPTION
I created RHCLOUD-40365, to refactor existing Slack templates into valid Json.