### PR TITLE
[RHCLOUD-41537] Add a severity transformer in notifications-backend

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/Severity.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/Severity.java
@@ -1,0 +1,21 @@
+package com.redhat.cloud.notifications;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Recognized levels for {@link com.redhat.cloud.notifications.ingress.Action#severity}
+ */
+public enum Severity {
+    @JsonProperty("Critical")
+    CRITICAL,
+    @JsonProperty("Important")
+    IMPORTANT,
+    @JsonProperty("Moderate")
+    MODERATE,
+    @JsonProperty("Low")
+    LOW,
+    @JsonProperty("None")
+    NONE,
+    @JsonProperty("Undefined")
+    UNDEFINED
+}

--- a/common/src/main/java/com/redhat/cloud/notifications/Severity.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/Severity.java
@@ -1,21 +1,13 @@
 package com.redhat.cloud.notifications;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * Recognized levels for {@link com.redhat.cloud.notifications.ingress.Action#severity}
  */
 public enum Severity {
-    @JsonProperty("Critical")
     CRITICAL,
-    @JsonProperty("Important")
     IMPORTANT,
-    @JsonProperty("Moderate")
     MODERATE,
-    @JsonProperty("Low")
     LOW,
-    @JsonProperty("None")
     NONE,
-    @JsonProperty("Undefined")
     UNDEFINED
 }

--- a/common/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
@@ -62,7 +62,9 @@ public class BaseTransformer {
             );
             message.put(ORG_ID, action.getOrgId());
             message.put(TIMESTAMP, action.getTimestamp().toString());
-            message.put(SEVERITY, action.getSeverity());
+            if (action.getSeverity() != null) {
+                message.put(SEVERITY, action.getSeverity());
+            }
 
             final JsonObject source = getEventSource(event);
 

--- a/common/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/transformers/BaseTransformer.java
@@ -27,6 +27,7 @@ public class BaseTransformer {
     public static final String ORG_ID = "org_id";
     public static final String PAYLOAD = "payload";
     public static final String SOURCE = "source";
+    public static final String SEVERITY = "severity";
     public static final String TIMESTAMP = "timestamp";
     public static final String RECIPIENTS_AUTHORIZATION_CRITERION = "recipients_authorization_criterion";
 
@@ -61,6 +62,7 @@ public class BaseTransformer {
             );
             message.put(ORG_ID, action.getOrgId());
             message.put(TIMESTAMP, action.getTimestamp().toString());
+            message.put(SEVERITY, action.getSeverity());
 
             final JsonObject source = getEventSource(event);
 

--- a/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
@@ -1,7 +1,6 @@
 package com.redhat.cloud.notifications.transformers;
 
 import com.redhat.cloud.notifications.Severity;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -28,18 +27,18 @@ public class SeverityTransformer {
      * </ol>
      *
      * @param data the transformed payload
-     * @return the determined severity level
+     * @return the determined severity level as a String
      */
-    public Severity getSeverity(JsonObject data) {
+    public String getSeverity(JsonObject data) {
         String severityField = data.getString(SEVERITY);
         if (severityField != null && !severityField.isEmpty()) {
             try {
-                return Severity.valueOf(severityField.toUpperCase());
+                return Severity.valueOf(severityField.toUpperCase()).name();
             } catch (IllegalArgumentException e) {
-                return Severity.UNDEFINED;
+                return Severity.UNDEFINED.name();
             }
         } else {
-            return extractLegacySeverity(data);
+            return extractLegacySeverity(data).name();
         }
     }
 

--- a/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
@@ -1,0 +1,113 @@
+package com.redhat.cloud.notifications.transformers;
+
+import com.redhat.cloud.notifications.Severity;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.APPLICATION;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.EVENTS;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.PAYLOAD;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.SEVERITY;
+
+@ApplicationScoped
+public class SeverityTransformer {
+
+    /**
+     * Retrieves the severity level of the notification.
+     * <br>
+     * Priority:
+     * <ol>
+     *     <li>Top-level {@link com.redhat.cloud.notifications.ingress.Action#severity severity} value</li>
+     *     <li>Migration from field of existing tenant</li>
+     *     <li>Default value of {@link Severity#UNDEFINED}</li>
+     * </ol>
+     *
+     * @param data the transformed payload
+     * @return the determined severity level
+     */
+    public Severity getSeverity(JsonObject data) {
+        String severityField = data.getString(SEVERITY);
+        if (severityField != null && !severityField.isEmpty()) {
+            try {
+                return Severity.valueOf(severityField.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                return Severity.UNDEFINED;
+            }
+        } else {
+            return extractLegacySeverity(data);
+        }
+    }
+
+    /**
+     * Handling of legacy severity values provided by some tenants.
+     *
+     * @return The highest severity within the payload events.
+     */
+    private Severity extractLegacySeverity(final JsonObject data) {
+        JsonArray events = data.getJsonArray(EVENTS);
+        if (events == null || events.isEmpty()) {
+            return Severity.UNDEFINED;
+        }
+
+        ArrayList<Severity> severities = switch (data.getString(APPLICATION)) {
+            case "errata-notifications" -> new ArrayList<>(events.stream().map(event -> Severity.valueOf(
+                    ((JsonObject) event).getJsonObject(PAYLOAD).getString(SEVERITY).toUpperCase()
+            )).toList());
+            case "cluster-manager" -> new ArrayList<>(events.stream().map(event -> OcmServiceLogSeverity.valueOf(
+                    ((JsonObject) event).getJsonObject("global_vars").getString(SEVERITY).toUpperCase())
+                    .mapToSeverity()
+            ).toList());
+            case "inventory" -> new ArrayList<>(events.stream().map(event -> {
+                JsonObject error = ((JsonObject) event).getJsonObject("error");
+                // Inventory payloads only send a severity of "error", if present
+                if (error != null && error.containsKey("severity") && error.getString("severity").equalsIgnoreCase("ERROR")) {
+                    return Severity.IMPORTANT;
+                } else {
+                    return Severity.UNDEFINED;
+                }
+            }).toList());
+            // Both OpenShift Advisor and RHEL Advisor use the same layout here
+            case "advisor" -> new ArrayList<>(events.stream().map(event -> mapAdvisorTotalRiskToSeverity(
+                    Integer.parseInt(((JsonObject) event).getJsonObject(PAYLOAD).getString("total_risk")))
+            ).toList());
+            default -> new ArrayList<>(List.of(Severity.UNDEFINED));
+        };
+
+        severities.sort(null);
+        return severities.getFirst();
+    }
+
+    private Severity mapAdvisorTotalRiskToSeverity(int risk) {
+        return switch (risk) {
+            case 1 -> Severity.LOW;
+            case 2 -> Severity.MODERATE;
+            case 3 -> Severity.IMPORTANT;
+            case 4 -> Severity.CRITICAL;
+            default -> Severity.UNDEFINED;
+        };
+    }
+
+    private enum OcmServiceLogSeverity {
+        CRITICAL,
+        MAJOR,
+        WARNING,
+        INFO,
+        DEBUG;
+
+        Severity mapToSeverity() {
+            return switch (this) {
+                case CRITICAL -> Severity.CRITICAL;
+                case MAJOR -> Severity.IMPORTANT;
+                case WARNING -> Severity.MODERATE;
+                case INFO -> Severity.LOW;
+                case DEBUG -> Severity.NONE;
+            };
+        }
+    }
+}
+

--- a/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
@@ -59,11 +59,11 @@ public class SeverityTransformer {
                     ((JsonObject) event).getJsonObject(PAYLOAD).getString(SEVERITY).toUpperCase()
             )).toList());
             case "cluster-manager" -> new ArrayList<>(events.stream().map(event -> OcmServiceLogSeverity.valueOf(
-                    ((JsonObject) event).getJsonObject("global_vars").getString(SEVERITY).toUpperCase())
+                    ((JsonObject) event).getJsonObject(PAYLOAD).getJsonObject("global_vars").getString(SEVERITY).toUpperCase())
                     .mapToSeverity()
             ).toList());
             case "inventory" -> new ArrayList<>(events.stream().map(event -> {
-                JsonObject error = ((JsonObject) event).getJsonObject("error");
+                JsonObject error = ((JsonObject) event).getJsonObject(PAYLOAD).getJsonObject("error");
                 // Inventory payloads only send a severity of "error", if present
                 if (error != null && error.containsKey("severity") && error.getString("severity").equalsIgnoreCase("ERROR")) {
                     return Severity.IMPORTANT;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
@@ -14,7 +14,9 @@ import com.redhat.cloud.notifications.processors.InsightsUrlsBuilder;
 import com.redhat.cloud.notifications.qute.templates.IntegrationType;
 import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
+import com.redhat.cloud.notifications.transformers.SeverityTransformer;
 import io.quarkus.logging.Log;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
 
@@ -22,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.events.EndpointProcessor.DELAYED_EXCEPTION_MSG;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.SEVERITY;
 
 public abstract class CamelProcessor extends EndpointTypeProcessor {
 
@@ -30,6 +33,9 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
 
     @Inject
     BaseTransformer baseTransformer;
+
+    @Inject
+    SeverityTransformer severityTransformer;
 
     @Inject
     Environment environment;
@@ -87,6 +93,7 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
 
     protected Map<String, Object> convertEventAsDataMap(Event event) {
         JsonObject data = baseTransformer.toJsonObject(event);
+        data.put(SEVERITY, Json.encode(severityTransformer.getSeverity(data)));
         insightsUrlsBuilder.buildInventoryUrl(data, getIntegrationType()).ifPresent(url -> data.put("inventory_url", url));
         data.put("application_url", insightsUrlsBuilder.buildApplicationUrl(data, getIntegrationType()));
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/camel/CamelProcessor.java
@@ -16,7 +16,6 @@ import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import com.redhat.cloud.notifications.transformers.SeverityTransformer;
 import io.quarkus.logging.Log;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
 
@@ -93,7 +92,7 @@ public abstract class CamelProcessor extends EndpointTypeProcessor {
 
     protected Map<String, Object> convertEventAsDataMap(Event event) {
         JsonObject data = baseTransformer.toJsonObject(event);
-        data.put(SEVERITY, Json.encode(severityTransformer.getSeverity(data)));
+        data.mergeIn(JsonObject.of(SEVERITY, severityTransformer.getSeverity(data)));
         insightsUrlsBuilder.buildInventoryUrl(data, getIntegrationType()).ifPresent(url -> data.put("inventory_url", url));
         data.put("application_url", insightsUrlsBuilder.buildApplicationUrl(data, getIntegrationType()));
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
@@ -21,7 +21,6 @@ import com.redhat.cloud.notifications.qute.templates.TemplateService;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import com.redhat.cloud.notifications.transformers.SeverityTransformer;
 import com.redhat.cloud.notifications.utils.RecipientsAuthorizationCriterionExtractor;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -90,7 +89,7 @@ public class DrawerProcessor extends SystemEndpointTypeProcessor {
 
         // build event thought qute template
         JsonObject data = baseTransformer.toJsonObject(event);
-        data.put(SEVERITY, Json.encode(severityTransformer.getSeverity(data)));
+        data.mergeIn(JsonObject.of(SEVERITY, severityTransformer.getSeverity(data)));
 
         Map<String, Object> dataAsMap;
         try {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
@@ -19,7 +19,9 @@ import com.redhat.cloud.notifications.qute.templates.IntegrationType;
 import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
 import com.redhat.cloud.notifications.qute.templates.TemplateService;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
+import com.redhat.cloud.notifications.transformers.SeverityTransformer;
 import com.redhat.cloud.notifications.utils.RecipientsAuthorizationCriterionExtractor;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -33,12 +35,16 @@ import static com.redhat.cloud.notifications.models.SubscriptionType.DRAWER;
 import static com.redhat.cloud.notifications.transformers.BaseTransformer.APPLICATION;
 import static com.redhat.cloud.notifications.transformers.BaseTransformer.BUNDLE;
 import static com.redhat.cloud.notifications.transformers.BaseTransformer.EVENT_TYPE;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.SEVERITY;
 
 @ApplicationScoped
 public class DrawerProcessor extends SystemEndpointTypeProcessor {
 
     @Inject
     BaseTransformer baseTransformer;
+
+    @Inject
+    SeverityTransformer severityTransformer;
 
     @Inject
     ObjectMapper objectMapper;
@@ -84,6 +90,7 @@ public class DrawerProcessor extends SystemEndpointTypeProcessor {
 
         // build event thought qute template
         JsonObject data = baseTransformer.toJsonObject(event);
+        data.put(SEVERITY, Json.encode(severityTransformer.getSeverity(data)));
 
         Map<String, Object> dataAsMap;
         try {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
@@ -18,6 +18,7 @@ import com.redhat.cloud.notifications.qute.templates.IntegrationType;
 import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
 import com.redhat.cloud.notifications.templates.TemplateService;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
+import com.redhat.cloud.notifications.transformers.SeverityTransformer;
 import com.redhat.cloud.notifications.utils.RecipientsAuthorizationCriterionExtractor;
 import io.quarkus.logging.Log;
 import io.quarkus.qute.TemplateInstance;
@@ -34,6 +35,7 @@ import java.util.Set;
 
 import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPTION;
 import static com.redhat.cloud.notifications.models.SubscriptionType.INSTANT;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.SEVERITY;
 
 @ApplicationScoped
 public class EmailProcessor extends SystemEndpointTypeProcessor {
@@ -72,6 +74,9 @@ public class EmailProcessor extends SystemEndpointTypeProcessor {
 
     @Inject
     BaseTransformer baseTransformer;
+
+    @Inject
+    SeverityTransformer severityTransformer;
 
     @Inject
     ObjectMapper objectMapper;
@@ -199,6 +204,7 @@ public class EmailProcessor extends SystemEndpointTypeProcessor {
 
     protected Map<String, Object> convertEventAsDataMap(Event event, EmailPendo pendoMessage, boolean ignoreUserPreferences) {
         JsonObject data = baseTransformer.toJsonObject(event);
+        data.mergeIn(JsonObject.of(SEVERITY, severityTransformer.getSeverity(data)));
         data.put("environment", JsonObject.mapFrom(environment));
         data.put("pendo_message", pendoMessage);
         data.put("ignore_user_preferences", ignoreUserPreferences);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/eventing/EventingProcessor.java
@@ -13,7 +13,6 @@ import com.redhat.cloud.notifications.transformers.BaseTransformer;
 import com.redhat.cloud.notifications.transformers.SeverityTransformer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.logging.Log;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -93,7 +92,7 @@ public class EventingProcessor extends EndpointTypeProcessor {
         }
 
         final JsonObject payload = baseTransformer.toJsonObject(event);
-        payload.put(SEVERITY, Json.encode(severityTransformer.getSeverity(payload)));
+        payload.mergeIn(JsonObject.of(SEVERITY, severityTransformer.getSeverity(payload)));
         insightsUrlsBuilder.buildInventoryUrl(payload, endpoint.getSubType()).ifPresent(url -> payload.put("inventory_url", url));
         payload.put("application_url", insightsUrlsBuilder.buildApplicationUrl(payload, endpoint.getSubType()));
         if (endpoint.getSubType().equals("splunk")) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
@@ -76,7 +76,7 @@ public class PagerDutyProcessor extends EndpointTypeProcessor {
         JsonObject transformedEvent = transformer.toJsonObject(event);
         insightsUrlsBuilder.buildInventoryUrl(transformedEvent, endpoint.getType().name()).ifPresent(url -> transformedEvent.put("inventory_url", url));
         transformedEvent.put("application_url", insightsUrlsBuilder.buildApplicationUrl(transformedEvent, endpoint.getType().name()));
-        // TODO replace this with tenant-provided severity levels (see RHCLOUD-41561)
+        // TODO RHCLOUD-41561: replace this with tenant-provided severity levels
         transformedEvent.put(SEVERITY, properties.getSeverity());
 
         connectorData.put(PAYLOAD, transformedEvent);

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/pagerduty/PagerDutyProcessor.java
@@ -22,6 +22,7 @@ import java.util.List;
 import static com.redhat.cloud.notifications.events.EndpointProcessor.DELAYED_EXCEPTION_MSG;
 import static com.redhat.cloud.notifications.processors.AuthenticationType.SECRET_TOKEN;
 import static com.redhat.cloud.notifications.transformers.BaseTransformer.PAYLOAD;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.SEVERITY;
 
 @ApplicationScoped
 public class PagerDutyProcessor extends EndpointTypeProcessor {
@@ -75,7 +76,8 @@ public class PagerDutyProcessor extends EndpointTypeProcessor {
         JsonObject transformedEvent = transformer.toJsonObject(event);
         insightsUrlsBuilder.buildInventoryUrl(transformedEvent, endpoint.getType().name()).ifPresent(url -> transformedEvent.put("inventory_url", url));
         transformedEvent.put("application_url", insightsUrlsBuilder.buildApplicationUrl(transformedEvent, endpoint.getType().name()));
-        transformedEvent.put("severity", properties.getSeverity());
+        // TODO replace this with tenant-provided severity levels (see RHCLOUD-41561)
+        transformedEvent.put(SEVERITY, properties.getSeverity());
 
         connectorData.put(PAYLOAD, transformedEvent);
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -12,7 +12,6 @@ import com.redhat.cloud.notifications.transformers.SeverityTransformer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.logging.Log;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -76,7 +75,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
         WebhookProperties properties = endpoint.getProperties(WebhookProperties.class);
 
         final JsonObject payload = transformer.toJsonObject(event);
-        payload.put(SEVERITY, Json.encode(severityTransformer.getSeverity(payload)));
+        payload.mergeIn(JsonObject.of(SEVERITY, severityTransformer.getSeverity(payload)));
 
         final JsonObject connectorData = new JsonObject();
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/webhooks/WebhookTypeProcessor.java
@@ -8,9 +8,11 @@ import com.redhat.cloud.notifications.models.WebhookProperties;
 import com.redhat.cloud.notifications.processors.ConnectorSender;
 import com.redhat.cloud.notifications.processors.EndpointTypeProcessor;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
+import com.redhat.cloud.notifications.transformers.SeverityTransformer;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.logging.Log;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -22,6 +24,7 @@ import java.util.Optional;
 import static com.redhat.cloud.notifications.events.EndpointProcessor.DELAYED_EXCEPTION_MSG;
 import static com.redhat.cloud.notifications.processors.AuthenticationType.BEARER;
 import static com.redhat.cloud.notifications.processors.AuthenticationType.SECRET_TOKEN;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.SEVERITY;
 
 @ApplicationScoped
 public class WebhookTypeProcessor extends EndpointTypeProcessor {
@@ -30,6 +33,9 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
 
     @Inject
     BaseTransformer transformer;
+
+    @Inject
+    SeverityTransformer severityTransformer;
 
     @Inject
     EngineConfig engineConfig;
@@ -70,6 +76,7 @@ public class WebhookTypeProcessor extends EndpointTypeProcessor {
         WebhookProperties properties = endpoint.getProperties(WebhookProperties.class);
 
         final JsonObject payload = transformer.toJsonObject(event);
+        payload.put(SEVERITY, Json.encode(severityTransformer.getSeverity(payload)));
 
         final JsonObject connectorData = new JsonObject();
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/AdvisorTestHelpers.java
@@ -74,7 +74,7 @@ public class AdvisorTestHelpers {
         return aggregation;
     }
 
-    private static Action createAction(String eventType, Map<String, String> rule) {
+    public static Action createAction(String eventType, Map<String, String> rule) {
         return new Action.ActionBuilder()
                 .withBundle("rhel")
                 .withApplication("advisor")

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -116,6 +116,7 @@ public class TestHelpers {
         emailActionMessage.setApplication(application);
         emailActionMessage.setTimestamp(LocalDateTime.of(2020, 10, 3, 15, 22, 13, 25));
         emailActionMessage.setEventType(eventType);
+        emailActionMessage.setSeverity(Severity.NONE.name());
         emailActionMessage.setRecipients(List.of());
 
         emailActionMessage.setContext(

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/camel/CamelProcessorTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.processors.camel;
 
+import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository;
 import com.redhat.cloud.notifications.events.EventWrapperAction;
 import com.redhat.cloud.notifications.ingress.Action;
@@ -145,6 +146,7 @@ public abstract class CamelProcessorTest {
                 .withEventType("policy-triggered")
                 .withOrgId(DEFAULT_ORG_ID)
                 .withTimestamp(LocalDateTime.now(UTC))
+                .withSeverity(Severity.MODERATE.name())
                 .withContext(contextBuilder.build())
                 .withEvents(List.of(
                         new com.redhat.cloud.notifications.ingress.Event.EventBuilder()

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessorTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.processors.drawer;
 
+import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.DrawerNotificationRepository;
@@ -161,6 +162,7 @@ class DrawerProcessorTest {
                 .withApplication("policies")
                 .withBundle("rhel")
                 .withTimestamp(LocalDateTime.of(2022, 8, 24, 13, 30, 0, 0))
+                .withSeverity(Severity.CRITICAL.name())
                 .withContext(
                     new Context.ContextBuilder()
                         .withAdditionalProperty("foo", "im foo")

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/eventing/EventingTypeProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/eventing/EventingTypeProcessorTest.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.processors.eventing;
 
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
+import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
@@ -46,6 +47,7 @@ import static com.redhat.cloud.notifications.processors.AuthenticationType.SECRE
 import static com.redhat.cloud.notifications.processors.ConnectorSender.CLOUD_EVENT_TYPE_PREFIX;
 import static com.redhat.cloud.notifications.processors.ConnectorSender.TOCAMEL_CHANNEL;
 import static com.redhat.cloud.notifications.processors.eventing.EventingProcessor.NOTIF_METADATA_KEY;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.SEVERITY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -172,6 +174,7 @@ class EventingTypeProcessorTest {
         JsonObject payload = message.getPayload();
         assertNotNull(payload.getJsonArray("events").getJsonObject(0).getString("payload"));
         assertEquals("https://localhost/insights/app?from=notifications&integration=sub-type", payload.getString("application_url"));
+        assertEquals(Severity.IMPORTANT.name(), payload.getString(SEVERITY));
 
         // The processor added a 'notif-metadata' field to the payload, let's have a look at it.
         JsonObject notifMetadata = payload.getJsonObject(NOTIF_METADATA_KEY);
@@ -247,6 +250,7 @@ class EventingTypeProcessorTest {
         action.setAccountId(FIXTURE_ACTION_ACCOUNT_ID);
         action.setOrgId(FIXTURE_ACTION_ORG_ID);
         action.setRecipients(FIXTURE_ACTION_RECIPIENTS);
+        action.setSeverity(Severity.IMPORTANT.name());
 
         Context context = new Context.ContextBuilder().build();
         context.setAdditionalProperty(FIXTURE_ACTION_CONTEXT, FIXTURE_ACTION_CONTEXT_VALUE);

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/BaseTransformerTest.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications.transformers;
 
+import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.events.EventWrapperAction;
 import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Context;
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.SEVERITY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -41,6 +43,7 @@ class BaseTransformerTest {
     private static final String FIXTURE_ORG_ID = "org-id-test";
     private static final String FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY = "event-payload-additional-property";
     private static final String FIXTURE_PAYLOAD_ADDITIONAL_PROPERTY_VALUE = "event-payload-additional-property-value";
+    private static final String FIXTURE_SEVERITY = Severity.LOW.name();
     private static final LocalDateTime FIXTURE_TIMESTAMP = LocalDateTime.of(2022, 1, 1, 0, 0, 0);
 
     /**
@@ -83,6 +86,7 @@ class BaseTransformerTest {
         action.setEventType(FIXTURE_EVENT_TYPE);
         action.setEvents(FIXTURE_EVENTS);
         action.setOrgId(FIXTURE_ORG_ID);
+        action.setSeverity(FIXTURE_SEVERITY);
         action.setTimestamp(FIXTURE_TIMESTAMP);
 
         // Create an event for the "toJsonObject" function.
@@ -102,6 +106,7 @@ class BaseTransformerTest {
         assertEquals(action.getBundle(), result.getString(BaseTransformer.BUNDLE), "the bundle isn't the same");
         assertEquals(action.getEventType(), result.getString(BaseTransformer.EVENT_TYPE), "the event type isn't the same");
         assertEquals(action.getOrgId(), result.getString(BaseTransformer.ORG_ID), "the org id isn't the same");
+        assertEquals(action.getSeverity(), result.getString(SEVERITY), "the severity isn't the same");
         assertEquals(action.getTimestamp(), LocalDateTime.parse(result.getString(BaseTransformer.TIMESTAMP)), "the timestamp isn't the same");
 
         // Assert the display names in the "source" key.

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/SeverityTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/SeverityTransformerTest.java
@@ -166,4 +166,17 @@ class SeverityTransformerTest {
         JsonObject multipleData = baseTransformer.toJsonObject(multipleEvent);
         assertEquals(Severity.MODERATE.name(), severityTransformer.getSeverity(multipleData));
     }
+
+    /** This is not an expected case, but it should still be handled gracefully. */
+    @Test
+    public void testOcmPayloadWithInvalidLegacySeverity() {
+        Optional<Map<String, Object>> legacySeverity = Optional.of(Map.of(SEVERITY, "this is not a valid severity level"));
+        Action action = OcmTestHelpers.createOcmAction("test-cluster-name", "Premium", "System rebooting",
+                "System reboot in progress", "test-title", legacySeverity);
+        Event event = new Event();
+        event.setEventWrapper(new EventWrapperAction(action));
+
+        JsonObject data = baseTransformer.toJsonObject(event);
+        assertEquals(Severity.UNDEFINED.name(), severityTransformer.getSeverity(data));
+    }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/SeverityTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/SeverityTransformerTest.java
@@ -1,0 +1,169 @@
+package com.redhat.cloud.notifications.transformers;
+
+import com.redhat.cloud.notifications.AdvisorTestHelpers;
+import com.redhat.cloud.notifications.ErrataTestHelpers;
+import com.redhat.cloud.notifications.InventoryTestHelpers;
+import com.redhat.cloud.notifications.OcmTestHelpers;
+import com.redhat.cloud.notifications.Severity;
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.events.EventWrapperAction;
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.models.Event;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.json.JsonObject;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.processors.email.aggregators.AdvisorEmailAggregator.*;
+import static com.redhat.cloud.notifications.transformers.BaseTransformer.SEVERITY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+class SeverityTransformerTest {
+
+    @Inject
+    BaseTransformer baseTransformer;
+
+    private final SeverityTransformer severityTransformer = new SeverityTransformer();
+
+    @Test
+    public void testPayloadWithSeverity() {
+        Action action = TestHelpers.createIntegrationsFailedAction();
+        action.setSeverity(Severity.MODERATE.name()); // "MODERATE"
+        Event event = new Event();
+        event.setEventWrapper(new EventWrapperAction(action));
+
+        JsonObject data = baseTransformer.toJsonObject(event);
+        assertEquals(Severity.MODERATE.name(), severityTransformer.getSeverity(data));
+
+        // Check with mixed case severity string
+        action.setSeverity("iMpOrTaNt");
+
+        JsonObject dataMixed = baseTransformer.toJsonObject(event);
+        assertEquals(Severity.IMPORTANT.name(), severityTransformer.getSeverity(dataMixed));
+    }
+
+    @Test
+    public void testPayloadWithInvalidSeverity() {
+        Action action = TestHelpers.createIntegrationsFailedAction();
+        action.setSeverity("this is not a valid severity level");
+        Event event = new Event();
+        event.setEventWrapper(new EventWrapperAction(action));
+
+        JsonObject data = baseTransformer.toJsonObject(event);
+        assertEquals(Severity.UNDEFINED.name(), severityTransformer.getSeverity(data));
+    }
+
+    @Test
+    public void testPayloadWithoutSeverity() {
+        Action action = TestHelpers.createIntegrationsFailedAction();
+        Event event = new Event();
+        event.setEventWrapper(new EventWrapperAction(action));
+
+        JsonObject data = baseTransformer.toJsonObject(event);
+        assertEquals(Severity.UNDEFINED.name(), severityTransformer.getSeverity(data));
+    }
+
+    @Test
+    public void testErrataPayloadWithLegacySeverity() {
+        // Single event
+        Action singleEventAction = ErrataTestHelpers.createErrataAction();
+        com.redhat.cloud.notifications.ingress.Event firstEvent = singleEventAction.getEvents().getFirst();
+        singleEventAction.setEvents(List.of(firstEvent));
+
+        Event singleEvent = new Event();
+        singleEvent.setEventWrapper(new EventWrapperAction(singleEventAction));
+
+        JsonObject singleEventData = baseTransformer.toJsonObject(singleEvent);
+        assertEquals(Severity.MODERATE.name(), severityTransformer.getSeverity(singleEventData));
+
+        // Multiple events, selects the highest severity found
+        Action multipleEventAction = ErrataTestHelpers.createErrataAction();
+        Event multipleEvent = new Event();
+        multipleEvent.setEventWrapper(new EventWrapperAction(multipleEventAction));
+
+        JsonObject multipleEventData = baseTransformer.toJsonObject(multipleEvent);
+        assertEquals(Severity.IMPORTANT.name(), severityTransformer.getSeverity(multipleEventData));
+    }
+
+    @Test
+    public void testOcmPayloadWithLegacySeverity() {
+        Optional<Map<String, Object>> legacySeverity = Optional.of(Map.of(SEVERITY, SeverityTransformer.OcmServiceLogSeverity.INFO.name()));
+        Action action = OcmTestHelpers.createOcmAction("test-cluster-name", "Premium", "System rebooting",
+                "System reboot in progress", "test-title", legacySeverity);
+        Event event = new Event();
+        event.setEventWrapper(new EventWrapperAction(action));
+
+        JsonObject data = baseTransformer.toJsonObject(event);
+        assertEquals(Severity.LOW.name(), severityTransformer.getSeverity(data));
+    }
+
+    @Test
+    public void testInventoryPayloadWithLegacySeverity() {
+        String tenant = "test-tenant";
+
+        // Single event with error severity
+        Action action = InventoryTestHelpers.createInventoryAction(tenant, "rhel", "inventory", "validation-error");
+        Event event = new Event();
+        event.setEventWrapper(new EventWrapperAction(action));
+
+        JsonObject data = baseTransformer.toJsonObject(event);
+        assertEquals(Severity.IMPORTANT.name(), severityTransformer.getSeverity(data));
+
+        // Multiple events, only one with an error
+        Map<String, String> secondEventErrorMap = Map.of(
+                "code", "AA001",
+                "message", "empty message",
+                "stack_trace", ""
+        );
+
+        action.setEvents(List.of(
+                new com.redhat.cloud.notifications.ingress.Event.EventBuilder()
+                        .withMetadata(new Metadata.MetadataBuilder().build())
+                        .withPayload(
+                                new Payload.PayloadBuilder()
+                                        .withAdditionalProperty("host_id", tenant)
+                                        .withAdditionalProperty("display_name", InventoryTestHelpers.displayName1)
+                                        .withAdditionalProperty("error", secondEventErrorMap)
+                                        .build()
+                        )
+                        .build(),
+                action.getEvents().getFirst()
+        ));
+
+        JsonObject multipleEventData = baseTransformer.toJsonObject(event);
+        assertEquals(Severity.IMPORTANT.name(), severityTransformer.getSeverity(multipleEventData));
+    }
+
+    @Test
+    public void testAdvisorPayloadWithLegacySeverity() {
+        // Single event, risk as string
+        Action singleAction = AdvisorTestHelpers.createAction("test-event-type", Map.of(
+                RULE_ID, UUID.randomUUID().toString(),
+                RULE_DESCRIPTION, "this is a rule",
+                TOTAL_RISK, "4", // Critical
+                HAS_INCIDENT, "false",
+                RULE_URL, UUID.randomUUID().toString()
+        ));
+        Event singleEvent = new Event();
+        singleEvent.setEventWrapper(new EventWrapperAction(singleAction));
+
+        JsonObject singleData = baseTransformer.toJsonObject(singleEvent);
+        assertEquals(Severity.CRITICAL.name(), severityTransformer.getSeverity(singleData));
+
+        // Multiple events, risk as integer
+        Action multipleAction = TestHelpers.createAdvisorAction("test-account-id", "deactivated-recommendation");
+        Event multipleEvent = new Event();
+        multipleEvent.setEventWrapper(new EventWrapperAction(multipleAction));
+
+        JsonObject multipleData = baseTransformer.toJsonObject(multipleEvent);
+        assertEquals(Severity.MODERATE.name(), severityTransformer.getSeverity(multipleData));
+    }
+}


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-41537

## Description

Central PR to add support for processing a new `severity` field for incoming notifications.

- A new enum `Severity` with six levels ([defined here](https://issues.redhat.com/browse/RHCLOUD-41547?focusedId=27801349&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27801349)).
- Extracting the string `severity` field in BaseTransformer, if present
- The `SeverityTransformer`, which extracts severity levels from the incoming payload, and can also handle legacy severity levels in Errata, OCM, Inventory, and RHEL/OpenShift Advisor payloads. (Mappings for the PagerDuty Integration will be added in [RHCLOUD-41561](https://issues.redhat.com/browse/RHCLOUD-41561) if confirmed.)
  - Implemented in all main processors (Camel, Eventing, PagerDuty, email, etc.)

## Compatibility

No impact except for certain legacy payloads, which will map to modern severity levels in the following cases:

- `subscription-services/errata-notifications`: if contains `.events[] | .payload.severity` which matches the [published severity ratings](https://access.redhat.com/security/updates/classification) (same as the `Severity` enum)
- `rhel/inventory`: if contains `.events[] | .payload.error.severity` which is equal to `"error"` (case insensitive)
- `rhel/advisor` and `openshift/advisor`: if contains `.events[] | .payload.total_risk` in the range of `1-4` (as a JSON number or string)
- `openshift/cluster-manager`: if contains `.events[] | .payload.global_vars.severity`, which maps to one of [the five OSL severity levels defined as of today](https://gitlab.cee.redhat.com/service/ocm-service-log/-/blob/6dbaff17c08f6ea5a056ba594b47598eed1450f1/pkg/api/service_log_types.go#L54-60)

## Testing

- added test cases for all processors to ensure the values are successfully extracted and sent to connectors
- added SeverityTransformerTest to validate for new and legacy severity fields

## AI code assistance

Assisted-by: claude-4-sonnet / Claude Code