### PR TITLE
[RHCLOUD-41606] add a feature flag on connector-drawer to enable common template module usage

### DIFF
--- a/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/config/DrawerConnectorConfig.java
+++ b/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/config/DrawerConnectorConfig.java
@@ -21,7 +21,7 @@ public class DrawerConnectorConfig extends HttpConnectorConfig {
     private String toggleUseCommonTemplateModule;
 
     @PostConstruct
-    void emailConnectorPostConstruct() {
+    void drawerConnectorPostConstruct() {
         toggleUseCommonTemplateModule = toggleRegistry.register("use-common-template-module", true);
     }
 

--- a/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/config/DrawerConnectorConfig.java
+++ b/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/config/DrawerConnectorConfig.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.connector.drawer.config;
 
 import com.redhat.cloud.notifications.connector.http.HttpConnectorConfig;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import java.util.Map;
@@ -17,19 +18,24 @@ public class DrawerConnectorConfig extends HttpConnectorConfig {
     @ConfigProperty(name = DRAWER_TOPIC)
     String outgoingDrawerTopic;
 
+    private String toggleUseCommonTemplateModule;
+
+    @PostConstruct
+    void emailConnectorPostConstruct() {
+        toggleUseCommonTemplateModule = toggleRegistry.register("use-common-template-module", true);
+    }
+
     @Override
     protected Map<String, Object> getLoggedConfiguration() {
         Map<String, Object> config = super.getLoggedConfiguration();
         config.put(DRAWER_TOPIC, outgoingDrawerTopic);
         config.put(RECIPIENTS_RESOLVER_USER_SERVICE_URL, recipientsResolverServiceURL);
+        config.put(toggleUseCommonTemplateModule, useCommonTemplateModule());
         return config;
     }
 
-    public String getOutgoingDrawerTopic() {
-        return outgoingDrawerTopic;
+    public boolean useCommonTemplateModule() {
+        return unleash.isEnabled(toggleUseCommonTemplateModule, false);
     }
 
-    public String getRecipientsResolverServiceURL() {
-        return recipientsResolverServiceURL;
-    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a toggle to enable or disable the common template module in the drawer connector and update processing logic to conditionally render and compare templates based on that flag.

Enhancements:
- Introduce Unleash feature flag "use-common-template-module" in DrawerConnectorConfig (default enabled) and include its state in logged configuration
- Make DrawerProcessor respect the feature flag by conditionally rendering templates via TemplateService and logging mismatches as errors and matches at debug level