### PR TITLE
RHCLOUD-40799 Authenticate with Sources using OIDC (backend)

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -53,6 +53,7 @@ public class BackendConfig {
     private String ignoreSourcesErrorOnEndpointDeleteToggle;
     private String useCommonTemplateModuleForUserPrefApisToggle;
     private String rbacOidcAuthToggle;
+    private String sourcesOidcAuthToggle;
 
     private static String toggleName(String feature) {
         return String.format("notifications-backend.%s.enabled", feature);
@@ -139,6 +140,7 @@ public class BackendConfig {
         kesselInventoryUseForPermissionsChecksToggle = toggleRegistry.register("kessel-inventory-permissions-checks", true);
         useCommonTemplateModuleForUserPrefApisToggle = toggleRegistry.register("use-common-template-module-for-user-pref-apis", true);
         rbacOidcAuthToggle = toggleRegistry.register("rbac-oidc-auth", true);
+        sourcesOidcAuthToggle = toggleRegistry.register("sources-oidc-auth", true);
     }
 
     void logConfigAtStartup(@Observes Startup event) {
@@ -159,6 +161,7 @@ public class BackendConfig {
         config.put(SECURED_EMAIL_TEMPLATES, useSecuredEmailTemplates);
         config.put(UNLEASH, unleashEnabled);
         config.put(rbacOidcAuthToggle, isRbacOidcAuthEnabled(null));
+        config.put(sourcesOidcAuthToggle, isSourcesOidcAuthEnabled(null));
 
         Log.info("=== Startup configuration ===");
         config.forEach((key, value) -> {
@@ -324,6 +327,15 @@ public class BackendConfig {
         if (unleashEnabled) {
             UnleashContext unleashContext = buildUnleashContextWithOrgId(orgId);
             return unleash.isEnabled(rbacOidcAuthToggle, unleashContext, false);
+        } else {
+            return false;
+        }
+    }
+
+    public boolean isSourcesOidcAuthEnabled(String orgId) {
+        if (unleashEnabled) {
+            UnleashContext unleashContext = buildUnleashContextWithOrgId(orgId);
+            return unleash.isEnabled(sourcesOidcAuthToggle, unleashContext, false);
         } else {
             return false;
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesOidcService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesOidcService.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.routers.sources;
 
 import com.redhat.cloud.notifications.Constants;
+import io.quarkus.oidc.client.filter.OidcClientFilter;
 import io.quarkus.rest.client.reactive.ClientExceptionMapper;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.ws.rs.DELETE;
@@ -16,7 +17,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.resteasy.reactive.RestPath;
 
 /**
- * <p>REST Client for the Sources API. The OpenAPI spec is available at:</p>
+ * <p>OIDC-enabled REST Client for the Sources API. The OpenAPI spec is available at:</p>
  *
  * <ul>
  *  <li><a href="https://console.stage.redhat.com/docs/api/sources/v3.1">OpenApi v3.1 in the stage environment.</a></li>
@@ -31,18 +32,18 @@ import org.jboss.resteasy.reactive.RestPath;
  *     <li>On the other hand, if sources is using the AWS Secrets Manager, then the whole secret will get encrypted.</li>
  * </ul>
  *
- * <p>The authentication to Sources works by using a service-to-service PSK that will be sent in the header that
- * Sources expects. At the same time, the organization id will be sent so that Sources knows to which tenants belongs
- * the operation that is going to be performed.</p>
+ * <p>The authentication to Sources works by using OIDC client credentials to obtain a bearer token that will be sent
+ * in the Authorization header. At the same time, the organization id will be sent so that Sources knows to which
+ * tenants belongs the operation that is going to be performed.</p>
  */
-@RegisterRestClient(configKey = "sources")
-public interface SourcesService {
+@RegisterRestClient(configKey = "sources-oidc")
+@OidcClientFilter
+public interface SourcesOidcService {
 
     /**
      * Get a single secret from Sources. In this case we need to hit the internal endpoint —which is only available for
      * requests coming from inside the cluster— to be able to get the password of these secrets.
      * @param xRhSourcesOrgId the organization id related to this operation for the tenant identification.
-     * @param xRhSourcesPsk the sources PSK required for the authorization.
      * @param id the secret id.
      * @return a {@link Secret} instance.
      */
@@ -51,14 +52,12 @@ public interface SourcesService {
     @Retry(maxRetries = 3)
     Secret getById(
         @HeaderParam(Constants.X_RH_SOURCES_ORG_ID) @NotBlank String xRhSourcesOrgId,
-        @HeaderParam(Constants.X_RH_SOURCES_PSK) @NotBlank String xRhSourcesPsk,
         @RestPath long id
     );
 
     /**
      * Create a secret on the Sources backend.
      * @param xRhSourcesOrgId the organization id related to this operation for the tenant identification.
-     * @param xRhSourcesPsk the sources PSK required for the authorization.
      * @param secret the {@link Secret} to be created.
      * @return the created secret.
      */
@@ -67,14 +66,12 @@ public interface SourcesService {
     @Retry(maxRetries = 3)
     Secret create(
         @HeaderParam(Constants.X_RH_SOURCES_ORG_ID) @NotBlank String xRhSourcesOrgId,
-        @HeaderParam(Constants.X_RH_SOURCES_PSK) @NotBlank String xRhSourcesPsk,
         Secret secret
     );
 
     /**
      * Update a secret on the Sources backend.
      * @param xRhSourcesOrgId the organization id related to this operation for the tenant identification.
-     * @param xRhSourcesPsk the sources PSK required for the authorization.
      * @param secret the {@link Secret} to be updated.
      * @return the updated secret.
      */
@@ -83,7 +80,6 @@ public interface SourcesService {
     @Retry(maxRetries = 3)
     Secret update(
         @HeaderParam(Constants.X_RH_SOURCES_ORG_ID) @NotBlank String xRhSourcesOrgId,
-        @HeaderParam(Constants.X_RH_SOURCES_PSK) String xRhSourcesPsk,
         @RestPath long id,
         Secret secret
     );
@@ -91,7 +87,6 @@ public interface SourcesService {
     /**
      * Delete a secret on the Sources backend.
      * @param xRhSourcesOrgId the organization id related to this operation for the tenant identification.
-     * @param xRhSourcesPsk the sources PSK required for the authorization.
      * @param id the id of the {@link Secret} to be deleted.
      */
     @DELETE
@@ -99,7 +94,6 @@ public interface SourcesService {
     @Retry(maxRetries = 3)
     void delete(
         @HeaderParam(Constants.X_RH_SOURCES_ORG_ID) @NotBlank String xRhSourcesOrgId,
-        @HeaderParam(Constants.X_RH_SOURCES_PSK) String xRhSourcesPsk,
         @RestPath long id
     );
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesPskService.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/sources/SourcesPskService.java
@@ -1,0 +1,117 @@
+package com.redhat.cloud.notifications.routers.sources;
+
+import com.redhat.cloud.notifications.Constants;
+import io.quarkus.rest.client.reactive.ClientExceptionMapper;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.reactive.RestPath;
+
+/**
+ * <p>PSK-based REST Client for the Sources API. The OpenAPI spec is available at:</p>
+ *
+ * <ul>
+ *  <li><a href="https://console.stage.redhat.com/docs/api/sources/v3.1">OpenApi v3.1 in the stage environment.</a></li>
+ *  <li><a href="https://console.redhat.com/docs/api/sources/v3.1">OpenApi v3.1 in the production environment.</a></li>
+ *  <li><a href="https://github.com/RedHatInsights/sources-api-go/blob/main/public/openapi-3-v3.1.json">OpenApi v3.1 JSON file on GitHub.</a></li>
+ * </ul>
+ *
+ * <p>Please be aware of the following:</p>
+ *
+ * <ul>
+ *     <li>If sources is using a database backend, only the {@link Secret#password} field will get encrypted.</li>
+ *     <li>On the other hand, if sources is using the AWS Secrets Manager, then the whole secret will get encrypted.</li>
+ * </ul>
+ *
+ * <p>The authentication to Sources works by using a service-to-service PSK that will be sent in the header that
+ * Sources expects. At the same time, the organization id will be sent so that Sources knows to which tenants belongs
+ * the operation that is going to be performed.</p>
+ */
+@RegisterRestClient(configKey = "sources")
+public interface SourcesPskService {
+
+    /**
+     * Get a single secret from Sources. In this case we need to hit the internal endpoint —which is only available for
+     * requests coming from inside the cluster— to be able to get the password of these secrets.
+     * @param xRhSourcesOrgId the organization id related to this operation for the tenant identification.
+     * @param xRhSourcesPsk the sources PSK required for the authorization.
+     * @param id the secret id.
+     * @return a {@link Secret} instance.
+     */
+    @GET
+    @Path("/internal/v2.0/secrets/{id}")
+    @Retry(maxRetries = 3)
+    Secret getById(
+        @HeaderParam(Constants.X_RH_SOURCES_ORG_ID) @NotBlank String xRhSourcesOrgId,
+        @HeaderParam(Constants.X_RH_SOURCES_PSK) @NotBlank String xRhSourcesPsk,
+        @RestPath long id
+    );
+
+    /**
+     * Create a secret on the Sources backend.
+     * @param xRhSourcesOrgId the organization id related to this operation for the tenant identification.
+     * @param xRhSourcesPsk the sources PSK required for the authorization.
+     * @param secret the {@link Secret} to be created.
+     * @return the created secret.
+     */
+    @Path("/api/sources/v3.1/secrets")
+    @POST
+    @Retry(maxRetries = 3)
+    Secret create(
+        @HeaderParam(Constants.X_RH_SOURCES_ORG_ID) @NotBlank String xRhSourcesOrgId,
+        @HeaderParam(Constants.X_RH_SOURCES_PSK) @NotBlank String xRhSourcesPsk,
+        Secret secret
+    );
+
+    /**
+     * Update a secret on the Sources backend.
+     * @param xRhSourcesOrgId the organization id related to this operation for the tenant identification.
+     * @param xRhSourcesPsk the sources PSK required for the authorization.
+     * @param secret the {@link Secret} to be updated.
+     * @return the updated secret.
+     */
+    @Path("/api/sources/v3.1/secrets/{id}")
+    @PATCH
+    @Retry(maxRetries = 3)
+    Secret update(
+        @HeaderParam(Constants.X_RH_SOURCES_ORG_ID) @NotBlank String xRhSourcesOrgId,
+        @HeaderParam(Constants.X_RH_SOURCES_PSK) String xRhSourcesPsk,
+        @RestPath long id,
+        Secret secret
+    );
+
+    /**
+     * Delete a secret on the Sources backend.
+     * @param xRhSourcesOrgId the organization id related to this operation for the tenant identification.
+     * @param xRhSourcesPsk the sources PSK required for the authorization.
+     * @param id the id of the {@link Secret} to be deleted.
+     */
+    @DELETE
+    @Path("/api/sources/v3.1/secrets/{id}")
+    @Retry(maxRetries = 3)
+    void delete(
+        @HeaderParam(Constants.X_RH_SOURCES_ORG_ID) @NotBlank String xRhSourcesOrgId,
+        @HeaderParam(Constants.X_RH_SOURCES_PSK) String xRhSourcesPsk,
+        @RestPath long id
+    );
+
+    /**
+     * Throws a runtime exception with the client's response for an easier debugging.
+     * @param response the received response from Sources.
+     * @return the {@link RuntimeException} to be thrown.
+     */
+    @ClientExceptionMapper
+    static RuntimeException toException(final Response response) {
+        final var errMessage = String.format("Sources responded with a %s status: %s", response.getStatus(), response.readEntity(String.class));
+
+        throw new WebApplicationException(errMessage, response);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -105,6 +105,13 @@ quarkus.rest-client.sources.trust-store=${clowder.endpoints.sources-api-svc.trus
 quarkus.rest-client.sources.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
 quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
+# Sources OIDC integration configuration for OIDC-based authentication
+quarkus.rest-client.sources-oidc.read-timeout=1000
+quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
+quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
+quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
+quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
+
 # OpenTelemetry -- see also jdbc driver above.
 quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317
 quarkus.otel.sdk.disabled=true

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/OidcServerMockResource.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/OidcServerMockResource.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.auth.rbac.workspace;
+package com.redhat.cloud.notifications.auth;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.mockserver.integration.ClientAndServer;

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/rbac/workspace/RbacServerMockResource.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/rbac/workspace/RbacServerMockResource.java
@@ -1,8 +1,10 @@
 package com.redhat.cloud.notifications.auth.rbac.workspace;
 
+import com.redhat.cloud.notifications.auth.OidcServerMockResource;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.MediaType;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/rbac/workspace/RbacWorkspacesOidcClientTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/rbac/workspace/RbacWorkspacesOidcClientTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.auth.rbac.workspace;
 
+import com.redhat.cloud.notifications.auth.OidcServerMockResource;
 import com.redhat.cloud.notifications.auth.rbac.RbacWorkspacesOidcClient;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;

--- a/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -29,7 +29,7 @@ import com.redhat.cloud.notifications.routers.internal.models.RequestDefaultBeha
 import com.redhat.cloud.notifications.routers.models.RequestSystemSubscriptionProperties;
 import com.redhat.cloud.notifications.routers.models.SettingsValuesByEventType;
 import com.redhat.cloud.notifications.routers.sources.Secret;
-import com.redhat.cloud.notifications.routers.sources.SourcesService;
+import com.redhat.cloud.notifications.routers.sources.SourcesPskService;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -119,7 +119,7 @@ public class LifecycleITest extends DbIsolatedTest {
      */
     @InjectMock
     @RestClient
-    SourcesService sourcesServiceMock;
+    SourcesPskService sourcesServiceMock;
 
     @BeforeEach
     void beforeEach() {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
@@ -43,7 +43,7 @@ import com.redhat.cloud.notifications.routers.engine.EndpointTestService;
 import com.redhat.cloud.notifications.routers.models.EndpointPage;
 import com.redhat.cloud.notifications.routers.models.RequestSystemSubscriptionProperties;
 import com.redhat.cloud.notifications.routers.sources.Secret;
-import com.redhat.cloud.notifications.routers.sources.SourcesService;
+import com.redhat.cloud.notifications.routers.sources.SourcesPskService;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.quarkus.logging.Log;
@@ -211,7 +211,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
      */
     @InjectMock
     @RestClient
-    SourcesService sourcesServiceMock;
+    SourcesPskService sourcesServiceMock;
 
     /**
      * Mocked RBAC's workspace utilities so that the {@link KesselTestHelper}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SecretUtilsTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SecretUtilsTest.java
@@ -22,7 +22,7 @@ public class SecretUtilsTest {
 
     @InjectMock
     @RestClient
-    SourcesService sourcesServiceMock;
+    SourcesPskService sourcesServiceMock;
 
     @Inject
     SecretUtils secretUtils;

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SourcesOidcServiceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SourcesOidcServiceTest.java
@@ -1,0 +1,175 @@
+package com.redhat.cloud.notifications.routers.sources;
+
+import com.redhat.cloud.notifications.auth.OidcServerMockResource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * <p>Integration test suite for {@link SourcesOidcService} that validates OIDC (OpenID Connect)
+ * client credentials authentication is properly implemented and functioning.</p>
+ *
+ * <p><strong>Test Objectives:</strong></p>
+ * <ul>
+ *   <li>Verify that {@code @OidcClientFilter} annotation automatically injects bearer tokens</li>
+ *   <li>Ensure all HTTP requests include the correct {@code Authorization: Bearer <token>} header</li>
+ *   <li>Validate that OIDC authentication works across all CRUD operations (GET, POST, PUT, DELETE)</li>
+ *   <li>Confirm proper integration between Quarkus OIDC client and Sources API endpoints</li>
+ * </ul>
+ *
+ * <p><strong>Mock Setup:</strong></p>
+ * <ul>
+ *   <li>{@link OidcServerMockResource} - Simulates an OIDC provider that issues access tokens</li>
+ *   <li>{@link SourcesServerMockResource} - Simulates the Sources API with authorization validation</li>
+ * </ul>
+ *
+ * <p><strong>Authentication Flow Tested:</strong></p>
+ * <ol>
+ *   <li>SourcesOidcService method is called</li>
+ *   <li>@OidcClientFilter intercepts the request</li>
+ *   <li>Filter obtains access token from mock OIDC server</li>
+ *   <li>Filter adds "Authorization: Bearer <token>" header to request</li>
+ *   <li>Mock Sources API validates the bearer token and responds accordingly</li>
+ * </ol>
+ *
+ * <p><strong>Test Validation Strategy:</strong><br>
+ * The mock Sources API returns HTTP 401 (Unauthorized) for requests missing or containing
+ * invalid authorization headers, and HTTP 2xx for requests with valid bearer tokens.
+ * Successful test execution without exceptions indicates OIDC authentication is working.</p>
+ */
+@QuarkusTest
+@QuarkusTestResource(OidcServerMockResource.class) // Provides mock OIDC server for token generation
+@QuarkusTestResource(SourcesServerMockResource.class) // Provides mock Sources API with auth validation
+public class SourcesOidcServiceTest {
+
+    @Inject
+    @RestClient
+    SourcesOidcService sourcesOidcService;
+
+    private static final String TEST_ORG_ID = "test-org-id";
+
+    /**
+     * <p>Tests the {@code getById} operation with OIDC authentication.</p>
+     *
+     * <p><strong>OIDC Behavior Tested:</strong></p>
+     * <ul>
+     *   <li>@OidcClientFilter automatically obtains an access token from the mock OIDC server</li>
+     *   <li>Filter injects "Authorization: Bearer <token>" header into the GET request</li>
+     *   <li>Mock Sources API validates the bearer token before returning secret data</li>
+     * </ul>
+     *
+     * <p><strong>Success Criteria:</strong><br>
+     * No exception is thrown and a valid {@link Secret} object is returned with the expected ID
+     * and password, confirming that OIDC authentication headers were properly included.</p>
+     *
+     * <p><strong>Failure Scenario:</strong><br>
+     * If OIDC authentication fails (missing/invalid token), the mock Sources API returns
+     * HTTP 401, causing this test to fail with a WebApplicationException.</p>
+     */
+    @Test
+    @DisplayName("Should successfully call getById with OIDC authentication")
+    void shouldSuccessfullyCallGetById() {
+        // Execute the getById operation - OIDC filter should automatically add auth header
+        var result = assertDoesNotThrow(() -> sourcesOidcService.getById(TEST_ORG_ID, 123L));
+
+        // Validate that the request succeeded with proper OIDC authentication
+        assertNotNull(result, "Secret should be returned when OIDC authentication succeeds");
+        assertEquals(123L, result.id, "Returned secret should have the requested ID");
+        assertEquals("test-password", result.password, "Mock server should return expected password");
+    }
+
+    /**
+     * <p>Tests the {@code create} operation with OIDC authentication.</p>
+     *
+     * <p><strong>OIDC Behavior Tested:</strong></p>
+     * <ul>
+     *   <li>@OidcClientFilter automatically adds bearer token to POST request</li>
+     *   <li>Authorization header enables successful creation of new secrets</li>
+     *   <li>Mock Sources API validates token before processing the creation request</li>
+     * </ul>
+     *
+     * <p><strong>Test Scenario:</strong><br>
+     * Creates a new secret with authentication type 'secret_token' and validates that
+     * the creation succeeds with proper OIDC authentication headers.</p>
+     */
+    @Test
+    @DisplayName("Should successfully call create with OIDC authentication")
+    void shouldSuccessfullyCallCreate() {
+        // Prepare a new secret for creation
+        Secret secret = new Secret();
+        secret.password = "new-secret";
+        secret.authenticationType = Secret.TYPE_SECRET_TOKEN;
+
+        // Execute the create operation - OIDC filter should automatically add auth header
+        var result = assertDoesNotThrow(() -> sourcesOidcService.create(TEST_ORG_ID, secret));
+
+        // Validate that the creation succeeded with proper OIDC authentication
+        assertNotNull(result, "Created secret should be returned when OIDC authentication succeeds");
+        assertEquals(456L, result.id, "Mock server should assign expected ID to new secret");
+        assertEquals("new-secret", result.password, "Created secret should retain the provided password");
+    }
+
+    /**
+     * <p>Tests the {@code update} operation with OIDC authentication.</p>
+     *
+     * <p><strong>OIDC Behavior Tested:</strong></p>
+     * <ul>
+     *   <li>@OidcClientFilter automatically adds bearer token to PUT request</li>
+     *   <li>Authorization header enables successful modification of existing secrets</li>
+     *   <li>Mock Sources API validates token before processing the update request</li>
+     * </ul>
+     *
+     * <p><strong>Test Scenario:</strong><br>
+     * Updates an existing secret's password and validates that the update succeeds
+     * with proper OIDC authentication headers.</p>
+     */
+    @Test
+    @DisplayName("Should successfully call update with OIDC authentication")
+    void shouldSuccessfullyCallUpdate() {
+        // Prepare updated secret data
+        Secret secret = new Secret();
+        secret.password = "updated-secret";
+
+        // Execute the update operation - OIDC filter should automatically add auth header
+        var result = assertDoesNotThrow(() -> sourcesOidcService.update(TEST_ORG_ID, 123L, secret));
+
+        // Validate that the update succeeded with proper OIDC authentication
+        assertNotNull(result, "Updated secret should be returned when OIDC authentication succeeds");
+        assertEquals(123L, result.id, "Updated secret should retain the original ID");
+        assertEquals("updated-secret", result.password, "Secret should have the updated password");
+    }
+
+    /**
+     * <p>Tests the {@code delete} operation with OIDC authentication.</p>
+     *
+     * <p><strong>OIDC Behavior Tested:</strong></p>
+     * <ul>
+     *   <li>@OidcClientFilter automatically adds bearer token to DELETE request</li>
+     *   <li>Authorization header enables successful deletion of secrets</li>
+     *   <li>Mock Sources API validates token before processing the deletion request</li>
+     * </ul>
+     *
+     * <p><strong>Success Criteria:</strong><br>
+     * No exception is thrown and the method completes successfully, indicating that
+     * the mock Sources API accepted the deletion request with valid OIDC authentication.</p>
+     *
+     * <p><strong>Note:</strong><br>
+     * DELETE operations typically return HTTP 204 (No Content) on success, so we only
+     * validate that no authorization-related exceptions are thrown.</p>
+     */
+    @Test
+    @DisplayName("Should successfully call delete with OIDC authentication")
+    void shouldSuccessfullyCallDelete() {
+        // Execute the delete operation - OIDC filter should automatically add auth header
+        // Success is indicated by no exception being thrown (mock returns 204 for valid auth)
+        assertDoesNotThrow(() -> sourcesOidcService.delete(TEST_ORG_ID, 123L),
+                "Delete operation should succeed when OIDC authentication is properly configured");
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SourcesServerMockResource.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/sources/SourcesServerMockResource.java
@@ -1,0 +1,159 @@
+package com.redhat.cloud.notifications.routers.sources;
+
+import com.redhat.cloud.notifications.auth.OidcServerMockResource;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+public class SourcesServerMockResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final String LOG_LEVEL_KEY = "mockserver.logLevel";
+    private static ClientAndServer clientAndServer;
+
+    @Override
+    public Map<String, String> start() {
+
+        setMockServerLogLevel();
+
+        clientAndServer = startClientAndServer();
+        String serverUrl = "http://localhost:" + clientAndServer.getPort();
+
+        setupMockExpectations();
+
+        Map<String, String> config = new HashMap<>();
+        config.put("quarkus.rest-client.sources-oidc.url", serverUrl);
+
+        System.out.println("Sources server mock started");
+
+        return config;
+    }
+
+    private static void setMockServerLogLevel() {
+        if (System.getProperty(LOG_LEVEL_KEY) == null) {
+            System.setProperty(LOG_LEVEL_KEY, "OFF");
+            System.out.println("MockServer log is disabled. Use '-D" + LOG_LEVEL_KEY + "=WARN|INFO|DEBUG|TRACE' to enable it.");
+        }
+    }
+
+    private static void setupMockExpectations() {
+
+        // Mock Sources endpoints - Return 200 for correct Authorization header, 401 otherwise
+
+        // Mock Sources getById endpoint - Success case
+        clientAndServer.when(
+            request()
+                .withMethod("GET")
+                .withPath("/internal/v2.0/secrets/123")
+                .withHeader("Authorization", "Bearer " + OidcServerMockResource.TEST_ACCESS_TOKEN)
+                .withHeader("x-rh-sources-org-id", "test-org-id")
+        ).respond(
+            response()
+                .withStatusCode(200)
+                .withContentType(MediaType.APPLICATION_JSON)
+                .withBody("""
+                    {
+                      "id": 123,
+                      "password": "test-password",
+                      "authtype": "notifications-secret-token"
+                    }
+                    """)
+        );
+
+        // Mock Sources create endpoint - Success case
+        clientAndServer.when(
+            request()
+                .withMethod("POST")
+                .withPath("/api/sources/v3.1/secrets")
+                .withHeader("Authorization", "Bearer " + OidcServerMockResource.TEST_ACCESS_TOKEN)
+                .withHeader("x-rh-sources-org-id", "test-org-id")
+        ).respond(
+            response()
+                .withStatusCode(201)
+                .withContentType(MediaType.APPLICATION_JSON)
+                .withBody("""
+                    {
+                      "id": 456,
+                      "password": "new-secret",
+                      "authtype": "notifications-secret-token"
+                    }
+                    """)
+        );
+
+        // Mock Sources update endpoint - Success case
+        clientAndServer.when(
+            request()
+                .withMethod("PATCH")
+                .withPath("/api/sources/v3.1/secrets/123")
+                .withHeader("Authorization", "Bearer " + OidcServerMockResource.TEST_ACCESS_TOKEN)
+                .withHeader("x-rh-sources-org-id", "test-org-id")
+        ).respond(
+            response()
+                .withStatusCode(200)
+                .withContentType(MediaType.APPLICATION_JSON)
+                .withBody("""
+                    {
+                      "id": 123,
+                      "password": "updated-secret",
+                      "authtype": "notifications-secret-token"
+                    }
+                    """)
+        );
+
+        // Mock Sources delete endpoint - Success case
+        clientAndServer.when(
+            request()
+                .withMethod("DELETE")
+                .withPath("/api/sources/v3.1/secrets/123")
+                .withHeader("Authorization", "Bearer " + OidcServerMockResource.TEST_ACCESS_TOKEN)
+                .withHeader("x-rh-sources-org-id", "test-org-id")
+        ).respond(
+            response()
+                .withStatusCode(204)
+        );
+
+        // Mock unauthorized responses for requests without proper Authorization header
+        // This will catch any request without the correct Bearer token
+        clientAndServer.when(
+            request()
+                .withPath("/internal/v2.0/secrets/.*")
+        ).respond(
+            response()
+                .withStatusCode(401)
+                .withContentType(MediaType.APPLICATION_JSON)
+                .withBody("""
+                    {
+                      "error": "Unauthorized"
+                    }
+                    """)
+        );
+
+        clientAndServer.when(
+            request()
+                .withPath("/api/sources/v3.1/secrets/.*")
+        ).respond(
+            response()
+                .withStatusCode(401)
+                .withContentType(MediaType.APPLICATION_JSON)
+                .withBody("""
+                    {
+                      "error": "Unauthorized"
+                    }
+                    """)
+        );
+    }
+
+    @Override
+    public void stop() {
+        if (clientAndServer != null) {
+            clientAndServer.stop();
+            System.out.println("Sources server mock stopped");
+        }
+    }
+}


### PR DESCRIPTION
Assisted-by: Claude-4-Sonnet (via Cursor)

This PR contains preparation work for the near future. Sources does not support OIDC authentication yet but when it will, `notifications-backend` will be immediately ready to use it with no changes in the codebase.

## Summary by Sourcery

Introduce optional OIDC-based authentication for Sources API secret management alongside existing PSK authentication, controlled by a feature toggle.

New Features:
- Add SourcesOidcService as a new REST client for OIDC authentication.
- Support switching between PSK and OIDC authentication based on a new "sources-oidc-auth" feature toggle.

Enhancements:
- Refactor SecretUtils to delegate secret create, fetch, update, and delete operations to either SourcesPskService or SourcesOidcService depending on the feature toggle.
- Add configuration properties for the OIDC rest client and register the new toggle in BackendConfig.

Tests:
- Add unit tests (SecretUtilsOidcTest) to verify client selection logic for PSK vs OIDC.
- Add integration tests (SourcesOidcServiceTest) with mock servers for OIDC and Sources endpoints.
- Introduce Quarkus test resources (SourcesServerMockResource and SourcesOidcServerMockResource) to simulate authenticated endpoints.

Chores:
- Rename SourcesService to SourcesPskService to distinguish from the new OIDC client.

## Summary by Sourcery

Prepare notifications-backend to support future OIDC-based authentication with Sources by introducing an OIDC REST client, integrating a feature toggle, updating secret management flows, and covering the changes with comprehensive tests.

New Features:
- Add SourcesOidcService and a feature toggle to support optional OIDC authentication alongside PSK for Sources API.

Enhancements:
- Refactor SecretUtils to delegate secret CRUD operations to either PSK or OIDC client based on the new toggle and update BackendConfig with OIDC client settings.

Tests:
- Add unit tests for secret client selection logic and integration tests with mock OIDC and Sources servers to verify OIDC authentication across all CRUD operations.

Chores:
- Rename existing SourcesService to SourcesPskService to distinguish the PSK client from the new OIDC client.