### PR TITLE
[RHCLOUD-40555] bump commons-beanutils

### DIFF
--- a/connector-pagerduty/pom.xml
+++ b/connector-pagerduty/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>commons-validator</artifactId>
             <version>1.9.0</version>
         </dependency>
+        <dependency>
+            <!-- Remove once commons-validator:1.10 is released (see https://issues.apache.org/jira/browse/VALIDATOR-500)-->
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
+        </dependency>
 
         <!-- Scope: test -->
         <!-- Some test dependencies are declared in the "profiles" section of this POM. -->

--- a/connector-servicenow/pom.xml
+++ b/connector-servicenow/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>commons-validator</artifactId>
             <version>1.9.0</version>
         </dependency>
+        <dependency>
+            <!-- Remove once commons-validator:1.10 is released (see https://issues.apache.org/jira/browse/VALIDATOR-500)-->
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
+        </dependency>
 
         <!-- Scope: test -->
         <!-- Some test dependencies are declared in the "profiles" section of this POM. -->

--- a/connector-splunk/pom.xml
+++ b/connector-splunk/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>commons-validator</artifactId>
             <version>1.9.0</version>
         </dependency>
+        <dependency>
+            <!-- Remove once commons-validator:1.10 is released (see https://issues.apache.org/jira/browse/VALIDATOR-500)-->
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
+        </dependency>
 
         <!-- Scope: test -->
         <!-- Some test dependencies are declared in the "profiles" section of this POM. -->


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-40555

## Description

Bump transitive dependency `commons-beanutils` to 1.11.0 in the PagerDuty, ServiceNow, and Splunk connectors. This override should be removed once a new version of `commons-validator` is released.

## Summary by Sourcery

Build:
- Add a direct commons-beanutils:1.11.0 dependency in PagerDuty, ServiceNow, and Splunk connectors