### PR TITLE
Reapply "Enable autoscaler via engine ClowdApp (#2798)"

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -196,6 +196,31 @@ objects:
           value: ${PROCESSOR_CONNECTORS_MIN_DELAY_SINCE_FIRST_SERVER_ERROR}
         - name: NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES
           value: ${NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES}
+      autoScaler:
+        minReplicaCount: ${{MIN_REPLICAS}}
+        maxReplicaCount: 6
+        externalHPA: true
+        triggers:
+          - metadata:
+              serverAddress: http://prometheus-app-sre.openshift-customer-monitoring.svc.cluster.local:9090
+              query: sum by(topic) (aws_kafka_sum_offset_lag_sum{topic=~".*platform.notifications.ingress"})
+              threshold: "25"
+            type: prometheus
+            metricType: Value
+        advanced:
+          horizontalPodAutoscalerConfig:
+            behavior:
+              scaleDown:
+                stabilizationWindowSeconds: 180
+                policies:
+                  - type: Pods
+                    value: 2
+                    periodSeconds: 60
+              scaleUp:
+                policies:
+                  - type: Pods
+                    value: 2
+                    periodSeconds: 30
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-28890

Reintroducing autoscaling, Prometheus issues should be resolved on the cluster side this time.