### PR TITLE
[RHCLOUD-41606] Render drawer templates from connector-drawer

### DIFF
--- a/common-template/pom.xml
+++ b/common-template/pom.xml
@@ -41,13 +41,6 @@
 
         <!-- Test -->
         <dependency>
-            <groupId>com.redhat.cloud.notifications</groupId>
-            <artifactId>notifications-common</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>1.5.8</version>

--- a/common-template/src/test/java/helpers/ErrataTestHelpers.java
+++ b/common-template/src/test/java/helpers/ErrataTestHelpers.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/common-template/src/test/java/helpers/InventoryTestHelpers.java
+++ b/common-template/src/test/java/helpers/InventoryTestHelpers.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
 
 public class InventoryTestHelpers {
 

--- a/common-template/src/test/java/helpers/OcmTestHelpers.java
+++ b/common-template/src/test/java/helpers/OcmTestHelpers.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
 
 public class OcmTestHelpers {
 

--- a/common-template/src/test/java/helpers/PatchTestHelpers.java
+++ b/common-template/src/test/java/helpers/PatchTestHelpers.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
 
 public class PatchTestHelpers {
 

--- a/common-template/src/test/java/helpers/RbacTestHelpers.java
+++ b/common-template/src/test/java/helpers/RbacTestHelpers.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
 
 public class RbacTestHelpers {
 

--- a/common-template/src/test/java/helpers/TestHelpers.java
+++ b/common-template/src/test/java/helpers/TestHelpers.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static java.time.ZoneOffset.UTC;
 
 @ApplicationScoped
@@ -39,7 +38,7 @@ public class TestHelpers {
     public static final String expectedTestEnvUrlValue = "https://localhost";
 
     public static final String HCC_LOGO_TARGET = "Logo-Red_Hat-Hybrid_Cloud_Console-A-Reverse-RGB.png";
-
+    public static final String DEFAULT_ORG_ID = "default-org-id";
     public static final String POLICY_ID_1 = "abcd-efghi-jkl-lmn";
     public static final String POLICY_NAME_1 = "Foobar";
     public static final String POLICY_ID_2 = "0123-456-789-5721f";

--- a/connector-drawer/pom.xml
+++ b/connector-drawer/pom.xml
@@ -33,13 +33,6 @@
             <dependencies>
                 <dependency>
                     <groupId>com.redhat.cloud.notifications</groupId>
-                    <artifactId>notifications-common</artifactId>
-                    <version>${project.version}</version>
-                    <type>test-jar</type>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.redhat.cloud.notifications</groupId>
                     <artifactId>notifications-connector-common</artifactId>
                     <version>${project.version}</version>
                     <type>test-jar</type>
@@ -47,7 +40,7 @@
                 </dependency>
                 <dependency>
                     <groupId>com.redhat.cloud.notifications</groupId>
-                    <artifactId>notifications-common-template</artifactId>
+                    <artifactId>notifications-common</artifactId>
                     <version>${project.version}</version>
                     <type>test-jar</type>
                     <scope>test</scope>

--- a/connector-drawer/pom.xml
+++ b/connector-drawer/pom.xml
@@ -45,6 +45,13 @@
                     <type>test-jar</type>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>com.redhat.cloud.notifications</groupId>
+                    <artifactId>notifications-common-template</artifactId>
+                    <version>${project.version}</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
         </profile>
 
@@ -58,6 +65,12 @@
         <dependency>
             <groupId>com.redhat.cloud.notifications</groupId>
             <artifactId>notifications-connector-common-http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.redhat.cloud.notifications</groupId>
+            <artifactId>notifications-common-template</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -99,6 +112,12 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty-no-dependencies</artifactId>
             <version>${mockserver-netty-no-dependencies.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>1.5.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/DrawerCloudEventDataExtractor.java
+++ b/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/DrawerCloudEventDataExtractor.java
@@ -24,5 +24,6 @@ public class DrawerCloudEventDataExtractor extends CloudEventDataExtractor {
         exchange.setProperty(ExchangeProperty.UNSUBSCRIBERS, notification.unsubscribers());
         exchange.setProperty(ExchangeProperty.AUTHORIZATION_CRITERIA, notification.authorizationCriteria());
         exchange.setProperty(ExchangeProperty.USE_SIMPLIFIED_ROUTE, drawerConnectorConfig.useSimplifiedRoute(notification.orgId()));
+        exchange.setProperty(ExchangeProperty.EVENT_DATA, notification.eventData());
     }
 }

--- a/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/constant/ExchangeProperty.java
+++ b/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/constant/ExchangeProperty.java
@@ -9,4 +9,5 @@ public class ExchangeProperty {
     public static final String AUTHORIZATION_CRITERIA = "authorization_criteria";
     public static final String USE_SIMPLIFIED_ROUTE = "use_simplified_route";
     public static final String ADDITIONAL_ERROR_DETAILS = "additionalErrorDetails";
+    public static final String EVENT_DATA = "event_data";
 }

--- a/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/model/DrawerNotificationToConnector.java
+++ b/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/model/DrawerNotificationToConnector.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.connector.drawer.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.json.JsonObject;
 import java.util.Collection;
+import java.util.Map;
 
 public record DrawerNotificationToConnector(
 
@@ -19,5 +20,8 @@ public record DrawerNotificationToConnector(
     Collection<String> unsubscribers,
 
     @JsonProperty("authorization_criteria")
-    JsonObject authorizationCriteria
+    JsonObject authorizationCriteria,
+
+    @JsonProperty("event_data")
+    Map<String, Object> eventData
 )  { }

--- a/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/ActionTemplateHelper.java
+++ b/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/ActionTemplateHelper.java
@@ -1,0 +1,52 @@
+package com.redhat.cloud.notifications.connector.drawer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+
+public class ActionTemplateHelper {
+
+    public static final String actionAsJson = "{" +
+        "   \"account_id\":null," +
+        "   \"application\":\"policies\"," +
+        "   \"bundle\":\"rhel\"," +
+        "   \"context\":{" +
+        "      \"foo\":\"im foo\"," +
+        "      \"bar\":{" +
+        "         \"baz\":\"im baz\"" +
+        "      }" +
+        "   }," +
+        "   \"event_type\":\"triggered\"," +
+        "   \"events\":[" +
+        "      {" +
+        "         \"metadata\":{" +
+        "            " +
+        "         }," +
+        "         \"payload\":{" +
+        "            " +
+        "         }" +
+        "      }" +
+        "   ]," +
+        "   \"org_id\":\"123456\"," +
+        "   \"timestamp\":\"2022-08-24T13:30\"," +
+        "   \"source\":{" +
+        "      \"application\":{" +
+        "         \"display_name\":\"The best app in the life\"" +
+        "      }," +
+        "      \"bundle\":{" +
+        "         \"display_name\":\"A bundle\"" +
+        "      }," +
+        "      \"event_type\":{" +
+        "         \"display_name\":\"Policies will take care of the rules\"" +
+        "      }" +
+        "   }" +
+        "}";
+
+    public static Map<String, Object> jsonActionToMap(String actionAsJson) {
+        try {
+            return (new ObjectMapper()).readValue(actionAsJson, Map.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Drawer notification data transformation failed", e);
+        }
+    }
+}

--- a/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorRoutesTest.java
+++ b/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorRoutesTest.java
@@ -111,7 +111,7 @@ class DrawerConnectorRoutesTest extends ConnectorRoutesTest {
         drawerEntryPayload.setBundle("My Bundle");
 
         RecipientSettings recipientSettings = new RecipientSettings();
-        return new DrawerNotificationToConnector(orgId, drawerEntryPayload, Set.of(recipientSettings), List.of("user-1", "user-2"), new JsonObject());
+        return new DrawerNotificationToConnector(orgId, drawerEntryPayload, Set.of(recipientSettings), List.of("user-1", "user-2"), new JsonObject(), ActionTemplateHelper.jsonActionToMap(ActionTemplateHelper.actionAsJson));
     }
 
     private HttpRequest getMockHttpRequest(String path, ExpectationResponseCallback expectationResponseCallback) {

--- a/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorWithSimplifiedRoutesTest.java
+++ b/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorWithSimplifiedRoutesTest.java
@@ -144,7 +144,7 @@ class DrawerConnectorWithSimplifiedRoutesTest extends CamelQuarkusTestSupport {
         drawerEntryPayload.setBundle("My Bundle");
 
         RecipientSettings recipientSettings = new RecipientSettings();
-        return new DrawerNotificationToConnector(orgId, drawerEntryPayload, Set.of(recipientSettings), List.of("user-1", "user-2"), new JsonObject());
+        return new DrawerNotificationToConnector(orgId, drawerEntryPayload, Set.of(recipientSettings), List.of("user-1", "user-2"), new JsonObject(), ActionTemplateHelper.jsonActionToMap(ActionTemplateHelper.actionAsJson));
     }
 
     private HttpRequest getMockHttpRequest(String path, ExpectationResponseCallback expectationResponseCallback) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerNotificationToConnector.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerNotificationToConnector.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.ingress.RecipientsAuthorizationCriterion;
 import com.redhat.cloud.notifications.models.DrawerEntryPayload;
 import com.redhat.cloud.notifications.processors.email.connector.dto.RecipientSettings;
 import java.util.Collection;
+import java.util.Map;
 
 public record DrawerNotificationToConnector(
 
@@ -21,5 +22,9 @@ public record DrawerNotificationToConnector(
     Collection<String> unsubscribers,
 
     @JsonProperty("recipients_authorization_criterion")
-    RecipientsAuthorizationCriterion recipientsAuthorizationCriterion
+    RecipientsAuthorizationCriterion recipientsAuthorizationCriterion,
+
+    @JsonProperty("event_data")
+    Map<String, Object> eventData
+
 )  { }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessorTest.java
@@ -137,6 +137,7 @@ class DrawerProcessorTest {
         assertNotNull(message);
         assertFalse(message.getPayload().isEmpty());
 
+        assertNotNull(message.getPayload().getJsonObject("event_data"));
         CloudEventMetadata cloudEventMetadata = message.getMetadata(CloudEventMetadata.class).get();
         assertNotNull(cloudEventMetadata);
         assertFalse(cloudEventMetadata.getId().isEmpty());


### PR DESCRIPTION
## Summary by Sourcery

Propagate raw event data through drawer notifications, refactor template rendering to use TemplateService in both the engine and connector, extend models to carry event_data, adjust build dependencies, and update tests to validate the new payload and rendering logic

New Features:
- Include full event_data map in drawer notification payload and expose it via the DrawerNotificationToConnector record
- Render drawer templates in the connector-drawer module using the injected TemplateService

Enhancements:
- Refactor engine DrawerProcessor to transform Event into a data map for template rendering
- Update engine buildNotificationMessage to use data map and TemplateService
- Add TemplateService injection and legacy output comparison in connector-drawer DrawerProcessor
- Add notifications-common-template dependency and swap common/test-jar modules in connector-drawer POM
- Remove redundant test dependency in common-template POM

Tests:
- Extend drawer connector tests to verify event_data inclusion and rendering via ActionTemplateHelper
- Centralize DEFAULT_ORG_ID in TestHelpers and update helper classes accordingly