### PR TITLE
OCM-14738 | fix: doc link only for rosa hcp upgrades

### DIFF
--- a/common-template/src/main/resources/templates/email/OCM/clusterUpdateInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterUpdateInstantEmailBody.html
@@ -34,14 +34,7 @@ This notification is for your <a href="https://cloud.redhat.com/openshift/detail
     </p>
 {#else if global_var.template_sub_type == 'upgrade-scheduled-template-rosa-hcp'}
     <p>
-        <strong>What can you expect?</strong>
-        <ul>
-            <li>Your cluster will remain operational during the upgrade.</li>
-            <li>During the upgrade, the control plane components hosted in the service account will be updated to the required version.</li>
-            <li>The machine pools hosting the applications will not be upgraded. The machine pools must be upgraded separately.</li>
-        </ul>
-
-        <strong>For more information, refer to</strong> our <a href="https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/upgrading/rosa-hcp-upgrading" target="_blank" title="Upgrading ROSA with HCP">Documentation</a>.
+        <strong>For more information, refer to</strong> our <a href="https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/latest/html/upgrading/rosa-hcp-upgrading" target="_blank" title="Upgrading ROSA with HCP">Documentation</a>.
     </p>
 {/if}
 

--- a/engine/src/main/resources/templates/OCM/clusterUpdateInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterUpdateInstantEmailBodyV2.html
@@ -34,14 +34,7 @@ This notification is for your <a href="https://cloud.redhat.com/openshift/detail
     </p>
 {#else if global_var.template_sub_type == 'upgrade-scheduled-template-rosa-hcp'}
     <p>
-        <strong>What can you expect?</strong>
-        <ul>
-            <li>Your cluster will remain operational during the upgrade.</li>
-            <li>During the upgrade, the control plane components hosted in the service account will be updated to the required version.</li>
-            <li>The machine pools hosting the applications will not be upgraded. The machine pools must be upgraded separately.</li>
-        </ul>
-
-        <strong>For more information, refer to</strong> our <a href="https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/upgrading/rosa-hcp-upgrading" target="_blank" title="Upgrading ROSA with HCP">Documentation</a>.
+        <strong>For more information, refer to</strong> our <a href="https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/latest/html/upgrading/rosa-hcp-upgrading" target="_blank" title="Upgrading ROSA with HCP">Documentation</a>.
     </p>
 {/if}
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOcmTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOcmTemplate.java
@@ -88,9 +88,7 @@ public class TestOcmTemplate extends EmailTemplatesInDbHelper {
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
         assertTrue(result.contains("Upgrade scheduled"));
         assertTrue(result.contains(((Map<String, String>) action.getEvents().get(0).getPayload().getAdditionalProperties().get("global_vars")).get("log_description")));
-        assertTrue(result.contains("What can you expect"));
         assertTrue(result.contains("Thank you for choosing Red Hat OpenShift Dedicated Trial."));
-        assertTrue(result.contains("The machine pools hosting the applications will not be upgraded. The machine pools must be upgraded separately."));
         assertFalse(result.contains("What should you do to minimize impact"));
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/common/TestOcmTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/common/TestOcmTemplate.java
@@ -93,9 +93,7 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
         assertTrue(result.contains("Upgrade scheduled"));
         assertTrue(result.contains(((Map<String, String>) action.getEvents().get(0).getPayload().getAdditionalProperties().get("global_vars")).get("log_description")));
-        assertTrue(result.contains("What can you expect"));
         assertTrue(result.contains("Thank you for choosing Red Hat OpenShift Dedicated Trial."));
-        assertTrue(result.contains("The machine pools hosting the applications will not be upgraded. The machine pools must be upgraded separately."));
         assertFalse(result.contains("What should you do to minimize impact"));
     }
 


### PR DESCRIPTION
Output documentation link for control plane and nodepool upgrades in email body only.

## Summary by Sourcery

Update OCM cluster update instant email templates to only display the documentation link for scheduled ROSA HCP upgrades and point the link to the latest documentation version.

Bug Fixes:
- Remove the informational bullet list for scheduled ROSA HCP upgrades in the email body.

Enhancements:
- Update the ROSA HCP upgrade documentation URL to reference the latest version in both V1 and V2 templates.