### PR TITLE
[RHCLOUD-28890] Update Prometheus cluster for CMA

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -201,12 +201,17 @@ objects:
         maxReplicaCount: 6
         externalHPA: true
         triggers:
-          - metadata:
-              serverAddress: http://prometheus-app-sre.openshift-customer-monitoring.svc.cluster.local:9090
-              query: sum by(topic) (aws_kafka_sum_offset_lag_sum{topic=~".*platform.notifications.ingress"})
-              threshold: "25"
-            type: prometheus
+          - type: prometheus
             metricType: Value
+            metadata:
+              serverAddress: https://prometheus.external-resources.${ENV_NAME}.devshift.net/
+              metricName: aws_kafka_sum_offset_lag_sum
+              threshold: "25"
+              query: sum by(topic) (aws_kafka_sum_offset_lag_sum{topic=~".*platform.notifications.ingress"})
+              authModes: bearer
+            authenticationRef:
+              name: cma-prometheus-trigger-auth
+              kind: TriggerAuthentication
         advanced:
           horizontalPodAutoscalerConfig:
             behavior:
@@ -221,6 +226,15 @@ objects:
                   - type: Pods
                     value: 2
                     periodSeconds: 30
+- apiVersion: keda.sh/v1alpha1
+  kind: TriggerAuthentication
+  metadata:
+    name: cma-prometheus-trigger-auth
+  spec:
+    secretTargetRef:
+    - parameter: bearerToken
+      name: ${CMA_TOKEN_CLUSTER}-app-sre-observability-per-cluster-integrations-cma
+      key: token
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
@@ -262,6 +276,8 @@ parameters:
   value: 250Mi
 - name: MIN_REPLICAS
   value: "3"
+- name: CMA_TOKEN_CLUSTER
+  value: ""
 - name: MP_MESSAGING_INCOMING_FROMCAMEL_ENABLED
   value: "true"
 - name: MP_MESSAGING_INCOMING_INGRESS_ENABLED


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-28890

## Description

Switches to the new external cluster for pulling CMA metrics for notifications-engine. Documentation can be found [here](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/runbook/custom-metrics-autoscaler.md?plain=0&ref_type=heads#use-prometheus-instance-in-a-different-cluster).

> [!WARNING]
> - [x] Do not merge until the secrets provider is available.

## Compatibility

This will make autoscaling actually work, once the secrets provider has been merged.

## Summary by Sourcery

Switch notifications-engine autoscaling to use the new external Prometheus cluster for CMA metrics and configure secure authentication for the trigger

New Features:
- Add a KEDA TriggerAuthentication resource to supply a bearer token for Prometheus authentication

Enhancements:
- Update the HPA Prometheus trigger to point at the external Prometheus endpoint
- Enable bearer auth mode and reference the new TriggerAuthentication in the HPA trigger