### PR TITLE
Use pipelinesascode.tekton.dev/pipeline in sc pipelines

### DIFF
--- a/.tekton/notifications-aggregator-sc-pull-request.yaml
+++ b/.tekton/notifications-aggregator-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-aggregator-sc
   workspaces:

--- a/.tekton/notifications-aggregator-sc-push.yaml
+++ b/.tekton/notifications-aggregator-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-aggregator-sc
   workspaces:

--- a/.tekton/notifications-backend-sc-pull-request.yaml
+++ b/.tekton/notifications-backend-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-backend-sc
   workspaces:

--- a/.tekton/notifications-backend-sc-push.yaml
+++ b/.tekton/notifications-backend-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-backend-sc
   workspaces:

--- a/.tekton/notifications-connector-drawer-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-drawer-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-drawer-sc
   workspaces:

--- a/.tekton/notifications-connector-drawer-sc-push.yaml
+++ b/.tekton/notifications-connector-drawer-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-drawer-sc
   workspaces:

--- a/.tekton/notifications-connector-email-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-email-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-email-sc
   workspaces:

--- a/.tekton/notifications-connector-email-sc-push.yaml
+++ b/.tekton/notifications-connector-email-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-email-sc
   workspaces:

--- a/.tekton/notifications-connector-google-chat-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-google-chat-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-google-chat-sc
   workspaces:

--- a/.tekton/notifications-connector-google-chat-sc-push.yaml
+++ b/.tekton/notifications-connector-google-chat-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-google-chat-sc
   workspaces:

--- a/.tekton/notifications-connector-microsoft-teams-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-microsoft-teams-sc
   workspaces:

--- a/.tekton/notifications-connector-microsoft-teams-sc-push.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-microsoft-teams-sc
   workspaces:

--- a/.tekton/notifications-connector-pagerduty-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-pagerduty-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-pagerduty-sc
   workspaces:

--- a/.tekton/notifications-connector-pagerduty-sc-push.yaml
+++ b/.tekton/notifications-connector-pagerduty-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-pagerduty-sc
   workspaces:

--- a/.tekton/notifications-connector-servicenow-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-servicenow-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-servicenow-sc
   workspaces:

--- a/.tekton/notifications-connector-servicenow-sc-push.yaml
+++ b/.tekton/notifications-connector-servicenow-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-servicenow-sc
   workspaces:

--- a/.tekton/notifications-connector-slack-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-slack-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-slack-sc
   workspaces:

--- a/.tekton/notifications-connector-slack-sc-push.yaml
+++ b/.tekton/notifications-connector-slack-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-slack-sc
   workspaces:

--- a/.tekton/notifications-connector-splunk-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-splunk-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-splunk-sc
   workspaces:

--- a/.tekton/notifications-connector-splunk-sc-push.yaml
+++ b/.tekton/notifications-connector-splunk-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-splunk-sc
   workspaces:

--- a/.tekton/notifications-connector-webhook-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-webhook-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-webhook-sc
   workspaces:

--- a/.tekton/notifications-connector-webhook-sc-push.yaml
+++ b/.tekton/notifications-connector-webhook-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-connector-webhook-sc
   workspaces:

--- a/.tekton/notifications-engine-sc-pull-request.yaml
+++ b/.tekton/notifications-engine-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-engine-sc
   workspaces:

--- a/.tekton/notifications-engine-sc-push.yaml
+++ b/.tekton/notifications-engine-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-engine-sc
   workspaces:

--- a/.tekton/notifications-recipients-resolver-sc-pull-request.yaml
+++ b/.tekton/notifications-recipients-resolver-sc-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -31,14 +32,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-recipients-resolver-sc
   workspaces:

--- a/.tekton/notifications-recipients-resolver-sc-push.yaml
+++ b/.tekton/notifications-recipients-resolver-sc-push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.18.0/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc
@@ -28,14 +29,7 @@ spec:
   - name: path-context
     value: .
   pipelineRef:
-    params:
-    - name: url
-      value: https://github.com/RedHatInsights/konflux-pipelines
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipelines/docker-build.yaml
-    resolver: git
+    name: docker-build
   taskRunTemplate:
     serviceAccountName: build-pipeline-notifications-recipients-resolver-sc
   workspaces:


### PR DESCRIPTION
## Summary by Sourcery

Simplify and standardize security-compliance pipeline triggers by switching from Git resolver parameters to a direct PipelineAsCode reference for the shared docker-build pipeline.

Enhancements:
- Add pipelinesascode.tekton.dev/pipeline annotation pointing to the v1.18.0 external docker-build.yaml pipeline across all security-compliance triggers
- Replace Git resolver and params with a direct pipelineRef name "docker-build" for both pull_request and push events in all notifications and connector components