### PR TITLE
Set DB Cleaner job pull policy to Always

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -38,6 +38,7 @@ objects:
             cpu: ${DB_CLEANER_CPU_LIMIT}
             memory: ${DB_CLEANER_MEMORY_LIMIT}
         image: registry.redhat.io/rhel9/postgresql-16:latest
+        imagePullPolicy: Always
         volumes:
           - name: notifications-db-cleaner-volume
             configMap:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Set imagePullPolicy to Always for the database cleaner job container