### PR TITLE
[RHCLOUD-38199] OCM doc url updates

### DIFF
--- a/common-template/src/main/resources/templates/email/OCM/capacityManagementInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/capacityManagementInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/clusterAccessInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterAccessInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/clusterAddOnInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterAddOnInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/clusterConfigurationInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterConfigurationInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/clusterLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterLifecycleInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/clusterNetworkingInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterNetworkingInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/clusterOwnershipInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterOwnershipInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/clusterScalingInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterScalingInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/clusterSecurityInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterSecurityInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/clusterSubscriptionInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/clusterSubscriptionInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/customerSupportInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/customerSupportInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/OCM/generalNotificationInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/generalNotificationInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/capacityManagementInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/capacityManagementInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/clusterAccessInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/clusterAccessInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/clusterAddOnInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/clusterAddOnInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/clusterConfigurationInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/clusterConfigurationInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/clusterLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/clusterLifecycleInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/clusterNetworkingInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/clusterNetworkingInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/clusterOwnershipInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/clusterOwnershipInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/clusterScalingInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/clusterScalingInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/clusterSecurityInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/clusterSecurityInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/clusterSubscriptionInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/clusterSubscriptionInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/customerSupportInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/customerSupportInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/generalNotificationInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/generalNotificationInstantEmailBody.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/common-template/src/test/java/email/TestOcmTemplate.java
+++ b/common-template/src/test/java/email/TestOcmTemplate.java
@@ -69,10 +69,10 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         assertFalse(result.contains("Check these resources for more information"));
         assertTrue(result.contains("What should you do to minimize impact"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
 
         action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template-rosa-hcp")));
@@ -102,10 +102,10 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertFalse(result.contains("Check these resources for more information"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
     }
 
@@ -216,10 +216,10 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         result = generateEmailBody(CLUSTER_LIFECYCLE, action);
         assertFalse(result.contains("Check these resources for more information"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_LIFECYCLE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
     }
 

--- a/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/capacityManagementInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/clusterAccessInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterAccessInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/clusterAddOnInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterAddOnInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/clusterConfigurationInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterConfigurationInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/clusterLifecycleInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterLifecycleInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/clusterNetworkingInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterNetworkingInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/clusterOwnershipInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterOwnershipInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/clusterScalingInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterScalingInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/clusterSecurityInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterSecurityInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/clusterSubscriptionInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/clusterSubscriptionInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/customerSupportInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/customerSupportInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/generalNotificationInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/generalNotificationInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/main/resources/templates/OCM/genericInstantEmailBodyV2.html
+++ b/engine/src/main/resources/templates/OCM/genericInstantEmailBodyV2.html
@@ -58,7 +58,7 @@ More info
 {#case 'ocm-approved-access-template'}
     <p>
         Your organization has enabled "Approved Access" for ROSA clusters. Red Hat SRE cannot access any cluster in your organization unless it is approved.
-        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.openshift.com/rosa/support/approved-access.html" target="_blank">here</a>.
+        As a reminder, the ROSA SLA can be affected if access to a cluster is not approved in a timely manner. More information can be found on this <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access" target="_blank">here</a>.
     </p>
 {#case}
     {#if global_vars.subscription_plan != 'OSDTrial'}

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOcmTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/TestOcmTemplate.java
@@ -77,10 +77,10 @@ public class TestOcmTemplate extends EmailTemplatesInDbHelper {
         assertFalse(result.contains("Check these resources for more information"));
         assertTrue(result.contains("What should you do to minimize impact"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
 
         action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template-rosa-hcp")));
@@ -110,10 +110,10 @@ public class TestOcmTemplate extends EmailTemplatesInDbHelper {
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertFalse(result.contains("Check these resources for more information"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
     }
 
@@ -224,10 +224,10 @@ public class TestOcmTemplate extends EmailTemplatesInDbHelper {
         result = generateEmailBody(CLUSTER_LIFECYCLE, action);
         assertFalse(result.contains("Check these resources for more information"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_LIFECYCLE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/common/TestOcmTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/common/TestOcmTemplate.java
@@ -75,10 +75,10 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         assertFalse(result.contains("Check these resources for more information"));
         assertTrue(result.contains("What should you do to minimize impact"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
 
         action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template-rosa-hcp")));
@@ -108,10 +108,10 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertFalse(result.contains("Check these resources for more information"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
     }
 
@@ -222,10 +222,10 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         result = generateEmailBody(CLUSTER_LIFECYCLE, action);
         assertFalse(result.contains("Check these resources for more information"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_LIFECYCLE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/common/secured/TestOcmTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/common/secured/TestOcmTemplate.java
@@ -88,11 +88,11 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         assertFalse(result.contains("Check these resources for more information"));
         assertTrue(result.contains("What should you do to minimize impact"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertTrue(result.contains(COMMON_SECURED_LABEL_CHECK));
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
 
         action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Upgrade scheduled", Optional.of(Map.of("template_sub_type", "upgrade-scheduled-template-rosa-hcp")));
@@ -125,10 +125,10 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertFalse(result.contains("Check these resources for more information"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "MOA", "<b>Batmobile</b> is ready to go", "Awesome subject", null, Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_UPDATE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
     }
 
@@ -245,10 +245,10 @@ public class TestOcmTemplate extends EmailTemplatesRendererHelper {
         result = generateEmailBody(CLUSTER_LIFECYCLE, action);
         assertFalse(result.contains("Check these resources for more information"));
 
-        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.openshift.com/rosa/ocm/ocm-overview.html", "https://console.redhat.com/openshift"))));
+        action = OcmTestHelpers.createOcmAction("Batcave", "OSDTrial", "<b>Batmobile</b> need a revision", "Awesome subject", "Trial delete", Optional.of(Map.of("template_sub_type", "osd-trial-deletion-template", "doc_references", List.of("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview", "https://console.redhat.com/openshift"))));
         result = generateEmailBody(CLUSTER_LIFECYCLE, action);
         assertTrue(result.contains("Check these resources for more information"));
-        assertTrue(result.contains("https://docs.openshift.com/rosa/ocm/ocm-overview.html"));
+        assertTrue(result.contains("https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview"));
         assertTrue(result.contains("https://console.redhat.com/openshift"));
     }
 


### PR DESCRIPTION
* from https://docs.openshift.com/rosa/support/approved-access.html to https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/support/approved-access.
* To be consistent, also updated from https://docs.openshift.com/rosa/ocm/ocm-overview.html to https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/red_hat_openshift_cluster_manager/ocm-overview used by unit tests only.

## Summary by Sourcery

Update OCM documentation URLs in email templates and unit tests to point to the new redhat.com documentation paths

Enhancements:
- Replace all approved-access links in OCM email templates with the new redhat.com URL
- Update OCM overview URL in unit tests to the new redhat.com documentation path

Tests:
- Adjust unit test assertions in both common-template and engine modules to expect the new redhat.com URLs