### PR TITLE
[RHCLOUD-41589] Add Org ID in unleash context for recipients-resolver user services

### DIFF
--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/config/RecipientsResolverConfig.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/config/RecipientsResolverConfig.java
@@ -135,8 +135,8 @@ public class RecipientsResolverConfig {
     void logConfigAtStartup(@Observes Startup event) {
 
         Map<String, Object> config = new TreeMap<>();
-        config.put(fetchUsersWithMbopToggle, isFetchUsersWithMbopEnabled());
-        config.put(fetchUsersWithRbacToggle, isFetchUsersWithRbacEnabled());
+        config.put(fetchUsersWithMbopToggle, isFetchUsersWithMbopEnabled(null));
+        config.put(fetchUsersWithRbacToggle, isFetchUsersWithRbacEnabled(null));
         config.put(MAX_RESULTS_PER_PAGE, getMaxResultsPerPage());
         config.put(MBOP_ENV, getMbopEnv());
         config.put(RETRY_INITIAL_BACKOFF, getInitialRetryBackoff());
@@ -156,17 +156,17 @@ public class RecipientsResolverConfig {
         });
     }
 
-    public boolean isFetchUsersWithMbopEnabled() {
+    public boolean isFetchUsersWithMbopEnabled(String orgId) {
         if (unleashEnabled) {
-            return unleash.isEnabled(fetchUsersWithMbopToggle, false);
+            return unleash.isEnabled(fetchUsersWithMbopToggle, UnleashContextBuilder.buildUnleashContextWithOrgId(orgId), false);
         } else {
             return fetchUsersWithMbopEnabled;
         }
     }
 
-    public boolean isFetchUsersWithRbacEnabled() {
+    public boolean isFetchUsersWithRbacEnabled(String orgId) {
         if (unleashEnabled) {
-            return unleash.isEnabled(fetchUsersWithRbacToggle, false);
+            return unleash.isEnabled(fetchUsersWithRbacToggle, UnleashContextBuilder.buildUnleashContextWithOrgId(orgId), false);
         } else {
             return fetchUsersWithRbacEnabled;
         }

--- a/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServices.java
+++ b/recipients-resolver/src/main/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServices.java
@@ -130,7 +130,7 @@ public class FetchUsersFromExternalServices {
         String supplier;
 
         try {
-            if (recipientsResolverConfig.isFetchUsersWithRbacEnabled()) {
+            if (recipientsResolverConfig.isFetchUsersWithRbacEnabled(orgId)) {
                 Log.debug("Fetching users with RBAC");
                 supplier = "RBAC";
                 users = getWithPagination(
@@ -144,7 +144,7 @@ public class FetchUsersFromExternalServices {
 
                         return rbacUserPage;
                     }));
-            } else if (recipientsResolverConfig.isFetchUsersWithMbopEnabled()) {
+            } else if (recipientsResolverConfig.isFetchUsersWithMbopEnabled(orgId)) {
                 Log.debug("Fetching users with BOP/MBOP");
                 supplier = "BOP";
                 users = fetchUsersWithMbop(orgId, adminsOnly);
@@ -405,9 +405,9 @@ public class FetchUsersFromExternalServices {
      * which is used with the three different user back ends.
      */
     private void incrementFailuresCounter() {
-        if (this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()) {
+        if (this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(null)) {
             this.incrementFailuresCounterWithTag(COUNTER_TAG_USER_PROVIDER_RBAC);
-        } else if (this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()) {
+        } else if (this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(null)) {
             this.incrementFailuresCounterWithTag(COUNTER_TAG_USER_PROVIDER_MBOP);
         } else {
             this.incrementFailuresCounterWithTag(COUNTER_TAG_USER_PROVIDER_IT);

--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServicesTest.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/resolver/FetchUsersFromExternalServicesTest.java
@@ -57,6 +57,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
@@ -201,7 +202,8 @@ public class FetchUsersFromExternalServicesTest {
 
     @Test
     public void getAllUsersFromDefaultGroupRBAC() {
-        when(recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
+        when(recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(true);
+        when(recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(true);
         RbacGroup defaultGroup = new RbacGroup();
         defaultGroup.setPlatformDefault(true);
         defaultGroup.setUuid(UUID.randomUUID());
@@ -252,7 +254,8 @@ public class FetchUsersFromExternalServicesTest {
 
     @Test
     public void getAllUsersCacheRBAC() {
-        when(recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
+        when(recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(true);
+        when(recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(true);
 
         int initialSize = 1095;
         int updatedSize = 1323;
@@ -309,7 +312,8 @@ public class FetchUsersFromExternalServicesTest {
      */
     @Test
     void testGetUsersMBOP() {
-        when(recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(true);
+        when(recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(true);
+        when(recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(true);
 
         // Fake a REST call to MBOP.
         final MBOPUsers firstPageMBOPUsers = this.mockGetMBOPUsersPage(recipientsResolverConfig.getMaxResultsPerPage());
@@ -365,7 +369,8 @@ public class FetchUsersFromExternalServicesTest {
         when(this.itUserService.getUsers(Mockito.any())).thenAnswer((answer) -> { throw new IOException(); });
 
         // Test that the RBAC failures counter gets incremented.
-        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(true);
 
         this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
@@ -377,8 +382,10 @@ public class FetchUsersFromExternalServicesTest {
         this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, this.recipientsResolverConfig.getMaxRetryAttempts(), Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
         // Test that the MBOP failures counter gets incremented.
-        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(false);
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(true);
 
         this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
 
@@ -390,7 +397,8 @@ public class FetchUsersFromExternalServicesTest {
         this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, this.recipientsResolverConfig.getMaxRetryAttempts(), Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
 
         // Test that the IT failures counter gets incremented.
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(false);
 
         this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT));
 
@@ -413,8 +421,10 @@ public class FetchUsersFromExternalServicesTest {
         when(this.itUserService.getUsers(Mockito.any())).thenAnswer((answer) -> { throw new WebApplicationException(); });
 
         // Test that the RBAC failures counter gets incremented.
-        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(false);
 
         this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
@@ -426,8 +436,10 @@ public class FetchUsersFromExternalServicesTest {
         this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, 1, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
         // Test that the MBOP failures counter gets incremented.
-        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(false);
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(true);
 
         this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
 
@@ -439,7 +451,8 @@ public class FetchUsersFromExternalServicesTest {
         this.micrometerAssertionHelper.assertCounterIncrementFilteredByTags(COUNTER_REQUESTS, 1, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_MBOP));
 
         // Test that the IT failures counter gets incremented.
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(false);
 
         this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_IT));
 
@@ -460,8 +473,10 @@ public class FetchUsersFromExternalServicesTest {
         when(this.rbacServiceToService.getGroup(Mockito.anyString(), Mockito.any())).thenAnswer((answer) -> { throw new ClientWebApplicationException(HttpStatus.SC_NOT_FOUND); });
 
         // Test that the RBAC failures counter gets incremented.
-        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(false);
 
         this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
@@ -481,8 +496,10 @@ public class FetchUsersFromExternalServicesTest {
         when(this.rbacServiceToService.getGroup(Mockito.anyString(), Mockito.any())).thenAnswer((answer) -> { throw new IOException(); });
 
         // Test that the RBAC failures counter gets incremented.
-        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(false);
 
         this.micrometerAssertionHelper.saveCounterValueBeforeTestFilteredByTags(COUNTER_REQUESTS, Tags.of(COUNTER_TAG_REQUEST_RESULT, COUNTER_TAG_FAILURES, COUNTER_TAG_USER_PROVIDER, COUNTER_TAG_USER_PROVIDER_RBAC));
 
@@ -503,8 +520,10 @@ public class FetchUsersFromExternalServicesTest {
     @Test
     void testIncrementSuccessfulUserFetchesRBAC() {
         // Mock a call to RBAC.
-        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(true);
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(false);
 
         final int mockedRbacPagesToFetch = 2;
         this.mockGetUsersRBAC(this.recipientsResolverConfig.getMaxResultsPerPage() * mockedRbacPagesToFetch, false);
@@ -529,8 +548,10 @@ public class FetchUsersFromExternalServicesTest {
     @Test
     void testIncrementSuccessfulUserFetchesMBOP() {
         // Mock a call to MBOP.
-        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(false);
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(true);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(true);
 
         final int mockedMbopPagesToFetch = 3;
         final int mockedMbopElements = this.recipientsResolverConfig.getMaxResultsPerPage();
@@ -556,8 +577,10 @@ public class FetchUsersFromExternalServicesTest {
     @Test
     void testIncrementSuccessfulUserFetchesIT() {
         // Mock an IT call.
-        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled()).thenReturn(false);
-        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled()).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithRbacEnabled(isNull())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(anyString())).thenReturn(false);
+        when(this.recipientsResolverConfig.isFetchUsersWithMbopEnabled(isNull())).thenReturn(false);
 
         final int mockedITUserPagesToFetch = 3;
         this.mockGetUsers(this.recipientsResolverConfig.getMaxResultsPerPage() * mockedITUserPagesToFetch, false);


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-41589

related to https://issues.redhat.com/browse/RHCLOUD-34917

## Description

Add Org ID context to MBOP and RBAC user service calls, allowing for per-organization configuration of which backend to contact.

## Compatibility

No impact

## Testing

Updated test cases in FetchUsersFromExternalServicesTest.

## Code generation

Assisted-by: claude-sonnet-4

## Summary by Sourcery

Enhance feature flag and retry logic to support organization-specific contexts

Enhancements:
- Include Org ID in UnleashContext for RBAC and MBOP feature toggles to enable per-organization configuration
- Refactor retry logic to use per-org RetryPolicy instances via a new getRetryPolicy(orgId) method and update retryOnError to accept orgId
- Update configuration and service methods to pass orgId through feature flag checks and user service calls

Tests:
- Adjust tests to mock feature flag evaluations with anyString() for orgId-based toggles