### PR TITLE
[RHCLOUD-42582] add ignore-severity-for-applications Unleash flag

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/Severity.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/Severity.java
@@ -22,7 +22,7 @@ public enum Severity {
     LOW,
     @JsonProperty("NONE")
     NONE,
-    /** A severity level was not provided, or could not be parsed. */
+    /** A severity level was not provided, or could not be parsed. Do not display this value in outgoing notifications. */
     @JsonProperty("UNDEFINED")
     UNDEFINED
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -62,6 +62,7 @@ public class EngineConfig {
     private String toggleUseCommonTemplateModuleToRenderEmailsEnabled;
     private String toggleUseBetaTemplatesEnabled;
     private String toggleIsConnectorTemplateTransformationEnabled;
+    private String toggleIgnoreSeverityForApplications;
 
     @ConfigProperty(name = UNLEASH, defaultValue = "false")
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
@@ -166,6 +167,7 @@ public class EngineConfig {
         toggleBlacklistedEndpoints = toggleRegistry.register("blacklisted-endpoints", true);
         toggleBlacklistedEventTypes = toggleRegistry.register("blacklisted-event-types", true);
         toggleIsConnectorTemplateTransformationEnabled = toggleRegistry.register("connectors-template-transformation", true);
+        toggleIgnoreSeverityForApplications = toggleRegistry.register("ignore-severity-for-applications", true);
     }
 
     void logConfigAtStartup(@Observes Startup event) {
@@ -364,6 +366,17 @@ public class EngineConfig {
     public boolean isConnectorTemplateTransformationEnabled(final String orgId) {
         if (unleashEnabled) {
             return unleash.isEnabled(toggleIsConnectorTemplateTransformationEnabled, UnleashContextBuilder.buildUnleashContextWithOrgId(orgId), false);
+        } else {
+            return false;
+        }
+    }
+
+    public boolean isIgnoreSeverityForApplicationsEnabled(final UUID application) {
+        if (unleashEnabled && application != null) {
+            UnleashContext unleashContext = UnleashContext.builder()
+                    .addProperty("application", application.toString())
+                    .build();
+            return unleash.isEnabled(toggleIgnoreSeverityForApplications, unleashContext, false);
         } else {
             return false;
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.events;
 
 import com.redhat.cloud.event.parser.ConsoleCloudEventParser;
 import com.redhat.cloud.event.parser.exceptions.ConsoleCloudEventParsingException;
+import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.cloudevent.transformers.CloudEventTransformer;
 import com.redhat.cloud.notifications.cloudevent.transformers.CloudEventTransformerFactory;
 import com.redhat.cloud.notifications.config.EngineConfig;
@@ -251,6 +252,13 @@ public class EventConsumer {
                             TAG_KEY_EVENT_TYPE_FQN, tags.getOrDefault(TAG_KEY_EVENT_TYPE_FQN, ""))
                             .increment();
                         return;
+                    }
+                    if (config.isIgnoreSeverityForApplicationsEnabled(eventType.getApplicationId())) {
+                        Log.debugf("Ignoring provided severity level for [bundle=%s, application=%s]",
+                                eventType.getApplication().getBundle().getName(), eventType.getApplication().getName());
+                        if (eventWrapper instanceof EventWrapperAction) {
+                            ((Action) eventWrapper.getEvent()).setSeverity(Severity.UNDEFINED.name());
+                        }
                     }
                 } catch (NoResultException | IllegalArgumentException e) {
                     /*


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-42582

## Description

> [!NOTE]
> 
> Before merging:
> - [ ] Add Unleash flag after approval

Adds a new Unleash flag `ignore-severity-for-applications`. This provides a field `application` which matches against application UUIDs. If a match is found: 

- The severity within the underlying `Action` will be set to `Severity.UNDEFINED`, to prevent it from being written in outgoing notifications.
- As a result, this will also be propagated to the `Event#severity` field.

## Compatibility

This will prevent severity from being parsed for flagged applications.

## Testing

Added test cases to `EventConsumerTest` to validate that the processing is successful in cases where severity is ignored, and unaffected otherwise.

## Summary by Sourcery

Add a new Unleash feature flag to suppress event severity for specified applications by overriding it to UNDEFINED and update related configuration, consumer logic, and tests.

New Features:
- Introduce the "ignore-severity-for-applications" Unleash flag to disable severity for matched applications.

Enhancements:
- Register the new toggle in EngineConfig and expose isIgnoreSeverityForApplicationsEnabled with UnleashContext based on application UUID.
- Enhance EventConsumer to check the flag and override Action/Event severity to UNDEFINED when enabled.
- Clarify the Severity.UNDEFINED enum javadoc to indicate it should not be displayed in notifications.

Tests:
- Add EventConsumerTest testValidPayloadWithIgnoredSeverityForApplication and a verifySeverity helper to assert both ignored and unaffected scenarios.