### PR TITLE
RHCLOUD-42173 Enable metrics for all recipients-resolver caches

### DIFF
--- a/recipients-resolver/src/main/resources/application.properties
+++ b/recipients-resolver/src/main/resources/application.properties
@@ -60,7 +60,9 @@ notifications.recipients-resolver.mbop.env=qa
 
 # Quarkus caches
 quarkus.cache.caffeine.recipients-users-provider-get-users.expire-after-write=PT10M
+quarkus.cache.caffeine.recipients-users-provider-get-users.metrics-enabled=true
 quarkus.cache.caffeine.recipients-users-provider-get-group-users.expire-after-write=PT10M
+quarkus.cache.caffeine.recipients-users-provider-get-group-users.metrics-enabled=true
 quarkus.cache.caffeine.find-recipients.expire-after-write=PT10M
 quarkus.cache.caffeine.find-recipients.metrics-enabled=true
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Enable metrics for all recipients-resolver caches (recipients-users-provider-get-users, recipients-users-provider-get-group-users, and find-recipients)