### PR TITLE
Update dependency github.com/RedHatInsights/konflux-pipelines to v1.37.1

### DIFF
--- a/.tekton/notifications-aggregator-pull-request.yaml
+++ b/.tekton/notifications-aggregator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-aggregator-push.yaml
+++ b/.tekton/notifications-aggregator-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-aggregator-sc-pull-request.yaml
+++ b/.tekton/notifications-aggregator-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-aggregator-sc-push.yaml
+++ b/.tekton/notifications-aggregator-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-backend-pull-request.yaml
+++ b/.tekton/notifications-backend-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-backend-push.yaml
+++ b/.tekton/notifications-backend-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-backend-sc-pull-request.yaml
+++ b/.tekton/notifications-backend-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-backend-sc-push.yaml
+++ b/.tekton/notifications-backend-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-drawer-pull-request.yaml
+++ b/.tekton/notifications-connector-drawer-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-drawer-push.yaml
+++ b/.tekton/notifications-connector-drawer-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-drawer-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-drawer-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-drawer-sc-push.yaml
+++ b/.tekton/notifications-connector-drawer-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-email-pull-request.yaml
+++ b/.tekton/notifications-connector-email-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-email-push.yaml
+++ b/.tekton/notifications-connector-email-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-email-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-email-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-email-sc-push.yaml
+++ b/.tekton/notifications-connector-email-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-google-chat-pull-request.yaml
+++ b/.tekton/notifications-connector-google-chat-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-google-chat-push.yaml
+++ b/.tekton/notifications-connector-google-chat-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-google-chat-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-google-chat-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-google-chat-sc-push.yaml
+++ b/.tekton/notifications-connector-google-chat-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-microsoft-teams-pull-request.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-microsoft-teams-push.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-microsoft-teams-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-microsoft-teams-sc-push.yaml
+++ b/.tekton/notifications-connector-microsoft-teams-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-pagerduty-pull-request.yaml
+++ b/.tekton/notifications-connector-pagerduty-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-pagerduty-push.yaml
+++ b/.tekton/notifications-connector-pagerduty-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-pagerduty-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-pagerduty-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-pagerduty-sc-push.yaml
+++ b/.tekton/notifications-connector-pagerduty-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-servicenow-pull-request.yaml
+++ b/.tekton/notifications-connector-servicenow-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-servicenow-push.yaml
+++ b/.tekton/notifications-connector-servicenow-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-servicenow-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-servicenow-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-servicenow-sc-push.yaml
+++ b/.tekton/notifications-connector-servicenow-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-slack-pull-request.yaml
+++ b/.tekton/notifications-connector-slack-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-slack-push.yaml
+++ b/.tekton/notifications-connector-slack-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-slack-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-slack-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-slack-sc-push.yaml
+++ b/.tekton/notifications-connector-slack-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-splunk-pull-request.yaml
+++ b/.tekton/notifications-connector-splunk-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-splunk-push.yaml
+++ b/.tekton/notifications-connector-splunk-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-splunk-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-splunk-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-splunk-sc-push.yaml
+++ b/.tekton/notifications-connector-splunk-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-webhook-pull-request.yaml
+++ b/.tekton/notifications-connector-webhook-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-webhook-push.yaml
+++ b/.tekton/notifications-connector-webhook-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-connector-webhook-sc-pull-request.yaml
+++ b/.tekton/notifications-connector-webhook-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-connector-webhook-sc-push.yaml
+++ b/.tekton/notifications-connector-webhook-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-engine-pull-request.yaml
+++ b/.tekton/notifications-engine-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-engine-push.yaml
+++ b/.tekton/notifications-engine-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-engine-sc-pull-request.yaml
+++ b/.tekton/notifications-engine-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-engine-sc-push.yaml
+++ b/.tekton/notifications-engine-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-recipients-resolver-pull-request.yaml
+++ b/.tekton/notifications-recipients-resolver-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-recipients-resolver-push.yaml
+++ b/.tekton/notifications-recipients-resolver-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications

--- a/.tekton/notifications-recipients-resolver-sc-pull-request.yaml
+++ b/.tekton/notifications-recipients-resolver-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc

--- a/.tekton/notifications-recipients-resolver-sc-push.yaml
+++ b/.tekton/notifications-recipients-resolver-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.36.0/pipelines/docker-build.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.37.1/pipelines/docker-build.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications-sc


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update Tekton pipelines-as-code references to use konflux-pipelines v1.37.1 for docker-build pipeline