### PR TITLE
[RHCLOUD-41813] Patch netty in mockserver

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -222,6 +222,14 @@
             <version>${mockserver-netty.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- io.netty:netty-codec-http2 is a transitive dependency of org.mock-server:mockserver-netty -->
+        <!-- do not remove unless RHCLOUD-41812 has been addressed -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.124.Final</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.reprezen.kaizen</groupId>
             <artifactId>openapi-parser</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -99,6 +99,14 @@
             <version>5.15.0</version>
             <scope>test</scope>
         </dependency>
+        <!-- io.netty:netty-codec-http2 is a transitive dependency of org.mock-server:mockserver-core -->
+        <!-- do not remove unless RHCLOUD-41812 has been addressed -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.124.Final</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -197,6 +197,14 @@
             <version>1.8</version>
             <scope>test</scope>
         </dependency>
+        <!-- io.netty:netty-codec-http2 is a transitive dependency of org.mock-server:mockserver-netty -->
+        <!-- do not remove unless RHCLOUD-41812 has been addressed -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.124.Final</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>

--- a/recipients-resolver/pom.xml
+++ b/recipients-resolver/pom.xml
@@ -148,6 +148,14 @@
             <version>1.8</version>
             <scope>test</scope>
         </dependency>
+        <!-- io.netty:netty-codec-http2 is a transitive dependency of org.mock-server:mockserver-netty -->
+        <!-- do not remove unless RHCLOUD-41812 has been addressed -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.124.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-41813

Applies a patch in modules where `io.netty:netty-codec-http2` is imported by mockserver, rather than Quarkus (who will patch the library themselves). Further discussion is included in [RHCLOUD-41812](https://issues.redhat.com/browse/RHCLOUD-41812).