### PR TITLE
RHCLOUD-35794 | Migrate Splunk connector testing from Eventing to Notifications

### DIFF
--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -11,7 +11,7 @@ objects:
   spec:
     envName: ${ENV_NAME}
     testing:
-      iqePlugin: eventing
+      iqePlugin: notifications
     dependencies:
     - notifications-engine
     - sources-api

--- a/.rhcicd/stage-splunk-post-deployment-tests.yaml
+++ b/.rhcicd/stage-splunk-post-deployment-tests.yaml
@@ -15,7 +15,7 @@ objects:
         debug: false
         dynaconfEnvName: stage_post_deploy
         filter: ''
-        marker: 'splunk and smoke'
+        marker: 'notif_splunk and api'
 parameters:
 - name: IMAGE_TAG
   value: ''


### PR DESCRIPTION
## Summary by Sourcery

Migrate Splunk connector testing from Eventing to Notifications plugin and update test markers accordingly

CI:
- Switch IQE plugin for Splunk connector tests from 'eventing' to 'notifications'
- Update post-deployment test marker to 'notif_splunk and api'