### PR TITLE
[RHCLOUD-40134] Move email template tests

### DIFF
--- a/common-template/pom.xml
+++ b/common-template/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>quarkus-rest-jackson</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mailer</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common-template/src/test/java/email/EmailTemplatesRendererHelper.java
+++ b/common-template/src/test/java/email/EmailTemplatesRendererHelper.java
@@ -1,0 +1,250 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.qute.templates.IntegrationType;
+import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
+import com.redhat.cloud.notifications.qute.templates.TemplateService;
+import email.pojo.DailyDigestSection;
+import email.pojo.EmailPendo;
+import email.pojo.Environment;
+import io.quarkus.logging.Log;
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.Mailer;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import io.vertx.core.json.JsonObject;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static org.mockito.Mockito.when;
+
+public abstract class EmailTemplatesRendererHelper {
+
+    protected static final String BUNDLE_RHEL = "rhel";
+
+    protected static final String COMMON_SECURED_LABEL_CHECK = "common template for secured env";
+
+    private static final boolean SHOULD_WRITE_ON_FILE_FOR_DEBUG = true;
+    private static final boolean SHOULD_SEND_EMAIL_FOR_DEBUG = false;
+
+    private static final String SEND_EMAIL_TO = "test.email@replace.me";
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Inject
+    Mailer mailer;
+
+    @Inject
+    Environment environment;
+
+    @InjectSpy
+    protected TemplateService templateService;
+
+    protected String eventTypeDisplayName;
+
+    @BeforeEach
+    protected void initData() {
+        when(templateService.isSecuredEmailTemplatesEnabled()).thenReturn(useSecuredTemplates());
+        templateService.init();
+    }
+
+    @AfterEach
+    protected void afterEach() {
+        when(templateService.isSecuredEmailTemplatesEnabled()).thenReturn(false);
+        templateService.init();
+    }
+
+    protected String generateEmailSubject(String eventTypeStr, Action action) {
+        TemplateDefinition templateDefinition = new TemplateDefinition(IntegrationType.EMAIL_TITLE, getBundle(), getApp(), eventTypeStr);
+        return generateEmail(templateDefinition, action, null);
+    }
+
+    protected String generateEmailBody(String eventTypeStr, Action action) {
+        return generateEmailBody(eventTypeStr, action, null, false);
+    }
+
+    protected String generateEmailBody(String eventTypeStr, Action event, EmailPendo pendo, boolean ignoreUserPreferences) {
+        TemplateDefinition templateDefinition = new TemplateDefinition(IntegrationType.EMAIL_BODY, getBundle(), getApp(), eventTypeStr);
+        return generateEmail(templateDefinition, event, pendo, ignoreUserPreferences);
+    }
+
+    protected String generateAggregatedEmailBody(String jsonContext) throws JsonProcessingException {
+        return generateAggregatedEmailBody(objectMapper.readValue(jsonContext, new TypeReference<Map<String, Object>>() { }));
+    }
+
+    protected String generateAggregatedEmailBody(Map<String, Object> context) {
+        return generateAggregatedEmailBody(context, null);
+    }
+
+    protected String generateAggregatedEmailBody(Map<String, Object> originalContext, EmailPendo emailPendo) {
+        TemplateDefinition templateDefinition = new TemplateDefinition(IntegrationType.EMAIL_DAILY_DIGEST_BODY, getBundle(), getApp(), null, true);
+        Map<String, Object> context = new HashMap<>(originalContext); // to patch immutable maps from individual test cases
+        context.put("application", getApp());
+
+        String applicationSectionResult = generateEmailFromContextMap(templateDefinition, context, emailPendo);
+        String titleData = applicationSectionResult.split("<!-- Body section -->")[0];
+        // Some application daily template such as Inventory can contain several sections
+        // each section have a "Jump to details" link that have to be added in the top of aggregated daily digest email
+        String[] sections = titleData.split("<!-- next section -->");
+
+        DailyDigestSection dailyDigestSection = new DailyDigestSection(
+            applicationSectionResult.split("<!-- Body section -->")[1],
+            Arrays.stream(sections).filter(e -> !e.isBlank()).toList());
+
+        Map<String, Object> mapData = Map.of("title", "Daily digest - Red Hat Enterprise Linux", "items", List.of(dailyDigestSection), "orgId", DEFAULT_ORG_ID);
+        TemplateDefinition globalDailyTemplateDefinition = new TemplateDefinition(IntegrationType.EMAIL_DAILY_DIGEST_BUNDLE_AGGREGATION_BODY, null, null, null);
+        return generateEmailFromContextMap(globalDailyTemplateDefinition, mapData, emailPendo);
+    }
+
+    protected String generateAggregatedEmailBody(Action action) {
+        return generateAggregatedEmailBody(templateService.convertActionToContextMap(action), null);
+    }
+
+    protected String generateEmail(TemplateDefinition templateDefinition, Action action, EmailPendo pendo) {
+        return generateEmail(templateDefinition, action, pendo, false);
+    }
+
+    protected String generateEmail(TemplateDefinition templateDefinition, Object action, EmailPendo emailPendo, boolean ignoreUserPreferences) {
+        Map<String, Object> additionalContext = new HashMap<>();
+        additionalContext.put("environment", environment);
+        additionalContext.put("pendo_message", emailPendo);
+        additionalContext.put("ignore_user_preferences", ignoreUserPreferences);
+        additionalContext.put("action", action);
+        additionalContext.put("source", getSourceEntry());
+
+        String result = templateService.renderTemplateWithCustomDataMap(templateDefinition, additionalContext);
+        writeOrSendEmailTemplate(result, templateService.getTemplateId(templateDefinition) + ".html");
+        return result;
+    }
+
+    protected String generateEmailFromContextMap(TemplateDefinition templateDefinition, Map<String, Object> context, EmailPendo emailPendo) {
+        Map<String, Object> action =  Map.of("context", context, "bundle", getBundle(), "timestamp", LocalDateTime.now());
+
+        Map<String, Object> additionalContext = new HashMap<>();
+        additionalContext.put("environment", environment);
+        additionalContext.put("pendo_message", emailPendo);
+        additionalContext.put("ignore_user_preferences", false);
+        additionalContext.put("action", action);
+
+        String result = templateService.renderTemplateWithCustomDataMap(templateDefinition, additionalContext);
+
+        writeOrSendEmailTemplate(result, templateService.getTemplateId(templateDefinition) + ".html");
+
+        return result;
+    }
+
+    private JsonObject getSourceEntry() {
+        // JSON property names' definition.
+        final String APPLICATION = "application";
+        final String BUNDLE = "bundle";
+        final String DISPLAY_NAME = "display_name";
+        final String EVENT_TYPE = "event_type";
+
+        final JsonObject source = new JsonObject();
+
+        final JsonObject sourceAppDisplayName = new JsonObject();
+        sourceAppDisplayName.put(DISPLAY_NAME, getAppDisplayName());
+        source.put(APPLICATION, sourceAppDisplayName);
+
+        final JsonObject sourceBundleDisplayName = new JsonObject();
+        sourceBundleDisplayName.put(DISPLAY_NAME, getBundleDisplayName());
+        source.put(BUNDLE, sourceBundleDisplayName);
+
+        final JsonObject sourceEventTypeDisplayName = new JsonObject();
+        sourceEventTypeDisplayName.put(DISPLAY_NAME, eventTypeDisplayName);
+        source.put(EVENT_TYPE, sourceEventTypeDisplayName);
+
+        return source;
+    }
+
+    private void addItem(Map<String, DailyDigestSection> dataMap, String applicationName, String payload) {
+        String titleData = payload.split("<!-- Body section -->")[0];
+        String[] sections = titleData.split("<!-- next section -->");
+
+        dataMap.put(applicationName,
+            new DailyDigestSection(payload.split("<!-- Body section -->")[1], Arrays.stream(sections)
+                .filter(e -> !e.isBlank()).toList()));
+    }
+
+    protected void generateAggregatedEmailBody(String jsonContext, String app, Map<String, DailyDigestSection> dataMap) throws JsonProcessingException {
+        generateAggregatedEmailBody(
+                objectMapper.readValue(jsonContext, new TypeReference<Map<String, Object>>() { }),
+                app,
+                dataMap);
+    }
+
+    protected void generateAggregatedEmailBody(Map<String, Object> context, String app, Map<String, DailyDigestSection> dataMap) {
+        context.put("application", app);
+        TemplateDefinition templateDefinition = new TemplateDefinition(IntegrationType.EMAIL_DAILY_DIGEST_BODY, getBundle(), app, null, true);
+
+        addItem(dataMap, app, generateEmailFromContextMap(templateDefinition, context, null));
+    }
+
+    protected String getBundle() {
+        return BUNDLE_RHEL;
+    }
+
+    protected String getBundleDisplayName() {
+        return "Red Hat Enterprise Linux";
+    }
+
+    protected String getAppDisplayName() {
+        return null;
+    }
+
+    protected String getApp() {
+        return null;
+    }
+
+    protected Boolean useSecuredTemplates() {
+        return false;
+    }
+
+    protected void writeOrSendEmailTemplate(String result, String fileName) {
+        if (SHOULD_WRITE_ON_FILE_FOR_DEBUG) {
+            writeEmailTemplate(result, fileName + UUID.randomUUID() + ".html");
+        }
+
+        if (SHOULD_SEND_EMAIL_FOR_DEBUG) {
+            Mail m = Mail.withHtml(SEND_EMAIL_TO,
+                fileName,
+                result
+            );
+            mailer.send(m);
+        }
+    }
+
+    protected List<String> getUsedEventTypeNames() {
+        return List.of();
+    }
+
+    public static void writeEmailTemplate(String result, String fileName) {
+        final String TARGET_DIR = "target";
+        try {
+            String[] splitPath = fileName.split("/");
+            String actualPath = TARGET_DIR;
+            for (int part = 0; part < splitPath.length - 1; part++) {
+                actualPath += "/" + splitPath[part];
+            }
+            Files.createDirectories(Paths.get(actualPath));
+            Files.write(Paths.get(TARGET_DIR + "/" + fileName), result.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            Log.error("An error occurred", e);
+        }
+    }
+}

--- a/common-template/src/test/java/email/TestAdvisorOpenShiftTemplate.java
+++ b/common-template/src/test/java/email/TestAdvisorOpenShiftTemplate.java
@@ -1,0 +1,76 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestAdvisorOpenShiftTemplate extends EmailTemplatesRendererHelper {
+
+    static final String NEW_RECOMMENDATION = "new-recommendation";
+
+    @Override
+    protected String getApp() {
+        return "advisor";
+    }
+
+    @Override
+    protected String getBundle() {
+        return "openshift";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "OpenShift";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Advisor";
+    }
+
+    @Test
+    public void testInstantEmailTitleForNewRecommendations() {
+        eventTypeDisplayName = "New Recommendation";
+        Action action = TestHelpers.createAdvisorAction("123456", NEW_RECOMMENDATION);
+
+        String result = generateEmailSubject(NEW_RECOMMENDATION, action);
+        assertEquals("Instant notification - New Recommendation - Advisor - OpenShift", result);
+    }
+
+    @Test
+    public void testInstantEmailBodyForNewRecommendation() {
+        Action action = TestHelpers.createAdvisorAction("123456", NEW_RECOMMENDATION);
+
+        String result = generateEmailBody(NEW_RECOMMENDATION, action);
+        checkNewRecommendationsBodyResults(action, result);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    private void checkNewRecommendationsBodyResults(Action action, final String result) {
+        action.getEvents().forEach(event -> {
+            assertTrue(
+                result.contains(event.getPayload().getAdditionalProperties().get("rule_id").toString()),
+                "Body should contain rule id " + event.getPayload().getAdditionalProperties().get("rule_id")
+            );
+            assertTrue(
+                result.contains(event.getPayload().getAdditionalProperties().get("rule_description").toString()),
+                "Body should contain rule description " + event.getPayload().getAdditionalProperties().get("rule_description")
+            );
+        });
+
+        assertTrue(result.contains("alt=\"Low severity\""), "Body should contain low severity rule image");
+        assertTrue(result.contains("alt=\"Moderate severity\""), "Body should contain moderate severity rule image");
+        assertTrue(result.contains("alt=\"Important severity\""), "Body should contain important severity rule image");
+        assertTrue(result.contains("alt=\"Critical severity\""), "Body should contain critical severity rule image");
+
+        // Display name
+        assertTrue(result.contains("My Host"), "Body should contain the display_name");
+
+        action.setEvents(action.getEvents().stream().filter(event -> event.getPayload().getAdditionalProperties().get("total_risk").equals("1")).toList());
+    }
+}

--- a/common-template/src/test/java/email/TestAdvisorTemplate.java
+++ b/common-template/src/test/java/email/TestAdvisorTemplate.java
@@ -1,0 +1,257 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static com.redhat.cloud.notifications.qute.templates.mapping.Rhel.ADVISOR_DEACTIVATED_RECOMMENDATION;
+import static com.redhat.cloud.notifications.qute.templates.mapping.Rhel.ADVISOR_RESOLVED_RECOMMENDATION;
+import static email.TestAdvisorOpenShiftTemplate.NEW_RECOMMENDATION;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class TestAdvisorTemplate extends EmailTemplatesRendererHelper {
+
+    @Override
+    protected String getApp() {
+        return "advisor";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Advisor";
+    }
+
+    public static final String JSON_ADVISOR_DEFAULT_AGGREGATION_CONTEXT = "{" +
+        "   \"advisor\":{" +
+        "      \"total_incident\":2," +
+        "      \"total_recommendation\":5," +
+        "      \"new_recommendations\":{" +
+        "         \"test|Active_rule_1\":{" +
+        "            \"total_risk\":\"3\"," +
+        "            \"rule_description\":\"Active rule 1\"," +
+        "            \"rule_url\":\"https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_1\"," +
+        "            \"has_incident\":\"true\"," +
+        "            \"systems\":1" +
+        "         }," +
+        "         \"test|Active_rule_6\":{" +
+        "            \"total_risk\":\"2\"," +
+        "            \"rule_description\":\"Active rule 6 with a very long text to validate the carriage return\"," +
+        "            \"rule_url\":\"https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_6\"," +
+        "            \"has_incident\":\"false\"," +
+        "            \"systems\":1" +
+        "         }" +
+        "      }," +
+        "      \"resolved_recommendations\":{" +
+        "         \"test|Active_rule_2\":{" +
+        "            \"total_risk\":\"1\"," +
+        "            \"rule_description\":\"Active rule 2\"," +
+        "            \"rule_url\":\"https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_2\"," +
+        "            \"has_incident\":\"false\"," +
+        "            \"systems\":1" +
+        "         }" +
+        "      }," +
+        "      \"deactivated_recommendations\":{" +
+        "         \"test|Active_rule_3\":{" +
+        "            \"total_risk\":\"4\"," +
+        "            \"rule_description\":\"Active rule 3\"," +
+        "            \"has_incident\":\"false\"," +
+        "            \"rule_url\":\"https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_3\"" +
+        "         }," +
+        "         \"test|Active_rule_4\":{" +
+        "            \"total_risk\":\"4\"," +
+        "            \"rule_description\":\"Active rule 4\"," +
+        "            \"has_incident\":\"true\"," +
+        "            \"rule_url\":\"https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_4\"" +
+        "         }" +
+        "      }" +
+        "   }," +
+        "   \"start_time\":\"2025-07-25T13:38:38.379873993\"," +
+        "   \"end_time\":\"2025-07-25T13:38:38.379899748\"" +
+        "}";
+
+    @Test
+    public void testDailyEmailBody() throws JsonProcessingException {
+        final String result = generateAggregatedEmailBody(JSON_ADVISOR_DEFAULT_AGGREGATION_CONTEXT);
+        assertTrue(result.contains("New Recommendations"));
+        assertTrue(result.contains("/insights/advisor/recommendations/test|Active_rule_1"));
+        assertTrue(result.contains("Active rule 1</a>"));
+        assertTrue(result.contains("https://console.redhat.com/apps/frontend-assets/email-assets/img_incident.png"));
+        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_important.png"));
+        assertTrue(result.contains("Resolved Recommendation"));
+        assertTrue(result.contains("/insights/advisor/recommendations/test|Active_rule_2"));
+        assertTrue(result.contains("Active rule 2</a>"));
+        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_low.png"));
+        assertTrue(result.contains("Deactivated Recommendations"));
+        assertTrue(result.contains("/insights/advisor/recommendations/test|Active_rule_3"));
+        assertTrue(result.contains("Active rule 3</a>"));
+        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_critical.png"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testDailyEmailBodyWithEmptyRuleValues() throws JsonProcessingException {
+
+        final String jsonContext = "{" +
+            "   \"advisor\":{" +
+            "      \"total_incident\":0," +
+            "      \"total_recommendation\":3," +
+            "      \"new_recommendations\":{" +
+            "         \"\":{" +
+            "            \"rule_description\":\"\"," +
+            "            \"total_risk\":\"\"," +
+            "            \"has_incident\":\"\"," +
+            "            \"rule_url\":\"\"," +
+            "            \"systems\":2" +
+            "         }" +
+            "      }," +
+            "      \"resolved_recommendations\":{" +
+            "         \"\":{" +
+            "            \"rule_description\":\"\"," +
+            "            \"total_risk\":\"\"," +
+            "            \"has_incident\":\"\"," +
+            "            \"rule_url\":\"\"," +
+            "            \"systems\":1" +
+            "         }" +
+            "      }," +
+            "      \"deactivated_recommendations\":{" +
+            "         \"\":{" +
+            "            \"rule_description\":\"\"," +
+            "            \"total_risk\":\"\"," +
+            "            \"has_incident\":\"\"," +
+            "            \"rule_url\":\"\"" +
+            "         }" +
+            "      }" +
+            "   }," +
+            "   \"start_time\":\"2025-07-25T13:51:20.657571343\"," +
+            "   \"end_time\":\"2025-07-25T13:51:20.657602689\"" +
+            "}";
+
+        final String result = generateAggregatedEmailBody(jsonContext);
+        // check that template is able to render sections, even if they are empty
+        assertTrue(result.contains("New Recommendation"));
+        assertTrue(result.contains("Resolved Recommendation"));
+        assertTrue(result.contains("Deactivated Recommendation"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testDailyEmailBodyResolvedOnly() throws JsonProcessingException {
+        final String jsonContext = "{" +
+            "   \"advisor\":{" +
+            "      \"total_incident\":0," +
+            "      \"total_recommendation\":1," +
+            "      \"resolved_recommendations\":{" +
+            "         \"test|Active_rule_2\":{" +
+            "            \"rule_description\":\"Active rule 2\"," +
+            "            \"total_risk\":\"1\"," +
+            "            \"has_incident\":\"false\"," +
+            "            \"rule_url\":\"https://console.redhat.com/insights/advisor/recommendations/test|Active_rule_2\"," +
+            "            \"systems\":1" +
+            "         }" +
+            "      }" +
+            "   }," +
+            "   \"start_time\":\"2025-07-25T13:56:28.213058072\"," +
+            "   \"end_time\":\"2025-07-25T13:56:28.213081719\"" +
+            "}";
+
+        final String result = generateAggregatedEmailBody(jsonContext);
+        assertTrue(result.contains("Resolved Recommendation"));
+        assertTrue(result.contains("/insights/advisor/recommendations/test|Active_rule_2"));
+        assertTrue(result.contains("Active rule 2</a>"));
+        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_low.png"));
+        assertFalse(result.contains("New Recommendation"));
+        assertFalse(result.contains("Deactivated Recommendation"));
+        assertFalse(result.contains("/apps/frontend-assets/email-assets/img_critical.png"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    void testInstantEmailTitleForResolvedRecommendations() {
+        eventTypeDisplayName = "Resolved recommendation";
+        Action action = TestHelpers.createAdvisorAction("123456", ADVISOR_RESOLVED_RECOMMENDATION);
+
+        String result = generateEmailSubject(ADVISOR_RESOLVED_RECOMMENDATION, action);
+        assertEquals("Instant notification - Resolved recommendation - Advisor - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testInstantEmailTitleForNewRecommendations() {
+        eventTypeDisplayName = "New recommendation";
+        Action action = TestHelpers.createAdvisorAction("123456", NEW_RECOMMENDATION);
+        String result = generateEmailSubject(NEW_RECOMMENDATION, action);
+        assertEquals("Instant notification - New recommendation - Advisor - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testInstantEmailBodyForNewRecommendation() {
+        Action action = TestHelpers.createAdvisorAction("123456", NEW_RECOMMENDATION);
+
+        String result = generateEmailBody(NEW_RECOMMENDATION, action);
+        checkNewRecommendationsBodyResults(action, result);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    private void checkNewRecommendationsBodyResults(Action action, final String result) {
+        action.getEvents().forEach(event -> {
+            assertTrue(
+                result.contains(event.getPayload().getAdditionalProperties().get("rule_id").toString()),
+                "Body should contain rule id" + event.getPayload().getAdditionalProperties().get("rule_id")
+            );
+            assertTrue(
+                result.contains(event.getPayload().getAdditionalProperties().get("rule_description").toString()),
+                "Body should contain rule description" + event.getPayload().getAdditionalProperties().get("rule_description")
+            );
+        });
+
+        assertTrue(result.contains("alt=\"Low severity\""), "Body should contain low severity rule image");
+        assertTrue(result.contains("alt=\"Moderate severity\""), "Body should contain moderate severity rule image");
+        assertTrue(result.contains("alt=\"Important severity\""), "Body should contain important severity rule image");
+        assertTrue(result.contains("alt=\"Critical severity\""), "Body should contain critical severity rule image");
+
+        // Display name
+        assertTrue(result.contains("My Host"), "Body should contain the display_name");
+
+        action.setEvents(action.getEvents().stream().filter(event -> event.getPayload().getAdditionalProperties().get("total_risk").equals("1")).toList());
+    }
+
+    @Test
+    public void testInstantEmailTitleForDeactivatedRecommendation() {
+        eventTypeDisplayName = "Deactivated recommendation";
+        Action action = TestHelpers.createAdvisorAction("123456", ADVISOR_DEACTIVATED_RECOMMENDATION);
+        String result = generateEmailSubject(ADVISOR_DEACTIVATED_RECOMMENDATION, action);
+        assertEquals("Instant notification - Deactivated recommendation - Advisor - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testInstantEmailBodyForDeactivatedRecommendation() {
+        Action action = TestHelpers.createAdvisorAction("123456", ADVISOR_DEACTIVATED_RECOMMENDATION);
+        String result = generateEmailBody(ADVISOR_DEACTIVATED_RECOMMENDATION, action);
+        checkDeactivatedRecommendationResults(action, result);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testInstantEmailBodyForResolvedRecommendation() {
+        Action action = TestHelpers.createAdvisorAction("123456", ADVISOR_RESOLVED_RECOMMENDATION);
+        String result = generateEmailBody(ADVISOR_RESOLVED_RECOMMENDATION, action);
+        checkNewRecommendationsBodyResults(action, result);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    private void checkDeactivatedRecommendationResults(Action action, final String result) {
+        action.getEvents().forEach(event -> {
+            assertTrue(result.contains(event.getPayload().getAdditionalProperties().get("rule_description").toString()),
+                "Body should contain rule description" + event.getPayload().getAdditionalProperties().get("rule_description"));
+            assertTrue(result.contains(event.getPayload().getAdditionalProperties().get("affected_systems").toString()),
+                "Body should contain affected systems" + event.getPayload().getAdditionalProperties().get("affected_systems"));
+            assertTrue(result.contains(event.getPayload().getAdditionalProperties().get("deactivation_reason").toString()),
+                "Body should contain deactivation reason" + event.getPayload().getAdditionalProperties().get("deactivation_reason"));
+        });
+
+        assertTrue(result.contains("alt=\"Low severity\""), "Body should contain low severity rule image");
+        assertTrue(result.contains("alt=\"Moderate severity\""), "Body should contain moderate severity rule image");
+    }
+}

--- a/common-template/src/test/java/email/TestAnsibleServiceOnAwsTemplate.java
+++ b/common-template/src/test/java/email/TestAnsibleServiceOnAwsTemplate.java
@@ -1,0 +1,46 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestAnsibleServiceOnAwsTemplate extends EmailTemplatesRendererHelper {
+
+    static final String NOTIFY_CUSTOMER_PROVISION_SUCCESS = "notify-customer-provision-success";
+
+    @Override
+    protected String getBundle() {
+        return "ansible-automation-platform";
+    }
+
+    @Override
+    protected String getApp() {
+        return "ansible-service-on-aws";
+    }
+
+    @Test
+    public void testInstantEmailTitle() {
+        Action action = TestHelpers.createAnsibleAction(NOTIFY_CUSTOMER_PROVISION_SUCCESS, null, null);
+
+        String result = generateEmailSubject(NOTIFY_CUSTOMER_PROVISION_SUCCESS, action);
+        assertEquals("Environment is ready - Ansible Automation Platform Service on AWS", result);
+    }
+
+    @Test
+    public void testInstantEmailBody() {
+        String envName  = "cus-" + RandomStringUtils.randomAlphanumeric(5).toLowerCase();
+        String bitwardenURL = "https://www.example.com";
+        Action action = TestHelpers.createAnsibleAction(NOTIFY_CUSTOMER_PROVISION_SUCCESS, envName, bitwardenURL);
+
+        String result = generateEmailBody(NOTIFY_CUSTOMER_PROVISION_SUCCESS, action);
+        assertTrue(result.contains(envName));
+        assertTrue(result.contains(bitwardenURL));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestComplianceTemplate.java
+++ b/common-template/src/test/java/email/TestComplianceTemplate.java
@@ -1,0 +1,63 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestComplianceTemplate extends EmailTemplatesRendererHelper {
+
+    static final String COMPLIANCE_BELOW_THRESHOLD = "compliance-below-threshold";
+    static final String REPORT_UPLOAD_FAILED = "report-upload-failed";
+    private static final Action ACTION = TestHelpers.createComplianceAction();
+
+    @Override
+    protected String getApp() {
+        return "compliance";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Compliance";
+    }
+
+    @Test
+    public void testInstantComplianceBelowThresholdEmailBody() {
+        String result = generateEmailBody(COMPLIANCE_BELOW_THRESHOLD, ACTION);
+        assertTrue(result.contains(ACTION.getEvents().get(0).getPayload().getAdditionalProperties().get("policy_id").toString()));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testInstantComplianceBelowThresholdEmailTitle() {
+        eventTypeDisplayName = "System is non compliant to SCAP policy";
+        String result = generateEmailSubject(COMPLIANCE_BELOW_THRESHOLD, ACTION);
+        assertEquals("Instant notification - System is non compliant to SCAP policy - Compliance - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testInstantReportUploadFailedEmailBody() {
+        String result = generateEmailBody(REPORT_UPLOAD_FAILED, ACTION);
+        assertTrue(result.contains(ACTION.getEvents().get(0).getPayload().getAdditionalProperties().get("error").toString()));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testInstantReportUploadFailedEmailTitle() {
+        eventTypeDisplayName = "Policy report failed to upload";
+        String result = generateEmailSubject(REPORT_UPLOAD_FAILED, ACTION);
+        assertEquals("Instant notification - Policy report failed to upload - Compliance - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testDailyReportEmailBody() {
+        String result = generateAggregatedEmailBody(Map.of());
+        assertTrue(result.contains("Red Hat Insights has identified one or more systems"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestCostManagementTemplate.java
+++ b/common-template/src/test/java/email/TestCostManagementTemplate.java
@@ -1,0 +1,140 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestCostManagementTemplate extends EmailTemplatesRendererHelper {
+
+    static final String MISSING_COST_MODEL = "missing-cost-model";
+    static final String COST_MODEL_CREATE = "cost-model-create";
+    static final String COST_MODEL_UPDATE = "cost-model-update";
+    static final String COST_MODEL_REMOVE = "cost-model-remove";
+    static final String CM_OPERATOR_STALE = "cm-operator-stale";
+    static final String CM_OPERATOR_DATA_PROCESSED = "cm-operator-data-processed";
+    static final String CM_OPERATOR_DATA_RECEIVED = "cm-operator-data-received";
+    private static final Action ACTION = TestHelpers.createCostManagementAction();
+
+    @Override
+    protected String getBundle() {
+        return "openshift";
+    }
+
+    @Override
+    protected String getApp() {
+        return "cost-management";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "OpenShift";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Cost management";
+    }
+
+    @Test
+    public void testInstantMissingCostModelEmailTitle() {
+        eventTypeDisplayName = "Missing Openshift Cost Model";
+        String result = generateEmailSubject(MISSING_COST_MODEL, ACTION);
+        assertEquals("Instant notification - Missing Openshift Cost Model - Cost management - OpenShift", result);
+    }
+
+    @Test
+    public void testInstantMissingCostModelEmailBody() {
+        String result = generateEmailBody(MISSING_COST_MODEL, ACTION);
+        assertTrue(result.contains("OpenShift source Dummy source name has no assigned cost model"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testInstantCostModelCreateEmailTitle() {
+        eventTypeDisplayName = "Cost Model Create";
+        String result = generateEmailSubject(COST_MODEL_CREATE, ACTION);
+        assertEquals("Instant notification - Cost Model Create - Cost management - OpenShift", result);
+    }
+
+    @Test
+    public void testInstantCostModelCreateEmailBody() {
+        String result = generateEmailBody(COST_MODEL_CREATE, ACTION);
+        assertTrue(result.contains("Cost model Sample model has been created"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testInstantCostModelUpdateEmailTitle() {
+        eventTypeDisplayName = "Cost Model Update";
+        String result = generateEmailSubject(COST_MODEL_UPDATE, ACTION);
+        assertEquals("Instant notification - Cost Model Update - Cost management - OpenShift", result);
+    }
+
+    @Test
+    public void testInstantCostModelUpdateEmailBody() {
+        String result = generateEmailBody(COST_MODEL_UPDATE, ACTION);
+        assertTrue(result.contains("Cost model Sample model has been updated"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testInstantCostModelRemoveEmailTitle() {
+        eventTypeDisplayName = "Cost Model Remove";
+        String result = generateEmailSubject(COST_MODEL_REMOVE, ACTION);
+        assertEquals("Instant notification - Cost Model Remove - Cost management - OpenShift", result);
+    }
+
+    @Test
+    public void testInstantCostModelRemoveEmailBody() {
+        String result = generateEmailBody(COST_MODEL_REMOVE, ACTION);
+        assertTrue(result.contains("Cost model Sample model has been removed"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testInstantCostModelOperatorStaleEmailTitle() {
+        eventTypeDisplayName = "CM Operator Stale Data";
+        String result = generateEmailSubject(CM_OPERATOR_STALE, ACTION);
+        assertEquals("Instant notification - CM Operator Stale Data - Cost management - OpenShift", result);
+    }
+
+    @Test
+    public void testInstantCostModelOperatorStaleEmailBody() {
+        String result = generateEmailBody(CM_OPERATOR_STALE, ACTION);
+        assertTrue(result.contains("OpenShift source Dummy source name has not received any payloads in the last 3 or more days"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testInstantCostModelOperatorDataProcessedEmailTitle() {
+        eventTypeDisplayName = "CM Operator Data Processed";
+        String result = generateEmailSubject(CM_OPERATOR_DATA_PROCESSED, ACTION);
+        assertEquals("Instant notification - CM Operator Data Processed - Cost management - OpenShift", result);
+    }
+
+    @Test
+    public void testInstantCostModelOperatorDataProcessedEmailBody() {
+        String result = generateEmailBody(CM_OPERATOR_DATA_PROCESSED, ACTION);
+        assertTrue(result.contains("Cost Management has completed processing for OpenShift source"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testInstantCostModelOperatorDataReceivedEmailTitle() {
+        eventTypeDisplayName = "CM Operator Data Received";
+        String result = generateEmailSubject(CM_OPERATOR_DATA_RECEIVED, ACTION);
+        assertEquals("Instant notification - CM Operator Data Received - Cost management - OpenShift", result);
+    }
+
+    @Test
+    public void testInstantCostModelOperatorDataReceivedEmailBody() {
+        String result = generateEmailBody(CM_OPERATOR_DATA_RECEIVED, ACTION);
+        assertTrue(result.contains("OpenShift source Dummy source name has received a new payload and processing should begin shortly"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestDefaultTemplate.java
+++ b/common-template/src/test/java/email/TestDefaultTemplate.java
@@ -1,0 +1,127 @@
+package email;
+
+import com.redhat.cloud.event.parser.ConsoleCloudEventParser;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.qute.templates.IntegrationType;
+import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
+import com.redhat.cloud.notifications.qute.templates.TemplateService;
+import email.pojo.NotificationsConsoleCloudEvent;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+public class TestDefaultTemplate extends EmailTemplatesRendererHelper {
+
+    private static final String EVENT_TYPE_NAME = "event-type-without-template";
+
+    @InjectSpy
+    protected TemplateService templateService;
+
+    @Override
+    protected String getApp() {
+        return "policies";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Policies";
+    }
+
+    final String jsonCloudEvent = "{" +
+        "  \"id\":\"2de1e968-b851-47b1-a8ac-1d355ad223bb\"," +
+        "  \"source\":\"urn:redhat:source:policies:insights:policies\"," +
+        "  \"subject\":\"urn:redhat:subject:rhel_system:2279dc9f-bbc6-4477-b7e3-6c68d39f0d07\"," +
+        "  \"time\":\"2023-05-03T02:09:06.245424792Z\"," +
+        "  \"type\":\"com.redhat.console.insights.policies.policy-triggered\"," +
+        "  \"data\":{" +
+        "    \"policies\":[" +
+        "      {" +
+        "        \"condition\":\"facts.arch = \\\"x86_64\\\"\"," +
+        "        \"description\":\"This is a sample policy for testing\"," +
+        "        \"id\":\"d41049d9-23e0-47ae-bd27-ecd1615fd200\"," +
+        "        \"name\":\"iqe-policies-2023-02-20-00:03:36:664678\"," +
+        "        \"url\":\"https://console.stage.redhat.com//insights/policies/policy/d41049d9-23e0-47ae-bd27-ecd1615fd200\"" +
+        "      }" +
+        "    ]," +
+        "    \"system\":{" +
+        "      \"check_in\":\"2023-05-03T02:09:05.828152Z\"," +
+        "      \"display_name\":\"iqe-patch-rhel-80-tag-a66a9f1f-6ffa-4925-815e-855467f70cec\"," +
+        "      \"tags\":[" +
+        "        {" +
+        "          \"key\":\"patch_1fi0\"," +
+        "          \"namespace\":\"insights-client\"," +
+        "          \"value\":\"patchman-ui\"" +
+        "        }" +
+        "      ]," +
+        "      \"inventory_id\":\"2279dc9f-bbc6-4477-b7e3-6c68d39f0d07\"" +
+        "    }" +
+        "  }," +
+        "  \"$schema\":\"https://console.redhat.com/api/schemas/events/v1/events.json\"," +
+        "  \"specversion\":\"1.0\"," +
+        "  \"dataschema\":\"https://console.redhat.com/api/schemas/apps/policies/v1/policy-triggered.json\"," +
+        "  \"redhatorgid\":\"11789772\"," +
+        "  \"redhataccount\":\"6089719\"" +
+        "}";
+
+    @BeforeEach
+    void beforeEach() {
+        when(templateService.isDefaultEmailTemplateEnabled()).thenReturn(true);
+        templateService.init();
+    }
+
+    @Test
+    public void testInstantEmailTitle() {
+        Action action = TestHelpers.createPoliciesAction("", "my-bundle", "my-app", "FooMachine");
+        eventTypeDisplayName = "Policy Triggered";
+
+        String result = generateEmailSubject(EVENT_TYPE_NAME, action);
+        assertEquals("Instant notification - Policy Triggered - Policies - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testInstantEmailBody() {
+        Action action = TestHelpers.createPoliciesAction("", "my-bundle", "my-app", "FooMachine");
+        eventTypeDisplayName = "Policy Triggered";
+        String result = generateEmailBody(EVENT_TYPE_NAME, action);
+
+        assertTrue(result.contains("Red Hat Enterprise Linux/Policies/Policy Triggered notification was triggered"), "Body should contain bundle/app/event-type");
+        assertTrue(result.contains("You are receiving this email because the email template associated with this event type is not configured properly"));
+    }
+
+
+    @Test
+    public void testInstantEmailTitleCloudEvents() {
+        NotificationsConsoleCloudEvent event = new ConsoleCloudEventParser().fromJsonString(
+            jsonCloudEvent,
+            NotificationsConsoleCloudEvent.class
+        );
+
+        eventTypeDisplayName = "Event without template";
+        TemplateDefinition templateDefinition = new TemplateDefinition(IntegrationType.EMAIL_TITLE, getBundle(), getApp(), EVENT_TYPE_NAME);
+        String result = generateEmail(templateDefinition, event, null, false);
+
+        assertEquals("Instant notification - Event without template - Policies - Red Hat Enterprise Linux", result.trim());
+    }
+
+    @Test
+    public void testInstantEmailBodyCloudEvents() {
+        NotificationsConsoleCloudEvent event = new ConsoleCloudEventParser().fromJsonString(
+            jsonCloudEvent,
+            NotificationsConsoleCloudEvent.class
+        );
+
+        eventTypeDisplayName = "Event without template";
+        TemplateDefinition templateDefinition = new TemplateDefinition(IntegrationType.EMAIL_BODY, getBundle(), getApp(), EVENT_TYPE_NAME);
+        String result = generateEmail(templateDefinition, event, null, false);
+
+        assertTrue(result.contains("Red Hat Enterprise Linux/Policies/Event without template notification was triggered."), "Body should contain bundle/app/event-type");
+        assertTrue(result.contains("You are receiving this email because the email template associated with this event type is not configured properly"));
+    }
+}

--- a/common-template/src/test/java/email/TestEdgeManagementTemplate.java
+++ b/common-template/src/test/java/email/TestEdgeManagementTemplate.java
@@ -1,0 +1,55 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestEdgeManagementTemplate extends EmailTemplatesRendererHelper {
+
+    static final String IMAGE_CREATION = "image-creation";
+    static final String UPDATE_DEVICES = "update-devices";
+    private static final Action ACTION = TestHelpers.createEdgeManagementAction();
+
+    @Override
+    protected String getApp() {
+        return "edge-management";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Edge Management";
+    }
+
+    @Test
+    public void testImageCreationEmailTitle() {
+        eventTypeDisplayName = "Image Creation";
+        String result = generateEmailSubject(IMAGE_CREATION, ACTION);
+        assertEquals("Instant notification - Image Creation - Edge Management - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testImageCreationEmailBody() {
+        String result = generateEmailBody(IMAGE_CREATION, ACTION);
+        assertTrue(result.contains("A new image named"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testUpdateDeviceEmailTitle() {
+        eventTypeDisplayName = "Update Devices";
+        String result = generateEmailSubject(UPDATE_DEVICES, ACTION);
+        assertEquals("Instant notification - Update Devices - Edge Management - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testUpdateDeviceEmailBody() {
+        String result = generateEmailBody(UPDATE_DEVICES, ACTION);
+        assertTrue(result.contains("An Update for the device"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestErrataTemplate.java
+++ b/common-template/src/test/java/email/TestErrataTemplate.java
@@ -1,0 +1,370 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.ErrataTestHelpers;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestErrataTemplate extends EmailTemplatesRendererHelper {
+
+    static final String NEW_SUBSCRIPTION_BUGFIX_ERRATA = "new-subscription-bugfix-errata";
+    static final String NEW_SUBSCRIPTION_SECURITY_UPDATE_ERRATA = "new-subscription-security-errata";
+    static final String NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA = "new-subscription-enhancement-errata";
+
+    private static final Action ACTION = ErrataTestHelpers.createErrataAction();
+
+    @Override
+    protected String getBundle() {
+        return "subscription-services";
+    }
+
+    @Override
+    protected String getApp() {
+        return "errata-notifications";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "Subscription Services";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Errata";
+    }
+
+    @Test
+    public void testNewSubscriptionBugfixErrataEmailTitle() {
+        eventTypeDisplayName = "Subscription Bug Fixes";
+        String result = generateEmailSubject(NEW_SUBSCRIPTION_BUGFIX_ERRATA, ACTION);
+        assertEquals("Instant notification - Subscription Bug Fixes - Errata - Subscription Services", result);
+    }
+
+    @Test
+    public void testNewSubscriptionBugfixErrataEmailBody() {
+        String result = generateEmailBody(NEW_SUBSCRIPTION_BUGFIX_ERRATA, ACTION);
+        assertTrue(result.contains("There are 4 bug fixes affecting your subscriptions."));
+        assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("secalert@redhat.com"));
+    }
+
+    @Test
+    public void testNewSubscriptionSecurityUpdateErrataEmailTitle() {
+        eventTypeDisplayName = "Subscription Security Updates";
+        String result = generateEmailSubject(NEW_SUBSCRIPTION_SECURITY_UPDATE_ERRATA, ACTION);
+        assertEquals("Instant notification - Subscription Security Updates - Errata - Subscription Services", result);
+    }
+
+    @Test
+    public void testNewSubscriptionSecurityUpdateErrataEmailBody() {
+        String result = generateEmailBody(NEW_SUBSCRIPTION_SECURITY_UPDATE_ERRATA, ACTION);
+        assertTrue(result.contains("There are 4 security updates affecting your subscriptions."));
+        assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("secalert@redhat.com"));
+        assertTrue(result.contains("Moderate"), "Security advisory severity has a dedicated column");
+    }
+
+    @Test
+    public void testNewSubscriptionEnhancementErrataEmailTitle() {
+        eventTypeDisplayName = "Subscription Enhancements";
+        String result = generateEmailSubject(NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA, ACTION);
+        assertEquals("Instant notification - Subscription Enhancements - Errata - Subscription Services", result);
+    }
+
+    @Test
+    public void testNewSubscriptionEnhancementErrataEmailBody() {
+        String result = generateEmailBody(NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA, ACTION);
+        assertTrue(result.contains("There are 4 enhancements affecting your subscriptions."));
+        assertTrue(result.contains("href=\"https://access.redhat.com/errata/RHSA-2024:3843\""));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("secalert@redhat.com"));
+    }
+
+    @Test
+    public void testDailyDigestEmailBody() throws JsonProcessingException {
+        final String result = generateAggregatedEmailBody(JSON_ERRATA_DEFAULT_AGGREGATION_CONTEXT);
+        assertTrue(result.contains("There are 9 bug fixes affecting your subscriptions."));
+        assertTrue(result.contains("There are 18 enhancements affecting your subscriptions."));
+        assertTrue(result.contains("There are 24 security updates affecting your subscriptions"));
+        assertEquals(51, StringUtils.countMatches(result, "https://access.redhat.com/errata/RHSA-2024:"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    public static final String JSON_ERRATA_DEFAULT_AGGREGATION_CONTEXT = "{" +
+        "   \"errata\":{" +
+        "      \"new-subscription-bugfix-errata\":[" +
+        "         {" +
+        "            \"id\":\"RHSA-2024:1074\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:279\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:5588\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:40\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:558\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:068\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:18\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:5579\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:1365\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }" +
+        "      ]," +
+        "      \"new-subscription-enhancement-errata\":[" +
+        "         {" +
+        "            \"id\":\"RHSA-2024:07\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:75\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:782\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:0\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:2921\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:737\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:82\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:8388\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:6\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:2\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:857\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:2\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:11\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:5339\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:970\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:666\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:2996\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:999\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }" +
+        "      ]," +
+        "      \"new-subscription-security-errata\":[" +
+        "         {" +
+        "            \"id\":\"RHSA-2024:0\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:835\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:521\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:3906\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:5568\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:699\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:86\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:49\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:81\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:95\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:7758\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:9409\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:34\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:573\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:47\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:1\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:8\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:728\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:132\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:1\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:0\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:461\"," +
+        "            \"severity\":\"Moderate\"," +
+        "            \"synopsis\":\"Red Hat build of Quarkus 3.8.4 release\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:6\"," +
+        "            \"severity\":\"Important\"," +
+        "            \"synopsis\":\"c-ares security update\"" +
+        "         }," +
+        "         {" +
+        "            \"id\":\"RHSA-2024:816\"," +
+        "            \"severity\":\"Low\"," +
+        "            \"synopsis\":\"cockpit security update\"" +
+        "         }" +
+        "      ]," +
+        "      \"base_url\":\"https://access.redhat.com/errata/\"" +
+        "   }," +
+        "   \"start_time\":null," +
+        "   \"end_time\":null" +
+        "}";
+}

--- a/common-template/src/test/java/email/TestImageBuilderTemplate.java
+++ b/common-template/src/test/java/email/TestImageBuilderTemplate.java
@@ -1,0 +1,94 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestImageBuilderTemplate extends EmailTemplatesRendererHelper {
+
+    static final String LAUNCH_SUCCESS = "launch-success";
+    static final String LAUNCH_FAILURE = "launch-failed";
+
+    private static final Action SUCCESS_ACTION = TestHelpers.createImageBuilderAction(LAUNCH_SUCCESS);
+    private static final Action FAILURE_ACTION = TestHelpers.createImageBuilderAction(LAUNCH_FAILURE);
+
+    @Override
+    protected String getApp() {
+        return "image-builder";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Images";
+    }
+
+    public static final String JSON_IMAGE_BUILDER_DEFAULT_AGGREGATION_CONTEXT = "{" +
+        "   \"images\":{" +
+        "      \"aws\":{" +
+        "         \"instances\":4," +
+        "         \"launch_success\":2," +
+        "         \"failure\":1" +
+        "      }," +
+        "      \"gcp\":{" +
+        "         \"instances\":0," +
+        "         \"launch_success\":0," +
+        "         \"failure\":0" +
+        "      }," +
+        "      \"azure\":{" +
+        "         \"instances\":0," +
+        "         \"launch_success\":0," +
+        "         \"failure\":0" +
+        "      }," +
+        "      \"errors\":[" +
+        "         null" +
+        "      ]," +
+        "      \"launch_success\":2" +
+        "   }," +
+        "   \"start_time\":null," +
+        "   \"end_time\":null" +
+        "}";
+
+    @Test
+    public void testSuccessLaunchEmailTitle() {
+        eventTypeDisplayName = "Launch completed";
+        String result = generateEmailSubject(LAUNCH_SUCCESS, SUCCESS_ACTION);
+        assertEquals("Instant notification - Launch completed - Images - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testSuccessLaunchEmailBody() {
+        String result = generateEmailBody(LAUNCH_SUCCESS, SUCCESS_ACTION);
+        assertTrue(result.contains("Instances launched successfully"));
+        assertTrue(result.contains("91.123.32.4"));
+        // testing empty dns value
+        assertTrue(result.contains("n/a"));
+    }
+
+    @Test
+    public void testFailedLaunchEmailTitle() {
+        eventTypeDisplayName = "Launch failed";
+        String result = generateEmailSubject(LAUNCH_FAILURE, FAILURE_ACTION);
+        assertEquals("Instant notification - Launch failed - Images - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testFailedLaunchEmailBody() {
+        String result = generateEmailBody(LAUNCH_FAILURE, FAILURE_ACTION);
+        assertTrue(result.contains("An image failed to launch"));
+        assertTrue(result.contains("Some launch error"));
+    }
+
+    @Test
+    public void testDailyTemplate() throws JsonProcessingException {
+        String resultBody = generateAggregatedEmailBody(JSON_IMAGE_BUILDER_DEFAULT_AGGREGATION_CONTEXT);
+        assertTrue(resultBody.contains("2 launch attempts deployed"));
+        assertTrue(resultBody.contains("1 launch attempts failed"));
+        assertTrue(resultBody.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestIntegrationsTemplate.java
+++ b/common-template/src/test/java/email/TestIntegrationsTemplate.java
@@ -1,0 +1,214 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Parser;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.redhat.cloud.notifications.qute.templates.mapping.Console.INTEGRATIONS_GENERAL_COMMUNICATION;
+import static com.redhat.cloud.notifications.qute.templates.mapping.Console.INTEGRATIONS_INTEGRATION_DISABLED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestIntegrationsTemplate extends EmailTemplatesRendererHelper {
+
+    @Override
+    protected String getBundle() {
+        return "console";
+    }
+
+    @Override
+    protected String getApp() {
+        return "integrations";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "Console";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Integrations";
+    }
+
+    @Test
+    void testIntegrationDisabledTitle() {
+        Action action = buildIntegrationDisabledAction("HTTP_4XX", "", 1, 401);
+        String result = generateEmailSubject(INTEGRATIONS_INTEGRATION_DISABLED, action);
+        assertEquals("Instant notification - Integration disabled - Integrations - Console", result);
+    }
+
+
+    @Test
+    void testIntegrationDisabledBodyWithClientError() {
+        Action action = buildIntegrationDisabledAction("HTTP_4XX", "", 1, 401);
+        String rendered = generateEmailBody(INTEGRATIONS_INTEGRATION_DISABLED, action);
+        assertTrue(rendered.contains("disabled because the remote endpoint responded with an HTTP status code 401"));
+        assertTrue(rendered.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    void testIntegrationDisabledBodyWithServerError() {
+        Action action = buildIntegrationDisabledAction("HTTP_5XX", "the HTTP server responded with an HTTP status", 2048, -1);
+        String rendered = generateEmailBody(INTEGRATIONS_INTEGRATION_DISABLED, action);
+        assertTrue(rendered.contains("disabled because the connection couldn't be established with the remote endpoint, or it responded too many times with a server error (HTTP status code 5xx) after 2048 attempts"));
+        assertTrue(rendered.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    /**
+     * Tests that the general communication email works as expected.
+     */
+    @Test
+    void testGeneralCommunication() {
+
+        final String actionAsString = "{" +
+            "   \"version\":\"2.0.0\"," +
+            "   \"bundle\":\"console\"," +
+            "   \"application\":\"integrations\"," +
+            "   \"event_type\":\"general-communication\"," +
+            "   \"timestamp\":\"2025-07-11T09:01:36.220643799\"," +
+            "   \"org_id\":\"%s\"," +
+            "   \"context\":{" +
+            "      \"integration_category\":\"Communications\"" +
+            "   }," +
+            "   \"events\":[" +
+            "      {" +
+            "         \"metadata\":{" +
+            "            \"communication-description\":\"General communication about customers' Microsoft Teams' URLs needing a review\"" +
+            "         }," +
+            "         \"payload\":{" +
+            "            \"integration_names\":[%s]" +
+            "         }" +
+            "      }" +
+            "   ]," +
+            "   \"recipients\":[" +
+            "      {" +
+            "         \"only_admins\":false," +
+            "         \"ignore_user_preferences\":true," +
+            "         \"users\":[]," +
+            "         \"emails\":[]," +
+            "         \"groups\":[]" +
+            "      }" +
+            "   ]" +
+            "}";
+
+        final String orgId = "12345";
+        final List<String> integrationNames = List.of(
+            "Integration one",
+            "Another integration",
+            "Third integration"
+        );
+
+        Action action = Parser.decode(
+            String.format(actionAsString,
+                orgId,
+                integrationNames.stream().map(integrationName -> "\"" +  integrationName + "\"").collect(Collectors.joining(",")))
+        );
+        final String rendered = generateEmailBody(INTEGRATIONS_GENERAL_COMMUNICATION, action);
+        assertTrue(rendered.contains("Dear Red Hat customer,"));
+        assertTrue(rendered.contains("We are contacting you because you have the following Microsoft Teams integrations set up for your organization in the"));
+        assertTrue(rendered.contains("Red Hat Hybrid Cloud Console"));
+        assertTrue(rendered.contains("Integration one"));
+        assertTrue(rendered.contains("Another integration"));
+        assertTrue(rendered.contains("Third integration"));
+        assertTrue(rendered.contains("Microsoft is"));
+        assertTrue(rendered.contains("updating the Teams connectors for security reasons"));
+        assertTrue(rendered.contains(", and they are recommending that their customers"));
+        assertTrue(rendered.contains("update any URLs for connectors"));
+        assertTrue(rendered.contains("they have set up. We identified the above Integrations in your account and are asking you to review, and update if needed, to avoid service interruption when Microsoft sunsets the old URLs."));
+        assertTrue(rendered.contains("If you have already updated your Integrations URLs, you can safely ignore this email"));
+        assertTrue(rendered.contains("To update your Microsoft Teams integrations, complete the following steps:"));
+        assertTrue(rendered.contains("Generate a new webhook URL from your Microsoft Teams client by following the steps in"));
+        assertTrue(rendered.contains("Update connectors URL"));
+        assertTrue(rendered.contains("in the Microsoft documentation"));
+        assertTrue(rendered.contains("Copy the URL to your clipboard to use in the Hybrid Cloud Console."));
+        assertTrue(rendered.contains("To update your integration, log in to the"));
+        assertTrue(rendered.contains("Hybrid Cloud Console"));
+        assertTrue(rendered.contains("Navigate to"));
+        assertTrue(rendered.contains("Settings"));
+        assertTrue(rendered.contains("(gear icon) >"));
+        assertTrue(rendered.contains("Integrations"));
+        assertTrue(rendered.contains("Click the"));
+        assertTrue(rendered.contains("Communications"));
+        assertTrue(rendered.contains("tab"));
+        assertTrue(rendered.contains("Locate your Microsoft Teams integration."));
+        assertTrue(rendered.contains("Next to your integration, click the options icon (⋮) and click"));
+        assertTrue(rendered.contains("Edit"));
+        assertTrue(rendered.contains("Click"));
+        assertTrue(rendered.contains("Next"));
+        assertTrue(rendered.contains("to continue past the Integration type step."));
+        assertTrue(rendered.contains("Paste the incoming webhook URL that you copied from Microsoft Teams into the"));
+        assertTrue(rendered.contains("Endpoint URL"));
+        assertTrue(rendered.contains("field."));
+        assertTrue(rendered.contains("Next"));
+        assertTrue(rendered.contains("Review the integration details and click"));
+        assertTrue(rendered.contains("Submit"));
+        assertTrue(rendered.contains("to update the integration."));
+        assertTrue(rendered.contains("Following the above steps will ensure that you will continue receiving the alerts and notifications in the Microsoft Teams channel that you have configured."));
+        assertTrue(rendered.contains("For more information about configuring Microsoft Teams integrations, see the"));
+        assertTrue(rendered.contains("Red Hat documentation"));
+        assertTrue(rendered.contains("Thank you for your attention."));
+        assertTrue(rendered.contains("Kind regards,"));
+        assertTrue(rendered.contains("Red Hat Hybrid Cloud Console."));
+    }
+
+    private Action buildIntegrationDisabledAction(final String errorType, final String errorDetails, final int errorCount, final int errorStatusCode) {
+        final String actionAsString = "{" +
+            "   \"version\":\"2.0.0\"," +
+            "   \"id\":\"9ee4a19b-297c-49f8-ad20-e777e6d71533\"," +
+            "   \"bundle\":\"console\"," +
+            "   \"application\":\"integrations\"," +
+            "   \"event_type\":\"integration-disabled\"," +
+            "   \"timestamp\":\"2025-07-25T08:25:09.119379869\"," +
+            "   \"org_id\":\"default-org-id\"," +
+            "   \"context\":{" +
+            "      \"error_type\":\"%s\"," +
+            "      \"error_details\":\"%s\"," +
+            "      \"endpoint_id\":\"c8a30166-526a-4e6c-b0c7-d24ec35279d3\"," +
+            "      \"endpoint_name\":\"Unreliable integration\"," +
+            "      \"endpoint_category\":\"Communications\"," +
+            "      \"errors_count\":%d," +
+            "      \"status_code\":%d" +
+            "   }," +
+            "   \"events\":[" +
+            "      {" +
+            "         \"payload\":{" +
+            "            " +
+            "         }," +
+            "         \"metadata\":{" +
+            "            " +
+            "         }" +
+            "      }" +
+            "   ]," +
+            "   \"recipients\":[" +
+            "      {" +
+            "         \"only_admins\":true," +
+            "         \"ignore_user_preferences\":true," +
+            "         \"users\":[" +
+            "            " +
+            "         ]," +
+            "         \"emails\":[" +
+            "            " +
+            "         ]," +
+            "         \"groups\":[" +
+            "            " +
+            "         ]" +
+            "      }" +
+            "   ]" +
+            "}";
+
+        eventTypeDisplayName = "Integration disabled";
+        return Parser.decode(
+            String.format(actionAsString,
+                errorType,
+                errorDetails,
+                errorCount,
+                errorStatusCode)
+        );
+    }
+}

--- a/common-template/src/test/java/email/TestInventoryTemplate.java
+++ b/common-template/src/test/java/email/TestInventoryTemplate.java
@@ -1,0 +1,322 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.InventoryTestHelpers;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestInventoryTemplate extends EmailTemplatesRendererHelper {
+
+    private static final String EVENT_TYPE_NEW_SYSTEM_REGISTERED = "new-system-registered";
+    private static final String EVENT_TYPE_SYSTEM_BECAME_STALE = "system-became-stale";
+    private static final String EVENT_TYPE_SYSTEM_DELETED = "system-deleted";
+    private static final String EVENT_TYPE_VALIDATION_ERROR = "validation-error";
+
+    private static final String EMAIL_SUBJECT_NEW_SYSTEM_REGISTERED = "Instant notification - New system registered - Inventory - Red Hat Enterprise Linux";
+    private static final String EMAIL_SUBJECT_SYSTEM_BECAME_STALE = "Instant notification - System became stale - Inventory - Red Hat Enterprise Linux";
+    private static final String EMAIL_SUBJECT_SYSTEM_DELETED = "Instant notification - System deleted - Inventory - Red Hat Enterprise Linux";
+
+    public static final String JSON_INVENTORY_DEFAULT_AGGREGATION_CONTEXT = "{" +
+        "   \"inventory\":{" +
+        "      \"errors\":[" +
+        "         {" +
+        "            \"message\":\"error 1\"," +
+        "            \"display_name\":\"random_name\"" +
+        "         }," +
+        "         {" +
+        "            \"message\":\"error 2\"," +
+        "            \"display_name\":\"random_name2\"" +
+        "         }" +
+        "      ]," +
+        "      \"new_systems\":[]," +
+        "      \"stale_systems\":[]," +
+        "      \"deleted_systems\":[]" +
+        "   }," +
+        "   \"start_time\":null," +
+        "   \"end_time\":null" +
+        "}";
+
+    @Override
+    protected String getApp() {
+        return "inventory";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Inventory";
+    }
+
+    @Test
+    public void testInstantEmailTitle() {
+        Action action = InventoryTestHelpers.createInventoryAction("123456", "rhel", "inventory", "Host Validation Error");
+        eventTypeDisplayName = "Validation error";
+        String result = generateEmailSubject(EVENT_TYPE_VALIDATION_ERROR, action);
+        assertEquals("Instant notification - Validation error - Inventory - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testInstantEmailBody() {
+        Action action = InventoryTestHelpers.createInventoryAction("", "", "", "FooEvent");
+        String result = generateEmailBody(EVENT_TYPE_VALIDATION_ERROR, action);
+        assertTrue(result.contains(InventoryTestHelpers.DISPLAY_NAME_1), "Body should contain host display name" + InventoryTestHelpers.DISPLAY_NAME_1);
+        assertTrue(result.contains(InventoryTestHelpers.ERROR_MESSAGE_1), "Body should contain error message" + InventoryTestHelpers.ERROR_MESSAGE_1);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"NEW", "STALE", "DELETED", "NEW_STALE", "NEW_STALE_DELETE"})
+    public void testDailyEmailBody(final String groupToValidte) throws JsonProcessingException {
+        Map<String, Object> aggregationContext = objectMapper.readValue(JSON_INVENTORY_DEFAULT_AGGREGATION_CONTEXT, new TypeReference<Map<String, Object>>() { });
+
+        Map<UUID, String> newSystemsMap = new HashMap<>();
+        Map<UUID, String> staleSystemsMap = new HashMap<>();
+        Map<UUID, String> deletedSystemsMap = new HashMap<>();
+
+        if (groupToValidte.contains("NEW")) {
+            // Add two new system events.
+            newSystemsMap = Map.of(
+                UUID.randomUUID(), "new-system-display-name",
+                UUID.randomUUID(), "new-second-system-display-name"
+            );
+
+            addToAggregationContext("new_systems", newSystemsMap, aggregationContext);
+        }
+
+        if (groupToValidte.contains("STALE")) {
+            // Add two "system became stale" events.
+            staleSystemsMap = Map.of(
+                UUID.randomUUID(), "stale-system-display-name",
+                UUID.randomUUID(), "second-stale-system-display-name"
+            );
+
+            addToAggregationContext("stale_systems", staleSystemsMap, aggregationContext);
+        }
+
+        if (groupToValidte.contains("DELETED")) {
+            // Add two "system deleted" events.
+            deletedSystemsMap = Map.of(
+                UUID.randomUUID(), "deleted-system-display-name",
+                UUID.randomUUID(), "second-deleted-system-display-name"
+            );
+
+            addToAggregationContext("deleted_systems", deletedSystemsMap, aggregationContext);
+        }
+
+        String result = generateAggregatedEmailBody(aggregationContext);
+        JsonObject context = new JsonObject(aggregationContext);
+        assertTrue(context.getJsonObject("inventory").getJsonArray("errors").size() < 10);
+        assertTrue(result.contains("Host Name"), "Body should contain 'Host Name' header");
+        assertTrue(result.contains("Error"), "Body should contain 'Error' header");
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+
+        assertOpenInventoryInsightsButtonPresent(result, false);
+
+        // Make sure that the section headline is present.
+        assertTrue(result.contains("Inventory"), "the \"Inventory\" header was not found as the section title");
+        assertTrue(result.contains(String.format("%s systems changed state", newSystemsMap.size() + staleSystemsMap.size() + deletedSystemsMap.size())), "the header's subtitle should contain the number of systems that changed of state, but it was not found in the resulting HTML file");
+
+        // Check that the new systems are present in the email.
+        assertEquals(!newSystemsMap.isEmpty(), result.contains("New system registered"), "the email should" + (newSystemsMap.isEmpty() ? " not " : "") + " contain the table's header for the new systems");
+        assertSystems(result, newSystemsMap, true, !newSystemsMap.isEmpty());
+
+        // Check that the stale systems are present in the email.
+        assertEquals(!staleSystemsMap.isEmpty(), result.contains("Stale system"), "the email should" + (staleSystemsMap.isEmpty() ? " not " : "") + " contain the table's header for the stale systems");
+        assertSystems(result, staleSystemsMap, true, !staleSystemsMap.isEmpty());
+
+        // Check that the stale systems are present in the email.
+        assertEquals(!deletedSystemsMap.isEmpty(), result.contains("System deleted"), "the email should" + (deletedSystemsMap.isEmpty() ? " not " : "") + " contain the table's header for the deleted systems");
+        assertSystems(result, deletedSystemsMap, false, !deletedSystemsMap.isEmpty());
+    }
+
+    private static void addToAggregationContext(String category, Map<UUID, String> newSystemsMap, Map<String, Object> aggregationContext) {
+        for (final Map.Entry<UUID, String> entry : newSystemsMap.entrySet()) {
+            ((ArrayList<Map<String, Object>>) ((Map<String, Object>) aggregationContext.get("inventory")).get(category)).add(
+                Map.of("inventory_id", entry.getKey(), "display_name",  entry.getValue())
+            );
+        }
+    }
+
+    /**
+     * Tests that the subject template for the "new system registered" event is
+     * correctly rendered and contains the expected text.
+     */
+    @Test
+    void testInstantNewSystemRegisteredSubject() {
+        final String hostDisplayName = "new-host";
+        final UUID inventoryId = UUID.randomUUID();
+        eventTypeDisplayName = "New system registered";
+        final Action action = InventoryTestHelpers.createInventoryActionV2("rhel", "inventory", EVENT_TYPE_NEW_SYSTEM_REGISTERED, inventoryId, hostDisplayName);
+        final String result = this.generateEmailSubject(EVENT_TYPE_NEW_SYSTEM_REGISTERED, action);
+
+        Assertions.assertEquals(EMAIL_SUBJECT_NEW_SYSTEM_REGISTERED, result);
+    }
+
+    /**
+     * Tests that the subject body for the "new system registered" event is
+     * correctly rendered and contains the expected text.
+     */
+    @Test
+    void testInstantNewSystemRegisteredBody() {
+        final String hostDisplayName = "new-host";
+        final UUID inventoryId = UUID.randomUUID();
+
+        final Action action = InventoryTestHelpers.createInventoryActionV2("rhel", "inventory", EVENT_TYPE_NEW_SYSTEM_REGISTERED, inventoryId, hostDisplayName);
+        final String result = this.generateEmailBody(EVENT_TYPE_NEW_SYSTEM_REGISTERED, action);
+
+        Assertions.assertTrue(result.contains(hostDisplayName), "the message body should contain the host's display name");
+        Assertions.assertTrue(result.contains("was registered in Inventory."), "the message body should indicate that the system was registered");
+
+        this.assertOpenInventoryInsightsButtonPresent(result, true);
+    }
+
+    /**
+     * Tests that the subject template for the "system became stale" event is
+     * correctly rendered and contains the expected text.
+     */
+    @Test
+    void testInstantSystemBecameStaleSubject() {
+        final String hostDisplayName = "stale-host";
+        final UUID inventoryId = UUID.randomUUID();
+        eventTypeDisplayName = "System became stale";
+        final Action action = InventoryTestHelpers.createInventoryActionV2("rhel", "inventory", EVENT_TYPE_SYSTEM_BECAME_STALE, inventoryId, hostDisplayName);
+        final String result = this.generateEmailSubject(EVENT_TYPE_SYSTEM_BECAME_STALE, action);
+
+        Assertions.assertEquals(EMAIL_SUBJECT_SYSTEM_BECAME_STALE, result);
+    }
+
+    /**
+     * Tests that the body template for the "system became stale" event is
+     * correctly rendered and contains the expected text.
+     */
+    @Test
+    void testInstantSystemBecameStaleBody() {
+        final String hostDisplayName = "stale-host";
+        final UUID inventoryId = UUID.randomUUID();
+
+        final Action action = InventoryTestHelpers.createInventoryActionV2("rhel", "inventory", EVENT_TYPE_SYSTEM_BECAME_STALE, inventoryId, hostDisplayName);
+        final String result = this.generateEmailBody(EVENT_TYPE_SYSTEM_BECAME_STALE, action);
+
+        Assertions.assertTrue(result.contains(hostDisplayName), "the message body should contain the host's display name");
+
+        Assertions.assertTrue(
+            Pattern
+                .compile(String.format("The state of system.+%s.+changed to stale in Inventory", hostDisplayName))
+                .matcher(result)
+                .find(),
+            "the message body should indicate that the system was registered"
+        );
+
+        this.assertOpenInventoryInsightsButtonPresent(result, true);
+    }
+
+    /**
+     * Tests that the subject template for the "system deleted" event is
+     * correctly rendered and contains the expected text.
+     */
+    @Test
+    void testInstantSystemDeletedSubject() {
+        final String hostDisplayName = "deleted-host";
+        final UUID inventoryId = UUID.randomUUID();
+        eventTypeDisplayName = "System deleted";
+        final Action action = InventoryTestHelpers.createInventoryActionV2("rhel", "inventory", "new-system-registered", inventoryId, hostDisplayName);
+        final String result = this.generateEmailSubject(EVENT_TYPE_SYSTEM_DELETED, action);
+
+        Assertions.assertEquals(EMAIL_SUBJECT_SYSTEM_DELETED, result);
+    }
+
+    /**
+     * Tests that the body template for the "system deleted" event is correctly
+     * rendered and contains the expected text.
+     */
+    @Test
+    void testInstantSystemDeletedBody() {
+        final String hostDisplayName = "deleted-host";
+        final UUID inventoryId = UUID.randomUUID();
+
+        final Action action = InventoryTestHelpers.createInventoryActionV2("rhel", "inventory", "new-system-registered", inventoryId, hostDisplayName);
+        final String result = this.generateEmailBody(EVENT_TYPE_SYSTEM_DELETED, action);
+
+        Assertions.assertTrue(result.contains(hostDisplayName), "the message body should contain the host's display name");
+        Assertions.assertTrue(result.contains("was deleted from Inventory."), "the message body should indicate that the system was deleted");
+
+        this.assertOpenInventoryInsightsButtonPresent(result, true);
+    }
+
+    /**
+     * Asserts that the "Open Inventory in Insights" button is present, with the correct Notifications query parameter.
+     * @param result the resulting HTML in which we need to perform the
+     *               assertion.
+     * @param instant_email specifies query parameter for instant or aggregation email
+     */
+    private void assertOpenInventoryInsightsButtonPresent(final String result, final boolean instant_email) {
+        Assertions.assertTrue(
+            result.contains(
+                String.format(
+                    "<a target=\"_blank\" href=\"%s/insights/inventory/%s\">Open Inventory in Insights</a>",
+                    this.environment.url(),
+                    instant_email ? "?from=notifications&integration=instant_email" : "?from=notifications&integration=daily_digest"
+                )
+            )
+        );
+    }
+
+    /**
+     * Asserts that the given system is present or not in the resulting HTML string.
+     * @param htmlString the resulting HTML for the email.
+     * @param systemsMap the collection of systems to check.
+     * @param isItALink if the flag is given, it will check that the system is
+     *                  surrounded with a link to the system in Inventory.
+     * @param expected is it expected
+     */
+    private void assertSystems(final String htmlString, final Map<UUID, String> systemsMap, final boolean isItALink, final boolean expected) {
+        for (final Map.Entry<UUID, String> entry : systemsMap.entrySet()) {
+            assertSystem(htmlString, entry, isItALink, expected);
+        }
+    }
+
+    /**
+     * Asserts that the given system is present or not in the resulting HTML string.
+     * @param htmlString the resulting HTML for the email.
+     * @param entry the entry of the aggregated system.
+     * @param isItALink if the flag is given, it will check that the system is
+     *                  surrounded with a link to the system in Inventory.
+     * @param expected is it expected
+     */
+    private void assertSystem(final String htmlString, final Map.Entry<UUID, String> entry, final boolean isItALink, final boolean expected) {
+        if (isItALink) {
+            assertEquals(expected,
+                htmlString.contains(
+                    String.format(
+                        "<a target=\"_blank\" href=\"%s/insights/inventory/%s\">%s</a>",
+                        this.environment.url(),
+                        entry.getKey(),
+                        entry.getValue()
+                    )
+                ),
+                String.format("the resulting HTML should contain the \"%s\" system with a link to it, but it was not found", entry.getValue())
+            );
+        } else {
+            assertEquals(expected,
+                htmlString.contains(
+                    entry.getValue()), String.format("the resulting HTML should contain the \"%s\" system, but it was not found", entry.getValue()
+                )
+            );
+        }
+    }
+}

--- a/common-template/src/test/java/email/TestMalwareDetectionTemplate.java
+++ b/common-template/src/test/java/email/TestMalwareDetectionTemplate.java
@@ -1,0 +1,42 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestMalwareDetectionTemplate extends EmailTemplatesRendererHelper {
+
+    static final String DETECTED_MALWARE = "detected-malware";
+
+    @Override
+    protected String getApp() {
+        return "malware-detection";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Malware";
+    }
+
+    @Test
+    public void testInstantEmailTitle() {
+        Action action = TestHelpers.createMalwareDetectionAction();
+        eventTypeDisplayName = "Detected Malware";
+        String result = generateEmailSubject(DETECTED_MALWARE, action);
+        assertEquals("Instant notification - Detected Malware - Malware - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testInstantEmailBody() {
+        Action action = TestHelpers.createMalwareDetectionAction();
+        String result = generateEmailBody(DETECTED_MALWARE, action);
+        assertTrue(result.contains("Signature name"));
+        assertTrue(result.contains("For more details, go to Malware Detection."));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestOcmTemplate.java
+++ b/common-template/src/test/java/email/TestOcmTemplate.java
@@ -1,0 +1,259 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.OcmTestHelpers;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestOcmTemplate extends EmailTemplatesRendererHelper {
+
+    private static final String CLUSTER_UPDATE = "cluster-update";
+    private static final String CLUSTER_LIFECYCLE = "cluster-lifecycle";
+    private static final String CLUSTER_CUSTOMER_SUPPORT = "customer-support";
+    private static final String CAPACITY_MANAGEMENT = "capacity-management";
+    private static final String CLUSTER_ACCESS = "cluster-access";
+    private static final String CLUSTER_ADD_ON = "cluster-add-on";
+    private static final String CLUSTER_CONFIGURATION = "cluster-configuration";
+    private static final String CLUSTER_NETWORKING = "cluster-networking";
+    private static final String CLUSTER_OWNERSHIP = "cluster-ownership";
+    private static final String CLUSTER_SCALING = "cluster-scaling";
+    private static final String CLUSTER_SECURITY = "cluster-security";
+    private static final String CLUSTER_SUBSCRIPTION = "cluster-subscription";
+    private static final String GENERAL_NOTIFICATION = "general-notification";
+
+    @Override
+    protected String getBundle() {
+        return "openshift";
+    }
+
+    @Override
+    protected String getApp() {
+        return "cluster-manager";
+    }
+
+    static final List<String> getIdenticalTemplateContentEventTypeNames() {
+        return new ArrayList<>(Arrays.asList(CAPACITY_MANAGEMENT, CLUSTER_ACCESS, CLUSTER_ADD_ON, CLUSTER_CONFIGURATION, CLUSTER_NETWORKING, CLUSTER_OWNERSHIP, CLUSTER_SCALING, CLUSTER_SECURITY, CLUSTER_SUBSCRIPTION, GENERAL_NOTIFICATION));
+    }
+
+    @Test
+    public void testUpgradeEmailTitle() {
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", null, Optional.empty());
+        eventTypeDisplayName = "Cluster Update";
+        String result = generateEmailSubject(CLUSTER_UPDATE, action);
+        assertEquals("Cluster Update - Awesome subject", result);
+    }
+
+    @Test
+    public void testUpgradeScheduledInstantEmailBody() {
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template")));
+        String result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Upgrade scheduled"));
+        assertTrue(result.contains(((Map<String, String>) action.getEvents().get(0).getPayload().getAdditionalProperties().get("global_vars")).get("log_description")));
+        assertTrue(result.contains("What can you expect"));
+        assertTrue(result.contains("Thank you for choosing Red Hat OpenShift Dedicated Trial."));
+        assertFalse(result.contains("Check these resources for more information"));
+        assertTrue(result.contains("What should you do to minimize impact"));
+
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains("Check these resources for more information"));
+        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://console.redhat.com/openshift"));
+
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template-rosa-hcp")));
+        result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Upgrade scheduled"));
+        assertTrue(result.contains(((Map<String, String>) action.getEvents().get(0).getPayload().getAdditionalProperties().get("global_vars")).get("log_description")));
+        assertTrue(result.contains("Thank you for choosing Red Hat OpenShift Dedicated Trial."));
+        assertFalse(result.contains("What should you do to minimize impact"));
+    }
+
+    @Test
+    public void testUpgradeEndedInstantEmailBody() {
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "upgrade-ended-template")));
+        String result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains(((Map<String, String>) action.getEvents().get(0).getPayload().getAdditionalProperties().get("global_vars")).get("log_description")));
+        assertFalse(result.contains("What can you expect"));
+        assertTrue(result.contains("Thank you for choosing Red Hat OpenShift Service on AWS."));
+        assertFalse(result.contains("Check these resources for more information"));
+
+        Map<String, Object> additionalMapParameters = new HashMap<>();
+        additionalMapParameters.put("template_sub_type", "upgrade-ended-template");
+        additionalMapParameters.put("doc_references", null);
+        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(additionalMapParameters));
+        result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertFalse(result.contains("Check these resources for more information"));
+
+        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        result = generateEmailBody(CLUSTER_UPDATE, action);
+        assertTrue(result.contains("Check these resources for more information"));
+        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://console.redhat.com/openshift"));
+    }
+
+    @Test
+    public void testApprovedAccessEmailBody() {
+        // test generic template case
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> need a revision", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "ocm-approved-access-template")));
+        String result = generateEmailBody(CLUSTER_CUSTOMER_SUPPORT, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertTrue(result.contains("Your organization has enabled \"Approved Access\" for ROSA clusters"));
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+    }
+
+    @Test
+    public void testClusterLifecycleInstantEmailBody() {
+        // test generic template case
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "OSD", "<b>Batmobile</b> need a revision", "Awesome subject");
+        String result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertTrue(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with osd trial
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject");
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with trial_creation subtype
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial creation", Optional.of(Map.of("template_sub_type", "osd-trial-creation-template")));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Trial creation"));
+        assertFalse(result.contains("Awesome subject"));
+        assertFalse(result.contains("This notification is for your"));
+        assertTrue(result.contains("Welcome to your OpenShift Dedicated"));
+        assertTrue(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertTrue(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with trial_reminder subtype
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial reminder", Optional.of(Map.of("template_sub_type", "osd-trial-reminder-template")));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Trial reminder"));
+        assertFalse(result.contains("Awesome subject"));
+        assertFalse(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertTrue(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertTrue(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with trial_delete subtype
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template")));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Trial delete"));
+        assertFalse(result.contains("Awesome subject"));
+        assertFalse(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertTrue(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertTrue(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+        assertFalse(result.contains("Check these resources for more information"));
+
+        Map<String, Object> additionalMapParameters = new HashMap<>();
+        additionalMapParameters.put("template_sub_type", "osd-trial-deletion-template");
+        additionalMapParameters.put("doc_references", null);
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(additionalMapParameters));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertFalse(result.contains("Check these resources for more information"));
+
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        assertTrue(result.contains("Check these resources for more information"));
+        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://console.redhat.com/openshift"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIdenticalTemplateContentEventTypeNames")
+    public void testIdenticalInstantEmailBody(String eventType) {
+        // test generic template case
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "OSD", "<b>Batmobile</b> need a revision", "Awesome subject");
+        String result = generateEmailBody(eventType, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertTrue(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+
+        // test generic template case with osd trial
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject");
+        result = generateEmailBody(eventType, action);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Awesome subject"));
+        assertTrue(result.contains("This notification is for your"));
+        assertFalse(result.contains("Welcome to your OpenShift Dedicated"));
+        assertFalse(result.contains("We are notifying you about your"));
+        assertFalse(result.contains("Thank you for trialing OpenShift Dedicated"));
+
+        assertFalse(result.contains("Your subscription provides"));
+        assertFalse(result.contains("To learn more about the OpenShift Dedicated trial"));
+        assertFalse(result.contains("You will be notified once your cluster is deleted"));
+        assertFalse(result.contains("about OpenShift Dedicated, and create a new cluster at any time"));
+    }
+}

--- a/common-template/src/test/java/email/TestPatchTemplate.java
+++ b/common-template/src/test/java/email/TestPatchTemplate.java
@@ -1,0 +1,83 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.PatchTestHelpers;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestPatchTemplate extends EmailTemplatesRendererHelper {
+
+    static final String NEW_ADVISORY = "new-advisory";
+
+    private static final Action ACTION = PatchTestHelpers.createPatchAction();
+
+    public static final String JSON_PATCH_DEFAULT_AGGREGATION_CONTEXT = "{" +
+        "   \"patch\":{" +
+        "      \"security\":[" +
+        "         {" +
+        "            \"name\":\"advisory_1\"," +
+        "            \"synopsis\":\"synopsis\"" +
+        "         }" +
+        "      ]," +
+        "      \"bugfix\":[" +
+        "         {" +
+        "            \"name\":\"advisory_4\"," +
+        "            \"synopsis\":\"synopsis\"" +
+        "         }" +
+        "      ]," +
+        "      \"enhancement\":[" +
+        "         {" +
+        "            \"name\":\"advisory_2\"," +
+        "            \"synopsis\":\"synopsis\"" +
+        "         }," +
+        "         {" +
+        "            \"name\":\"advisory_3\"," +
+        "            \"synopsis\":\"synopsis\"" +
+        "         }" +
+        "      ]," +
+        "      \"other\":[" +
+        "         " +
+        "      ]" +
+        "   }," +
+        "   \"total_advisories\":4," +
+        "   \"start_time\":null," +
+        "   \"end_time\":null" +
+        "}";
+
+    @Override
+    protected String getApp() {
+        return "patch";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Patch";
+    }
+
+    @Test
+    public void testNewAdvisoryEmailTitle() {
+        eventTypeDisplayName = "New advisory";
+        String result = generateEmailSubject(NEW_ADVISORY, ACTION);
+        assertEquals("Instant notification - New advisory - Patch - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testNewAdvisoryEmailBody() {
+        String result = generateEmailBody(NEW_ADVISORY, ACTION);
+        assertTrue(result.contains("Red Hat Insights has just released new Advisories for your organization"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testDailyDigestEmailBody() throws JsonProcessingException {
+        String result = generateAggregatedEmailBody(JSON_PATCH_DEFAULT_AGGREGATION_CONTEXT);
+        assertTrue(result.contains("There are 4 new advisories affecting your systems."));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestPendoMessage.java
+++ b/common-template/src/test/java/email/TestPendoMessage.java
@@ -1,0 +1,46 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import email.pojo.EmailPendo;
+import helpers.PatchTestHelpers;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static email.pojo.EmailPendo.GENERAL_PENDO_MESSAGE;
+import static email.pojo.EmailPendo.GENERAL_PENDO_TITLE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestPendoMessage extends EmailTemplatesRendererHelper {
+
+    private static final String EVENT_TYPE_NAME = "new-advisory";
+
+    @Override
+    protected String getApp() {
+        return "patch";
+    }
+
+    @Test
+    public void testInstantEmailBody() {
+        EmailPendo emailPendo = new EmailPendo(GENERAL_PENDO_TITLE, String.format(GENERAL_PENDO_MESSAGE, environment.url()));
+
+        Action action = PatchTestHelpers.createPatchAction();
+        String result = generateEmailBody(EVENT_TYPE_NAME, action);
+        commonValidations(result);
+        assertFalse(result.contains(emailPendo.getPendoTitle()));
+        assertFalse(result.contains(emailPendo.getPendoMessage()));
+
+        result = generateEmailBody(EVENT_TYPE_NAME, action, emailPendo, false);
+        commonValidations(result);
+        assertTrue(result.contains(emailPendo.getPendoTitle()));
+        assertTrue(result.contains(emailPendo.getPendoMessage()));
+    }
+
+    private static void commonValidations(String result) {
+        assertTrue(result.contains("name 1"));
+        assertTrue(result.contains("synopsis 2"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestPendoMessageOcm.java
+++ b/common-template/src/test/java/email/TestPendoMessageOcm.java
@@ -1,0 +1,48 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import email.pojo.EmailPendo;
+import helpers.OcmTestHelpers;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestPendoMessageOcm extends EmailTemplatesRendererHelper {
+
+    private static final String CLUSTER_LIFECYCLE = "cluster-lifecycle";
+
+    @Override
+    protected String getBundle() {
+        return "openshift";
+    }
+
+    @Override
+    protected String getApp() {
+        return "cluster-manager";
+    }
+
+    @Test
+    public void testInstantEmailBody() {
+        EmailPendo emailPendo = new EmailPendo("OCM_PENDO_TITLE", "OCM_PENDO_MESSAGE");
+
+        Action action = OcmTestHelpers.createOcmAction("Batcave", "OSD", "<b>Batmobile</b> need a revision", "Awesome subject");
+        String result = generateEmailBody(CLUSTER_LIFECYCLE, action);
+        commonValidations(result);
+        assertFalse(result.contains(emailPendo.getPendoTitle()));
+        assertFalse(result.contains(emailPendo.getPendoMessage()));
+
+        result = generateEmailBody(CLUSTER_LIFECYCLE, action, emailPendo, false);
+        commonValidations(result);
+        assertTrue(result.contains(emailPendo.getPendoTitle()));
+        assertTrue(result.contains(emailPendo.getPendoMessage()));
+    }
+
+    private static void commonValidations(String result) {
+        assertTrue(result.contains("Batmobile"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestPoliciesTemplate.java
+++ b/common-template/src/test/java/email/TestPoliciesTemplate.java
@@ -1,0 +1,123 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestPoliciesTemplate extends EmailTemplatesRendererHelper {
+
+    private static final String EVENT_TYPE_NAME = "policy-triggered";
+
+    @Override
+    protected String getApp() {
+        return "policies";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Policies";
+    }
+
+    @Test
+    void testInstantEmailTitle() {
+        Action action = TestHelpers.createPoliciesAction("", "", "", "FooMachine");
+        eventTypeDisplayName = "Policy Triggered";
+        String result = generateEmailSubject(EVENT_TYPE_NAME, action);
+        assertEquals("Instant notification - Policy Triggered - Policies - Red Hat Enterprise Linux", result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testInstantEmailBody(boolean ignoreUserPreferences) {
+        Action action = TestHelpers.createPoliciesAction("", "", "", "FooMachine");
+        String result = generateEmailBody(EVENT_TYPE_NAME, action, null, ignoreUserPreferences);
+        assertTrue(result.contains(TestHelpers.POLICY_ID_1), "Body should contain policy id" + TestHelpers.POLICY_ID_1);
+        assertTrue(result.contains(TestHelpers.POLICY_NAME_1), "Body should contain policy name" + TestHelpers.POLICY_NAME_1);
+
+        assertTrue(result.contains(TestHelpers.POLICY_ID_2), "Body should contain policy id" + TestHelpers.POLICY_ID_2);
+        assertTrue(result.contains(TestHelpers.POLICY_NAME_2), "Body should contain policy name" + TestHelpers.POLICY_NAME_2);
+
+        // Display name
+        assertTrue(result.contains("FooMachine"), "Body should contain the display_name");
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+
+        assertEquals(ignoreUserPreferences, result.contains("This email was sent by Red Hat Hybrid Cloud Console, it is critical or requires action."));
+        assertEquals(ignoreUserPreferences, result.contains("Therefore, you are receiving this message regardless of your email preferences."));
+        assertNotEquals(ignoreUserPreferences, result.contains("This email was sent by Red Hat Hybrid Cloud Console |"));
+        assertNotEquals(ignoreUserPreferences, result.contains("Manage email preferences"));
+    }
+
+    @Test
+    void testDailyEmailBodyMultiplePoliciesAndSystems() {
+        String result = generateAggregatedEmailBody(buildPoliciesAggregatedPayload());
+        assertTrue(result.contains("Review the 3 policies that triggered 3 unique systems"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    public static Map<String, Object> buildPoliciesAggregatedPayload() {
+        LocalDateTime startTime = LocalDateTime.of(2021, 4, 22, 13, 15, 33);
+        LocalDateTime endTime = LocalDateTime.of(2021, 4, 22, 14, 15, 33);
+
+        Map<String, Object> policy01 = new HashMap<>();
+        policy01.put("policy_id", "policy-01");
+        policy01.put("policy_name", "My policy 01");
+        policy01.put("unique_system_count", 2);
+
+        Map<String, Object> policy02 = new HashMap<>();
+        policy02.put("policy_id", "policy-02");
+        policy02.put("policy_name", "My policy 02");
+        policy02.put("unique_system_count", 1);
+
+        Map<String, Object> policy03 = new HashMap<>();
+        policy03.put("policy_id", "policy-03");
+        policy03.put("policy_name", "My policy 03");
+        policy03.put("unique_system_count", 1);
+
+        Map<String, Object> policies = new HashMap<>();
+        policies.put("policy-01", policy01);
+        policies.put("policy-02", policy02);
+        policies.put("policy-03", policy03);
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("start_time", startTime);
+        payload.put("end_time", endTime);
+        payload.put("policies", policies);
+        payload.put("unique_system_count", 3);
+        return payload;
+    }
+
+    @Test
+    void testDailyEmailBodyOnePoliciesAndOneSystem() {
+        LocalDateTime startTime = LocalDateTime.of(2021, 4, 22, 13, 15, 33);
+        LocalDateTime endTime = LocalDateTime.of(2021, 4, 22, 14, 15, 33);
+
+        Map<String, Object> policy01 = new HashMap<>();
+        policy01.put("policy_id", "policy-01");
+        policy01.put("policy_name", "My policy 01");
+        policy01.put("unique_system_count", 1);
+
+        Map<String, Object> policies = new HashMap<>();
+        policies.put("policy-01", policy01);
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("start_time", startTime);
+        payload.put("end_time", endTime);
+        payload.put("policies", policies);
+        payload.put("unique_system_count", 1);
+
+        String result = generateAggregatedEmailBody(payload);
+        assertTrue(result.contains("Review the 1 policy that triggered 1 system"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestRbacTemplate.java
+++ b/common-template/src/test/java/email/TestRbacTemplate.java
@@ -1,0 +1,229 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.RbacTestHelpers;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestRbacTemplate extends EmailTemplatesRendererHelper {
+
+    static final String RH_NEW_ROLE_AVAILABLE = "rh-new-role-available";
+    static final String RH_PLATFORM_DEFAULT_ROLE_UPDATED = "rh-platform-default-role-updated";
+    static final String RH_NON_PLATFORM_DEFAULT_ROLE_UPDATED = "rh-non-platform-default-role-updated";
+    static final String CUSTOM_ROLE_CREATED = "custom-role-created";
+    static final String CUSTOM_ROLE_UPDATED = "custom-role-updated";
+    static final String CUSTOM_ROLE_DELETED = "custom-role-deleted";
+    static final String RH_NEW_ROLE_ADDED_TO_DEFAULT_ACCESS = "rh-new-role-added-to-default-access";
+    static final String RH_ROLE_REMOVED_FROM_DEFAULT_ACCESS = "rh-role-removed-from-default-access";
+    static final String CUSTOM_DEFAULT_ACCESS_UPDATED = "custom-default-access-updated";
+    static final String GROUP_CREATED = "group-created";
+    static final String GROUP_UPDATED = "group-updated";
+    static final String GROUP_DELETED = "group-deleted";
+    static final String PLATFORM_DEFAULT_GROUP_TURNED_INTO_CUSTOM = "platform-default-group-turned-into-custom";
+    static final String REQUEST_ACCESS = "request-access";
+    static final String RH_TAM_ACCESS_REQUESTED = "rh-new-tam-request-created";
+
+    static Stream<Arguments> RBAC_EVENT_TYPE_NAMES() {
+        return Stream.of(
+            Arguments.of(RH_NEW_ROLE_AVAILABLE, "New Red Hat role available"),
+            Arguments.of(RH_PLATFORM_DEFAULT_ROLE_UPDATED, "Red Hat role in platform default access group updated"),
+            Arguments.of(RH_NON_PLATFORM_DEFAULT_ROLE_UPDATED, "Red Hat role not in platform default access group updated"),
+            Arguments.of(CUSTOM_ROLE_CREATED, "Custom role created"),
+            Arguments.of(CUSTOM_ROLE_UPDATED, "Custom role updated"),
+            Arguments.of(CUSTOM_ROLE_DELETED, "Custom role deleted"),
+            Arguments.of(RH_NEW_ROLE_ADDED_TO_DEFAULT_ACCESS, "New Red Hat role added to platform default access group"),
+            Arguments.of(RH_ROLE_REMOVED_FROM_DEFAULT_ACCESS, "Red Hat role removed from platform default access group"),
+            Arguments.of(CUSTOM_DEFAULT_ACCESS_UPDATED, "Custom platform default access group updated"),
+            Arguments.of(GROUP_CREATED, "Group created"),
+            Arguments.of(GROUP_UPDATED, "Group updated"),
+            Arguments.of(GROUP_DELETED, "Group deleted"),
+            Arguments.of(PLATFORM_DEFAULT_GROUP_TURNED_INTO_CUSTOM, "Platform default access group turned into custom"),
+            Arguments.of(REQUEST_ACCESS, "Request access"),
+            Arguments.of(RH_TAM_ACCESS_REQUESTED, "New TAM access request created")
+        );
+    }
+
+    @Override
+    protected String getBundle() {
+        return "console";
+    }
+
+    @Override
+    protected String getApp() {
+        return "rbac";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "Console";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "User Access";
+    }
+
+    @MethodSource("RBAC_EVENT_TYPE_NAMES")
+    @ParameterizedTest
+    void shouldTestAllEventTypeTemplateTitles(String eventType, String eventTypeDispName) {
+        Action action = RbacTestHelpers.createRbacAction();
+        eventTypeDisplayName = eventTypeDispName;
+        String result = generateEmailSubject(eventType, action);
+        testTitle(eventType, result);
+    }
+
+    @MethodSource("RBAC_EVENT_TYPE_NAMES")
+    @ParameterizedTest
+    void shouldTestAllEventTypeTemplateBodies(String eventType) {
+        Action action = RbacTestHelpers.createRbacAction();
+        String result = generateEmailBody(eventType, action);
+        testBody(eventType, result);
+    }
+
+
+    private void testTitle(String eventType, String result) {
+        switch (eventType) {
+            case RH_NEW_ROLE_AVAILABLE:
+                assertEquals("Instant notification - New Red Hat role available - User Access - Console", result);
+                break;
+            case RH_PLATFORM_DEFAULT_ROLE_UPDATED:
+                assertEquals("Instant notification - Red Hat role in platform default access group updated - User Access - Console", result);
+                break;
+            case RH_NON_PLATFORM_DEFAULT_ROLE_UPDATED:
+                assertEquals("Instant notification - Red Hat role not in platform default access group updated - User Access - Console", result);
+                break;
+            case CUSTOM_ROLE_CREATED:
+                assertEquals("Instant notification - Custom role created - User Access - Console", result);
+                break;
+            case CUSTOM_ROLE_UPDATED:
+                assertEquals("Instant notification - Custom role updated - User Access - Console", result);
+                break;
+            case CUSTOM_ROLE_DELETED:
+                assertEquals("Instant notification - Custom role deleted - User Access - Console", result);
+                break;
+            case RH_NEW_ROLE_ADDED_TO_DEFAULT_ACCESS:
+                assertEquals("Instant notification - New Red Hat role added to platform default access group - User Access - Console", result);
+                break;
+            case RH_ROLE_REMOVED_FROM_DEFAULT_ACCESS:
+                assertEquals("Instant notification - Red Hat role removed from platform default access group - User Access - Console", result);
+                break;
+            case CUSTOM_DEFAULT_ACCESS_UPDATED:
+                assertEquals("Instant notification - Custom platform default access group updated - User Access - Console", result);
+                break;
+            case GROUP_CREATED:
+                assertEquals("Instant notification - Group created - User Access - Console", result);
+                break;
+            case GROUP_UPDATED:
+                assertEquals("Instant notification - Group updated - User Access - Console", result);
+                break;
+            case GROUP_DELETED:
+                assertEquals("Instant notification - Group deleted - User Access - Console", result);
+                break;
+            case PLATFORM_DEFAULT_GROUP_TURNED_INTO_CUSTOM:
+                assertEquals("Instant notification - Platform default access group turned into custom - User Access - Console", result);
+                break;
+            case REQUEST_ACCESS:
+                assertEquals("Instant notification - Request access - User Access - Console", result);
+                break;
+            case RH_TAM_ACCESS_REQUESTED:
+                assertEquals("Instant notification - New TAM access request created - User Access - Console", result);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void testBody(String eventType, String result) {
+        switch (eventType) {
+            case RH_NEW_ROLE_AVAILABLE:
+                assertTrue(result.contains("Red Hat now provides a new role"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case RH_PLATFORM_DEFAULT_ROLE_UPDATED:
+                assertTrue(result.contains("Red Hat has updated the role"));
+                assertTrue(result.contains("The role belongs to the platform default access group and"));
+                assertTrue(result.contains("will be inherited by all users within your account."));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case RH_NON_PLATFORM_DEFAULT_ROLE_UPDATED:
+                assertTrue(result.contains("Red Hat has updated the role"));
+                assertTrue(result.contains("The role does not belong to the platform default access group."));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case CUSTOM_ROLE_CREATED:
+                assertTrue(result.contains("custom role"));
+                assertTrue(result.contains("has been created by"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case CUSTOM_ROLE_UPDATED:
+                assertTrue(result.contains("has been updated by"));
+                assertTrue(result.contains("Custom role"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case CUSTOM_ROLE_DELETED:
+                assertTrue(result.contains("Custom role"));
+                assertTrue(result.contains("has been deleted by"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case RH_NEW_ROLE_ADDED_TO_DEFAULT_ACCESS:
+                assertTrue(result.contains("Red Hat added a role"));
+                assertTrue(result.contains("to platform default access group."));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case RH_ROLE_REMOVED_FROM_DEFAULT_ACCESS:
+                assertTrue(result.contains("Red Hat removed a role"));
+                assertTrue(result.contains("from platform default access group"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case CUSTOM_DEFAULT_ACCESS_UPDATED:
+                assertTrue(result.contains("Custom platform default access group has been updated by"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case GROUP_CREATED:
+                assertTrue(result.contains("A custom group"));
+                assertTrue(result.contains("has been created by"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case GROUP_UPDATED:
+                assertTrue(result.contains("Custom group has been updated by"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case GROUP_DELETED:
+                assertTrue(result.contains("Custom group"));
+                assertTrue(result.contains("has been deleted by"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case PLATFORM_DEFAULT_GROUP_TURNED_INTO_CUSTOM:
+                assertTrue(result.contains("Platform default group is modified by"));
+                assertTrue(result.contains("Red Hat will not be responsible for managing it from now on."));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case REQUEST_ACCESS:
+                assertTrue(result.contains("Request for access received"));
+                assertTrue(result.contains("within console.redhat.com. Please review this request and decide whether to grant or deny access."));
+                assertTrue(result.contains("Granting Access:"));
+                assertTrue(result.contains("Denying Access:"));
+                assertTrue(result.contains("https://console.redhat.com/stuff"));
+                assertTrue(result.contains("I want access to stuff"));
+                assertTrue(result.contains("testUser AT somewhere"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case RH_TAM_ACCESS_REQUESTED:
+                assertTrue(result.contains("New TAM Access Request"));
+                assertTrue(result.contains("A technical account manager requested to access your account."));
+                assertTrue(result.contains("Check the request in Insights"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/common-template/src/test/java/email/TestResourceOptimizationTemplate.java
+++ b/common-template/src/test/java/email/TestResourceOptimizationTemplate.java
@@ -1,0 +1,49 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestResourceOptimizationTemplate extends EmailTemplatesRendererHelper {
+
+    public static final String JSON_RESOURCE_OPTIMIZATION_DEFAULT_AGGREGATION_CONTEXT = "{" +
+        "   \"event_name\":\"New suggestion\"," +
+        "   \"systems_with_suggestions\":134," +
+        "   \"start_time\":\"2020-08-03T15:22:42.199046\"," +
+        "   \"aggregated_data\":{" +
+        "      \"systems_with_suggestions\":134," +
+        "      \"systems_triggered\":2," +
+        "      \"states\":[" +
+        "         {" +
+        "            \"system_count\":7," +
+        "            \"state\":\"IDLING\"" +
+        "         }," +
+        "         {" +
+        "            \"system_count\":1," +
+        "            \"state\":\"UNKNOWN\"" +
+        "         }," +
+        "         {" +
+        "            \"system_count\":4," +
+        "            \"state\":\"UNDER_PRESSURE\"" +
+        "         }" +
+        "      ]" +
+        "   }" +
+        "}";
+
+    @Override
+    protected String getApp() {
+        return "resource-optimization";
+    }
+
+    @Test
+    public void testDailyDigestEmailBody() throws JsonProcessingException {
+        String result = generateAggregatedEmailBody(JSON_RESOURCE_OPTIMIZATION_DEFAULT_AGGREGATION_CONTEXT);
+        assertTrue(result.contains("Today, rules triggered on"));
+        assertTrue(result.contains("IDLING"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+}

--- a/common-template/src/test/java/email/TestRhelDailyTemplate.java
+++ b/common-template/src/test/java/email/TestRhelDailyTemplate.java
@@ -1,0 +1,109 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.redhat.cloud.notifications.qute.templates.IntegrationType;
+import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
+import com.redhat.cloud.notifications.qute.templates.TemplateService;
+import email.pojo.DailyDigestSection;
+import email.pojo.EmailPendo;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static email.TestAdvisorTemplate.JSON_ADVISOR_DEFAULT_AGGREGATION_CONTEXT;
+import static email.TestImageBuilderTemplate.JSON_IMAGE_BUILDER_DEFAULT_AGGREGATION_CONTEXT;
+import static email.TestInventoryTemplate.JSON_INVENTORY_DEFAULT_AGGREGATION_CONTEXT;
+import static email.TestPatchTemplate.JSON_PATCH_DEFAULT_AGGREGATION_CONTEXT;
+import static email.TestResourceOptimizationTemplate.JSON_RESOURCE_OPTIMIZATION_DEFAULT_AGGREGATION_CONTEXT;
+import static email.pojo.EmailPendo.GENERAL_PENDO_MESSAGE;
+import static email.pojo.EmailPendo.GENERAL_PENDO_TITLE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestRhelDailyTemplate extends EmailTemplatesRendererHelper {
+
+    String myCurrentApp;
+
+    @Override
+    protected String getApp() {
+        return myCurrentApp;
+    }
+
+    @Inject
+    TemplateService templateService;
+
+    @Test
+    public void testDailyEmailBodyAllApplications() throws JsonProcessingException {
+
+        Map<String, DailyDigestSection> dataMap = new HashMap<>();
+
+        generateAggregatedEmailBody(TestPoliciesTemplate.buildPoliciesAggregatedPayload(), "policies", dataMap);
+
+        generateAggregatedEmailBody(JSON_ADVISOR_DEFAULT_AGGREGATION_CONTEXT, "advisor", dataMap);
+
+        generateAggregatedEmailBody(templateService.convertActionToContextMap(TestHelpers.createComplianceAction()), "compliance", dataMap);
+
+        generateAggregatedEmailBody(JSON_INVENTORY_DEFAULT_AGGREGATION_CONTEXT, "inventory", dataMap);
+
+        generateAggregatedEmailBody(JSON_PATCH_DEFAULT_AGGREGATION_CONTEXT, "patch", dataMap);
+
+        generateAggregatedEmailBody(JSON_RESOURCE_OPTIMIZATION_DEFAULT_AGGREGATION_CONTEXT, "resource-optimization", dataMap);
+
+        generateAggregatedEmailBody(templateService.convertActionToContextMap(TestHelpers.createVulnerabilityAction()), "vulnerability", dataMap);
+
+        generateAggregatedEmailBody(JSON_IMAGE_BUILDER_DEFAULT_AGGREGATION_CONTEXT, "image-builder", dataMap);
+
+        // sort application by name
+        List<DailyDigestSection> result = dataMap.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(Map.Entry::getValue)
+            .toList();
+
+        TemplateDefinition globalDailyTemplateDefinition = new TemplateDefinition(IntegrationType.EMAIL_DAILY_DIGEST_BUNDLE_AGGREGATION_BODY, null, null, null);
+
+        Map<String, Object> mapData = Map.of("title", "Daily digest - Red Hat Enterprise Linux", "items", result, "orgId", DEFAULT_ORG_ID);
+
+        EmailPendo emailPendo = new EmailPendo(GENERAL_PENDO_TITLE, String.format(GENERAL_PENDO_MESSAGE, environment.url()));
+
+        String templateResult = generateEmailFromContextMap(globalDailyTemplateDefinition, mapData, null);
+        templateResultChecks(templateResult);
+        assertFalse(templateResult.contains(emailPendo.getPendoTitle()));
+        assertFalse(templateResult.contains(emailPendo.getPendoMessage()));
+
+        templateResult = generateEmailFromContextMap(globalDailyTemplateDefinition, mapData, emailPendo);
+        templateResultChecks(templateResult);
+        assertTrue(templateResult.contains(emailPendo.getPendoTitle()));
+        assertTrue(templateResult.contains(emailPendo.getPendoMessage()));
+    }
+
+    private static void templateResultChecks(String templateResult) {
+        assertTrue(templateResult.contains("\"#advisor-section1\""));
+        assertTrue(templateResult.contains("\"#compliance-section1\""));
+        assertTrue(templateResult.contains("\"#image-builder-section1\""));
+        assertTrue(templateResult.contains("\"#image-builder-section2\""));
+        assertTrue(templateResult.contains("\"#inventory-section1\""));
+        assertTrue(templateResult.contains("\"#patch-section1\""));
+        assertTrue(templateResult.contains("\"#policies-section1\""));
+        assertTrue(templateResult.contains("\"#resource-optimization-section1\""));
+        assertTrue(templateResult.contains("\"#vulnerability-section1\""));
+
+        assertTrue(templateResult.contains("\"advisor-section1\""));
+        assertTrue(templateResult.contains("\"compliance-section1\""));
+        assertTrue(templateResult.contains("\"image-builder-section1\""));
+        assertTrue(templateResult.contains("\"image-builder-section2\""));
+        assertTrue(templateResult.contains("\"inventory-section1\""));
+        assertTrue(templateResult.contains("\"patch-section1\""));
+        assertTrue(templateResult.contains("\"policies-section1\""));
+        assertTrue(templateResult.contains("\"resource-optimization-section1\""));
+        assertTrue(templateResult.contains("\"vulnerability-section1\""));
+
+        // Query parameters in URLs
+        assertTrue(templateResult.contains("/insights/patch/advisories/advisory_3?from=notifications&integration=daily_digest\">advisory_3</a>"));
+    }
+}

--- a/common-template/src/test/java/email/TestSourcesTemplate.java
+++ b/common-template/src/test/java/email/TestSourcesTemplate.java
@@ -1,0 +1,50 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestSourcesTemplate extends EmailTemplatesRendererHelper {
+
+    static final String AVAILABILITY_STATUS = "availability-status";
+    private static final Action ACTION = TestHelpers.createSourcesAction();
+
+    @Override
+    protected String getBundle() {
+        return "console";
+    }
+
+    @Override
+    protected String getApp() {
+        return "sources";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "Console";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Sources";
+    }
+
+    @Test
+    public void testAvailabilityStatusEmailBody() {
+        String result = generateEmailBody(AVAILABILITY_STATUS, ACTION);
+        assertTrue(result.contains("availability status was changed"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testAvailabilityStatusEmailTitle() {
+        eventTypeDisplayName = "Availability Status";
+        String result = generateEmailSubject(AVAILABILITY_STATUS, ACTION);
+        assertEquals("Instant notification - Availability Status - Sources - Console", result);
+    }
+}

--- a/common-template/src/test/java/email/TestSubscriptionServicesDailyTemplate.java
+++ b/common-template/src/test/java/email/TestSubscriptionServicesDailyTemplate.java
@@ -1,0 +1,74 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.redhat.cloud.notifications.qute.templates.IntegrationType;
+import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
+import com.redhat.cloud.notifications.qute.templates.mapping.SubscriptionServices;
+import email.pojo.DailyDigestSection;
+import email.pojo.EmailPendo;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static email.TestErrataTemplate.JSON_ERRATA_DEFAULT_AGGREGATION_CONTEXT;
+import static email.pojo.EmailPendo.GENERAL_PENDO_MESSAGE;
+import static email.pojo.EmailPendo.GENERAL_PENDO_TITLE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class TestSubscriptionServicesDailyTemplate extends EmailTemplatesRendererHelper {
+
+    String myCurrentApp;
+
+    @Override
+    protected String getApp() {
+        return myCurrentApp;
+    }
+
+    @Override
+    protected String getBundle() {
+        return SubscriptionServices.BUNDLE_NAME;
+    }
+
+    @Test
+    void testDailyEmailBodyAllApplications() throws JsonProcessingException {
+
+        Map<String, DailyDigestSection> dataMap = new HashMap<>();
+
+        generateAggregatedEmailBody(JSON_ERRATA_DEFAULT_AGGREGATION_CONTEXT, SubscriptionServices.ERRATA_APP_NAME, dataMap);
+
+        // sort application by name
+        List<DailyDigestSection> result = dataMap.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(Map.Entry::getValue)
+            .toList();
+
+        TemplateDefinition globalDailyTemplateDefinition = new TemplateDefinition(IntegrationType.EMAIL_DAILY_DIGEST_BUNDLE_AGGREGATION_BODY, null, null, null);
+
+        Map<String, Object> mapData = Map.of("title", "Daily digest - Subscription Services", "items", result, "orgId", DEFAULT_ORG_ID);
+
+        EmailPendo emailPendo = new EmailPendo(GENERAL_PENDO_TITLE, String.format(GENERAL_PENDO_MESSAGE, environment.url()));
+
+        String templateResult = generateEmailFromContextMap(globalDailyTemplateDefinition, mapData, null);
+        templateResultChecks(templateResult);
+        assertFalse(templateResult.contains(emailPendo.getPendoTitle()));
+        assertFalse(templateResult.contains(emailPendo.getPendoMessage()));
+
+        templateResult = generateEmailFromContextMap(globalDailyTemplateDefinition, mapData, emailPendo);
+        templateResultChecks(templateResult);
+        assertTrue(templateResult.contains(emailPendo.getPendoTitle()));
+        assertTrue(templateResult.contains(emailPendo.getPendoMessage()));
+    }
+
+    private static void templateResultChecks(String templateResult) {
+        assertTrue(templateResult.contains("\"#errata-notifications-section1-1\""));
+        assertTrue(templateResult.contains("\"#errata-notifications-section1-2\""));
+        assertTrue(templateResult.contains("\"#errata-notifications-section1-3\""));
+    }
+
+
+}

--- a/common-template/src/test/java/email/TestTasksTemplate.java
+++ b/common-template/src/test/java/email/TestTasksTemplate.java
@@ -1,0 +1,64 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TasksTestHelpers;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestTasksTemplate extends EmailTemplatesRendererHelper {
+
+    private static final String EVENT_TYPE_EXECUTED_TASK_COMPLETED = "executed-task-completed";
+
+    private static final String EVENT_TYPE_JOB_FAILED = "job-failed";
+
+    @Override
+    protected String getApp() {
+        return "tasks";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Tasks";
+    }
+
+    @Test
+    public void testExecutedTaskCompletedEmailTitle() {
+        Action action = TasksTestHelpers.createTasksExecutedTaskCompletedAction(EVENT_TYPE_EXECUTED_TASK_COMPLETED);
+        eventTypeDisplayName = "Executed Task completed";
+        String result = generateEmailSubject(EVENT_TYPE_EXECUTED_TASK_COMPLETED, action);
+        assertEquals("Instant notification - Executed Task completed - Tasks - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testExecutedTaskCompletedEmailBody() {
+        Action action = TasksTestHelpers.createTasksExecutedTaskCompletedAction(EVENT_TYPE_EXECUTED_TASK_COMPLETED);
+        String result = generateEmailBody(EVENT_TYPE_EXECUTED_TASK_COMPLETED, action);
+        assertTrue(result.contains("Executed task completed"));
+        assertTrue(result.contains("has been executed and ended with status"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testJobFailedEmailTitle() {
+        Action action = TasksTestHelpers.createTasksJobFailedAction(EVENT_TYPE_JOB_FAILED);
+        eventTypeDisplayName = "Job failed";
+        String result = generateEmailSubject(EVENT_TYPE_JOB_FAILED, action);
+        assertEquals("Instant notification - Job failed - Tasks - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testJobFailedEmailBody() {
+        Action action = TasksTestHelpers.createTasksJobFailedAction(EVENT_TYPE_JOB_FAILED);
+        String result = generateEmailBody(EVENT_TYPE_JOB_FAILED, action);
+        assertTrue(result.contains("Job failed"));
+        assertTrue(result.contains("from task"));
+        assertTrue(result.contains("has failed"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+}

--- a/common-template/src/test/java/email/TestVulnerabilityTemplate.java
+++ b/common-template/src/test/java/email/TestVulnerabilityTemplate.java
@@ -1,0 +1,113 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@QuarkusTest
+public class TestVulnerabilityTemplate extends EmailTemplatesRendererHelper {
+
+    private static final Action ACTION = TestHelpers.createVulnerabilityAction();
+
+    static final String NEW_CVE_HIGH_CVSS_EVENT = "new-cve-cvss";
+    static final String NEW_CVE_CRIT_SEVERITY_EVENT = "new-cve-severity";
+    static final String NEW_CVE_SECURITY_RULE_EVENT = "new-cve-security-rule";
+    static final String ANY_CVE_KNOWN_EXPLOIT_EVENT = "any-cve-known-exploit";
+
+    @Override
+    protected String getApp() {
+        return "vulnerability";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Vulnerability";
+    }
+
+    static Stream<Arguments> getEventTypeNames() {
+        return Stream.of(
+            Arguments.of(ANY_CVE_KNOWN_EXPLOIT_EVENT, "Any vulnerability with known exploit"),
+            Arguments.of(NEW_CVE_CRIT_SEVERITY_EVENT, "New vulnerability with Critical Severity"),
+            Arguments.of(NEW_CVE_HIGH_CVSS_EVENT, "New vulnerability with CVSS >= 7.0"),
+            Arguments.of(NEW_CVE_SECURITY_RULE_EVENT, "New vulnerability containing Security rule")
+        );
+    }
+
+    @Test
+    public void testDailyDigestEmailBody() {
+        String result = generateAggregatedEmailBody(ACTION);
+        assertTrue(result.contains("Red Hat Insights has identified one or more CVEs that require your attention"));
+        assertTrue(result.contains("CVE3"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @MethodSource("getEventTypeNames")
+    @ParameterizedTest
+    public void testInstantEmailTitle(String eventType, String eventTypeDispName) {
+        eventTypeDisplayName = eventTypeDispName;
+        String result = generateEmailSubject(eventType, ACTION);
+        testTitle(eventType, result);
+    }
+
+    private void testTitle(String eventType, String result) {
+        switch (eventType) {
+            case ANY_CVE_KNOWN_EXPLOIT_EVENT:
+                assertEquals("Instant notification - Any vulnerability with known exploit - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
+            case NEW_CVE_CRIT_SEVERITY_EVENT:
+                assertEquals("Instant notification - New vulnerability with Critical Severity - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
+            case NEW_CVE_HIGH_CVSS_EVENT:
+                assertEquals("Instant notification - New vulnerability with CVSS >= 7.0 - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
+            case NEW_CVE_SECURITY_RULE_EVENT:
+                assertEquals("Instant notification - New vulnerability containing Security rule - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
+            default:
+                fail();
+                break;
+        }
+    }
+
+    @ValueSource(strings = { ANY_CVE_KNOWN_EXPLOIT_EVENT, NEW_CVE_CRIT_SEVERITY_EVENT, NEW_CVE_HIGH_CVSS_EVENT, NEW_CVE_SECURITY_RULE_EVENT })
+    @ParameterizedTest
+    public void testInstantEmailBody(String eventType) {
+        String result = generateEmailBody(eventType, ACTION);
+        testBody(eventType, result);
+    }
+
+    private void testBody(String eventType, String result) {
+        assertTrue(result.contains(ACTION.getEvents().get(0).getPayload().getAdditionalProperties().get("reported_cve").toString()));
+        switch (eventType) {
+            case ANY_CVE_KNOWN_EXPLOIT_EVENT:
+                assertTrue(result.contains("Red Hat Insights has just identified a CVE with the Known Exploit label"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case NEW_CVE_CRIT_SEVERITY_EVENT:
+                assertTrue(result.contains("Red Hat Insights has just identified a CVE with a severity of Critical"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case NEW_CVE_HIGH_CVSS_EVENT:
+                assertTrue(result.contains("Red Hat Insights has just identified a CVE with a CVSS score of >= 7"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case NEW_CVE_SECURITY_RULE_EVENT:
+                assertTrue(result.contains("Red Hat Insights has just identified a newly published CVE with the Security rule label"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            default:
+                fail();
+                break;
+        }
+    }
+}

--- a/common-template/src/test/java/email/pojo/DailyDigestSection.java
+++ b/common-template/src/test/java/email/pojo/DailyDigestSection.java
@@ -1,0 +1,29 @@
+package email.pojo;
+
+import java.util.List;
+
+public class DailyDigestSection {
+    String body;
+    List<String> headerLink;
+
+    public DailyDigestSection(String body, List<String> headerLink) {
+        this.body = body;
+        this.headerLink = headerLink;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public List<String> getHeaderLink() {
+        return headerLink;
+    }
+
+    public void setHeaderLink(List<String> headerLink) {
+        this.headerLink = headerLink;
+    }
+}

--- a/common-template/src/test/java/email/pojo/EmailPendo.java
+++ b/common-template/src/test/java/email/pojo/EmailPendo.java
@@ -1,0 +1,25 @@
+package email.pojo;
+
+public class EmailPendo {
+    public static String GENERAL_PENDO_MESSAGE = "You can also receive notifications on tools like Slack, Microsoft Teams, Google chat, and more! Go to <b><a href=\"%s/settings/integrations\" target=\"_blank\">integrations</a></b> to set those up.";
+    public static String GENERAL_PENDO_TITLE = "Did you know?";
+
+    public static final String OUTAGE_PENDO_MESSAGE = "Between Aug 22, 07:19 AM UTC and Aug 26, 12:47 PM UTC, the notifications email service experienced an outage. This email was delayed from that time period.";
+    public static final String OUTAGE_PENDO_TITLE = "Outage notice";
+
+    private String pendoTitle;
+    private String pendoMessage;
+
+    public EmailPendo(String pendoTitle, String pendoMessage) {
+        this.pendoTitle = pendoTitle;
+        this.pendoMessage = pendoMessage;
+    }
+
+    public String getPendoTitle() {
+        return pendoTitle;
+    }
+
+    public String getPendoMessage() {
+        return pendoMessage;
+    }
+}

--- a/common-template/src/test/java/email/pojo/Environment.java
+++ b/common-template/src/test/java/email/pojo/Environment.java
@@ -1,0 +1,41 @@
+package email.pojo;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class Environment {
+
+    public static final String LOCAL_ENV = "local-dev";
+    public static final String STAGE_ENV = "stage";
+
+    @ConfigProperty(name = "env.name", defaultValue = LOCAL_ENV)
+    String environment;
+
+    @ConfigProperty(name = "env.base.url", defaultValue = "https://localhost")
+    String url;
+
+    public String name() {
+        return this.environment;
+    }
+
+    public String url() {
+        return this.url;
+    }
+
+    /**
+     * Checks if the "ENV_NAME" environment variable is set to "local-dev".
+     * @return true if the "ENV_NAME" environment variable is set to "local-dev".
+     */
+    public boolean isLocal() {
+        return LOCAL_ENV.equals(this.environment);
+    }
+
+    /**
+     * Checks if the "ENV_NAME" environment variable is set to "stage".
+     * @return true if the "ENV_NAME" environment variable is set to "stage".
+     */
+    public boolean isStage() {
+        return STAGE_ENV.equals(this.environment);
+    }
+}

--- a/common-template/src/test/java/email/pojo/NotificationsConsoleCloudEvent.java
+++ b/common-template/src/test/java/email/pojo/NotificationsConsoleCloudEvent.java
@@ -1,0 +1,13 @@
+package email.pojo;
+
+import com.redhat.cloud.event.core.v1.Notification;
+import com.redhat.cloud.event.core.v1.Recipients;
+import com.redhat.cloud.event.parser.ConsoleCloudEvent;
+import java.util.Optional;
+
+public class NotificationsConsoleCloudEvent extends ConsoleCloudEvent {
+
+    public Optional<Recipients> getRecipients() {
+        return this.getData(Notification.class).map(Notification::getNotificationRecipients);
+    }
+}

--- a/common-template/src/test/java/helpers/InventoryTestHelpers.java
+++ b/common-template/src/test/java/helpers/InventoryTestHelpers.java
@@ -8,6 +8,7 @@ import com.redhat.cloud.notifications.ingress.Payload;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
@@ -47,6 +48,41 @@ public class InventoryTestHelpers {
                         )
                         .build()
         ));
+
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+
+        return emailActionMessage;
+    }
+
+    /**
+     * Creates an inventory action.
+     * @param bundle the bundle of the triggered event.
+     * @param application the application of the triggered event.
+     * @param eventType the type of the triggered event.
+     * @param inventoryId the inventory object that triggered the event.
+     * @param hostDisplayName the display name of the host that triggered the
+     *                        event.
+     * @return the build action.
+     */
+    public static Action createInventoryActionV2(
+        final String bundle,
+        final String application,
+        final String eventType,
+        final UUID inventoryId,
+        final String hostDisplayName
+    ) {
+        final Action emailActionMessage = new Action();
+        emailActionMessage.setBundle(bundle);
+        emailActionMessage.setApplication(application);
+        emailActionMessage.setTimestamp(LocalDateTime.now());
+        emailActionMessage.setEventType(eventType);
+
+        emailActionMessage.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("display_name", hostDisplayName)
+                .withAdditionalProperty("inventory_id", inventoryId)
+                .build()
+        );
 
         emailActionMessage.setOrgId(DEFAULT_ORG_ID);
 

--- a/common-template/src/test/java/helpers/OcmTestHelpers.java
+++ b/common-template/src/test/java/helpers/OcmTestHelpers.java
@@ -1,5 +1,6 @@
 package helpers;
 
+import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
@@ -16,6 +17,54 @@ import java.util.Optional;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
 public class OcmTestHelpers {
+
+    public static Action createOcmAction(String clusterDisplayName, String subscriptionPlan, String logDescription, String subject) {
+        return createOcmAction(clusterDisplayName, subscriptionPlan, logDescription, subject, null, Optional.empty());
+    }
+
+    public static Action createOcmAction(String clusterDisplayName, String subscriptionPlan, String logDescription, String subject, String title, Optional<Map<String, Object>> specificGlobalVars) {
+        Action emailActionMessage = new Action();
+        emailActionMessage.setBundle("openshift");
+        emailActionMessage.setApplication("cluster-manager");
+        emailActionMessage.setTimestamp(LocalDateTime.now());
+        emailActionMessage.setEventType("testEmailSubscriptionInstant");
+
+        emailActionMessage.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("system_check_in", "2021-07-13T15:22:42.199046")
+                .withAdditionalProperty("tags", List.of())
+                .build()
+        );
+        Map<String, Object> globalVars = new HashMap<>();
+        globalVars.put("cluster_display_name", clusterDisplayName);
+        globalVars.put("subscription_id", "2XqNHRdLNEAzshh7MkkOql6fx6I");
+        globalVars.put("subscription_plan", subscriptionPlan);
+        globalVars.put("log_description", logDescription);
+        globalVars.put("internal_cluster_id", "fekelklflef");
+
+        if (specificGlobalVars.isPresent()) {
+            globalVars.putAll(specificGlobalVars.get());
+        }
+
+        emailActionMessage.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("global_vars", globalVars)
+                        .withAdditionalProperty("subject", subject)
+                        .withAdditionalProperty("title", title)
+                        .build()
+                )
+                .build()
+        ));
+
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+
+        return emailActionMessage;
+    }
+
+
 
     public static JsonObject createOcmMessage(String clusterDisplayName, String subscriptionPlan, String logDescription, String subject) {
         return createOcmMessage(clusterDisplayName, subscriptionPlan, logDescription, subject, null, Optional.empty());

--- a/common-template/src/test/java/helpers/RbacTestHelpers.java
+++ b/common-template/src/test/java/helpers/RbacTestHelpers.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
@@ -57,6 +58,7 @@ public class RbacTestHelpers {
 
     private static class TestRole {
         public String name;
+        public UUID uuid = UUID.randomUUID();
 
         TestRole(String name) {
             this.name = name;

--- a/common-template/src/test/java/helpers/TasksTestHelpers.java
+++ b/common-template/src/test/java/helpers/TasksTestHelpers.java
@@ -1,0 +1,61 @@
+package helpers;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
+public class TasksTestHelpers {
+
+    private static Action createTasksAction(String eventType, Payload payload) {
+        Action emailActionMessage = new Action();
+        emailActionMessage.setBundle("rhel");
+        emailActionMessage.setApplication("tasks");
+        emailActionMessage.setTimestamp(LocalDateTime.now());
+        emailActionMessage.setEventType(eventType);
+
+        emailActionMessage.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(payload)
+                .build()
+        ));
+
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+
+        return emailActionMessage;
+    }
+
+    public static Action createTasksExecutedTaskCompletedAction(String eventType) {
+        Payload payload = new Payload.PayloadBuilder()
+            .withAdditionalProperty("task_name", "RHEL pre-upgrade analysis utility")
+            .withAdditionalProperty("executed_task_id", 9651)
+            .withAdditionalProperty("status", "Completed")
+            .build();
+
+        return createTasksAction(eventType, payload);
+    }
+
+    public static Action createTasksJobFailedAction(String eventType) {
+        Payload payload = new Payload.PayloadBuilder()
+            .withAdditionalProperty("system_uuid", "0c1fa20b-889b-469c-993d-775c06480cd8")
+            .withAdditionalProperty("display_name", "iqe-jenkins-tasks-rhel-89-prod")
+            .withAdditionalProperty("status", "TIMEOUT")
+            .build();
+        Action action = createTasksAction(eventType, payload);
+
+        action.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("task_name", "test_task")
+                .withAdditionalProperty("task_slug", "leapp-preupgrade")
+                .withAdditionalProperty("executed_task_id", 10750)
+                .build()
+        );
+        return action;
+    }
+}

--- a/common-template/src/test/java/helpers/TestHelpers.java
+++ b/common-template/src/test/java/helpers/TestHelpers.java
@@ -14,10 +14,6 @@ import com.redhat.cloud.notifications.qute.templates.TemplateService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -198,72 +194,6 @@ public class TestHelpers {
         return emailActionMessage;
     }
 
-    public static Action createAdvisorOpenshiftAction(String accountId, String eventType) {
-        Action emailActionMessage = new Action();
-        emailActionMessage.setBundle("openshift");
-        emailActionMessage.setApplication("advisor");
-        emailActionMessage.setTimestamp(LocalDateTime.of(2021, 5, 20, 15, 22, 13, 25));
-        emailActionMessage.setEventType(eventType);
-        emailActionMessage.setAccountId(accountId);
-        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
-
-        if (eventType.equals("new-recommendation")) {
-            emailActionMessage.setContext(
-                    new Context.ContextBuilder()
-                            .withAdditionalProperty("display_name", "some-cluster-name")
-                            .withAdditionalProperty("host_url", "some-ocm-url-to-the-cluster")
-                            .build()
-            );
-            emailActionMessage.setEvents(List.of(
-                    new Event.EventBuilder()
-                        .withMetadata(new Metadata.MetadataBuilder().build())
-                        .withPayload(
-                                new Payload.PayloadBuilder()
-                                        .withAdditionalProperty("rule_description", "nice rule with low risk")
-                                        .withAdditionalProperty("total_risk", "1")
-                                        .withAdditionalProperty("publish_date", "2020-08-03T15:22:42.199046")
-                                        .withAdditionalProperty("rule_url", "http://the-rule-id-low-001")
-                                        .build()
-                        )
-                        .build(),
-                    new Event.EventBuilder()
-                        .withMetadata(new Metadata.MetadataBuilder().build())
-                        .withPayload(
-                                new Payload.PayloadBuilder()
-                                        .withAdditionalProperty("rule_description", "nice rule with moderate risk")
-                                        .withAdditionalProperty("total_risk", "2")
-                                        .withAdditionalProperty("publish_date", "2020-08-03T15:22:42.199046")
-                                        .withAdditionalProperty("rule_url", "http://the-rule-id-moderate-001")
-                                        .build()
-                        )
-                        .build(),
-                    new Event.EventBuilder()
-                        .withMetadata(new Metadata.MetadataBuilder().build())
-                        .withPayload(
-                                new Payload.PayloadBuilder()
-                                        .withAdditionalProperty("rule_description", "nice rule with important risk")
-                                        .withAdditionalProperty("total_risk", "3")
-                                        .withAdditionalProperty("publish_date", "2020-08-03T15:22:42.199046")
-                                        .withAdditionalProperty("rule_url", "http://the-rule-id-important-001")
-                                        .build()
-                        )
-                        .build(),
-                    new Event.EventBuilder()
-                        .withMetadata(new Metadata.MetadataBuilder().build())
-                        .withPayload(
-                                new Payload.PayloadBuilder()
-                                        .withAdditionalProperty("rule_description", "nice rule with critical risk")
-                                        .withAdditionalProperty("total_risk", "4")
-                                        .withAdditionalProperty("publish_date", "2020-08-03T15:22:42.199046")
-                                        .withAdditionalProperty("rule_url", "http://the-rule-id-critical-001")
-                                        .build()
-                        )
-                        .build()
-            ));
-        }
-        return emailActionMessage;
-    }
-
     public static Action createComplianceAction() {
         Action emailActionMessage = new Action();
         emailActionMessage.setBundle(StringUtils.EMPTY);
@@ -374,39 +304,6 @@ public class TestHelpers {
 
         return emailActionMessage;
     }
-
-    public static Action createIntegrationsFailedAction() {
-        Action emailActionMessage = new Action();
-        emailActionMessage.setBundle(StringUtils.EMPTY);
-        emailActionMessage.setApplication(StringUtils.EMPTY);
-        emailActionMessage.setTimestamp(LocalDateTime.of(2020, 10, 3, 15, 22, 13, 25));
-        emailActionMessage.setEventType(EVENT_TYPE);
-        emailActionMessage.setRecipients(List.of());
-
-        emailActionMessage.setContext(
-            new Context.ContextBuilder()
-                .withAdditionalProperty("system_check_in", "2020-08-03T15:22:42.199046")
-                .withAdditionalProperty("failed-integration", "Failed integration")
-                .build()
-        );
-
-        emailActionMessage.setEvents(List.of(
-            new Event.EventBuilder()
-                .withMetadata(new Metadata.MetadataBuilder().build())
-                .withPayload(
-                    new Payload.PayloadBuilder()
-                        .withAdditionalProperty("outcome", "test outcome data")
-                        .build()
-                )
-                .build()
-        ));
-
-        emailActionMessage.setAccountId(StringUtils.EMPTY);
-        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
-
-        return emailActionMessage;
-    }
-
 
     public static Action createSourcesAction() {
         Action emailActionMessage = new Action();
@@ -576,22 +473,6 @@ public class TestHelpers {
             .withEvents(List.of(event))
             .withRecipients(List.of(recipients))
             .build();
-    }
-
-    public static void writeEmailTemplate(String result, String fileName) {
-        final String TARGET_DIR = "target";
-        try {
-            String[] splitPath = fileName.split("/");
-            String actualPath = TARGET_DIR;
-            for (int part = 0; part < splitPath.length - 1; part++) {
-                actualPath += "/" + splitPath[part];
-            }
-            Files.createDirectories(Paths.get(actualPath));
-            Files.write(Paths.get(TARGET_DIR + "/" + fileName), result.getBytes(StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            System.out.println("An error occurred");
-            e.printStackTrace();
-        }
     }
 
     public static Map<String, Map<String, String>> buildSourceParameter(String bundleDisplayName, String applicationDisplayName, String eventTypeDisplayName) {


### PR DESCRIPTION
## Summary by Sourcery

Move and reorganize email template tests into a dedicated email package, refactor test helpers for specialized scenarios, and extend coverage with comprehensive unit tests for all email templates.

New Features:
- Add dedicated helper methods for OCM and Inventory email action creation in test helpers
- Add quarkus-mailer dependency to support email template testing

Enhancements:
- Refactor TestHelpers by removing obsolete methods and delegating to specialized helper classes
- Introduce EmailTemplatesRendererHelper and reorganize email template tests under email package
- Add UUID generation for test roles in RbacTestHelpers

Build:
- Include quarkus-mailer as a test-scoped dependency in the common-template pom

Tests:
- Add comprehensive unit tests for email template rendering across multiple applications covering instant notifications, daily digests, and Pendo messages
- Parameterize and extend tests for various event types in email templates