### PR TITLE
[RHCLOUD-41591] Handle multiple bundle commands in Aggregator module

### DIFF
--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -83,8 +83,13 @@ public class DailyEmailAggregationJob {
             Log.infof("found %s commands", aggregationCommands.size());
             Log.debugf("Aggregation commands: %s", aggregationCommands);
 
-            aggregationCommands.stream().collect(Collectors.groupingBy(AggregationCommand::getOrgId))
-                .values().forEach(this::sendIt);
+            aggregationCommands.stream()
+                .collect(Collectors.groupingBy(AggregationCommand::getOrgId))
+                .values()
+                .forEach(val -> val.stream()
+                    .collect(Collectors.groupingBy(AggregationCommand::getBundleId))
+                    .values()
+                    .forEach(this::sendIt));
 
             List<String> orgIdsToUpdate = aggregationCommands.stream().map(aggregationCommand -> aggregationCommand.getOrgId()).collect(Collectors.toList());
             Log.debugf("Found following org IDs to update: %s", orgIdsToUpdate);
@@ -151,7 +156,6 @@ public class DailyEmailAggregationJob {
     }
 
     private void sendIt(List<AggregationCommand> aggregationCommands) {
-
         List<Event> eventList = new ArrayList<>();
         aggregationCommands.stream().forEach(aggregationCommand -> {
             Payload.PayloadBuilder payloadBuilder = new Payload.PayloadBuilder();

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/db/EmailAggregationRepository.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/db/EmailAggregationRepository.java
@@ -38,7 +38,7 @@ public class EmailAggregationRepository {
             //"EXISTS (SELECT 1 FROM EventTypeEmailSubscription es where ev.orgId = es.id.orgId and es.id.subscriptionType='DAILY' and es.eventType = ev.eventType and es.subscribed is true) " + warning: need an new index on EventTypeEmailSubscription before being enabled
 
             // check for linked email integration linked to this event type (to honor legacy mechanism)
-            "AND EXISTS (SELECT 1 FROM Endpoint ep, EndpointEventType eet where ev.orgId = ep.orgId and ep.compositeType.type = 'EMAIL_SUBSCRIPTION' and eet.eventType = ev.eventType and eet.endpoint = ep) " +
+            "AND EXISTS (SELECT 1 FROM Endpoint ep, EndpointEventType eet where (ev.orgId = ep.orgId or ep.orgId is null) and ep.compositeType.type = 'EMAIL_SUBSCRIPTION' and eet.eventType = ev.eventType and eet.endpoint = ep) " +
             // filter on new events since the latest run of this org aggregation, and not older than two days
             "AND (ev.created > acp.lastRun OR acp.lastRun is null) AND ev.created > :twoDaysAgo AND ev.created <= :now " +
             // filter on org scheduled execution time

--- a/common/src/main/java/com/redhat/cloud/notifications/models/AggregationCommand.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/AggregationCommand.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.models;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.UUID;
 
 public class AggregationCommand {
 
@@ -47,6 +48,10 @@ public class AggregationCommand {
 
     public String getOrgId() {
         return aggregationKey.getOrgId();
+    }
+
+    public UUID getBundleId() {
+        return aggregationKey.getBundleId();
     }
 
     @Override

--- a/common/src/test/java/com/redhat/cloud/notifications/models/ResourceHelpers.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/models/ResourceHelpers.java
@@ -129,13 +129,18 @@ public abstract class ResourceHelpers {
         getEntityManager().remove(getEntityManager().find(Event.class, event.getId()));
     }
 
-    public Application findOrCreateApplication(String bundleName, String appName) {
+    public Bundle findOrCreateBundle(String bundleName) {
         Bundle bundle = null;
         try {
             bundle = findBundle(bundleName);
         } catch (NoResultException nre) {
             bundle = createBundle(bundleName);
         }
+        return bundle;
+    }
+
+    public Application findOrCreateApplication(String bundleName, String appName) {
+        Bundle bundle = findOrCreateBundle(bundleName);
 
         Application app = null;
         try {


### PR DESCRIPTION
## Features
This PR adresses two issues:

1. Events to aggregate are ignored if they are link to a system behavior group (common endpoint with orgId=null)
2. Aggregation commands are grouped by orgId instead of OrgId+BundleId (application from several bundles could be part of the same aggregation comand)

## Summary by Sourcery

Enable the Aggregator to handle multiple bundles per organization by grouping commands accordingly, support default (system) endpoints alongside org-specific ones, and update tests and helpers to cover these scenarios.

New Features:
- Group daily aggregation commands by both organization and bundle to send separate Kafka messages per bundle

Enhancements:
- Add and purge system-level email endpoints in tests via a new helper flag and update repository queries to include null orgId for default endpoints
- Parameterize EmailAggregationRepositoryTest to validate pending aggregation logic for both org-specific and system-wide endpoints
- Refactor DailyEventAggregationJobTest with reusable methods for extracting commands and retrieving actions and add a test for multi-bundle aggregations
- Introduce findOrCreateBundle in common ResourceHelpers and add getBundleId to AggregationCommand model