### PR TITLE
[RHCLOUD-42284] Add endpoint Id on connectors logs for Kibana reports

### DIFF
--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExchangeProperty.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ExchangeProperty.java
@@ -13,6 +13,7 @@ public class ExchangeProperty {
      */
     public static final String KAFKA_REINJECTION_DELAY = "kafkaReinjectionDelay";
     public static final String ORG_ID = "orgId";
+    public static final String ENDPOINT_ID = "endpointId";
     /**
      * Holds the original Cloud Event as received from the "incoming" Kafka
      * topic.

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/IncomingCloudEventProcessor.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.ENDPOINT_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORIGINAL_CLOUD_EVENT;
@@ -44,6 +45,7 @@ public class IncomingCloudEventProcessor implements Processor {
         JsonObject data = cloudEvent.getJsonObject(CLOUD_EVENT_DATA);
 
         exchange.setProperty(ORG_ID, data.getString("org_id"));
+        exchange.setProperty(ENDPOINT_ID, data.getString("endpoint_id"));
 
         cloudEventDataExtractor.extract(exchange, data);
     }

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/OutgoingCloudEventBuilder.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/OutgoingCloudEventBuilder.java
@@ -10,6 +10,7 @@ import org.apache.camel.util.json.JsonObject;
 
 import java.time.LocalDateTime;
 
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.ENDPOINT_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.OUTCOME;
@@ -48,8 +49,9 @@ public class OutgoingCloudEventBuilder implements Processor {
         data.put("duration", System.currentTimeMillis() - exchange.getProperty(START_TIME, Long.class));
         data.put("details", details);
 
-        Log.infof("Notification sent [orgId=%s, type=%s, historyId=%s, duration=%d, successful=%b]",
+        Log.infof("Notification sent [orgId=%s, EndpointId=%s, type=%s, historyId=%s, duration=%d, successful=%b]",
             exchange.getProperty(ORG_ID, String.class),
+            exchange.getProperty(ENDPOINT_ID, String.class),
             exchange.getProperty(RETURN_SOURCE, String.class),
             exchange.getProperty(ID, String.class),
             data.get("duration"),

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/ConnectorSender.java
@@ -77,6 +77,7 @@ public class ConnectorSender {
 
     public void send(Event event, Endpoint endpoint, JsonObject payload) {
         payload.put("org_id", event.getOrgId());
+        payload.put("endpoint_id", endpoint.getId());
 
         String connector = getConnector(endpoint);
 


### PR DESCRIPTION
## Summary by Sourcery

Propagate the endpoint ID through the connector flow and include it in log output and outgoing payload for improved traceability in Kibana

Enhancements:
- Add ENDPOINT_ID constant to ExchangeProperty
- Extract and store endpoint_id from incoming CloudEvent in IncomingCloudEventProcessor
- Include endpoint_id in outgoing payload in ConnectorSender
- Log endpointId in OutgoingCloudEventBuilder log statements