### PR TITLE
Revert "Enable autoscaler via engine ClowdApp (#2798)"

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -194,31 +194,6 @@ objects:
           value: ${PROCESSOR_CONNECTORS_MIN_DELAY_SINCE_FIRST_SERVER_ERROR}
         - name: NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES
           value: ${NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES}
-      autoScaler:
-        minReplicaCount: ${{MIN_REPLICAS}}
-        maxReplicaCount: 6
-        externalHPA: true
-        triggers:
-          - metadata:
-              serverAddress: http://prometheus-app-sre.openshift-customer-monitoring.svc.cluster.local:9090
-              query: kafka_consumergroup_group_topic_sum_lag{topic=~".*platform.notifications.ingress"}
-              threshold: "25"
-            type: prometheus
-            metricType: Value
-        advanced:
-          horizontalPodAutoscalerConfig:
-            behavior:
-              scaleDown:
-                stabilizationWindowSeconds: 180
-                policies:
-                  - type: Pods
-                    value: 2
-                    periodSeconds: 60
-              scaleUp:
-                policies:
-                  - type: Pods
-                    value: 2
-                    periodSeconds: 30
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)


### PR DESCRIPTION
Rolling back autoscaling (commit c6d4fba2032032ec92a65ceeee18cdf84e7131c3) as mentioned [on Slack](https://redhat-internal.slack.com/archives/C024CDDPRHD/p1749827328348839). Will pick up in 1-2 weeks.

## Summary by Sourcery

Chores:
- Remove the `autoScaler` block from `.rhcicd/clowdapp-engine.yaml` to disable autoscaling temporarily