### PR TITLE
Add missing OIDC client ID env var

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -134,6 +134,13 @@ objects:
           value: ${ENV_NAME}
         - name: QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL
           value: ${NOTIFICATIONS_KESSEL_OIDC_ISSUER}
+        - name: QUARKUS_OIDC_CLIENT_CLIENT_ENABLED
+          value: ${QUARKUS_OIDC_CLIENT_CLIENT_ENABLED}
+        - name: QUARKUS_OIDC_CLIENT_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: kessel-authentication
+              key: relations-api.client.id
         - name: QUARKUS_OIDC_CLIENT_CREDENTIALS_SECRET
           valueFrom:
             secretKeyRef:
@@ -141,8 +148,6 @@ objects:
               key: relations-api.client.secret
         - name: QUARKUS_OIDC_CLIENT_EARLY_TOKENS_ACQUISITION
           value: ${QUARKUS_OIDC_CLIENT_EARLY_TOKENS_ACQUISITION}
-        - name: QUARKUS_OIDC_CLIENT_CLIENT_ENABLED
-          value: ${QUARKUS_OIDC_CLIENT_CLIENT_ENABLED}
         - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE
           value: ${IT_SERVICE_TO_SERVICE_KEY_STORE}
         - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE_PASSWORD
@@ -251,11 +256,11 @@ parameters:
 - name: QUARKUS_LOG_CLOUDWATCH_MAX_QUEUE_SIZE
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
-- name: QUARKUS_OIDC_CLIENT_EARLY_TOKENS_ACQUISITION
-  description: If true, all filters which use OidcClient will acquire the tokens at application startup time, possibly failing and preventing Quarkus from starting if the OIDC auth server is not available.
-  value: "false"
 - name: QUARKUS_OIDC_CLIENT_CLIENT_ENABLED
   description: If true, the OIDC client will be enabled.
+  value: "false"
+- name: QUARKUS_OIDC_CLIENT_EARLY_TOKENS_ACQUISITION
+  description: If true, all filters which use OidcClient will acquire the tokens at application startup time, possibly failing and preventing Quarkus from starting if the OIDC auth server is not available.
   value: "false"
 - name: QUARKUS_REST_CLIENT_LOGGING_SCOPE
   description: When set to 'request-response', rest-client will log the request and response contents


### PR DESCRIPTION
## Summary by Sourcery

Add missing OIDC client ID environment variable, remove duplicate client-enabled variable, and reorder related configuration parameters in the Clowdapp recipients resolver manifest.

Enhancements:
- Add QUARKUS_OIDC_CLIENT_CLIENT_ID environment variable referencing the relations-api.client.id secret.
- Remove duplicate QUARKUS_OIDC_CLIENT_CLIENT_ENABLED entry and reposition it in the environment variable list.
- Reorder QUARKUS_OIDC_CLIENT_EARLY_TOKENS_ACQUISITION parameter definition below the client-enabled setting.