### PR TITLE
RHCLOUD-42841 Make notifications-aggregator a headless service

### DIFF
--- a/.rhcicd/clowdapp-aggregator.yaml
+++ b/.rhcicd/clowdapp-aggregator.yaml
@@ -12,7 +12,7 @@ objects:
       app: notifications-aggregator
   spec:
     envName: ${ENV_NAME}
-    dependencies:
+    optionalDependencies:
     - notifications-backend
     database:
       sharedDbAppName: notifications-backend


### PR DESCRIPTION
This is needed for multicluster.

## Summary by Sourcery

Enhancements:
- Switch the notifications-aggregator clowdapp configuration to use optionalDependencies instead of dependencies