### PR TITLE
[RHCLOUD-38973] Fix refactored drawer outgoing message format

### DIFF
--- a/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/DrawerProcessor.java
+++ b/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/DrawerProcessor.java
@@ -90,7 +90,7 @@ public class DrawerProcessor implements Processor {
         drawerEntry.setUsernames(recipients);
         JsonObject myPayload = JsonObject.mapFrom(drawerEntry);
 
-        OutgoingCloudEventMetadata<String> cloudEventMetadata = OutgoingCloudEventMetadata.<String>builder()
+        OutgoingCloudEventMetadata<JsonObject> cloudEventMetadata = OutgoingCloudEventMetadata.<JsonObject>builder()
             .withId(entryPayloadModel.getEventId().toString())
             .withType(CE_TYPE)
             .withSpecVersion(CE_SPEC_VERSION)

--- a/connector-drawer/src/main/resources/application.properties
+++ b/connector-drawer/src/main/resources/application.properties
@@ -55,7 +55,6 @@ quarkus.rest-client.recipients-resolver.trust-store-type=${clowder.endpoints.not
 # Output queue to drawer
 mp.messaging.outgoing.drawer.connector=smallrye-kafka
 mp.messaging.outgoing.drawer.topic=platform.chrome
-mp.messaging.outgoing.drawer.group.id=integrations
 mp.messaging.outgoing.drawer.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.drawer.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.drawer.cloud-events-source=urn:redhat:source:notifications:drawer

--- a/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorWithSimplifiedRoutesTest.java
+++ b/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorWithSimplifiedRoutesTest.java
@@ -13,6 +13,8 @@ import com.redhat.cloud.notifications.connector.drawer.model.RecipientSettings;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
+import io.smallrye.reactive.messaging.ce.OutgoingCloudEventMetadata;
+import io.smallrye.reactive.messaging.ce.impl.DefaultOutgoingCloudEventMetadata;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import io.smallrye.reactive.messaging.memory.InMemorySink;
 import io.vertx.core.json.JsonArray;
@@ -252,14 +254,14 @@ class DrawerConnectorWithSimplifiedRoutesTest extends CamelQuarkusTestSupport {
 
         //inMemoryToCamelSink.
         for (Message<JsonObject> message : inMemoryToCamelSink.received()) {
-            JsonObject payload = message.getPayload();
-            assertEquals("com.redhat.console.notifications.drawer", payload.getString("type"));
-            assertEquals("1.0.2", payload.getString("specversion"));
-            assertNotNull(payload.getString("id"));
-            assertEquals("urn:redhat:source:notifications:drawer", payload.getString("source"));
-            assertNotNull(payload.getString("time"));
+            OutgoingCloudEventMetadata<JsonObject> cloudEventMetadata  = message.getMetadata().get(DefaultOutgoingCloudEventMetadata.class).get();
+            assertEquals("com.redhat.console.notifications.drawer", cloudEventMetadata.getType());
+            assertEquals("1.0.2", cloudEventMetadata.getSpecVersion());
+            assertNotNull(cloudEventMetadata.getId());
+            assertEquals("urn:redhat:source:notifications:drawer", cloudEventMetadata.getSource().toString());
+            assertNotNull(cloudEventMetadata.getTimeStamp());
 
-            JsonObject data = payload.getJsonObject("data");
+            JsonObject data = message.getPayload();
 
             assertEquals(expectedNumberOfUsers, data.getJsonArray("usernames").size());
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Drawer connector to send CloudEvent-wrapped messages by introducing a centralized buildMessage method that wraps payloads in a DrawerEntry and attaches CloudEvent metadata, and remove the deprecated group ID config

Enhancements:
- Consolidate outgoing drawer message logic to use a buildMessage helper that wraps the payload in a DrawerEntry and adds CloudEvent metadata

Chores:
- Remove obsolete mp.messaging.outgoing.drawer.group.id setting from application.properties