### PR TITLE
[RHCLOUD-34917] Create new volume for storing P12 archive

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -38,11 +38,20 @@ objects:
             items:
               - key: keystore.jks
                 path: clientkeystore.jks
+              - key: keystore.p12
+                path: keystore.p12
             defaultMode: 420
             optional: true
         - name: it-services-cert
           secret:
             secretName: it-services-cert
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+              - key: ca.crt
+                path: ca.crt
             optional: ${{IT_SERVICE_OPTIONAL}}
         # Due to read-only volume restrictions, this volume must be independent from mounted ConfigMaps and secrets.
         - name: p12-archive


### PR DESCRIPTION
## Jira issue

https://issues.redhat.com/browse/RHCLOUD-34917

## Description

Created a new, writable volume to store the PKCS12 archive in. The generated certificate is now stored in `/mnt/it-services-cert`

## Compatibility

Still part of cert switchover, currently not active

## Testing

Will check IQE

## Summary by Sourcery

Add a dedicated writable volume for storing generated PKCS#12 archives and update paths accordingly

Enhancements:
- Define and mount a new p12-archive volume for PKCS#12 output
- Mount the certificate secret at /mnt/it-services-cert for reading TLS assets
- Update the init script to reference the new /mnt/it-services-cert paths for certificate, key, and CA before generating the P12 archive