### PR TITLE
RHCLOUD-40807 Fine-tune OIDC auth in recipients-resolver

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -133,9 +133,9 @@ objects:
         - name: QUARKUS_LOG_SENTRY_ENVIRONMENT
           value: ${ENV_NAME}
         - name: QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL
-          value: ${NOTIFICATIONS_KESSEL_OIDC_ISSUER}
+          value: ${OIDC_ISSUER}
         - name: QUARKUS_OIDC_CLIENT_CLIENT_ENABLED
-          value: ${QUARKUS_OIDC_CLIENT_CLIENT_ENABLED}
+          value: ${OIDC_CLIENT_ENABLED}
         - name: QUARKUS_OIDC_CLIENT_CLIENT_ID
           valueFrom:
             secretKeyRef:
@@ -146,8 +146,6 @@ objects:
             secretKeyRef:
               name: kessel-authentication
               key: relations-api.client.secret
-        - name: QUARKUS_OIDC_CLIENT_EARLY_TOKENS_ACQUISITION
-          value: ${QUARKUS_OIDC_CLIENT_EARLY_TOKENS_ACQUISITION}
         - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE
           value: ${IT_SERVICE_TO_SERVICE_KEY_STORE}
         - name: QUARKUS_REST_CLIENT_IT_S2S_KEY_STORE_PASSWORD
@@ -256,12 +254,12 @@ parameters:
 - name: QUARKUS_LOG_CLOUDWATCH_MAX_QUEUE_SIZE
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
-- name: QUARKUS_OIDC_CLIENT_CLIENT_ENABLED
+- name: OIDC_CLIENT_ENABLED
   description: If true, the OIDC client will be enabled.
-  value: "false"
-- name: QUARKUS_OIDC_CLIENT_EARLY_TOKENS_ACQUISITION
-  description: If true, all filters which use OidcClient will acquire the tokens at application startup time, possibly failing and preventing Quarkus from starting if the OIDC auth server is not available.
-  value: "false"
+  value: "true"
+- name: OIDC_ISSUER
+  description: The issuer of the OIDC tokens.
+  value: https://redhat.com/realms/redhat-external
 - name: QUARKUS_REST_CLIENT_LOGGING_SCOPE
   description: When set to 'request-response', rest-client will log the request and response contents
   value: ""

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/config/RecipientsResolverConfig.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/config/RecipientsResolverConfig.java
@@ -49,7 +49,7 @@ public class RecipientsResolverConfig {
     private String fetchUsersWithMbopToggle;
     private String fetchUsersWithRbacToggle;
     private String useKesselToggle;
-    private String rbacOidcAuthEnabledToggle;
+    private String rbacOidcAuthToggle;
 
     @ConfigProperty(name = UNLEASH, defaultValue = "false")
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
@@ -128,7 +128,7 @@ public class RecipientsResolverConfig {
         fetchUsersWithMbopToggle = toggleRegistry.register("fetch-users-with-mbop", true);
         fetchUsersWithRbacToggle = toggleRegistry.register("fetch-users-with-rbac", true);
         useKesselToggle = toggleRegistry.register("use-kessel", true);
-        rbacOidcAuthEnabledToggle = toggleRegistry.register("rbac-oidc-auth-enabled", true);
+        rbacOidcAuthToggle = toggleRegistry.register("rbac-oidc-auth", true);
     }
 
     void logConfigAtStartup(@Observes Startup event) {
@@ -144,7 +144,7 @@ public class RecipientsResolverConfig {
         config.put(WARN_IF_DURATION_EXCEEDS, getLogTooLongRequestLimit());
         config.put(UNLEASH, unleashEnabled);
         config.put(useKesselToggle, isUseKesselEnabled(null));
-        config.put(rbacOidcAuthEnabledToggle, isRbacOidcAuthEnabled());
+        config.put(rbacOidcAuthToggle, isRbacOidcAuthEnabled());
         config.put(KESSEL_TARGET_URL, getKesselTargetUrl());
         config.put(KESSEL_USE_SECURE_CLIENT, isKesselUseSecureClient());
         config.put(KESSEL_DOMAIN, getKesselDomain());
@@ -181,7 +181,7 @@ public class RecipientsResolverConfig {
 
     public boolean isRbacOidcAuthEnabled() {
         if (unleashEnabled) {
-            return unleash.isEnabled(rbacOidcAuthEnabledToggle, false);
+            return unleash.isEnabled(rbacOidcAuthToggle, false);
         } else {
             return false;
         }

--- a/recipients-resolver/src/main/resources/application.properties
+++ b/recipients-resolver/src/main/resources/application.properties
@@ -44,13 +44,11 @@ quarkus.rest-client.rbac-s2s-oidc.trust-store-type=${clowder.endpoints.rbac-serv
 quarkus.rest-client.rbac-s2s-oidc.connect-timeout=2000
 quarkus.rest-client.rbac-s2s-oidc.read-timeout=120000
 
-# RBAC service-to-service OIDC client configuration (disabled by default)
-# Enable via Unleash feature flag: rbac-oidc-auth-enabled
-quarkus.oidc-client.client-id=insights-notifications
-quarkus.oidc-client.credentials.secret=development-value-123
+# RBAC service-to-service OIDC client configuration
+quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
+quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
+quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
-quarkus.oidc-client.discovery-enabled=false
-quarkus.oidc-client.token-path=/protocol/openid-connect/token
 
 quarkus.log.category."io.quarkus.cache.runtime.caffeine.CaffeineCacheManagerBuilder".level=DEBUG
 


### PR DESCRIPTION
## Summary by Sourcery

Fine-tune the OpenID Connect authentication setup in recipients-resolver by renaming and parameterizing environment variables, updating application properties, and streamlining the RBAC OIDC auth feature toggle.

Enhancements:
- Rename OIDC-related deployment parameters from Quarkus-specific names to generic OIDC_ISSUER and OIDC_CLIENT_ENABLED and drop unused early tokens setting
- Set OIDC_CLIENT_ENABLED default to true and add new OIDC_ISSUER parameter with example value in CI/CD config
- Replace hard-coded OIDC client properties in application.properties with environment variable placeholders for auth-server-url, client-id, and credentials
- Rename the RBAC OIDC authentication feature toggle from rbacOidcAuthEnabled to rbacOidcAuth in configuration and code, and update its usage