### PR TITLE
[RHCLOUD-42343] Render daily digest from email connector

### DIFF
--- a/common-template/pom.xml
+++ b/common-template/pom.xml
@@ -80,6 +80,20 @@
                 </executions>
             </plugin>
 
+            <!-- This module provides test classes to other modules. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>

--- a/connector-email/pom.xml
+++ b/connector-email/pom.xml
@@ -43,6 +43,13 @@
                     <type>test-jar</type>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>com.redhat.cloud.notifications</groupId>
+                    <artifactId>notifications-common-template</artifactId>
+                    <version>${project.version}</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailAggregationProcessor.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailAggregationProcessor.java
@@ -1,0 +1,104 @@
+package com.redhat.cloud.notifications.connector.email;
+
+import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
+import com.redhat.cloud.notifications.connector.email.model.DailyDigestSection;
+import com.redhat.cloud.notifications.connector.email.model.EmailNotification;
+import com.redhat.cloud.notifications.qute.templates.IntegrationType;
+import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
+import com.redhat.cloud.notifications.qute.templates.TemplateService;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class EmailAggregationProcessor {
+
+    @Inject
+    TemplateService templateService;
+
+    @Inject
+    EmailConnectorConfig emailConnectorConfig;
+
+    public String aggregate(final EmailNotification emailNotification, final String orgId, String emailTitle) {
+        Map<String, Object> environment = (Map<String, Object>) emailNotification.eventData().get("environment");
+        String bundleName = emailNotification.eventData().get("bundle_name").toString();
+
+        List<Map<String, Object>> listApplicationAggregatedData = (List<Map<String, Object>>) emailNotification.eventData().get("application_aggregated_data_list");
+
+        Log.info("Starting aggregation for bundleName: " + bundleName);
+        Map<String, DailyDigestSection> dataMap  = new HashMap<>();
+        for (Map<String, Object> applicationAggregatedDataAsMap : listApplicationAggregatedData) {
+            String appName =  (String) applicationAggregatedDataAsMap.get("appName");
+            try {
+                dataMap.put(appName, renderApplicationDailyDigestBody(bundleName, appName, (Map<String, Object>) applicationAggregatedDataAsMap.get("aggregatedData"), orgId, environment));
+            } catch (Exception ex) {
+                Log.error("Error rendering application template for " + appName, ex);
+            }
+        }
+
+        if (!dataMap.isEmpty()) {
+            // sort application by name
+            List<DailyDigestSection> result = dataMap.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(Map.Entry::getValue)
+                .toList();
+
+            Map<String, Object> actionContext = new HashMap<>(Map.of("title", emailTitle, "items", result, "orgId", orgId));
+            Map<String, Object> action = Map.of("context", actionContext, "bundle", bundleName);
+
+            try {
+                TemplateDefinition templateDefinition = new TemplateDefinition(IntegrationType.EMAIL_DAILY_DIGEST_BUNDLE_AGGREGATION_BODY, null, null, null);
+                Map<String, Object> additionalContext = buildFullTemplateContext(action, environment);
+
+                return templateService.renderTemplateWithCustomDataMap(templateDefinition, additionalContext);
+            } catch (Exception e) {
+                Log.error(String.format("Error rendering daily digest email template for %s", bundleName), e);
+                throw e;
+            }
+        }
+        return null;
+    }
+
+    private DailyDigestSection renderApplicationDailyDigestBody(String bundle, String app, Map<String, Object> context, String orgId, final Map<String, Object> environment) {
+        context.put("application", app);
+
+        Map<String, Object> action =  Map.of("context", context, "bundle", bundle);
+
+        DailyDigestSection builtSection = null;
+
+        try {
+            TemplateDefinition templateDefinition = new TemplateDefinition(IntegrationType.EMAIL_DAILY_DIGEST_BODY, bundle, app, null, emailConnectorConfig.isUseBetaTemplatesEnabled(orgId, null));
+            Map<String, Object> additionalContext = buildFullTemplateContext(action, environment);
+
+            String renderedAppTemplate = templateService.renderTemplateWithCustomDataMap(templateDefinition, additionalContext);
+            builtSection = addItem(renderedAppTemplate);
+        } catch (Exception e) {
+            Log.error(String.format("Error rendering aggregated email template for %s/%s", bundle, app), e);
+        }
+
+        return builtSection;
+    }
+
+    private DailyDigestSection addItem(String template) {
+        String titleData = template.split("<!-- Body section -->")[0];
+        String bodyData = template.split("<!-- Body section -->")[1];
+        String[] sections = titleData.split("<!-- next section -->");
+
+        return new DailyDigestSection(bodyData, Arrays.stream(sections).filter(e -> !e.isBlank()).collect(Collectors.toList()));
+    }
+
+    private Map<String, Object> buildFullTemplateContext(final Map<String, Object> action, final Map<String, Object> environment) {
+        Map<String, Object> additionalContext = new HashMap<>();
+        additionalContext.put("environment", environment);
+        additionalContext.put("ignore_user_preferences", false);
+        additionalContext.put("action", action);
+        additionalContext.put("pendo_message", null);
+        return additionalContext;
+    }
+}

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailCloudEventDataExtractor.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailCloudEventDataExtractor.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.redhat.cloud.notifications.connector.ExchangeProperty.ID;
+import static com.redhat.cloud.notifications.connector.ExchangeProperty.ORG_ID;
+import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_DAILY_DIGEST_BUNDLE_AGGREGATION_TITLE;
 import static java.util.stream.Collectors.toSet;
 
 @ApplicationScoped
@@ -34,6 +36,9 @@ public class EmailCloudEventDataExtractor extends CloudEventDataExtractor {
 
     @Inject
     TemplateService templateService;
+
+    @Inject
+    EmailAggregationProcessor emailAggregationProcessor;
 
     /**
      * Extracts the relevant information for the email connector from the
@@ -62,10 +67,18 @@ public class EmailCloudEventDataExtractor extends CloudEventDataExtractor {
                 .collect(toSet());
 
         final String historyId = exchange.getProperty(ID, String.class);
-        exchange.setProperty(ExchangeProperty.RENDERED_BODY,
-            renderEmailTemplateFromCommonModule(emailNotification, IntegrationType.EMAIL_BODY, emailNotification.emailBody(), historyId));
-        exchange.setProperty(ExchangeProperty.RENDERED_SUBJECT,
-            renderEmailTemplateFromCommonModule(emailNotification, IntegrationType.EMAIL_TITLE, emailNotification.emailSubject(), historyId));
+
+        exchange.setProperty(ExchangeProperty.RENDERED_SUBJECT, emailNotification.emailSubject());
+        exchange.setProperty(ExchangeProperty.RENDERED_BODY, emailNotification.emailBody());
+
+        if (emailNotification.isDailyDigest()) {
+            renderDailyDigestFromCommonModule(exchange, emailNotification, historyId);
+        } else {
+            exchange.setProperty(ExchangeProperty.RENDERED_BODY,
+                renderInstantEmailFromCommonModule(emailNotification, IntegrationType.EMAIL_BODY, emailNotification.emailBody(), historyId));
+            exchange.setProperty(ExchangeProperty.RENDERED_SUBJECT,
+                renderInstantEmailFromCommonModule(emailNotification, IntegrationType.EMAIL_TITLE, emailNotification.emailSubject(), historyId));
+        }
         exchange.setProperty(ExchangeProperty.RECIPIENT_SETTINGS, emailNotification.recipientSettings());
         exchange.setProperty(ExchangeProperty.SUBSCRIBED_BY_DEFAULT, emailNotification.subscribedByDefault());
         exchange.setProperty(ExchangeProperty.SUBSCRIBERS, emailNotification.subscribers());
@@ -76,7 +89,29 @@ public class EmailCloudEventDataExtractor extends CloudEventDataExtractor {
         exchange.setProperty(ExchangeProperty.USE_SIMPLIFIED_EMAIL_ROUTE, emailConnectorConfig.useSimplifiedEmailRoute(emailNotification.orgId()));
     }
 
-    private String renderEmailTemplateFromCommonModule(EmailNotification emailNotification, IntegrationType integrationType, final String renderedContentFromEngine, String historyId) {
+    private void renderDailyDigestFromCommonModule(Exchange exchange, EmailNotification emailNotification, String historyId) {
+        if (null != emailNotification.eventData()) {
+            try {
+                String emailTitle = renderEmailAggregationTitleTemplateFromCommonModule(emailNotification.eventData().get("bundle_display_name").toString());
+                exchange.setProperty(ExchangeProperty.RENDERED_SUBJECT, emailTitle);
+
+                if (exchange.getProperty(ORG_ID) == null) {
+                    exchange.setProperty(ORG_ID, emailNotification.oldOrgId());
+                }
+                String builtAggregatedEmailBody = emailAggregationProcessor.aggregate(emailNotification, exchange.getProperty(ORG_ID, String.class), emailTitle);
+                if (!emailNotification.emailBody().equals(builtAggregatedEmailBody)) {
+                    Log.errorf("Legacy and new rendered messages are different for daily digest (history Id %s): '%s' vs. '%s'", historyId, emailNotification.emailBody(), builtAggregatedEmailBody);
+                } else {
+                    Log.infof("Legacy and new rendered messages are identical for daily digest");
+                    exchange.setProperty(ExchangeProperty.RENDERED_BODY, builtAggregatedEmailBody);
+                }
+            } catch (Exception ex) {
+                Log.errorf(ex, "Error rendering data with common-template module for daily digest (history Id %s)", historyId);
+            }
+        }
+    }
+
+    private String renderInstantEmailFromCommonModule(EmailNotification emailNotification, IntegrationType integrationType, final String renderedContentFromEngine, String historyId) {
         if (null != emailNotification.eventData()) {
             try {
                 Map<String, Object> additionalContext = new HashMap<>();
@@ -104,5 +139,13 @@ public class EmailCloudEventDataExtractor extends CloudEventDataExtractor {
             }
         }
         return renderedContentFromEngine;
+    }
+
+    private String renderEmailAggregationTitleTemplateFromCommonModule(String bundleDisplayName) {
+        TemplateDefinition templateDefinition = new TemplateDefinition(
+            EMAIL_DAILY_DIGEST_BUNDLE_AGGREGATION_TITLE, null, null, null
+        );
+        Map<String, Object> mapDataTitle = Map.of("source", Map.of("bundle", Map.of("display_name", bundleDisplayName)));
+        return templateService.renderTemplateWithCustomDataMap(templateDefinition, mapDataTitle);
     }
 }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailCloudEventDataExtractor.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/EmailCloudEventDataExtractor.java
@@ -68,10 +68,10 @@ public class EmailCloudEventDataExtractor extends CloudEventDataExtractor {
 
         final String historyId = exchange.getProperty(ID, String.class);
 
-        exchange.setProperty(ExchangeProperty.RENDERED_SUBJECT, emailNotification.emailSubject());
-        exchange.setProperty(ExchangeProperty.RENDERED_BODY, emailNotification.emailBody());
 
         if (emailNotification.isDailyDigest()) {
+            exchange.setProperty(ExchangeProperty.RENDERED_SUBJECT, emailNotification.emailSubject());
+            exchange.setProperty(ExchangeProperty.RENDERED_BODY, emailNotification.emailBody());
             renderDailyDigestFromCommonModule(exchange, emailNotification, historyId);
         } else {
             exchange.setProperty(ExchangeProperty.RENDERED_BODY,

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/DailyDigestSection.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/DailyDigestSection.java
@@ -1,0 +1,29 @@
+package com.redhat.cloud.notifications.connector.email.model;
+
+import java.util.List;
+
+public class DailyDigestSection {
+    String body;
+    List<String> headerLink;
+
+    public DailyDigestSection(String body, List<String> headerLink) {
+        this.body = body;
+        this.headerLink = headerLink;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public List<String> getHeaderLink() {
+        return headerLink;
+    }
+
+    public void setHeaderLink(List<String> headerLink) {
+        this.headerLink = headerLink;
+    }
+}

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/EmailAggregation.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/EmailAggregation.java
@@ -1,0 +1,13 @@
+package com.redhat.cloud.notifications.connector.email.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.redhat.cloud.notifications.connector.email.model.aggregation.ApplicationAggregatedData;
+import com.redhat.cloud.notifications.connector.email.model.aggregation.Environment;
+import java.util.List;
+
+public record EmailAggregation(
+    @JsonProperty("bundle_name")            String bundleName,
+    @JsonProperty("bundle_display_name")    String bundleDisplayName,
+    @JsonProperty("environment")            Environment environment,
+    @JsonProperty("application_aggregated_data_list") List<ApplicationAggregatedData> applicationAggregatedDataList
+) { }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/EmailNotification.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/EmailNotification.java
@@ -33,12 +33,15 @@ public record EmailNotification(
     @JsonProperty("email_sender")           String emailSender,
     @JsonProperty("org_id")                 String orgId,
     @JsonProperty("orgId")                  String oldOrgId,
+    // This was a typo that was introduced a long time ago;
+    // the cloud event extractor in common-connector expects a property named org_id.
+    // We need to keep both for the next production rollout.
     @JsonProperty("recipient_settings")     Collection<RecipientSettings> recipientSettings,
     @JsonProperty("subscribers")            Collection<String> subscribers,
     @JsonProperty("unsubscribers")          Collection<String> unsubscribers,
     @JsonProperty("subscribed_by_default")  boolean subscribedByDefault,
     @JsonProperty("recipients_authorization_criterion") JsonObject recipientsAuthorizationCriterion,
-    @JsonProperty("event_data") Map<String, Object> eventData,
+    @JsonProperty("event_data")             Map<String, Object> eventData,
     @JsonProperty("id_daily_digest")        boolean isDailyDigest
 ) { }
 

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/EmailNotification.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/EmailNotification.java
@@ -31,12 +31,14 @@ public record EmailNotification(
     @JsonProperty("email_body")             String emailBody,
     @JsonProperty("email_subject")          String emailSubject,
     @JsonProperty("email_sender")           String emailSender,
-    @JsonProperty("orgId")                  String orgId,
+    @JsonProperty("org_id")                 String orgId,
+    @JsonProperty("orgId")                  String oldOrgId,
     @JsonProperty("recipient_settings")     Collection<RecipientSettings> recipientSettings,
     @JsonProperty("subscribers")            Collection<String> subscribers,
     @JsonProperty("unsubscribers")          Collection<String> unsubscribers,
     @JsonProperty("subscribed_by_default")  boolean subscribedByDefault,
     @JsonProperty("recipients_authorization_criterion") JsonObject recipientsAuthorizationCriterion,
-    @JsonProperty("event_data") Map<String, Object> eventData
-)  { }
+    @JsonProperty("event_data") Map<String, Object> eventData,
+    @JsonProperty("id_daily_digest")        boolean isDailyDigest
+) { }
 

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/AggregationAction.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/AggregationAction.java
@@ -1,0 +1,6 @@
+package com.redhat.cloud.notifications.connector.email.model.aggregation;
+
+public record AggregationAction(
+    String bundle,
+    AggregationActionContext context
+) { }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/AggregationActionContext.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/AggregationActionContext.java
@@ -1,0 +1,9 @@
+package com.redhat.cloud.notifications.connector.email.model.aggregation;
+
+import java.util.List;
+
+public record AggregationActionContext(
+    String title,
+    List<DailyDigestSection> items,
+    String orgId
+) { }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/ApplicationAggregatedData.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/ApplicationAggregatedData.java
@@ -1,0 +1,31 @@
+package com.redhat.cloud.notifications.connector.email.model.aggregation;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class ApplicationAggregatedData {
+    public Map<String, Object> aggregatedData;
+    public String appName;
+
+    public ApplicationAggregatedData(Map<String, Object> aggregatedData, String appName) {
+        this.aggregatedData = aggregatedData;
+        this.appName = appName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ApplicationAggregatedData that = (ApplicationAggregatedData) o;
+        return Objects.equals(aggregatedData, that.aggregatedData) && Objects.equals(appName, that.appName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(aggregatedData, appName);
+    }
+}

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/ApplicationAggregatedData.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/ApplicationAggregatedData.java
@@ -1,31 +1,9 @@
 package com.redhat.cloud.notifications.connector.email.model.aggregation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
-import java.util.Objects;
 
-public class ApplicationAggregatedData {
-    public Map<String, Object> aggregatedData;
-    public String appName;
-
-    public ApplicationAggregatedData(Map<String, Object> aggregatedData, String appName) {
-        this.aggregatedData = aggregatedData;
-        this.appName = appName;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ApplicationAggregatedData that = (ApplicationAggregatedData) o;
-        return Objects.equals(aggregatedData, that.aggregatedData) && Objects.equals(appName, that.appName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(aggregatedData, appName);
-    }
-}
+public record ApplicationAggregatedData(
+    @JsonProperty("app_name")           String appName,
+    @JsonProperty("aggregated_data")    Map<String, Object> aggregatedData
+) { }

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/DailyDigestSection.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/DailyDigestSection.java
@@ -1,4 +1,4 @@
-package com.redhat.cloud.notifications.connector.email.model;
+package com.redhat.cloud.notifications.connector.email.model.aggregation;
 
 import java.util.List;
 

--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/Environment.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/Environment.java
@@ -1,0 +1,8 @@
+package com.redhat.cloud.notifications.connector.email.model.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Environment(
+    @JsonProperty("url")        String url,
+    @JsonProperty("ocm_url")    String ocmUrl
+) { }

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderTest.java
@@ -364,12 +364,14 @@ public class EmailRouteBuilderTest extends CamelQuarkusTestSupport {
             "test email subject",
             "Not used",
             "123456",
+            "123456",
             List.of(recipientSettings),
             new ArrayList<>(),
             new ArrayList<>(),
             false,
             null,
-            new HashMap<>()
+            new HashMap<>(),
+            false
         );
         final JsonObject payload = JsonObject.mapFrom(emailNotification);
 

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderWithSimplifiedRouteTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderWithSimplifiedRouteTest.java
@@ -1,15 +1,22 @@
 package com.redhat.cloud.notifications.connector.email;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.MockServerLifecycleManager;
 import com.redhat.cloud.notifications.connector.email.config.EmailConnectorConfig;
 import com.redhat.cloud.notifications.connector.email.model.EmailNotification;
+import com.redhat.cloud.notifications.connector.email.model.aggregation.ApplicationAggregatedData;
 import com.redhat.cloud.notifications.connector.email.model.settings.RecipientSettings;
 import com.redhat.cloud.notifications.connector.email.model.settings.User;
 import com.redhat.cloud.notifications.connector.email.processors.bop.BOPManager;
+import com.redhat.cloud.notifications.qute.templates.TemplateService;
+import email.TestPoliciesTemplate;
+import helpers.TestHelpers;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
 import org.apache.camel.Exchange;
@@ -39,6 +46,11 @@ import static com.redhat.cloud.notifications.connector.EngineToConnectorRouteBui
 import static com.redhat.cloud.notifications.connector.IncomingCloudEventFilter.X_RH_NOTIFICATIONS_CONNECTOR_HEADER;
 import static com.redhat.cloud.notifications.connector.IncomingCloudEventProcessor.*;
 import static com.redhat.cloud.notifications.connector.email.CloudEventHistoryBuilder.TOTAL_RECIPIENTS_KEY;
+import static email.TestAdvisorTemplate.JSON_ADVISOR_DEFAULT_AGGREGATION_CONTEXT;
+import static email.TestImageBuilderTemplate.JSON_IMAGE_BUILDER_DEFAULT_AGGREGATION_CONTEXT;
+import static email.TestInventoryTemplate.JSON_INVENTORY_DEFAULT_AGGREGATION_CONTEXT;
+import static email.TestPatchTemplate.JSON_PATCH_DEFAULT_AGGREGATION_CONTEXT;
+import static email.TestResourceOptimizationTemplate.JSON_RESOURCE_OPTIMIZATION_DEFAULT_AGGREGATION_CONTEXT;
 import static org.apache.camel.builder.AdviceWith.adviceWith;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -51,6 +63,8 @@ import static org.mockserver.model.HttpResponse.response;
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
 class EmailRouteBuilderWithSimplifiedRouteTest extends CamelQuarkusTestSupport {
+    private static final String PATCH_TEST_EVENT = "{\"account_id\":\"\",\"application\":\"patch\",\"bundle\":\"rhel\",\"context\":{\"system_check_in\":\"2022-08-03T15:22:42.199046\",\"start_time\":\"2022-08-03T15:22:42.199046\",\"patch\":{\"Alpha\":[\"advA\",\"advB\",\"advC\"],\"Roman\":[\"advI\",\"advII\",\"advIII\"],\"Numerical\":[\"adv1\",\"adv2\"]}},\"event_type\":\"new-advisory\",\"events\":[{\"metadata\":{},\"payload\":{\"advisory_name\":\"name 1\",\"synopsis\":\"synopsis 1\"}},{\"metadata\":{},\"payload\":{\"advisory_name\":\"name 2\",\"synopsis\":\"synopsis 2\"}}],\"orgId\":\"default-org-id\",\"timestamp\":\"2022-10-03T15:22:13.000000025\",\"source\":{\"application\":{\"display_name\":\"Patch\"},\"bundle\":{\"display_name\":\"Red Hat Enterprise Linux\"},\"event_type\":{\"display_name\":\"New Advisory\"}},\"environment\":{\"url\":\"https://localhost\",\"ocmUrl\":\"https://localhost\"},\"pendo_message\":null,\"ignore_user_preferences\":true}";
+
     @InjectSpy
     EmailConnectorConfig emailConnectorConfig;
 
@@ -65,9 +79,17 @@ class EmailRouteBuilderWithSimplifiedRouteTest extends CamelQuarkusTestSupport {
     @InjectSpy
     BOPManager bopManager;
 
+    @Inject
+    TemplateService templateService;
+
+    Map<String, Object> eventData;
+    boolean isDailyDigest = false;
+
     @BeforeEach
     void beforeEach() {
         when(emailConnectorConfig.useSimplifiedEmailRoute(anyString())).thenReturn(true);
+        eventData = buildInstantEmailContext();
+        isDailyDigest = false;
     }
 
     void initCamelRoutes() throws Exception {
@@ -128,6 +150,38 @@ class EmailRouteBuilderWithSimplifiedRouteTest extends CamelQuarkusTestSupport {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testWithRecipients(boolean emailsInternalOnlyEnabled) throws Exception {
+        try {
+            emailConnectorConfig.setEmailsInternalOnlyEnabled(emailsInternalOnlyEnabled);
+            Set<User> users = TestUtils.createUsers("user-1", "user-2", "user-3", "user-4", "user-5", "user-6", "user-7");
+            String strUsers = objectMapper.writeValueAsString(users);
+            ExpectationResponseCallback recipientsResolverResponse = req -> response().withContentType(MediaType.APPLICATION_JSON).withBody(strUsers).withStatusCode(200);
+            ExpectationResponseCallback bopResponse = req -> response().withContentType(MediaType.APPLICATION_JSON).withStatusCode(200);
+            initMocks(recipientsResolverResponse, bopResponse);
+
+            Set<String> additionalEmails = Set.of("redhat_user@redhat.com", "external_user@noway.com");
+            int usersAndRecipientsTotalNumber = users.size() + additionalEmails.size();
+
+            kafkaConnectorToEngine.expectedMessageCount(1);
+
+            buildCloudEventAndSendIt(additionalEmails);
+
+            kafkaConnectorToEngine.assertIsSatisfied(2000);
+
+            final ArgumentCaptor<List<String>> listCaptor = ArgumentCaptor.forClass((Class) List.class);
+            verify(bopManager, times(3))
+                .sendToBop(listCaptor.capture(), anyString(), anyString(), anyString());
+
+            checkRecipientsAndHistory(usersAndRecipientsTotalNumber, listCaptor.getAllValues(), kafkaConnectorToEngine, emailsInternalOnlyEnabled, "external_user@noway.com");
+        } finally {
+            emailConnectorConfig.setEmailsInternalOnlyEnabled(false);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testWithRecipientsForDailyDigest(boolean emailsInternalOnlyEnabled) throws Exception {
+        eventData = buildRhelDailyDigestEmailContext();
+        isDailyDigest = true;
         try {
             emailConnectorConfig.setEmailsInternalOnlyEnabled(emailsInternalOnlyEnabled);
             Set<User> users = TestUtils.createUsers("user-1", "user-2", "user-3", "user-4", "user-5", "user-6", "user-7");
@@ -311,12 +365,14 @@ class EmailRouteBuilderWithSimplifiedRouteTest extends CamelQuarkusTestSupport {
             "test email subject",
             "Not used",
             "123456",
+            "123456",
             List.of(recipientSettings),
             new ArrayList<>(),
             new ArrayList<>(),
             false,
             null,
-            new HashMap<>()
+            eventData,
+            isDailyDigest
         );
         final JsonObject payload = JsonObject.mapFrom(emailNotification);
 
@@ -327,5 +383,66 @@ class EmailRouteBuilderWithSimplifiedRouteTest extends CamelQuarkusTestSupport {
         cloudEvent.put(CLOUD_EVENT_TYPE, "com.redhat.console.notification.toCamel." + emailConnectorConfig.getConnectorName());
         cloudEvent.put(CLOUD_EVENT_DATA, JsonObject.mapFrom(payload));
         return cloudEvent;
+    }
+
+    private Map<String, Object> buildRhelDailyDigestEmailContext() {
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() { };
+
+        List<ApplicationAggregatedData> applicationAggregatedDataList = new ArrayList<>();
+        try {
+            applicationAggregatedDataList.add(new ApplicationAggregatedData(
+                objectMapper.readValue(JSON_ADVISOR_DEFAULT_AGGREGATION_CONTEXT, typeRef),
+                "advisor"
+            ));
+            applicationAggregatedDataList.add(new ApplicationAggregatedData(
+                templateService.convertActionToContextMap(TestHelpers.createComplianceAction()),
+                "compliance"
+            ));
+            applicationAggregatedDataList.add(new ApplicationAggregatedData(
+                objectMapper.readValue(JSON_IMAGE_BUILDER_DEFAULT_AGGREGATION_CONTEXT, typeRef),
+                "image-builder"
+            ));
+            applicationAggregatedDataList.add(new ApplicationAggregatedData(
+                objectMapper.readValue(JSON_INVENTORY_DEFAULT_AGGREGATION_CONTEXT, typeRef),
+                "inventory"
+            ));
+            applicationAggregatedDataList.add(new ApplicationAggregatedData(
+                objectMapper.readValue(JSON_PATCH_DEFAULT_AGGREGATION_CONTEXT, typeRef),
+                "patch"
+            ));
+            applicationAggregatedDataList.add(new ApplicationAggregatedData(
+                TestPoliciesTemplate.buildPoliciesAggregatedPayload(),
+                "policies"
+            ));
+            applicationAggregatedDataList.add(new ApplicationAggregatedData(
+                objectMapper.readValue(JSON_RESOURCE_OPTIMIZATION_DEFAULT_AGGREGATION_CONTEXT, typeRef),
+                "resource-optimization"
+            ));
+            applicationAggregatedDataList.add(new ApplicationAggregatedData(
+                templateService.convertActionToContextMap(TestHelpers.createVulnerabilityAction()),
+                "vulnerability"
+            ));
+        } catch (JsonProcessingException e) {
+            fail(e);
+        }
+
+        Map<String, Object> additionalContext = new HashMap<>();
+        additionalContext.put("environment", Map.of("url", "https://root.env.url.com"));
+        additionalContext.put("bundle_name", "rhel");
+        additionalContext.put("bundle_display_name", "Red Hat Enterprise Linux");
+        additionalContext.put("pendo_message", null);
+        additionalContext.put("application_aggregated_data_list", new JsonArray(objectMapper.convertValue(applicationAggregatedDataList, List.class)));
+
+        return additionalContext;
+    }
+
+    private Map<String, Object> buildInstantEmailContext() {
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<>() { };
+        try {
+            return objectMapper.readValue(PATCH_TEST_EVENT, typeRef);
+        } catch (JsonProcessingException e) {
+            fail(e);
+            return null;
+        }
     }
 }

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderWithSimplifiedRouteTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderWithSimplifiedRouteTest.java
@@ -391,36 +391,36 @@ class EmailRouteBuilderWithSimplifiedRouteTest extends CamelQuarkusTestSupport {
         List<ApplicationAggregatedData> applicationAggregatedDataList = new ArrayList<>();
         try {
             applicationAggregatedDataList.add(new ApplicationAggregatedData(
-                objectMapper.readValue(JSON_ADVISOR_DEFAULT_AGGREGATION_CONTEXT, typeRef),
-                "advisor"
+                "advisor",
+                objectMapper.readValue(JSON_ADVISOR_DEFAULT_AGGREGATION_CONTEXT, typeRef)
             ));
             applicationAggregatedDataList.add(new ApplicationAggregatedData(
-                templateService.convertActionToContextMap(TestHelpers.createComplianceAction()),
-                "compliance"
+                "Compliance",
+                templateService.convertActionToContextMap(TestHelpers.createComplianceAction())
             ));
             applicationAggregatedDataList.add(new ApplicationAggregatedData(
-                objectMapper.readValue(JSON_IMAGE_BUILDER_DEFAULT_AGGREGATION_CONTEXT, typeRef),
-                "image-builder"
+                "image-builder",
+                objectMapper.readValue(JSON_IMAGE_BUILDER_DEFAULT_AGGREGATION_CONTEXT, typeRef)
             ));
             applicationAggregatedDataList.add(new ApplicationAggregatedData(
-                objectMapper.readValue(JSON_INVENTORY_DEFAULT_AGGREGATION_CONTEXT, typeRef),
-                "inventory"
+                "inventory",
+                objectMapper.readValue(JSON_INVENTORY_DEFAULT_AGGREGATION_CONTEXT, typeRef)
             ));
             applicationAggregatedDataList.add(new ApplicationAggregatedData(
-                objectMapper.readValue(JSON_PATCH_DEFAULT_AGGREGATION_CONTEXT, typeRef),
-                "patch"
+                "patch",
+                objectMapper.readValue(JSON_PATCH_DEFAULT_AGGREGATION_CONTEXT, typeRef)
             ));
             applicationAggregatedDataList.add(new ApplicationAggregatedData(
-                TestPoliciesTemplate.buildPoliciesAggregatedPayload(),
-                "policies"
+                "policies",
+                TestPoliciesTemplate.buildPoliciesAggregatedPayload()
             ));
             applicationAggregatedDataList.add(new ApplicationAggregatedData(
-                objectMapper.readValue(JSON_RESOURCE_OPTIMIZATION_DEFAULT_AGGREGATION_CONTEXT, typeRef),
-                "resource-optimization"
+                "resource-optimization",
+                objectMapper.readValue(JSON_RESOURCE_OPTIMIZATION_DEFAULT_AGGREGATION_CONTEXT, typeRef)
             ));
             applicationAggregatedDataList.add(new ApplicationAggregatedData(
-                templateService.convertActionToContextMap(TestHelpers.createVulnerabilityAction()),
-                "vulnerability"
+                "vulnerability",
+                templateService.convertActionToContextMap(TestHelpers.createVulnerabilityAction())
             ));
         } catch (JsonProcessingException e) {
             fail(e);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.processors.email;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
@@ -432,7 +433,11 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
     }
 
     public class ApplicationAggregatedData {
+
+        @JsonProperty("aggregated_data")
         Map<String, Object> aggregatedData;
+
+        @JsonProperty("app_name")
         String appName;
 
         public ApplicationAggregatedData(Map<String, Object> aggregatedData, String appName) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
@@ -34,6 +34,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.quarkus.logging.Log;
 import io.quarkus.qute.TemplateInstance;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -323,6 +324,11 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
                 Set<String> recipientsUsernames = listApplicationWithUserCollection.getValue().stream().map(User::getUsername).collect(Collectors.toSet());
                 Set<RecipientSettings> recipientSettings = extractAndTransformRecipientSettings(aggregatorEvent, List.of(endpoint));
 
+                Map<String, Object> aggregatedDataToRenderOnConnector = null;
+                if (engineConfig.isConnectorTemplateTransformationEnabled(aggregatorEvent.getOrgId())) {
+                    aggregatedDataToRenderOnConnector = buildFullConnectorTemplateContext(listApplicationWithUserCollection.getKey(), bundle);
+                }
+
                 // Prepare all the data to be sent to the connector.
                 final EmailNotification emailNotification = new EmailNotification(
                     bodyStr,
@@ -341,13 +347,24 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
                     false,
                     // because recipient list has already been computed using authz constraints, we don't need it for the aggregated email
                     null,
-                    null);
+                    aggregatedDataToRenderOnConnector,
+                    true
+                );
 
                 connectorSender.send(aggregatorEvent, endpoint, JsonObject.mapFrom(emailNotification));
 
                 Log.debugf("Sent email notification to connector: %s", emailNotification);
             }
         });
+    }
+
+    private Map<String, Object> buildFullConnectorTemplateContext(List<ApplicationAggregatedData> action, Bundle bundle) {
+        Map<String, Object> additionalContext = new HashMap<>();
+        additionalContext.put("environment", environment);
+        additionalContext.put("bundle_name", bundle.getName());
+        additionalContext.put("bundle_display_name", bundle.getDisplayName());
+        additionalContext.put("application_aggregated_data_list", new JsonArray(objectMapper.convertValue(action, List.class)));
+        return additionalContext;
     }
 
     private String renderEmailFromTemplatesInDb(Map<String, Object> action) {
@@ -421,6 +438,14 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
         public ApplicationAggregatedData(Map<String, Object> aggregatedData, String appName) {
             this.aggregatedData = aggregatedData;
             this.appName = appName;
+        }
+
+        public Map<String, Object> getAggregatedData() {
+            return aggregatedData;
+        }
+
+        public String getAppName() {
+            return appName;
         }
 
         @Override

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
@@ -185,7 +185,8 @@ public class EmailProcessor extends SystemEndpointTypeProcessor {
             unsubscribers,
             event.getEventType().isSubscribedByDefault(),
             recipientsAuthorizationCriterionExtractor.extract(event),
-            eventData
+            eventData,
+            false
         );
 
         Log.debugf("[org_id: %s] Sending email notification to connector", emailNotification);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/connector/dto/EmailNotification.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/connector/dto/EmailNotification.java
@@ -30,10 +30,12 @@ public record EmailNotification(
     @JsonProperty("email_body")             String emailBody,
     @JsonProperty("email_subject")          String emailSubject,
     @JsonProperty("email_sender")           String emailSender,
-    @JsonProperty("orgId")                  String orgId,
+    @JsonProperty("org_id")                 String orgId,
     @JsonProperty("recipient_settings")     Collection<RecipientSettings> recipientSettings,
     @JsonProperty("subscribers")            Collection<String> subscribers,
     @JsonProperty("unsubscribers")          Collection<String> unsubscribers,
     @JsonProperty("subscribed_by_default")  boolean subscribedByDefault,
     @JsonProperty("recipients_authorization_criterion") RecipientsAuthorizationCriterion recipientsAuthorizationCriterion,
-    @JsonProperty("event_data") Map<String, Object> eventData)  { }
+    @JsonProperty("event_data") Map<String, Object> eventData,
+    @JsonProperty("id_daily_digest")        boolean isDailyDigest
+) { }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailProcessorTest.java
@@ -371,7 +371,7 @@ public class EmailProcessorTest {
         final JsonObject payload = capturedPayload.getValue();
         final String resultEmailBody = payload.getString("email_body");
         final String resultEmailSubject = payload.getString("email_subject");
-        final String resultOrgId = payload.getString("orgId");
+        final String resultOrgId = payload.getString("org_id");
         final String resultEmailSender = payload.getString("email_sender");
         final Set<String> resultSubscribers = payload.getJsonArray("subscribers").stream().map(String.class::cast).collect(toSet());
         final Set<RecipientSettings> resultRecipientSettings = payload.getJsonArray("recipient_settings")


### PR DESCRIPTION
## Summary by Sourcery

Implement daily digest support in the email connector by adding aggregation processing, extending notification models and template rendering logic, introducing a beta template feature toggle, and validating the flow with new tests.

New Features:
- Introduce daily digest email rendering in the connector via a new EmailAggregationProcessor
- Add isDailyDigest flag and extended event_data context to EmailNotification records for digest support
- Provide a feature toggle (use-beta-templates) in EmailConnectorConfig for enabling beta templates

Enhancements:
- Branch template rendering in EmailCloudEventDataExtractor between instant emails and daily digests
- Enhance engine-side aggregation to supply full connector template context for daily digests
- Refactor and extract common-template rendering methods for titles and bodies of daily digest emails

Build:
- Add notifications-common-template as test-jar dependency in connector-email
- Configure maven-jar-plugin to produce test-jar in common-template module

Tests:
- Add parameterized tests in EmailRouteBuilderWithSimplifiedRouteTest for daily digest recipient resolution
- Introduce helper methods to build instant and daily digest email contexts in tests

Chores:
- Rename orgId mapping in EmailNotification to org_id/oldOrgId across connector and engine modules