### PR TITLE
[RHCLOUD-41295] Use common template module and intant email by default in all envs

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -118,6 +118,8 @@ objects:
           value: ${HOSTNAME}
         - name: NOTIFICATIONS_EMAILS_ONLY_MODE_ENABLED
           value: ${NOTIFICATIONS_EMAILS_ONLY_MODE_ENABLED}
+        - name: NOTIFICATIONS_USE_SECURED_EMAIL_TEMPLATES_ENABLED
+          value: ${NOTIFICATIONS_USE_SECURED_EMAIL_TEMPLATES_ENABLED}
         - name: NOTIFICATIONS_ERRATA_MIGRATION_BATCH_SIZE
           value: ${NOTIFICATIONS_ERRATA_MIGRATION_BATCH_SIZE}
         - name: NOTIFICATIONS_EPHEMERAL_DATA
@@ -275,12 +277,14 @@ parameters:
 - name: MIN_REPLICAS
   value: "3"
 - name: NOTIFICATIONS_INSTANT_EMAILS_ENABLED
-  value: "false"
+  value: "true"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
   value: INFO
 - name: NOTIFICATIONS_EMAILS_ONLY_MODE_ENABLED
   description: When this is true, all integration types except emails are disabled
+  value: "true"
+- name: NOTIFICATIONS_USE_SECURED_EMAIL_TEMPLATES_ENABLED
   value: "true"
 - name: NOTIFICATIONS_ERRATA_MIGRATION_BATCH_SIZE
   description: Defines the number of Errata subscription elements that will be loaded into memory before storing the batch in the database.

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -23,6 +23,7 @@ public class BackendConfig {
      */
     private static final String DEFAULT_TEMPLATE = "notifications.use-default-template";
     private static final String EMAILS_ONLY_MODE = "notifications.emails-only-mode.enabled";
+    private static final String SECURED_EMAIL_TEMPLATES = "notifications.use-secured-email-templates.enabled";
     private static final String ERRATA_MIGRATION_BATCH_SIZE = "notifications.errata.migration.batch.size";
     private static final String INSTANT_EMAILS = "notifications.instant-emails.enabled";
     private static final String KESSEL_INVENTORY_CLIENT_ID = "inventory-api.authn.client.id";
@@ -115,6 +116,10 @@ public class BackendConfig {
     @ConfigProperty(name = KESSEL_RELATIONS_URL, defaultValue = "localhost:9000")
     String kesselRelationsUrl;
 
+    // Only used in special environments.
+    @ConfigProperty(name = SECURED_EMAIL_TEMPLATES, defaultValue = "false")
+    boolean useSecuredEmailTemplates;
+
     @Inject
     ToggleRegistry toggleRegistry;
 
@@ -149,6 +154,7 @@ public class BackendConfig {
         config.put(INSTANT_EMAILS, isInstantEmailsEnabled());
         config.put(KESSEL_DOMAIN, getKesselDomain());
         config.put(RBAC_ENABLED, isRBACEnabled());
+        config.put(SECURED_EMAIL_TEMPLATES, useSecuredEmailTemplates);
         config.put(UNLEASH, unleashEnabled);
 
         Log.info("=== Startup configuration ===");
@@ -258,9 +264,9 @@ public class BackendConfig {
 
     public boolean isUseCommonTemplateModuleForUserPrefApisToggle() {
         if (unleashEnabled) {
-            return unleash.isEnabled(useCommonTemplateModuleForUserPrefApisToggle, false);
+            return unleash.isEnabled(useCommonTemplateModuleForUserPrefApisToggle, true);
         } else {
-            return false;
+            return true;
         }
     }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -342,9 +342,9 @@ public class EngineConfig {
 
     public boolean isUseCommonTemplateModuleToRenderEmailsEnabled() {
         if (unleashEnabled) {
-            return unleash.isEnabled(toggleUseCommonTemplateModuleToRenderEmailsEnabled, false);
+            return unleash.isEnabled(toggleUseCommonTemplateModuleToRenderEmailsEnabled, true);
         } else {
-            return false;
+            return true;
         }
     }
 


### PR DESCRIPTION
## Please review [RHCLOUD-41295](https://issues.redhat.com/browse/RHCLOUD-41295) description before merging it



## Summary by Sourcery

Introduce a secure email templates toggle, enable instant emails by default, and default on the common template module for both user preference APIs and email rendering, updating environment configurations accordingly.

New Features:
- Add 'useSecuredEmailTemplates' configuration toggle for secured email templates

Enhancements:
- Enable instant emails by default across all environments
- Default the common template module on for user preference APIs
- Default the common template module on for email rendering

Deployment:
- Expose the secure email templates toggle and default settings in clowdapp-backend.yaml environment variables