### PR TITLE
[RHCLOUD-41538] Update severity in email subjects

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/SeverityExtension.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/SeverityExtension.java
@@ -8,12 +8,12 @@ public class SeverityExtension {
 
     /** Cloud events do not support the severity field */
     @TemplateExtension
-    static String severityAsEmailTitle(ConsoleCloudEvent event) {
+    public static String severityAsEmailTitle(ConsoleCloudEvent event) {
         return "";
     }
 
     @TemplateExtension
-    static String severityAsEmailTitle(Action action) {
+    public static String severityAsEmailTitle(Action action) {
         String severity = action.getSeverity();
         if (severity == null || "UNDEFINED".equals(severity) || "NONE".equals(severity)) {
             return "";

--- a/common-template/src/main/resources/templates/email/Common/insightsEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Common/insightsEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle}Instant notification - {source.event_type.display_name} - {source.application.display_name} - {source.bundle.display_name}
+{action.severityAsEmailTitle()}Instant notification - {source.event_type.display_name} - {source.application.display_name} - {source.bundle.display_name}

--- a/common-template/src/main/resources/templates/email/Default/instantEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Default/instantEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle}{source.bundle.display_name}/{source.application.display_name}/{source.event_type.display_name} triggered
+{action.severityAsEmailTitle()}{source.bundle.display_name}/{source.application.display_name}/{source.event_type.display_name} triggered

--- a/common-template/src/main/resources/templates/email/OCM/instantEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/OCM/instantEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle}{source.event_type.display_name} - {action.events[0].payload.subject}
+{action.severityAsEmailTitle()}{source.event_type.display_name} - {action.events[0].payload.subject}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/instantEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/instantEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle}{source.event_type.display_name} - {action.events[0].payload.subject}
+{action.severityAsEmailTitle()}{source.event_type.display_name} - {action.events[0].payload.subject}

--- a/common-template/src/main/resources/templates/email/SubscriptionWatch/usageThresholdExceededEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/SubscriptionWatch/usageThresholdExceededEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle}Instant notification - Exceeded Utilization Threshold - Subscription Watch - Subscription Services
+{action.severityAsEmailTitle()}Instant notification - Exceeded Utilization Threshold - Subscription Watch - Subscription Services

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderWithSimplifiedRouteTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/EmailRouteBuilderWithSimplifiedRouteTest.java
@@ -63,7 +63,7 @@ import static org.mockserver.model.HttpResponse.response;
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
 class EmailRouteBuilderWithSimplifiedRouteTest extends CamelQuarkusTestSupport {
-    private static final String PATCH_TEST_EVENT = "{\"account_id\":\"\",\"application\":\"patch\",\"bundle\":\"rhel\",\"context\":{\"system_check_in\":\"2022-08-03T15:22:42.199046\",\"start_time\":\"2022-08-03T15:22:42.199046\",\"patch\":{\"Alpha\":[\"advA\",\"advB\",\"advC\"],\"Roman\":[\"advI\",\"advII\",\"advIII\"],\"Numerical\":[\"adv1\",\"adv2\"]}},\"event_type\":\"new-advisory\",\"events\":[{\"metadata\":{},\"payload\":{\"advisory_name\":\"name 1\",\"synopsis\":\"synopsis 1\"}},{\"metadata\":{},\"payload\":{\"advisory_name\":\"name 2\",\"synopsis\":\"synopsis 2\"}}],\"orgId\":\"default-org-id\",\"timestamp\":\"2022-10-03T15:22:13.000000025\",\"source\":{\"application\":{\"display_name\":\"Patch\"},\"bundle\":{\"display_name\":\"Red Hat Enterprise Linux\"},\"event_type\":{\"display_name\":\"New Advisory\"}},\"environment\":{\"url\":\"https://localhost\",\"ocmUrl\":\"https://localhost\"},\"pendo_message\":null,\"ignore_user_preferences\":true}";
+    private static final String PATCH_TEST_EVENT = "{\"account_id\":\"\",\"application\":\"patch\",\"bundle\":\"rhel\",\"context\":{\"system_check_in\":\"2022-08-03T15:22:42.199046\",\"start_time\":\"2022-08-03T15:22:42.199046\",\"patch\":{\"Alpha\":[\"advA\",\"advB\",\"advC\"],\"Roman\":[\"advI\",\"advII\",\"advIII\"],\"Numerical\":[\"adv1\",\"adv2\"]}},\"event_type\":\"new-advisory\",\"events\":[{\"metadata\":{},\"payload\":{\"advisory_name\":\"name 1\",\"synopsis\":\"synopsis 1\"}},{\"metadata\":{},\"payload\":{\"advisory_name\":\"name 2\",\"synopsis\":\"synopsis 2\"}}],\"orgId\":\"default-org-id\",\"timestamp\":\"2022-10-03T15:22:13.000000025\",\"severity\":\"MODERATE\",\"source\":{\"application\":{\"display_name\":\"Patch\"},\"bundle\":{\"display_name\":\"Red Hat Enterprise Linux\"},\"event_type\":{\"display_name\":\"New Advisory\"}},\"environment\":{\"url\":\"https://localhost\",\"ocmUrl\":\"https://localhost\"},\"pendo_message\":null,\"ignore_user_preferences\":true}";
 
     @InjectSpy
     EmailConnectorConfig emailConnectorConfig;
@@ -362,7 +362,7 @@ class EmailRouteBuilderWithSimplifiedRouteTest extends CamelQuarkusTestSupport {
 
         final EmailNotification emailNotification = new EmailNotification(
             "test email body",
-            "test email subject",
+            "[MODERATE] test email subject",
             "Not used",
             "123456",
             "123456",

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -116,7 +116,7 @@ public class TestHelpers {
         emailActionMessage.setApplication(application);
         emailActionMessage.setTimestamp(LocalDateTime.of(2020, 10, 3, 15, 22, 13, 25));
         emailActionMessage.setEventType(eventType);
-        emailActionMessage.setSeverity(Severity.NONE.name());
+        emailActionMessage.setSeverity(Severity.MODERATE.name());
         emailActionMessage.setRecipients(List.of());
 
         emailActionMessage.setContext(

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailProcessorTest.java
@@ -391,7 +391,7 @@ public class EmailProcessorTest {
 
         Assertions.assertTrue(resultEmailBody.contains("<p>You are receiving this email because the email template associated with this event type is not configured properly.</p>"), "the rendered email's body from the email notification does not match with expectation");
         if (useCommonQuteTemplateModule) {
-            Assertions.assertTrue(resultEmailSubject.contains("Instant notification - Policy triggered - Policies - Red Hat Enterprise Linux"), "the rendered email's subject from the email notification does not match with expectation ");
+            Assertions.assertTrue(resultEmailSubject.contains("[MODERATE] Instant notification - Policy triggered - Policies - Red Hat Enterprise Linux"), "the rendered email's subject from the email notification does not match with expectation ");
         } else {
             Assertions.assertTrue(resultEmailSubject.contains("rhel/policies/policy-triggered triggered"), "the rendered email's subject from the email notification does not match with expectation ");
         }

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/common/TestDefaultTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/common/TestDefaultTemplate.java
@@ -46,7 +46,7 @@ public class TestDefaultTemplate extends EmailTemplatesRendererHelper {
         eventTypeDisplayName = "Policy Triggered";
 
         String result = generateEmailSubject(EVENT_TYPE_NAME, action);
-        assertEquals("Instant notification - Policy Triggered - Policies - Red Hat Enterprise Linux", result);
+        assertEquals("[MODERATE] Instant notification - Policy Triggered - Policies - Red Hat Enterprise Linux", result);
     }
 
     @Test

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/common/TestPoliciesTemplate.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/common/TestPoliciesTemplate.java
@@ -35,7 +35,7 @@ public class TestPoliciesTemplate extends EmailTemplatesRendererHelper {
         Action action = TestHelpers.createPoliciesAction("", "", "", "FooMachine");
         eventTypeDisplayName = "Policy Triggered";
         String result = generateEmailSubject(EVENT_TYPE_NAME, action);
-        assertEquals("Instant notification - Policy Triggered - Policies - Red Hat Enterprise Linux", result);
+        assertEquals("[MODERATE] Instant notification - Policy Triggered - Policies - Red Hat Enterprise Linux", result);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
- Update the `action.severityAsEmailTitle` call in email subjects to handle an odd error with Quarkus extensions.
- Update the test case in EmailProcessor so that a severity level will actually be rendered.
- Add severity test cases for EmailRouteBuilder

## Summary by Sourcery

Prefix email subjects with the event severity and update tests to validate the severity rendering

New Features:
- Include severity level (e.g., [MODERATE]) at the start of email subjects

Tests:
- Add severity field to JSON test events and set default severity to MODERATE in TestHelpers
- Update EmailProcessorTest and EmailRouteBuilder tests to assert that email subjects include the severity prefix