### PR TITLE
[RHCLOUD-42268] Use email template in DB for backup only. Use Qute module by default for aggregations.

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/TemplateService.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/TemplateService.java
@@ -13,6 +13,7 @@ import com.redhat.cloud.notifications.qute.templates.mapping.SecureEmailTemplate
 import com.redhat.cloud.notifications.qute.templates.mapping.SubscriptionServices;
 import io.quarkus.logging.Log;
 import io.quarkus.qute.Engine;
+import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.runtime.Startup;
 import jakarta.annotation.PostConstruct;
@@ -108,7 +109,7 @@ public class TemplateService {
      *
      * @throws TemplateNotFoundException
      */
-    private TemplateInstance compileTemplate(final TemplateDefinition originalTemplateDefinition) throws TemplateNotFoundException {
+    private Template compileTemplate(final TemplateDefinition originalTemplateDefinition) throws TemplateNotFoundException {
 
         // try to find template path with full config parameters
         String path = templatesConfigMap.get(originalTemplateDefinition);
@@ -155,7 +156,7 @@ public class TemplateService {
         }
         final String filePath = buildTemplateFilePath(templateDefinition, templatesConfigMap.get(templateDefinition));
         // ask Qute to load the template instance from its file path, such as drawer/Policies/policyTriggeredBody.md
-        return engine.getTemplate(filePath).instance();
+        return engine.getTemplate(filePath);
     }
 
     public String renderTemplate(final TemplateDefinition config, final Action action) {
@@ -179,7 +180,7 @@ public class TemplateService {
     }
 
     public String getTemplateId(final TemplateDefinition config) {
-        return compileTemplate(config).getTemplate().getId();
+        return compileTemplate(config).getId();
     }
 
     public Map<String, Object> convertActionToContextMap(final Action action) {

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -77,9 +77,13 @@ public class ResourceHelpers {
             .executeUpdate();
     }
 
-    @Transactional
     public Bundle createBundle(String bundleName) {
-        Bundle bundle = new Bundle(bundleName, "A bundle");
+        return createBundle(bundleName, "A bundle");
+    }
+
+    @Transactional
+    public Bundle createBundle(String bundleName, String bundleDisplayName) {
+        Bundle bundle = new Bundle(bundleName, bundleDisplayName);
         entityManager.persist(bundle);
         return bundle;
     }
@@ -266,31 +270,30 @@ public class ResourceHelpers {
         return createInstantEmailTemplate(eventType.getId(), blankTemplate.getId(), blankTemplate.getId(), true);
     }
 
-    public Application findOrCreateApplication(String bundleName, String appName) {
-        Bundle bundle = null;
+    public Bundle findOrCreateBundle(String bundleName) {
         try {
-            bundle = findBundle(bundleName);
+            return findBundle(bundleName);
         } catch (NoResultException nre) {
-            bundle = createBundle(bundleName);
+            return createBundle(bundleName);
         }
+    }
 
-        Application app = null;
+    public Application findOrCreateApplication(String bundleName, String appName) {
+        Bundle bundle = findOrCreateBundle(bundleName);
+
         try {
-            app = findApp(bundleName, appName);
+            return findApp(bundleName, appName);
         } catch (NoResultException nre) {
-            app = createApp(bundle.getId(), appName);
+            return createApp(bundle.getId(), appName);
         }
-        return app;
     }
 
     public EventType findOrCreateEventType(UUID applicationId, String eventTypeName) {
-        EventType eventType = null;
         try {
-            eventType = findEventType(applicationId, eventTypeName);
+            return findEventType(applicationId, eventTypeName);
         } catch (NoResultException nre) {
-            eventType = createEventType(applicationId, eventTypeName);
+            return createEventType(applicationId, eventTypeName);
         }
-        return eventType;
     }
 
     @Transactional

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/LifecycleITest.java
@@ -27,8 +27,6 @@ import com.redhat.cloud.notifications.models.HttpType;
 import com.redhat.cloud.notifications.models.NotificationHistory;
 import com.redhat.cloud.notifications.models.SystemSubscriptionProperties;
 import com.redhat.cloud.notifications.models.WebhookProperties;
-import com.redhat.cloud.notifications.qute.templates.TemplateService;
-import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
@@ -107,12 +105,9 @@ public class LifecycleITest {
     @InjectSpy
     EngineConfig engineConfig;
 
-    @InjectMock
-    TemplateService templateService;
-
-    String bundleName;
-    String applicationName;
-    String eventTypeName;
+    final String bundleName = "rhel";
+    final String applicationName = "patch";
+    final String eventTypeName = "new-advisory";
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
@@ -121,15 +116,12 @@ public class LifecycleITest {
         final String username = "user";
 
         when(engineConfig.isUseDirectEndpointToEventTypeEnabled()).thenReturn(useEndpointToEventTypeDirectLink);
-        bundleName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-        applicationName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-        eventTypeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+        when(engineConfig.isUseCommonTemplateModuleToRenderEmailsEnabled()).thenReturn(true);
 
         // First, we need a bundle, an app and an event type. Let's create them!
-        Bundle bundle = resourceHelpers.createBundle(bundleName);
-        Application app = resourceHelpers.createApp(bundle.getId(), applicationName);
-        EventType eventType = resourceHelpers.createEventType(app.getId(), eventTypeName);
-        setupEmailMock();
+        Bundle bundle = resourceHelpers.findOrCreateBundle(bundleName);
+        Application app = resourceHelpers.findOrCreateApplication(bundleName, applicationName);
+        EventType eventType = resourceHelpers.findOrCreateEventType(app.getId(), eventTypeName);
 
         // We also need behavior groups.
         BehaviorGroup behaviorGroup1 = createBehaviorGroup(accountId, bundle);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessorTest.java
@@ -142,11 +142,16 @@ class EmailAggregationProcessorTest {
         mockUsers(user1, user2, user3);
         when(templateRepository.findAggregationEmailTemplate(anyString(), anyString(), eq(DAILY))).thenCallRealMethod();
         resourceHelpers.clearEvents();
+        resourceHelpers.deleteBundle("rhel");
+        resourceHelpers.createBundle("rhel", "Red Hat Enterprise Linux");
+        initData("patch", "new-advisory");
+        initData("policies", "policy-triggered");
     }
 
     @AfterEach
     void afterEach() {
         resourceHelpers.deleteApp("rhel", "patch");
+        resourceHelpers.deleteApp("rhel", "policies");
         resourceHelpers.clearEvents();
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
@@ -99,7 +99,7 @@ class EmailAggregatorTest {
     @Test
     void shouldTestRecipientsFromSubscription() {
         // init test environment
-        application = resourceHelpers.findApp("rhel", "policies");
+        application = resourceHelpers.findOrCreateApplication("rhel", "policies");
         eventType1 = resourceHelpers.findOrCreateEventType(application.getId(), TestHelpers.eventType);
         eventType2 = resourceHelpers.findOrCreateEventType(application.getId(), "not-used");
         resourceHelpers.findOrCreateEventType(application.getId(), "event-type-2");


### PR DESCRIPTION
[RHCLOUD-42268] Use email template in DB for backup only. Use Qute module by default for aggregations.

## Summary by Sourcery

Default to Qute module for email rendering in aggregations and reserve DB-stored templates as a fallback, while refactoring related helper methods and tests to support this change.

Enhancements:
- Default to Qute template rendering for email aggregations and fall back to DB-stored templates only on missing or rendering errors
- Refactor ResourceHelpers to add findOrCreateBundle and simplify findOrCreate* methods with transactional overloads
- Update TemplateService.compileTemplate to return Template instead of TemplateInstance and adjust getTemplateId
- Revise EmailProcessor to validate Qute templates via isValidTemplateDefinition and defer to DB templates on exceptions

Tests:
- Adjust lifecycle and aggregation tests to use fixed bundle/app names and new findOrCreate helper methods
- Update EmailAggregationProcessorTest and EmailAggregatorTest setup and teardown to create and delete resources via ResourceHelpers