### PR TITLE
[RHCLOUD-40987] Replace DB cleaner with rhel9/postgresql-16

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -37,7 +37,7 @@ objects:
           limits:
             cpu: ${DB_CLEANER_CPU_LIMIT}
             memory: ${DB_CLEANER_MEMORY_LIMIT}
-        image: quay.io/cloudservices/postgresql-rds:12
+        image: registry.redhat.io/rhel9/postgresql-16:latest
         volumes:
           - name: notifications-db-cleaner-volume
             configMap:


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-40987

## Description

Replace cloudservices image for backend db cleaner with `rhel9/postgresql-16:latest`

## Compatibility

This updates the CLI used to issue commands from PostgreSQL 12 to 16, but it shouldn't have any impact on the cleaner script that is being run. The backend is already running PostgreSQL 16.

## Validation

Not applicable, but a similar upgrade was done in https://github.com/RedHatInsights/payload-tracker-go/pull/351

## Summary by Sourcery

CI:
- Update the ClowdApp backend CI configuration to use registry.redhat.io/rhel9/postgresql-16:latest for the DB cleaner image