### PR TITLE
[RHCLOUD-42582] change context value for ignore-severity-for-applications

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -374,7 +374,7 @@ public class EngineConfig {
     public boolean isIgnoreSeverityForApplicationsEnabled(final UUID application) {
         if (unleashEnabled && application != null) {
             UnleashContext unleashContext = UnleashContext.builder()
-                    .addProperty("application", application.toString())
+                    .addProperty("appId", application.toString())
                     .build();
             return unleash.isEnabled(toggleIgnoreSeverityForApplications, unleashContext, false);
         } else {


### PR DESCRIPTION
Just realized that context values in Unleash are environment defined, so I'm renaming the field for `ignore-severity-for-applications` to be clearer.

Change from `applications` to `appId`