### PR TITLE
Remove Kessel Clowder dependencies

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -16,8 +16,6 @@ objects:
     - notifications-engine
     - rbac
     optionalDependencies:
-    - kessel-inventory
-    - kessel-relations
     - sources-api # https://issues.redhat.com/browse/RHCLOUD-23993
     database:
       name: notifications-backend

--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -14,8 +14,6 @@ objects:
     envName: ${ENV_NAME}
     dependencies:
     - rbac
-    optionalDependencies:
-    - kessel-relations
     featureFlags: true
     deployments:
     - name: service


### PR DESCRIPTION
Remove not used Kessel dependencies in clowder config to save ressources in ephemeral