### PR TITLE
SWATCH-3874: Add usage-threshold-exceeded instant email for subscription watch

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/SubscriptionServices.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/SubscriptionServices.java
@@ -1,11 +1,13 @@
 package com.redhat.cloud.notifications.qute.templates.mapping;
 
 import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
+
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.DRAWER;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_BODY;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_DAILY_DIGEST_BODY;
+import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_TITLE;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.GOOGLE_CHAT;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.MS_TEAMS;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.SLACK;
@@ -17,9 +19,14 @@ public class SubscriptionServices {
     public static final String ERRATA_APP_NAME = "errata-notifications";
     static final String ERRATA_FOLDER_NAME = "Errata/";
 
+    public static final String SUBSCRIPTION_WATCH_APP_NAME = "subscription-watch";
+    static final String SUBSCRIPTION_WATCH_FOLDER_NAME = "SubscriptionWatch/";
+
     public static final String ERRATA_NEW_SUBSCRIPTION_BUGFIX_ERRATA = "new-subscription-bugfix-errata";
     public static final String ERRATA_NEW_SUBSCRIPTION_SECURITY_ERRATA = "new-subscription-security-errata";
     public static final String ERRATA_NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA = "new-subscription-enhancement-errata";
+
+    public static final String SUBSCRIPTION_WATCH_USAGE_THRESHOLD_EXCEEDED = "usage-threshold-exceeded";
 
     public static final Map<TemplateDefinition, String> templatesMap = Map.ofEntries(
 
@@ -41,6 +48,10 @@ public class SubscriptionServices {
         entry(new TemplateDefinition(MS_TEAMS, BUNDLE_NAME, ERRATA_APP_NAME, ERRATA_NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA), ERRATA_FOLDER_NAME + "newSubscriptionEnhancementErrata.json"),
         entry(new TemplateDefinition(SLACK, BUNDLE_NAME, ERRATA_APP_NAME, ERRATA_NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA), ERRATA_FOLDER_NAME + "newSubscriptionEnhancementErrata.json"),
 
-        entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, ERRATA_APP_NAME, null, true), ERRATA_FOLDER_NAME + "beta/dailyEmailBody.html")
+        entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, ERRATA_APP_NAME, null, true), ERRATA_FOLDER_NAME + "beta/dailyEmailBody.html"),
+
+        // Subscription Watch
+        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, SUBSCRIPTION_WATCH_APP_NAME, SUBSCRIPTION_WATCH_USAGE_THRESHOLD_EXCEEDED), SUBSCRIPTION_WATCH_FOLDER_NAME + "usageThresholdExceededEmailTitle.txt"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SUBSCRIPTION_WATCH_APP_NAME, SUBSCRIPTION_WATCH_USAGE_THRESHOLD_EXCEEDED), SUBSCRIPTION_WATCH_FOLDER_NAME + "usageThresholdExceededEmailBody.html")
     );
 }

--- a/common-template/src/main/resources/templates/email/SubscriptionWatch/usageThresholdExceededEmailBody.html
+++ b/common-template/src/main/resources/templates/email/SubscriptionWatch/usageThresholdExceededEmailBody.html
@@ -1,0 +1,14 @@
+{@boolean renderSection1=true}
+{@boolean renderButtonSection1=false}
+{#include email/Common/insightsEmailBody}
+{#content-title}
+    Subscription Watch - Subscription Services
+{/content-title}
+{#content-title-section1}
+    Usage Threshold Exceeded
+{/content-title-section1}
+{#content-body-section1}
+    <p>
+        Your <b>{action.context.product_tag}</b> subscription usage has exceeded <b>{action.context.threshold_percentage}%</b> of capacity.
+    </p>
+{/content-body-section1}

--- a/common-template/src/main/resources/templates/email/SubscriptionWatch/usageThresholdExceededEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/SubscriptionWatch/usageThresholdExceededEmailTitle.txt
@@ -1,0 +1,1 @@
+RHEL Usage Alert - Org: {action.context.org_id}

--- a/common-template/src/test/java/email/TestSubscriptionWatchTemplate.java
+++ b/common-template/src/test/java/email/TestSubscriptionWatchTemplate.java
@@ -1,0 +1,52 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.SubscriptionWatchTestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestSubscriptionWatchTemplate extends EmailTemplatesRendererHelper {
+
+    static final String USAGE_THRESHOLD_EXCEEDED = "usage-threshold-exceeded";
+
+    private static final Action ACTION = SubscriptionWatchTestHelpers.createSubscriptionWatchAction();
+
+    @Override
+    protected String getBundle() {
+        return "subscription-services";
+    }
+
+    @Override
+    protected String getApp() {
+        return "subscription-watch";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "Subscription Services";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Subscription Watch";
+    }
+
+    @Test
+    public void testUsageThresholdExceededEmailTitle() {
+        eventTypeDisplayName = "Usage Threshold Exceeded";
+        String result = generateEmailSubject(USAGE_THRESHOLD_EXCEEDED, ACTION);
+        assertEquals("RHEL Usage Alert - Org: 123456789", result);
+    }
+
+    @Test
+    public void testUsageThresholdExceededEmailBody() {
+        String result = generateEmailBody(USAGE_THRESHOLD_EXCEEDED, ACTION);
+        assertTrue(result.contains("Subscription Watch - Subscription Services"));
+        assertTrue(result.contains("Usage Threshold Exceeded"));
+        assertTrue(result.contains("Your <b>RHEL for x86</b> subscription usage has exceeded <b>85%</b> of capacity."));
+    }
+}

--- a/common-template/src/test/java/helpers/SubscriptionWatchTestHelpers.java
+++ b/common-template/src/test/java/helpers/SubscriptionWatchTestHelpers.java
@@ -1,0 +1,49 @@
+package helpers;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
+
+public class SubscriptionWatchTestHelpers {
+
+    public static Action createSubscriptionWatchAction() {
+        Action emailActionMessage = new Action();
+        emailActionMessage.setBundle("subscription-services");
+        emailActionMessage.setApplication("subscription-watch");
+        emailActionMessage.setTimestamp(LocalDateTime.of(2020, 10, 3, 15, 22, 13, 25));
+        emailActionMessage.setEventType("usage-threshold-exceeded");
+        emailActionMessage.setRecipients(List.of());
+
+        emailActionMessage.setContext(
+                new Context.ContextBuilder()
+                        .withAdditionalProperty("org_id", "123456789")
+                        .withAdditionalProperty("product_tag", "RHEL for x86")
+                        .withAdditionalProperty("threshold_percentage", "85")
+                        .build()
+        );
+
+        emailActionMessage.setEvents(List.of(
+                new Event.EventBuilder()
+                        .withMetadata(new Metadata.MetadataBuilder().build())
+                        .withPayload(
+                                new Payload.PayloadBuilder()
+                                        .withAdditionalProperty("org_id", "123456789")
+                                        .withAdditionalProperty("product_tag", "RHEL for x86")
+                                        .withAdditionalProperty("threshold_percentage", "85")
+                                        .build()
+                        )
+                        .build()
+        ));
+
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+
+        return emailActionMessage;
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -476,6 +476,15 @@ public class EmailTemplateMigrationService {
             );
 
             /*
+             * Former src/main/resources/templates/SubscriptionWatch folder.
+             */
+            createInstantEmailTemplate(
+                    warnings, "subscription-services", "subscription-watch", List.of("usage-threshold-exceeded"),
+                    "SubscriptionWatch/usageThresholdExceededEmailTitle", "txt", "SubscriptionWatch usage threshold exceeded email title",
+                    "SubscriptionWatch/usageThresholdExceededEmailBody", "html", "SubscriptionWatch usage threshold exceeded email body"
+            );
+
+            /*
              * Former src/main/resources/templates/Tasks folder.
              */
             createInstantEmailTemplate(

--- a/engine/src/main/resources/templates/SubscriptionWatch/usageThresholdExceededEmailBodyV2.html
+++ b/engine/src/main/resources/templates/SubscriptionWatch/usageThresholdExceededEmailBodyV2.html
@@ -1,0 +1,15 @@
+{@boolean renderSection1=true}
+{@boolean renderButtonSection1=false}
+{#include Common/insightsEmailBody}
+{#content-title}
+    Subscription Watch - Subscription Services
+{/content-title}
+{#content-title-section1}
+    Usage Threshold Exceeded
+{/content-title-section1}
+{#content-body-section1}
+    <p>
+        Your <b>{action.context.product_tag}</b> subscription usage has exceeded <b>{action.context.threshold_percentage}%</b> of capacity.
+    </p>
+{/content-body-section1}
+{/include}

--- a/engine/src/main/resources/templates/SubscriptionWatch/usageThresholdExceededEmailTitleV2.txt
+++ b/engine/src/main/resources/templates/SubscriptionWatch/usageThresholdExceededEmailTitleV2.txt
@@ -1,0 +1,1 @@
+RHEL Usage Alert - Org: {action.context.org_id}


### PR DESCRIPTION
https://issues.redhat.com/browse/SWATCH-3874

Creating a placeholder email template to test SWATCH integration.