### PR TITLE
[RHCLOUD-40644] Remove Basic authentication from database

### DIFF
--- a/database/src/main/resources/db/migration/V1.116.0__RHCLOUD-40644_remove_basic_authentication.sql
+++ b/database/src/main/resources/db/migration/V1.116.0__RHCLOUD-40644_remove_basic_authentication.sql
@@ -1,0 +1,5 @@
+ALTER TABLE endpoint_webhooks
+    DROP COLUMN basic_authentication_id;
+
+ALTER TABLE camel_properties
+    DROP COLUMN basic_authentication_id;


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-40644

## Description

This includes a database migration (`V1.116.0`) to remove references to Basic authentication secrets from the Notifications database. See #3530 for more information.

> [!IMPORTANT]
> Merge after #3530.  This code is branched from that PR.
>
> **Do not merge** until #3530 has been deployed to the special environment.

## Compatibility

This **removes all known references** to Basic authentication credentials in Sources. These tokens should be removed from Sources before this PR is merged.

## Summary by Sourcery

Remove Basic authentication support from the Notifications service by dropping the related database columns and stripping Basic auth code paths across SecretUtils, models, connectors, mappers, processors, and tests.

Enhancements:
- Eliminate BasicAuthentication fields, methods, and enum values to streamline endpoint authentication to only secret tokens and bearer tokens
- Simplify SecretUtils to load, create, update, and delete only secret token and bearer authentication secrets

Build:
- Add database migration V1.116.0 to drop basic_authentication_id columns from endpoint_webhooks and camel_properties tables

Tests:
- Remove or update test cases to discard Basic authentication scenarios and assertions

Chores:
- Purge BasicAuthenticationDTO and related DTO mappings, OpenAPI filter settings, and resource helpers handling basic auth

## Summary by Sourcery

Remove Basic authentication support entirely from the database schema and application code, consolidating endpoint authentication around secret tokens and bearer tokens only.

Enhancements:
- Remove Basic authentication support and related code paths across services to streamline authentication to secret token and bearer token only
- Simplify secret management utilities to only create, load, update, and delete secret token and bearer authentication secrets

Build:
- Add database migration V1.116.0 to drop basic_authentication_id columns from endpoint_webhooks and camel_properties tables

Tests:
- Remove or update test cases and fixtures to discard Basic authentication scenarios

Chores:
- Purge BasicAuthentication class, DTOs, enums, mapper targets, connectors, processors, and filters related to Basic authentication