### PR TITLE
[RHCLOUD-39778] Handle integer format for total recipients counter

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -246,12 +246,7 @@ public class EventResource {
                 if (totalRecipients instanceof Integer recipientsAsInteger) {
                     return Optional.of(recipientsAsInteger);
                 }
-                try {
-                    Integer recipientsCount = Integer.valueOf((String) totalRecipients);
-                    return Optional.of(recipientsCount);
-                } catch (NumberFormatException e) {
-                    Log.warnf(e, "Could not parse total_recipients to an Integer [history_id=%s, total_recipients=%s]", notificationHistory.getId(), totalRecipients);
-                }
+                Log.warnf("total_recipients field must be an Integer [history_id=%s, total_recipients=%s]", notificationHistory.getId(), totalRecipients);
             }
         }
         return Optional.empty();

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -243,6 +243,9 @@ public class EventResource {
         if (notificationHistory.getDetails() != null) {
             Object totalRecipients = notificationHistory.getDetails().get(TOTAL_RECIPIENTS);
             if (totalRecipients != null) {
+                if (totalRecipients instanceof Integer recipientsAsInteger) {
+                    return Optional.of(recipientsAsInteger);
+                }
                 try {
                     Integer recipientsCount = Integer.valueOf((String) totalRecipients);
                     return Optional.of(recipientsCount);

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -243,7 +243,7 @@ public class ResourceHelpers {
         return createNotificationHistory(event, endpoint, status, null);
     }
 
-    public NotificationHistory createNotificationHistory(Event event, Endpoint endpoint, NotificationStatus status, String totalRecipients) {
+    public NotificationHistory createNotificationHistory(Event event, Endpoint endpoint, NotificationStatus status, Object totalRecipients) {
         NotificationHistory history = new NotificationHistory();
         history.setId(UUID.randomUUID());
         history.setInvocationTime(1L);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -981,12 +981,7 @@ public class EventResourceTest extends DbIsolatedTest {
                         if (totalRecipients instanceof Integer recipientsAsInteger) {
                             assertEquals(recipientsAsInteger, eventLogEntryAction.getRecipientsCount());
                         } else {
-                            try {
-                                Integer recipientsCount = Integer.valueOf((String) totalRecipients);
-                                assertEquals(recipientsCount, eventLogEntryAction.getRecipientsCount());
-                            } catch (NumberFormatException e) {
-                                assertNull(eventLogEntryAction.getRecipientsCount());
-                            }
+                            assertNull(eventLogEntryAction.getRecipientsCount());
                         }
                     }
                 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -236,7 +236,7 @@ public class EventResourceTest extends DbIsolatedTest {
         Endpoint endpoint5 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, PAGERDUTY);
         NotificationHistory history1 = resourceHelpers.createNotificationHistory(event1, endpoint1, NotificationStatus.SUCCESS, "123");
         NotificationHistory history2 = resourceHelpers.createNotificationHistory(event1, endpoint2, NotificationStatus.FAILED_INTERNAL, "I'm not a valid Integer");
-        NotificationHistory history3 = resourceHelpers.createNotificationHistory(event2, endpoint1, NotificationStatus.SUCCESS);
+        NotificationHistory history3 = resourceHelpers.createNotificationHistory(event2, endpoint1, NotificationStatus.SUCCESS, 123);
         NotificationHistory history4 = resourceHelpers.createNotificationHistory(event3, endpoint2, NotificationStatus.SUCCESS);
         NotificationHistory history5 = resourceHelpers.createNotificationHistory(event3, endpoint3, NotificationStatus.SUCCESS);
         NotificationHistory history6 = resourceHelpers.createNotificationHistory(event1, endpoint4, NotificationStatus.FAILED_INTERNAL);
@@ -978,11 +978,15 @@ public class EventResourceTest extends DbIsolatedTest {
                 if (historyEntry.get().getDetails() != null) {
                     Object totalRecipients = historyEntry.get().getDetails().get(TOTAL_RECIPIENTS);
                     if (totalRecipients != null) {
-                        try {
-                            Integer recipientsCount = Integer.valueOf((String) totalRecipients);
-                            assertEquals(recipientsCount, eventLogEntryAction.getRecipientsCount());
-                        } catch (NumberFormatException e) {
-                            assertNull(eventLogEntryAction.getRecipientsCount());
+                        if (totalRecipients instanceof Integer recipientsAsInteger) {
+                            assertEquals(recipientsAsInteger, eventLogEntryAction.getRecipientsCount());
+                        } else {
+                            try {
+                                Integer recipientsCount = Integer.valueOf((String) totalRecipients);
+                                assertEquals(recipientsCount, eventLogEntryAction.getRecipientsCount());
+                            } catch (NumberFormatException e) {
+                                assertNull(eventLogEntryAction.getRecipientsCount());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary by Sourcery

Handle integer-formatted recipient counts by treating Integer details directly and updating tests and helpers accordingly

Enhancements:
- Support direct Integer values for the totalRecipients field in event histories
- Allow test helpers to accept Object-typed totalRecipients rather than only strings

Tests:
- Update assertion logic to handle both Integer and String formats for recipients count
- Modify tests to pass integer values for totalRecipients