### PR TITLE
Correct swatch app event names

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/SubscriptionServices.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/SubscriptionServices.java
@@ -19,14 +19,14 @@ public class SubscriptionServices {
     public static final String ERRATA_APP_NAME = "errata-notifications";
     static final String ERRATA_FOLDER_NAME = "Errata/";
 
-    public static final String SUBSCRIPTION_WATCH_APP_NAME = "subscription-watch";
+    public static final String SUBSCRIPTION_WATCH_APP_NAME = "subscriptions";
     static final String SUBSCRIPTION_WATCH_FOLDER_NAME = "SubscriptionWatch/";
 
     public static final String ERRATA_NEW_SUBSCRIPTION_BUGFIX_ERRATA = "new-subscription-bugfix-errata";
     public static final String ERRATA_NEW_SUBSCRIPTION_SECURITY_ERRATA = "new-subscription-security-errata";
     public static final String ERRATA_NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA = "new-subscription-enhancement-errata";
 
-    public static final String SUBSCRIPTION_WATCH_USAGE_THRESHOLD_EXCEEDED = "usage-threshold-exceeded";
+    public static final String SUBSCRIPTION_WATCH_EXCEEDED_UTILIZATION_THRESHOLD = "exceeded-utilization-threshold";
 
     public static final Map<TemplateDefinition, String> templatesMap = Map.ofEntries(
 
@@ -51,7 +51,7 @@ public class SubscriptionServices {
         entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, ERRATA_APP_NAME, null, true), ERRATA_FOLDER_NAME + "beta/dailyEmailBody.html"),
 
         // Subscription Watch
-        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, SUBSCRIPTION_WATCH_APP_NAME, SUBSCRIPTION_WATCH_USAGE_THRESHOLD_EXCEEDED), SUBSCRIPTION_WATCH_FOLDER_NAME + "usageThresholdExceededEmailTitle.txt"),
-        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SUBSCRIPTION_WATCH_APP_NAME, SUBSCRIPTION_WATCH_USAGE_THRESHOLD_EXCEEDED), SUBSCRIPTION_WATCH_FOLDER_NAME + "usageThresholdExceededEmailBody.html")
+        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, SUBSCRIPTION_WATCH_APP_NAME, SUBSCRIPTION_WATCH_EXCEEDED_UTILIZATION_THRESHOLD), SUBSCRIPTION_WATCH_FOLDER_NAME + "usageThresholdExceededEmailTitle.txt"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SUBSCRIPTION_WATCH_APP_NAME, SUBSCRIPTION_WATCH_EXCEEDED_UTILIZATION_THRESHOLD), SUBSCRIPTION_WATCH_FOLDER_NAME + "usageThresholdExceededEmailBody.html")
     );
 }

--- a/common-template/src/test/java/email/TestSubscriptionWatchTemplate.java
+++ b/common-template/src/test/java/email/TestSubscriptionWatchTemplate.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 public class TestSubscriptionWatchTemplate extends EmailTemplatesRendererHelper {
 
-    static final String USAGE_THRESHOLD_EXCEEDED = "usage-threshold-exceeded";
+    static final String EXCEEDED_UTILIZATION_THRESHOLD = "exceeded-utilization-threshold";
 
     private static final Action ACTION = SubscriptionWatchTestHelpers.createSubscriptionWatchAction();
 
@@ -22,7 +22,7 @@ public class TestSubscriptionWatchTemplate extends EmailTemplatesRendererHelper 
 
     @Override
     protected String getApp() {
-        return "subscription-watch";
+        return "subscriptions";
     }
 
     @Override
@@ -38,13 +38,13 @@ public class TestSubscriptionWatchTemplate extends EmailTemplatesRendererHelper 
     @Test
     public void testUsageThresholdExceededEmailTitle() {
         eventTypeDisplayName = "Usage Threshold Exceeded";
-        String result = generateEmailSubject(USAGE_THRESHOLD_EXCEEDED, ACTION);
+        String result = generateEmailSubject(EXCEEDED_UTILIZATION_THRESHOLD, ACTION);
         assertEquals("Instant notification - Exceeded Utilization Threshold - Subscription Watch - Subscription Services", result);
     }
 
     @Test
     public void testUsageThresholdExceededEmailBody() {
-        String result = generateEmailBody(USAGE_THRESHOLD_EXCEEDED, ACTION);
+        String result = generateEmailBody(EXCEEDED_UTILIZATION_THRESHOLD, ACTION);
         assertTrue(result.contains("Subscription Watch - Subscription Services"));
         assertTrue(result.contains("Usage Threshold Exceeded"));
         assertTrue(result.contains("Your <b>RHEL for x86</b> subscription usage has exceeded <b>85%</b> of capacity."));

--- a/common-template/src/test/java/helpers/SubscriptionWatchTestHelpers.java
+++ b/common-template/src/test/java/helpers/SubscriptionWatchTestHelpers.java
@@ -15,9 +15,9 @@ public class SubscriptionWatchTestHelpers {
     public static Action createSubscriptionWatchAction() {
         Action emailActionMessage = new Action();
         emailActionMessage.setBundle("subscription-services");
-        emailActionMessage.setApplication("subscription-watch");
+        emailActionMessage.setApplication("subscriptions");
         emailActionMessage.setTimestamp(LocalDateTime.of(2020, 10, 3, 15, 22, 13, 25));
-        emailActionMessage.setEventType("usage-threshold-exceeded");
+        emailActionMessage.setEventType("exceeded-utilization-threshold");
         emailActionMessage.setRecipients(List.of());
 
         emailActionMessage.setEvents(List.of(

--- a/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/templates/EmailTemplateMigrationService.java
@@ -479,7 +479,7 @@ public class EmailTemplateMigrationService {
              * Former src/main/resources/templates/SubscriptionWatch folder.
              */
             createInstantEmailTemplate(
-                    warnings, "subscription-services", "subscription-watch", List.of("usage-threshold-exceeded"),
+                    warnings, "subscription-services", "subscriptions", List.of("exceeded-utilization-threshold"),
                     "SubscriptionWatch/usageThresholdExceededEmailTitle", "txt", "SubscriptionWatch usage threshold exceeded email title",
                     "SubscriptionWatch/usageThresholdExceededEmailBody", "html", "SubscriptionWatch usage threshold exceeded email body"
             );


### PR DESCRIPTION
App name and event type did not match what was previously configured.

App name is "subscriptions" and event type is exceeded-utilization-threshold.

## Summary by Sourcery

Correct the subscription watch app name and event type to match configuration across templates, migration logic, and tests

Bug Fixes:
- Align subscription watch app name to "subscriptions" and event type to "exceeded-utilization-threshold" in template mappings

Enhancements:
- Update email template migration service to use the new app name and event type

Tests:
- Adjust subscription watch email template tests to reflect the updated app name and event type