### PR TITLE
[RHCLOUD-40775] Add endpoint blacklist capacity

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -5,7 +5,6 @@ import com.redhat.cloud.notifications.unleash.UnleashContextBuilder;
 import io.getunleash.Unleash;
 import io.getunleash.UnleashContext;
 import io.quarkus.logging.Log;
-import jakarta.annotation.Nonnull;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -267,8 +266,8 @@ public class EngineConfig {
         }
     }
 
-    public boolean isBlacklistedEndpoint(@Nonnull final UUID endpointId) {
-        if (unleashEnabled) {
+    public boolean isBlacklistedEndpoint(final UUID endpointId) {
+        if (unleashEnabled && null != endpointId) {
             UnleashContext unleashContext = UnleashContext.builder()
                 .addProperty("endpointId", endpointId.toString())
                 .build();


### PR DESCRIPTION
## Summary by Sourcery

Enable configurable endpoint blacklisting by adding a new feature toggle, integrate blacklist filtering into the event processing flow, and augment tests with a helper and new cases

New Features:
- Register a new Unleash feature toggle “blacklisted-endpoints” and expose an isBlacklistedEndpoint method in EngineConfig to drive endpoint blacklisting

Enhancements:
- Filter out and skip any endpoints marked as blacklisted in EndpointProcessor based on the new toggle
- Refactor test code by extracting a buildAction helper to eliminate duplication

Tests:
- Add a parameterized test to validate that blacklisted endpoints are correctly skipped under both direct-link and BGS fetch modes