### PR TITLE
Revert quarkus-logging-cloudwatch updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <insights-notification-schemas-java.version>0.23</insights-notification-schemas-java.version>
         <clowder-quarkus-config-source.version>2.7.1</clowder-quarkus-config-source.version>
 
-        <quarkus-logging-cloudwatch.version>6.14.2</quarkus-logging-cloudwatch.version>
+        <quarkus-logging-cloudwatch.version>6.13.0</quarkus-logging-cloudwatch.version>
         <quarkus-logging-sentry.version>2.1.6</quarkus-logging-sentry.version>
         <quarkus-unleash.version>1.10.0</quarkus-unleash.version>
 


### PR DESCRIPTION
All minors from 6.14 are broken.

## Summary by Sourcery

Bug Fixes:
- Revert quarkus-logging-cloudwatch version from 6.14.2 back to 6.13.0 to address breakages in 6.14.x releases.