### PR TITLE
[RHCLOUD-41538] Update severity in email subjects

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/SeverityExtension.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/SeverityExtension.java
@@ -1,21 +1,12 @@
 package com.redhat.cloud.notifications.qute.templates.extensions;
 
-import com.redhat.cloud.event.parser.ConsoleCloudEvent;
-import com.redhat.cloud.notifications.ingress.Action;
 import io.quarkus.qute.TemplateExtension;
 
 public class SeverityExtension {
 
-    /** Cloud events do not support the severity field */
     @TemplateExtension
-    public static String severityAsEmailTitle(ConsoleCloudEvent event) {
-        return "";
-    }
-
-    @TemplateExtension
-    public static String severityAsEmailTitle(Action action) {
-        String severity = action.getSeverity();
-        if (severity == null || "UNDEFINED".equals(severity) || "NONE".equals(severity)) {
+    public static String severityAsEmailTitle(String severity) {
+        if ("".equals(severity) || "UNDEFINED".equals(severity) || "NONE".equals(severity)) {
             return "";
         } else {
             return String.format("[%s] ", severity);

--- a/common-template/src/main/resources/templates/email/Common/insightsEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Common/insightsEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle()}Instant notification - {source.event_type.display_name} - {source.application.display_name} - {source.bundle.display_name}
+{action.severity.or('').severityAsEmailTitle}Instant notification - {source.event_type.display_name} - {source.application.display_name} - {source.bundle.display_name}

--- a/common-template/src/main/resources/templates/email/Default/instantEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Default/instantEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle()}{source.bundle.display_name}/{source.application.display_name}/{source.event_type.display_name} triggered
+{action.severity.or('').severityAsEmailTitle}{source.bundle.display_name}/{source.application.display_name}/{source.event_type.display_name} triggered

--- a/common-template/src/main/resources/templates/email/OCM/instantEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/OCM/instantEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle()}{source.event_type.display_name} - {action.events[0].payload.subject}
+{action.severity.or('').severityAsEmailTitle}{source.event_type.display_name} - {action.events[0].payload.subject}

--- a/common-template/src/main/resources/templates/email/Secure/OCM/instantEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Secure/OCM/instantEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle()}{source.event_type.display_name} - {action.events[0].payload.subject}
+{action.severity.or('').severityAsEmailTitle}{source.event_type.display_name} - {action.events[0].payload.subject}

--- a/common-template/src/main/resources/templates/email/SubscriptionWatch/usageThresholdExceededEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/SubscriptionWatch/usageThresholdExceededEmailTitle.txt
@@ -1,1 +1,1 @@
-{action.severityAsEmailTitle()}Instant notification - Exceeded Utilization Threshold - Subscription Watch - Subscription Services
+{action.severity.or('').severityAsEmailTitle}Instant notification - Exceeded Utilization Threshold - Subscription Watch - Subscription Services


### PR DESCRIPTION
## Summary by Sourcery

Centralize severity handling in EventConsumer by introducing a dedicated updateSeverity method that defaults all event severities to Critical, and simplify email subject generation by refactoring the Qute template extension and updating email title templates to use a raw severity prefix.

Enhancements:
- Introduce updateSeverity method in EventConsumer to unify and enforce a Critical severity on all events
- Remove legacy ignore-severity-for-application logic and inline severity transformer call
- Refactor SeverityExtension to accept a raw severity string instead of event or action objects
- Update email subject templates to leverage the revised severityAsEmailTitle extension for prefixing subjects