### PR TITLE
[RHCLOUD-41414] Refactor Rest Query.Sort handler

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Query.java
@@ -1,23 +1,11 @@
 package com.redhat.cloud.notifications.db;
 
-import io.quarkus.logging.Log;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.QueryParam;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-
-import static java.util.regex.Pattern.CASE_INSENSITIVE;
-
 public class Query {
-
-    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9_-]+(:(asc|desc))?$", CASE_INSENSITIVE);
 
     public static final int DEFAULT_RESULTS_PER_PAGE = 20;
 
@@ -36,34 +24,11 @@ public class Query {
     Integer offset;
 
     @QueryParam("sort_by")
-    String sortBy;
+    public String sortBy;
 
     @QueryParam("sortBy")
     @Deprecated
     String sortByDeprecated;
-
-    private String defaultSortBy;
-    private Map<String, String> sortFields;
-
-    // Used by test
-    public static Query queryWithSortBy(String sortBy) {
-        Query query = new Query();
-        query.sortBy = sortBy;
-        return query;
-    }
-
-    public void setSortFields(Map<String, String> sortFields) {
-        sortFields.keySet().forEach(key -> {
-            if (!key.toLowerCase().equals(key)) {
-                throw new IllegalArgumentException("All keys of sort fields must be specified in lower case");
-            }
-        });
-        this.sortFields = Map.copyOf(sortFields);
-    }
-
-    public void setDefaultSortBy(String defaultSortBy) {
-        this.defaultSortBy = defaultSortBy;
-    }
 
     public static class Limit {
         private final int limit;
@@ -102,123 +67,6 @@ public class Query {
         return new Limit(pageSize, offset);
     }
 
-    public static class Sort {
-        private String sortColumn;
-
-        public enum Order {
-            ASC, DESC
-        }
-
-        private Order sortOrder;
-
-        public Sort(String sortColumn) {
-            this(sortColumn, Order.ASC);
-        }
-
-        public Sort(String sortColumn, Order sortOrder) {
-            this.sortColumn = sortColumn;
-            this.sortOrder = sortOrder;
-        }
-
-        public String getSortColumn() {
-            return sortColumn;
-        }
-
-        public void setSortColumn(String sortColumn) {
-            this.sortColumn = sortColumn;
-        }
-
-        public Order getSortOrder() {
-            return sortOrder;
-        }
-
-        public void setSortOrder(Order sortOrder) {
-            this.sortOrder = sortOrder;
-        }
-
-        public String getSortQuery() {
-            return "ORDER BY " + this.getSortColumn() + " " + this.getSortOrder().toString();
-        }
-    }
-
-    String getSortBy() {
-        if (sortBy != null) {
-            return sortBy;
-        } else if (sortByDeprecated != null) {
-            return sortByDeprecated;
-        }
-
-        return defaultSortBy;
-    }
-
-    public Optional<Sort> getSort() {
-        // Endpoints: sort by: name, type, "last connection status" (?), enabled
-        //      -> endpoint_id, name, endpoint_type, enabled are the accepted parameter names
-        // TODO Should they be id, name, type, enabled for consistency and then modified in the actual query to Postgres?
-        // And if it's not an accepted value? Throw exception?
-
-        String sortBy = getSortBy();
-
-        if (sortBy == null || sortBy.length() < 1) {
-            return Optional.empty();
-        }
-
-        if (sortFields == null) {
-            Log.error("Sort fields are not set - this means that an API is using sorting without specifying what sort values are allowed");
-            throw new InternalServerErrorException("SortFields are not set");
-        }
-
-        if (!SORT_BY_PATTERN.matcher(sortBy).matches()) {
-            throw new BadRequestException("Invalid 'sort_by' query parameter");
-        }
-
-        String[] sortSplit = sortBy.split(":");
-        Sort sort = new Sort(sortSplit[0]);
-        final String lowerCaseSortColumn = sort.sortColumn.toLowerCase();
-        if (!sortFields.containsKey(lowerCaseSortColumn)) {
-            throw new BadRequestException("Unknown sort field specified: " + sort.sortColumn);
-        } else {
-            sort.sortColumn = sortFields.get(lowerCaseSortColumn);
-        }
-
-        if (sortSplit.length > 1) {
-            try {
-                Sort.Order order = Sort.Order.valueOf(sortSplit[1].toUpperCase());
-                sort.setSortOrder(order);
-            } catch (IllegalArgumentException | NullPointerException iae) {
-            }
-        }
-
-        return Optional.of(sort);
-    }
-
-    public String getModifiedQuery(String basicQuery) {
-        // Use the internal Query
-        // What's the proper order? SORT first, then LIMIT? COUNT as last one?
-        String query = basicQuery;
-        Optional<Sort> sort = getSort();
-        if (sort.isPresent()) {
-            query = modifyWithSort(query, sort.get());
-        }
-        return query;
-    }
-
-    public static Function<String, String> modifyToCountQuery() {
-        return s -> "SELECT COUNT(*) FROM (" +
-                s +
-                ") counted";
-    }
-
-    public static String modifyToCountQuery(String theQuery) {
-        return "SELECT COUNT(*) FROM (" +
-                theQuery +
-                ") counted";
-    }
-
-    private static String modifyWithSort(String theQuery, Query.Sort sorter) {
-        return theQuery + " " + sorter.getSortQuery();
-    }
-
     @Override
     public String toString() {
         return "Query{" +
@@ -226,8 +74,6 @@ public class Query {
             ", pageNumber=" + pageNumber +
             ", offset=" + offset +
             ", sortBy='" + sortBy + '\'' +
-            ", defaultSortBy='" + defaultSortBy + '\'' +
-            ", sortFields=" + sortFields +
             '}';
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/Sort.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/Sort.java
@@ -1,0 +1,130 @@
+package com.redhat.cloud.notifications.db;
+
+import io.quarkus.logging.Log;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+
+public class Sort {
+    private static final Pattern SORT_BY_PATTERN = Pattern.compile("^[a-z0-9_-]+(:(asc|desc))?$", CASE_INSENSITIVE);
+
+    public enum Order {
+        ASC, DESC
+    }
+
+    public String sortColumn;
+
+    public Order sortOrder;
+
+    private Sort(String sortColumn) {
+        this(sortColumn, Order.ASC);
+    }
+
+    private Sort(String sortColumn, Order sortOrder) {
+        this.sortColumn = sortColumn;
+        this.sortOrder = sortOrder;
+    }
+
+    public String getSortColumn() {
+        return sortColumn;
+    }
+
+    public Order getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(Order sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    static void validateSortFields(Map<String, String> sortFields) {
+        sortFields.keySet().forEach(key -> {
+            if (!key.toLowerCase().equals(key)) {
+                throw new IllegalArgumentException("All keys of sort fields must be specified in lower case");
+            }
+        });
+    }
+
+
+    static String getSortBy(Query restQuery, String defaultSortBy) {
+        if (restQuery.sortBy != null) {
+            return restQuery.sortBy;
+        } else if (restQuery.sortByDeprecated != null) {
+            return restQuery.sortByDeprecated;
+        }
+
+        return defaultSortBy;
+    }
+
+    public static Optional<Sort> getSort(Query restQuery, String defaultSortBy, Map<String, String> sortFields) {
+        // Endpoints: sort by: name, type, enabled
+        //      -> endpoint_id, name, endpoint_type, enabled are the accepted parameter names
+        // And if it's not an accepted value, Throw exception.
+
+        String sortBy = getSortBy(restQuery, defaultSortBy);
+
+        if (sortBy == null || sortBy.length() < 1) {
+            return Optional.empty();
+        }
+
+        if (sortFields == null) {
+            Log.error("Sort fields are not set - this means that an API is using sorting without specifying what sort values are allowed");
+            throw new InternalServerErrorException("SortFields are not set");
+        }
+
+        validateSortFields(sortFields);
+
+        if (!SORT_BY_PATTERN.matcher(sortBy).matches()) {
+            throw new BadRequestException("Invalid 'sort_by' query parameter");
+        }
+
+        String[] sortSplit = sortBy.split(":");
+        Sort sort = new Sort(sortSplit[0]);
+        final String lowerCaseSortColumn = sort.sortColumn.toLowerCase();
+        if (!sortFields.containsKey(lowerCaseSortColumn)) {
+            throw new BadRequestException("Unknown sort field specified: " + sort.sortColumn);
+        } else {
+            sort.sortColumn = sortFields.get(lowerCaseSortColumn);
+        }
+
+        if (sortSplit.length > 1) {
+            try {
+                Sort.Order order = Sort.Order.valueOf(sortSplit[1].toUpperCase());
+                sort.setSortOrder(order);
+            } catch (IllegalArgumentException | NullPointerException iae) {
+            }
+        }
+
+        return Optional.of(sort);
+    }
+
+    public static String getModifiedQuery(String basicQuery, Query restQuery, Map<String, String> sortFields, String defaultSortBy) {
+        if (sortFields == null) {
+            Log.error("Sort fields are not set - this means that an API is using sorting without specifying what sort values are allowed");
+            throw new InternalServerErrorException("SortFields are not set");
+        }
+
+        validateSortFields(sortFields);
+
+        // Use the internal Query
+        // What's the proper order? SORT first, then LIMIT? COUNT as last one?
+        String query = basicQuery;
+        Optional<Sort> sort = getSort(restQuery, defaultSortBy, sortFields);
+        if (sort.isPresent()) {
+            query = modifyWithSort(query, sort.get());
+        }
+        return query;
+    }
+
+    public String getSortQuery() {
+        return "ORDER BY " + this.getSortColumn() + " " + this.getSortOrder().toString();
+    }
+
+    private static String modifyWithSort(String theQuery, Sort sorter) {
+        return theQuery + " " + sorter.getSortQuery();
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/builder/QueryBuilder.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/builder/QueryBuilder.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db.builder;
 
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import jakarta.persistence.TypedQuery;
 
 import java.util.Map;
@@ -53,10 +54,8 @@ public class QueryBuilder<T> {
         return this;
     }
 
-    public QueryBuilder<T> sort(Optional<Query.Sort> sort) {
-        if (sort.isPresent()) {
-            rawSort = " " + sort.get().getSortQuery();
-        }
+    public QueryBuilder<T> sort(Optional<Sort> sort) {
+        sort.ifPresent(value -> rawSort = " " + value.getSortQuery());
 
         return this;
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.db.builder.JoinBuilder;
 import com.redhat.cloud.notifications.db.builder.QueryBuilder;
 import com.redhat.cloud.notifications.db.builder.WhereBuilder;
@@ -271,14 +272,10 @@ public class ApplicationRepository {
     }
 
     public List<EventType> getEventTypes(Query limiter, Set<UUID> appIds, UUID bundleId, String eventTypeName, boolean excludeMutedTypes, List<UUID> unmutedEventTypeIds) {
-        if (limiter != null) {
-            limiter.setSortFields(EventType.SORT_FIELDS);
-        }
-
         return getEventTypesQueryBuilder(appIds, bundleId, eventTypeName, excludeMutedTypes, unmutedEventTypeIds)
                 .join(JoinBuilder.builder().leftJoinFetch("e.application"))
                 .limit(limiter != null ? limiter.getLimit() : null)
-                .sort(limiter != null ? limiter.getSort() : null)
+                .sort(limiter != null ? Sort.getSort(limiter, null, EventType.SORT_FIELDS) : null)
                 .build(entityManager::createQuery)
                 .getResultList();
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Endpoint;
@@ -613,8 +614,7 @@ public class BehaviorGroupRepository {
         String query = "SELECT bg FROM BehaviorGroup bg JOIN bg.behaviors b WHERE (bg.orgId = :orgId OR bg.orgId IS NULL) AND b.eventType.id = :eventTypeId";
 
         if (limiter != null) {
-            limiter.setSortFields(BehaviorGroup.SORT_FIELDS);
-            query = limiter.getModifiedQuery(query);
+            query = Sort.getModifiedQuery(query, limiter, BehaviorGroup.SORT_FIELDS, null);
         }
 
         TypedQuery<BehaviorGroup> typedQuery = entityManager.createQuery(query, BehaviorGroup.class)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/DrawerNotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/DrawerNotificationRepository.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.models.DrawerEntryPayload;
 import com.redhat.cloud.notifications.models.DrawerNotification;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -38,9 +39,9 @@ public class DrawerNotificationRepository {
 
     public List<DrawerEntryPayload> getNotifications(String orgId, String username, Set<UUID> bundleIds, Set<UUID> appIds, Set<UUID> eventTypeIds,
                                               LocalDateTime startDate, LocalDateTime endDate, Boolean readStatus, Query query) {
-        query.setSortFields(DrawerNotification.SORT_FIELDS);
-        query.setDefaultSortBy("created:DESC");
-        Optional<Query.Sort> sort = query.getSort();
+
+        Optional<Sort> sort = Sort.getSort(query, "created:DESC", DrawerNotification.SORT_FIELDS);
+
         String hql = "SELECT dn.id.eventId, dn.read, " +
             "dn.event.bundleDisplayName, dn.event.applicationDisplayName, dn.event.eventTypeDisplayName, dn.created, dn.event.renderedDrawerNotification, bundle.name "
             + "FROM DrawerNotification dn join Bundle bundle on dn.event.bundleId = bundle.id where dn.id.orgId = :orgId and dn.id.userId = :userid";
@@ -139,7 +140,7 @@ public class DrawerNotificationRepository {
         }
     }
 
-    private String getOrderBy(Query.Sort sort) {
+    private String getOrderBy(Sort sort) {
         if (!sort.getSortColumn().equals("dn.created")) {
             return " " + sort.getSortQuery() + ", dn.created DESC";
         } else {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointEventTypeRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointEventTypeRepository.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.EventType;
@@ -46,9 +47,7 @@ public class EndpointEventTypeRepository {
         }
 
         if (limiter != null) {
-            limiter.setSortFields(Endpoint.SORT_FIELDS);
-            limiter.setDefaultSortBy("name:DESC");
-            query = limiter.getModifiedQuery(query);
+            query = Sort.getModifiedQuery(query, limiter, Endpoint.SORT_FIELDS, "name:DESC");
         }
 
         TypedQuery<Endpoint> typedQuery = entityManager.createQuery(query, Endpoint.class)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.db.builder.QueryBuilder;
 import com.redhat.cloud.notifications.db.builder.WhereBuilder;
 import com.redhat.cloud.notifications.models.CamelProperties;
@@ -97,12 +98,8 @@ public class EndpointRepository {
     }
 
     public List<Endpoint> getEndpointsPerCompositeType(String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly, Query limiter, final Set<UUID> authorizedIds) {
-        if (limiter != null) {
-            limiter.setSortFields(Endpoint.SORT_FIELDS);
-        }
-
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
-        Optional<Query.Sort> sort = limiter == null ? Optional.empty() : limiter.getSort();
+        Optional<Sort> sort = limiter == null ? Optional.empty() : Sort.getSort(limiter, null, Endpoint.SORT_FIELDS);
 
         Log.debugf("[org_id: %s][name: %s][composite_type: %s][active_only: %s][query: %s][authorized_ids: %s] Looking up endpoints in our database", orgId, name, type, activeOnly, limiter, authorizedIds);
         List<Endpoint> endpoints = EndpointRepository.queryBuilderEndpointsPerType(orgId, name, type, activeOnly, authorizedIds)

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Event;
@@ -56,9 +57,9 @@ public class EventRepository {
                                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                       Set<Boolean> invocationResults, boolean fetchNotificationHistory, Set<NotificationStatus> status, Query query,
                                       Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion) {
-        query.setSortFields(Event.SORT_FIELDS);
-        query.setDefaultSortBy("created:DESC");
-        Optional<Query.Sort> sort = query.getSort();
+
+        Optional<Sort> sort = Sort.getSort(query, "created:DESC", Event.SORT_FIELDS);
+
         List<UUID> eventIds = getEventIds(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, query, uuidToExclude, includeEventsWithAuthCriterion);
         if (eventIds.isEmpty()) {
             return new ArrayList<>();
@@ -94,7 +95,7 @@ public class EventRepository {
         return query.getSingleResult();
     }
 
-    private String getOrderBy(Query.Sort sort) {
+    private String getOrderBy(Sort sort) {
         if (!sort.getSortColumn().equals("e.created")) {
             return " " + sort.getSortQuery() + ", e.created DESC";
         } else {
@@ -108,7 +109,7 @@ public class EventRepository {
         String hql = "SELECT e.id FROM Event e WHERE e.orgId = :orgId";
 
         hql = addHqlConditions(hql, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, uuidToExclude, includeEventsWithAuthCriterion);
-        Optional<Query.Sort> sort = query.getSort();
+        Optional<Sort> sort = Sort.getSort(query, "created:DESC", Event.SORT_FIELDS);
 
         if (sort.isPresent()) {
             hql += getOrderBy(sort.get());

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonObject;
@@ -31,8 +32,7 @@ public class NotificationRepository {
         query += ") FROM NotificationHistory nh WHERE nh.endpoint.id = :endpointId AND nh.event.orgId = :orgId";
 
         if (limiter != null) {
-            limiter.setSortFields(NotificationHistory.SORT_FIELDS);
-            query = limiter.getModifiedQuery(query);
+            query = Sort.getModifiedQuery(query, limiter, NotificationHistory.SORT_FIELDS, null);
         }
 
         TypedQuery<NotificationHistory> historyQuery = entityManager.createQuery(query, NotificationHistory.class)

--- a/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications;
 
 import com.redhat.cloud.notifications.auth.principal.ConsoleIdentity;
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import io.restassured.http.Header;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -89,27 +90,28 @@ public class TestHelpers {
             String sortField,
             Function<Query, List<T>> producer,
             Function<List<T>, List<P>> testAdapter,
-            Query.Sort.Order defaultOrder,
+            Sort.Order defaultOrder,
             List<P> expectedDefault) {
 
         List<P> asc = new ArrayList<>(expectedDefault);
         List<P> desc = new ArrayList<>(expectedDefault);
 
-        if (defaultOrder == Query.Sort.Order.ASC) {
+        if (defaultOrder == Sort.Order.ASC) {
             Collections.reverse(desc);
         } else {
             Collections.reverse(asc);
         }
 
-        Query query = Query.queryWithSortBy(sortField);
+        Query query = new Query();
+        query.sortBy = sortField;
         List<T> values = producer.apply(query);
         assertEquals(expectedDefault, testAdapter.apply(values));
 
-        query = Query.queryWithSortBy(sortField + ":asc");
+        query.sortBy = sortField + ":asc";
         values = producer.apply(query);
         assertEquals(asc, testAdapter.apply(values));
 
-        query = Query.queryWithSortBy(sortField + ":desc");
+        query.sortBy = sortField + ":desc";
         values = producer.apply(query);
         assertEquals(desc, testAdapter.apply(values));
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/QueryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/QueryTest.java
@@ -44,8 +44,7 @@ public class QueryTest {
     @Test
     public void testEmptySort() {
         // Sort is empty if nothing is provided
-        Query query = new Query();
-        assertTrue(query.getSort().isEmpty());
+        assertTrue(Sort.getSort(new Query(), null, null).isEmpty());
     }
 
     @Test
@@ -53,15 +52,14 @@ public class QueryTest {
         // Throws InternalServerError if sortBy* is provided without sort fields
         Query query = new Query();
         query.sortBy = "foo:desc";
-        assertThrows(InternalServerErrorException.class, query::getSort);
+        assertThrows(InternalServerErrorException.class, () -> Sort.getSort(query, null, null));
     }
 
     @Test
     public void testUnknownSort() {
         Query query = new Query();
         query.sortBy = "foo:desc";
-        query.setSortFields(Map.of("bar", "e.bar"));
-        assertThrows(BadRequestException.class, query::getSort);
+        assertThrows(BadRequestException.class, () -> Sort.getSort(query, null, Map.of("bar", "e.bar")));
     }
 
     @Test
@@ -69,8 +67,7 @@ public class QueryTest {
         // Throws BadRequest if sortBy* has a wrong syntax
         Query query = new Query();
         query.sortBy = "i am not a valid sortby::";
-        query.setSortFields(Map.of("bar", "e.bar"));
-        assertThrows(BadRequestException.class, query::getSort);
+        assertThrows(BadRequestException.class, () -> Sort.getSort(query, null, Map.of("bar", "e.bar")));
     }
 
     @Test
@@ -78,10 +75,9 @@ public class QueryTest {
         // sortBy defaults to order asc if not specified
         Query query = new Query();
         query.sortBy = "bar";
-        query.setSortFields(Map.of("bar", "e.bar"));
-        Query.Sort sort = query.getSort().get();
+        Sort sort = Sort.getSort(query, null, Map.of("bar", "e.bar")).get();
         assertEquals("e.bar", sort.getSortColumn());
-        assertEquals(Query.Sort.Order.ASC, sort.getSortOrder());
+        assertEquals(Sort.Order.ASC, sort.getSortOrder());
     }
 
     @Test
@@ -89,8 +85,7 @@ public class QueryTest {
         // throws BadRequest if the order is not valid
         Query query = new Query();
         query.sortBy = "bar:foo";
-        query.setSortFields(Map.of("bar", "e.bar"));
-        assertThrows(BadRequestException.class, query::getSort);
+        assertThrows(BadRequestException.class, () -> Sort.getSort(query, null, Map.of("bar", "e.bar")));
     }
 
     @Test
@@ -98,7 +93,7 @@ public class QueryTest {
         // sortBy (sortByDeprecated) is used if sort_by is not specified
         Query query = new Query();
         query.sortByDeprecated = "foo";
-        assertEquals("foo", query.getSortBy());
+        assertEquals("foo", Sort.getSortBy(query, null));
     }
 
     @Test
@@ -107,22 +102,19 @@ public class QueryTest {
         Query query = new Query();
         query.sortBy = "foo";
         query.sortByDeprecated = "bar";
-        assertEquals("foo", query.getSortBy());
+        assertEquals("foo", Sort.getSortBy(query, null));
     }
 
     @Test
     void testDefaultSortBy() {
         // default sortBy is used if none of the sortBy* were specified
-        Query query = new Query();
-        query.setDefaultSortBy("foo");
-        assertEquals("foo", query.getSortBy());
+        assertEquals("foo", Sort.getSortBy(new Query(), "foo"));
     }
 
     @Test
     void testNoDefaultAndNothingProvided() {
         // null if provided if no default or any sortBy* is used
-        Query query = new Query();
-        assertNull(query.getSortBy());
+        assertNull(Sort.getSortBy(new Query(), null));
     }
 
     /**

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/builder/QueryBuilderTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/builder/QueryBuilderTest.java
@@ -1,11 +1,11 @@
 package com.redhat.cloud.notifications.db.builder;
 
 import com.redhat.cloud.notifications.db.Query;
+import com.redhat.cloud.notifications.db.Sort;
 import jakarta.persistence.TypedQuery;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
@@ -191,10 +191,12 @@ public class QueryBuilderTest {
 
     @Test
     public void usingQuerySort() {
+        Query query = new Query();
+        query.sortBy = "col:ASC";
         assertEquals(
                 "SELECT o FROM Object o ORDER BY o.col ASC",
                 QueryBuilder.builder(Object.class).alias("o")
-                        .sort(Optional.of(new Query.Sort("o.col", Query.Sort.Order.ASC)))
+                        .sort(Sort.getSort(query, null, Map.of("col", "o.col")))
                         .buildRawQuery()
         );
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -4,8 +4,8 @@ import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
-import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.BehaviorGroupAction;
@@ -406,7 +406,7 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
                 "display_name",
                 query -> behaviorGroupRepository.findBehaviorGroupsByEventTypeId(DEFAULT_ORG_ID, eventType.getId(), query),
                 behaviorGroups -> behaviorGroups.stream().map(BehaviorGroup::getDisplayName).collect(Collectors.toList()),
-                Query.Sort.Order.ASC,
+                Sort.Order.ASC,
                 IntStream.range(0, 10).boxed().map(Object::toString).collect(Collectors.toList())
         );
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.db.repositories;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
@@ -81,7 +82,7 @@ public class EndpointRepositoryTest {
                 "id",
                 provider,
                 endpoints -> endpoints.stream().map(Endpoint::getId).collect(Collectors.toList()),
-                Query.Sort.Order.ASC,
+                Sort.Order.ASC,
                 createdEndpointList.stream().map(Endpoint::getId).map(UUID::toString).sorted().map(UUID::fromString).collect(Collectors.toList())
         );
 
@@ -89,7 +90,7 @@ public class EndpointRepositoryTest {
                 "name",
                 provider,
                 endpoints -> endpoints.stream().map(Endpoint::getName).collect(Collectors.toList()),
-                Query.Sort.Order.ASC,
+                Sort.Order.ASC,
                 createdEndpointList.stream().map(Endpoint::getName).sorted().collect(Collectors.toList())
         );
 
@@ -97,7 +98,7 @@ public class EndpointRepositoryTest {
                 "enabled",
                 provider,
                 endpoints -> endpoints.stream().map(Endpoint::isEnabled).collect(Collectors.toList()),
-                Query.Sort.Order.ASC,
+                Sort.Order.ASC,
                 List.of(Boolean.FALSE, Boolean.FALSE, Boolean.FALSE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE)
         );
 
@@ -105,7 +106,7 @@ public class EndpointRepositoryTest {
                 "type",
                 provider,
                 endpoints -> endpoints.stream().map(Endpoint::getType).collect(Collectors.toList()),
-                Query.Sort.Order.ASC,
+                Sort.Order.ASC,
                 List.of(EndpointType.CAMEL, EndpointType.CAMEL, EndpointType.CAMEL, EndpointType.CAMEL, EndpointType.DRAWER, EndpointType.EMAIL_SUBSCRIPTION, EndpointType.PAGERDUTY, EndpointType.WEBHOOK)
         );
 
@@ -113,7 +114,7 @@ public class EndpointRepositoryTest {
                 "created",
                 provider,
                 endpoints -> endpoints.stream().map(Endpoint::getCreated).collect(Collectors.toList()),
-                Query.Sort.Order.ASC,
+                Sort.Order.ASC,
                 createdEndpointList.stream().map(Endpoint::getCreated).sorted().collect(Collectors.toList())
         );
     }


### PR DESCRIPTION
## Summary by Sourcery

Move REST query sorting logic from Query into a new standalone Sort class and update all consumers to use the new API

Enhancements:
- Extract and centralize sorting logic into a new com.redhat.cloud.notifications.db.Sort class
- Remove inner Sort class and related defaultSortBy, sortFields, and methods from Query
- Update repositories and QueryBuilder to use Sort.getSort and Sort.getModifiedQuery instead of Query methods
- Clean up Query class by stripping out deprecated sort handlers and related fields

Tests:
- Update tests to reference the new Sort class and its static methods instead of Query.Sort