### PR TITLE
RHCLOUD-35792 | Configure ServiceNow automation to use Notifications test plugin

### DIFF
--- a/.rhcicd/clowdapp-connector-servicenow.yaml
+++ b/.rhcicd/clowdapp-connector-servicenow.yaml
@@ -11,7 +11,7 @@ objects:
   spec:
     envName: ${ENV_NAME}
     testing:
-      iqePlugin: eventing
+      iqePlugin: notifications
     dependencies:
     - notifications-engine
     - sources-api

--- a/.rhcicd/stage-servicenow-post-deployment-tests.yaml
+++ b/.rhcicd/stage-servicenow-post-deployment-tests.yaml
@@ -15,7 +15,7 @@ objects:
         debug: false
         dynaconfEnvName: stage_post_deploy
         filter: ''
-        marker: 'snow and smoke'
+        marker: 'notif_snow and api'
 parameters:
 - name: IMAGE_TAG
   value: ''


### PR DESCRIPTION
## Summary by Sourcery

Configure ServiceNow automation tests to use the Notifications IQE plugin and revise post-deployment test markers

CI:
- Switch ServiceNow CI configuration to use the Notifications IQE plugin instead of Eventing
- Update post-deployment test marker filter to 'notif_snow and api'