### PR TITLE
updating output images to reflect desired path

### DIFF
--- a/.tekton/notifications-aggregator-sc-pull-request.yaml
+++ b/.tekton/notifications-aggregator-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-aggregator-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-aggregator-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-aggregator-sc-push.yaml
+++ b/.tekton/notifications-aggregator-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-aggregator-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-aggregator-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-aggregator.jvm
   - name: path-context

--- a/.tekton/notifications-backend-sc-pull-request.yaml
+++ b/.tekton/notifications-backend-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-backend-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-backend-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-backend-sc-push.yaml
+++ b/.tekton/notifications-backend-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-backend-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-backend-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-backend.jvm
   - name: path-context

--- a/.tekton/notifications-connector-drawer-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-drawer-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-drawer-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-drawer-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-connector-drawer-sc-push.yaml
+++ b/.tekton/notifications-connector-drawer-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-drawer-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-drawer-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-connector-drawer.jvm
   - name: path-context

--- a/.tekton/notifications-connector-email-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-email-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-email-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-email-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-connector-email-sc-push.yaml
+++ b/.tekton/notifications-connector-email-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-email-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-email-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-connector-email.jvm
   - name: path-context

--- a/.tekton/notifications-connector-google-chat-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-google-chat-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-google-chat-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-google-chat-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-connector-google-chat-sc-push.yaml
+++ b/.tekton/notifications-connector-google-chat-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-google-chat-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-google-chat-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-connector-google-chat.jvm
   - name: path-context

--- a/.tekton/notifications-connector-microsoft-teams-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-microsoft-teams-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-microsoft-teams-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-connector-microsoft-teams-sc-push.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-microsoft-teams-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-microsoft-teams-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-connector-microsoft-teams.jvm
   - name: path-context

--- a/.tekton/notifications-connector-pagerduty-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-pagerduty-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-pagerduty-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-pagerduty-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-connector-pagerduty-sc-push.yaml
+++ b/.tekton/notifications-connector-pagerduty-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-pagerduty-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-pagerduty-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-connector-pagerduty.jvm
   - name: path-context

--- a/.tekton/notifications-connector-servicenow-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-servicenow-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-servicenow-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-servicenow-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-connector-servicenow-sc-push.yaml
+++ b/.tekton/notifications-connector-servicenow-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-servicenow-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-servicenow-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-connector-servicenow.jvm
   - name: path-context

--- a/.tekton/notifications-connector-slack-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-slack-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-slack-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-slack-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-connector-slack-sc-push.yaml
+++ b/.tekton/notifications-connector-slack-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-slack-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-slack-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-connector-slack.jvm
   - name: path-context

--- a/.tekton/notifications-connector-splunk-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-splunk-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-splunk-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-splunk-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-connector-splunk-sc-push.yaml
+++ b/.tekton/notifications-connector-splunk-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-splunk-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-splunk-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-connector-splunk.jvm
   - name: path-context

--- a/.tekton/notifications-connector-webhook-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-webhook-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-webhook-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-webhook-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-connector-webhook-sc-push.yaml
+++ b/.tekton/notifications-connector-webhook-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-connector-webhook-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-connector-webhook-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-connector-webhook.jvm
   - name: path-context

--- a/.tekton/notifications-engine-sc-pull-request.yaml
+++ b/.tekton/notifications-engine-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-engine-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-engine-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-engine-sc-push.yaml
+++ b/.tekton/notifications-engine-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-engine-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-engine-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-engine.jvm
   - name: path-context

--- a/.tekton/notifications-recipients-resolver-sc-pull-request.yaml
+++ b/.tekton/notifications-recipients-resolver-sc-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-recipients-resolver-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-recipients-resolver-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-recipients-resolver-sc-push.yaml
+++ b/.tekton/notifications-recipients-resolver-sc-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-recipients-resolver-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-recipients-resolver-sc:{{revision}}
   - name: dockerfile
     value: ./docker/Dockerfile.notifications-recipients-resolver.jvm
   - name: path-context


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Fix output-image repository path by removing the unnecessary 'hcc-fr-tenant' prefix in Tekton YAMLs for notifications aggregator, backend, connectors, engine, and recipients resolver.