### PR TITLE
[RHCLOUD-39481] fix Gchat connector port

### DIFF
--- a/.rhcicd/clowdapp-connector-google-chat.yaml
+++ b/.rhcicd/clowdapp-connector-google-chat.yaml
@@ -177,7 +177,7 @@ parameters:
   value: "false"
 - name: QUARKUS_HTTP_PORT
   description: Quarkus HTTP server port
-  value: "9000"
+  value: "8000"
 - name: QUARKUS_LOG_CLOUDWATCH_API_CALL_TIMEOUT
   description: Amount of time to allow the CloudWatch client to complete the execution of an API call expressed with the ISO-8601 duration format PnDTnHnMn.nS.
   value: PT30S


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update QUARKUS_HTTP_PORT from 9000 to 8000 in the Google Chat connector CI config