### PR TITLE
[RHCLOUD-40664] Bump event-schemas-java and insights-notification-schemas-java dependencies

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -209,8 +209,8 @@
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty-no-dependencies</artifactId>
-            <version>${mockserver-netty-no-dependencies.version}</version>
+            <artifactId>mockserver-netty</artifactId>
+            <version>${mockserver-netty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/ValidationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/ValidationResource.java
@@ -92,7 +92,7 @@ public class ValidationResource {
         } catch (ParsingException parsingException) {
             MessageValidationResponse responseMessage = new MessageValidationResponse();
             for (ValidationMessage message : parsingException.getValidationMessages()) {
-                responseMessage.addError(message.getPath(), message.getMessage());
+                responseMessage.addError(message.getProperty(), message.getMessage());
             }
             return Response.status(BAD_REQUEST).entity(responseMessage).build();
         }
@@ -122,7 +122,7 @@ public class ValidationResource {
         } catch (ConsoleCloudEventValidationException exception) {
             MessageValidationResponse responseMessage = new MessageValidationResponse();
             for (ValidationMessage message : exception.getValidationMessages()) {
-                responseMessage.addError(message.getPath(), message.getMessage());
+                responseMessage.addError(message.getProperty(), message.getMessage());
             }
             return Response.status(BAD_REQUEST).entity(responseMessage).build();
         }

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -195,6 +195,7 @@
             <groupId>com.github.fge</groupId>
             <artifactId>jackson-coreutils</artifactId>
             <version>1.8</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -179,9 +179,22 @@
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty-no-dependencies</artifactId>
-            <version>${mockserver-netty-no-dependencies.version}</version>
+            <artifactId>mockserver-netty</artifactId>
+            <version>${mockserver-netty.version}</version>
             <scope>test</scope>
+        </dependency>
+        <!-- io.swagger.core.v3:swagger-models is requested by org.mock-server:mockserver-netty -->
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-models</artifactId>
+            <version>${swagger-v3-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- com.github.fge:jackson-coreutils is requested by org.mock-server:mockserver-netty -->
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>jackson-coreutils</artifactId>
+            <version>1.8</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,9 @@
         <failsafe.version>3.3.2</failsafe.version>
 
         <mockserver-netty-no-dependencies.version>5.15.0</mockserver-netty-no-dependencies.version>
+        <mockserver-netty.version>5.15.0</mockserver-netty.version>
 
-        <insights-notification-schemas-java.version>0.22</insights-notification-schemas-java.version>
+        <insights-notification-schemas-java.version>0.23</insights-notification-schemas-java.version>
         <clowder-quarkus-config-source.version>2.7.1</clowder-quarkus-config-source.version>
 
         <quarkus-logging-cloudwatch.version>6.13.0</quarkus-logging-cloudwatch.version>
@@ -82,7 +83,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.23.3</quarkus.platform.version>
-        <redhat.event-schemas.version>1.4.11</redhat.event-schemas.version>
+        <redhat.event-schemas.version>1.4.12</redhat.event-schemas.version>
 
         <sonar.maven.plugin.version>5.1.0.4751</sonar.maven.plugin.version>
         <jacoco.output.directory>${project.build.directory}/jacoco-report</jacoco.output.directory>


### PR DESCRIPTION
## Summary by Sourcery

Update schema dependencies, adjust mockserver dependency setup, and fix validation error mapping

Bug Fixes:
- Use getProperty() instead of getPath() when mapping validation errors in ValidationResource

Build:
- Bump insights-notification-schemas-java from 0.22 to 0.23 and redhat.event-schemas from 1.4.11 to 1.4.12
- Replace mockserver-netty-no-dependencies with mockserver-netty and introduce mockserver-netty.version property
- Add io.swagger.core.v3:swagger-models and com.github.fge:jackson-coreutils dependencies for mockserver