### PR TITLE
[RHCLOUD-40471] Fix openApi default value for Query.limit property

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -19,7 +19,7 @@ public class Query {
 
     private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9_-]+(:(asc|desc))?$", CASE_INSENSITIVE);
 
-    private static final int DEFAULT_RESULTS_PER_PAGE = 20;
+    public static final int DEFAULT_RESULTS_PER_PAGE = 20;
 
     @QueryParam("limit")
     @DefaultValue(DEFAULT_RESULTS_PER_PAGE + "")

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/drawer/DrawerResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/drawer/DrawerResource.java
@@ -20,6 +20,10 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.jboss.resteasy.reactive.RestQuery;
 
 import java.time.LocalDateTime;
@@ -31,6 +35,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
+import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getUsername;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -48,6 +53,12 @@ public class DrawerResource {
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve drawer notifications entries.", description =
             "Allowed `sort_by` fields are `bundleIds`, `applicationIds`, `eventTypeIds`, `startTime`, `endTime` and `read`. The ordering can be optionally specified by appending `:asc` or `:desc` to the field, e.g. `bundle:desc`. Defaults to `desc` for the `created` field and to `asc` for all other fields."
+    )
+    @Parameter(
+        name = "limit",
+        in = ParameterIn.QUERY,
+        description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used",
+        schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
     )
     public Page<DrawerEntryPayload> getDrawerEntries(@Context SecurityContext securityContext, @Context UriInfo uriInfo,
                                          @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
@@ -96,7 +96,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.redhat.cloud.notifications.db.repositories.NotificationRepository.MAX_NOTIFICATION_HISTORY_RESULTS;
+import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.models.EndpointType.DRAWER;
 import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPTION;
@@ -175,8 +175,8 @@ public class EndpointResource {
             @Parameter(
                 name = "limit",
                 in = ParameterIn.QUERY,
-                description = "Number of items per page, if not specified or 0 is used, returns a maximum of " + MAX_NOTIFICATION_HISTORY_RESULTS + " elements.",
-                schema = @Schema(type = SchemaType.INTEGER)
+                description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
+                schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
                 ),
             @Parameter(
                 name = "pageNumber",
@@ -210,8 +210,8 @@ public class EndpointResource {
         @Parameter(
                 name = "limit",
                 in = ParameterIn.QUERY,
-                description = "Number of items per page. If the value is 0, it will return all elements",
-                schema = @Schema(type = SchemaType.INTEGER)
+                description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used",
+                schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
             ),
         @Parameter(
                 name = "pageNumber",

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceV2.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceV2.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.redhat.cloud.notifications.db.repositories.NotificationRepository.MAX_NOTIFICATION_HISTORY_RESULTS;
+import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getUsername;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -54,8 +54,8 @@ public class EndpointResourceV2 extends EndpointResource {
             @Parameter(
                 name = "limit",
                 in = ParameterIn.QUERY,
-                description = "Number of items per page, if not specified or 0 is used, returns a maximum of " + MAX_NOTIFICATION_HISTORY_RESULTS + " elements.",
-                schema = @Schema(type = SchemaType.INTEGER)
+                description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
+                schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
             ),
             @Parameter(
                 name = "pageNumber",

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -31,6 +31,10 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.jboss.resteasy.reactive.RestQuery;
 
 import java.time.LocalDate;
@@ -47,6 +51,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
+import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -70,6 +75,12 @@ public class EventResource {
     @GET
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve the event log entries", description = "Retrieves the event log entries. Use this endpoint to review a full history of the events related to the tenant. You can sort by the bundle, application, event, and created fields. You can specify the sort order by appending :asc or :desc to the field, for example bundle:desc. Sorting defaults to desc for the created field and to asc for all other fields."
+    )
+    @Parameter(
+        name = "limit",
+        in = ParameterIn.QUERY,
+        description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
+        schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
     )
     @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS, workspacePermissions = {WorkspacePermission.EVENT_LOG_VIEW})
     public Page<EventLogEntry> getEvents(@Context SecurityContext securityContext, @Context UriInfo uriInfo,

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResource.java
@@ -56,6 +56,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -76,6 +77,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getAccountId;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getUsername;
@@ -123,6 +125,12 @@ public class NotificationResource {
         @Path("/eventTypes/{eventTypeId}/behaviorGroups")
         @Produces(APPLICATION_JSON)
         @Operation(summary = "List the behavior groups linked to an event type", description = "Lists the behavior groups that are linked to an event type. Use this endpoint to see which behavior groups will be affected if you delete an event type.")
+        @Parameter(
+            name = "limit",
+            in = ParameterIn.QUERY,
+            description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
+            schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
+        )
         @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.BEHAVIOR_GROUPS_VIEW, WorkspacePermission.EVENT_TYPES_VIEW})
         public List<BehaviorGroup> getLinkedBehaviorGroups(
             @Context SecurityContext sec,
@@ -139,6 +147,12 @@ public class NotificationResource {
     @Path("/eventTypes")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List all event types", description = "Lists all event types. You can filter the returned list by bundle, application name, or unmuted types.")
+    @Parameter(
+        name = "limit",
+        in = ParameterIn.QUERY,
+        description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
+        schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
+    )
     @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.EVENT_TYPES_VIEW})
     public Page<EventType> getEventTypes(
         @Context SecurityContext securityContext, @Context UriInfo uriInfo, @BeanParam @Valid Query query, @QueryParam("applicationIds") Set<UUID> applicationIds,

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResourceV2.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResourceV2.java
@@ -19,10 +19,15 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 
 import java.util.List;
 import java.util.UUID;
 
+import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -31,6 +36,12 @@ public class NotificationResourceV2 extends NotificationResource {
     @GET
     @Path("/eventTypes/{eventTypeId}/behaviorGroups")
     @Produces(APPLICATION_JSON)
+    @Parameter(
+        name = "limit",
+        in = ParameterIn.QUERY,
+        description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
+        schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
+    )
     @Operation(summary = "Retrieve the behavior groups linked to an event type.")
     public Page<BehaviorGroup> getLinkedBehaviorGroups(
         @Context SecurityContext sec,


### PR DESCRIPTION
Some OpenApi validator tools may fail because `Query.limit` default value is rendered as "20" (String format) and not 20.

Validation done on exposed public openApis:
- Integrations V1
- Integrations V2
- Notifications V1
- Notifications V2



## Summary by Sourcery

Standardize OpenAPI default limit parameter for query pagination across multiple endpoints and expose the default-page-size constant for reuse.

Enhancements:
- Add defaultValue to the `limit` query parameter in OpenAPI annotations for various resource endpoints to use DEFAULT_RESULTS_PER_PAGE
- Update parameter descriptions to reference DEFAULT_RESULTS_PER_PAGE instead of custom or MAX_NOTIFICATION_HISTORY_RESULTS text
- Make DEFAULT_RESULTS_PER_PAGE constant public in Query class to support its usage in annotations