### PR TITLE
Remove no more used feature flag from tests

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -1,7 +1,6 @@
 package com.redhat.cloud.notifications.config;
 
 import com.redhat.cloud.notifications.unleash.ToggleRegistry;
-import com.redhat.cloud.notifications.unleash.UnleashContextBuilder;
 import io.getunleash.Unleash;
 import io.getunleash.UnleashContext;
 import io.quarkus.logging.Log;
@@ -54,7 +53,6 @@ public class EngineConfig {
     private String asyncEventProcessingToggle;
     private String drawerToggle;
     private String kafkaConsumedTotalCheckerToggle;
-    private String fetchAggregationBasedOnEvents;
     private String toggleBlacklistedEndpoints;
     private String toggleBlacklistedEventTypes;
     private String toggleKafkaOutgoingHighVolumeTopic;
@@ -158,7 +156,6 @@ public class EngineConfig {
         asyncEventProcessingToggle = toggleRegistry.register("async-event-processing", true);
         drawerToggle = toggleRegistry.register("drawer", true);
         kafkaConsumedTotalCheckerToggle = toggleRegistry.register("kafka-consumed-total-checker", true);
-        fetchAggregationBasedOnEvents = toggleRegistry.register("fetch-aggregation-based-on-events", true);
         toggleKafkaOutgoingHighVolumeTopic = toggleRegistry.register("kafka-outgoing-high-volume-topic", true);
         toggleDirectEndpointToEventTypeDryRunEnabled = toggleRegistry.register("endpoint-to-event-type-dry-run", true);
         toggleUseDirectEndpointToEventTypeEnabled = toggleRegistry.register("use-endpoint-to-event-type", true);
@@ -258,14 +255,6 @@ public class EngineConfig {
 
     public boolean isSecuredEmailTemplatesEnabled() {
         return useSecuredEmailTemplates;
-    }
-
-    public boolean isAggregationBasedOnEventEnabled(final String orgId) {
-        if (unleashEnabled) {
-            return unleash.isEnabled(fetchAggregationBasedOnEvents, UnleashContextBuilder.buildUnleashContextWithOrgId(orgId), false);
-        } else {
-            return false;
-        }
     }
 
     public boolean isBlacklistedEndpoint(final UUID endpointId) {

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessorTest.java
@@ -210,7 +210,6 @@ class EmailAggregationProcessorTest {
     void shouldSuccessfullySendOneAggregatedEmailWithTwoRecipientsWithTwoApps(final boolean useCommonTemplateModuleToRenderEmails) {
         when(engineConfig.isUseCommonTemplateModuleToRenderEmailsEnabled()).thenReturn(useCommonTemplateModuleToRenderEmails);
         try {
-            when(engineConfig.isAggregationBasedOnEventEnabled(anyString())).thenReturn(true);
             initData("patch", "new-advisory");
 
             // Because this test will use a real Payload Aggregator
@@ -273,7 +272,6 @@ class EmailAggregationProcessorTest {
     void shouldSuccessfullySendOneAggEmailWithOneAppHandlingAggregationError(final boolean useCommonTemplateModuleToRenderEmails) {
         when(engineConfig.isUseCommonTemplateModuleToRenderEmailsEnabled()).thenReturn(useCommonTemplateModuleToRenderEmails);
         try {
-            when(engineConfig.isAggregationBasedOnEventEnabled(anyString())).thenReturn(true);
             initData("patch", "new-advisory");
 
             // Because this test will use a real Payload Aggregator
@@ -322,7 +320,6 @@ class EmailAggregationProcessorTest {
     void shouldSuccessfullySendOneAggEmailWithOneAppHandlingTemplateError(final boolean useCommonTemplateModuleToRenderEmails) {
         when(engineConfig.isUseCommonTemplateModuleToRenderEmailsEnabled()).thenReturn(useCommonTemplateModuleToRenderEmails);
         try {
-            when(engineConfig.isAggregationBasedOnEventEnabled(anyString())).thenReturn(true);
             when(templateRepository.findAggregationEmailTemplate(anyString(), anyString(), eq(DAILY))).thenCallRealMethod();
 
             when(templateRepository.findAggregationEmailTemplate(anyString(), anyString(), eq(DAILY)))
@@ -401,7 +398,6 @@ class EmailAggregationProcessorTest {
     @ValueSource(booleans = {true, false})
     void shouldNotSendAggEmailBecauseNoAppSucceedToRender(final boolean useCommonTemplateModuleToRenderEmails) {
         when(engineConfig.isUseCommonTemplateModuleToRenderEmailsEnabled()).thenReturn(useCommonTemplateModuleToRenderEmails);
-        when(engineConfig.isAggregationBasedOnEventEnabled(anyString())).thenReturn(true);
         when(templateRepository.findAggregationEmailTemplate(anyString(), anyString(), eq(DAILY))).thenCallRealMethod();
 
         // Because this test will use a real Payload Aggregator
@@ -423,7 +419,6 @@ class EmailAggregationProcessorTest {
     @ValueSource(booleans = {true, false})
     void shouldNotSendAggregatedEmailBecausePatchAggIsEmpty(final boolean useCommonTemplateModuleToRenderEmails) {
         when(engineConfig.isUseCommonTemplateModuleToRenderEmailsEnabled()).thenReturn(useCommonTemplateModuleToRenderEmails);
-        when(engineConfig.isAggregationBasedOnEventEnabled(anyString())).thenReturn(true);
 
         try {
             initData("patch", "new-advisory");


### PR DESCRIPTION
## Summary by Sourcery

Remove the unused fetch-aggregation-based-on-events feature flag and its related method from EngineConfig, and delete corresponding test stubbings in EmailAggregationProcessorTest

Chores:
- Remove fetchAggregationBasedOnEvents field and registration from EngineConfig
- Delete isAggregationBasedOnEventEnabled method
- Remove related when(...) stubbings from aggregation email processor tests