### PR TITLE
Cleanup recipients-resolver requests logs

### DIFF
--- a/recipients-resolver/src/main/resources/application.properties
+++ b/recipients-resolver/src/main/resources/application.properties
@@ -21,13 +21,6 @@ quarkus.http.access-log.pattern=combined
 quarkus.log.category."com.redhat.cloud.notifications".level=INFO
 %test.quarkus.log.category."com.redhat.cloud.notifications".level=DEBUG
 
-# Log rest client request/response for debug
-quarkus.rest-client.logging.scope=request-response
-quarkus.rest-client.logging.body-limit=5000
-quarkus.rest-client.extensions-api.scope=all
-quarkus.log.console.level=DEBUG
-quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG
-
 # RBAC configuration used to retrieve email recipients. It is used when an email notification is sent.
 quarkus.rest-client.rbac-s2s.url=${clowder.endpoints.rbac-service.url:https://ci.cloud.redhat.com}
 quarkus.rest-client.rbac-s2s.trust-store=${clowder.endpoints.rbac-service.trust-store-path}


### PR DESCRIPTION
## Summary by Sourcery

Remove debug logging configuration from the recipients-resolver application properties

Enhancements:
- Remove rest-client request/response logging scope
- Remove rest-client logging body-limit property
- Remove rest-client extensions-api scope configuration
- Remove console log level set to DEBUG
- Remove JBoss Resteasy reactive client debug log category