### PR TITLE
Draft: [Do-Not-Merge] Configure hermetic build with Maven artifacts file

### DIFF
--- a/.tekton/notifications-connector-drawer-pull-request.yaml
+++ b/.tekton/notifications-connector-drawer-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "generic", "path": "./connector-drawer", "lockfile": "artifacts.lock.yaml"}]'
+    value: '[{"type": "generic", "path": "./connector-drawer"}]'
   pipelineRef:
     name: docker-build
   taskRunTemplate:

--- a/.tekton/notifications-connector-drawer-pull-request.yaml
+++ b/.tekton/notifications-connector-drawer-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: ./docker/Dockerfile.notifications-connector-drawer.jvm
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "generic", "path": "./connector-drawer", "lockfile": "artifacts.lock.yaml"}]'
   pipelineRef:
     name: docker-build
   taskRunTemplate:

--- a/.tekton/notifications-connector-drawer-push.yaml
+++ b/.tekton/notifications-connector-drawer-push.yaml
@@ -28,6 +28,10 @@ spec:
     value: ./docker/Dockerfile.notifications-connector-drawer.jvm
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "generic", "path": "./connector-drawer", "lockfile": "artifacts.lock.yaml"}]'
   pipelineRef:
     name: docker-build
   taskRunTemplate:

--- a/.tekton/notifications-connector-drawer-push.yaml
+++ b/.tekton/notifications-connector-drawer-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "generic", "path": "./connector-drawer", "lockfile": "artifacts.lock.yaml"}]'
+    value: '[{"type": "generic", "path": "./connector-drawer"}]'
   pipelineRef:
     name: docker-build
   taskRunTemplate:

--- a/.tekton/notifications-connector-drawer-sc-push.yaml
+++ b/.tekton/notifications-connector-drawer-sc-push.yaml
@@ -28,10 +28,6 @@ spec:
     value: ./docker/Dockerfile.notifications-connector-drawer.jvm
   - name: path-context
     value: .
-  - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    value: '[{"type": "generic", "path": "./connector-drawer", "lockfile": "artifacts.lock.yaml"}]'
   pipelineRef:
     name: docker-build
   taskRunTemplate:

--- a/.tekton/notifications-connector-drawer-sc-push.yaml
+++ b/.tekton/notifications-connector-drawer-sc-push.yaml
@@ -28,6 +28,10 @@ spec:
     value: ./docker/Dockerfile.notifications-connector-drawer.jvm
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "generic", "path": "./connector-drawer", "lockfile": "artifacts.lock.yaml"}]'
   pipelineRef:
     name: docker-build
   taskRunTemplate:

--- a/connector-drawer/artifacts.lock.yaml
+++ b/connector-drawer/artifacts.lock.yaml
@@ -2,24 +2,6 @@ metadata:
   version: '1.0'
 artifacts:
 - type: maven
-  filename: notifications-connector-common-http-1.0.0-SNAPSHOT.jar
-  attributes:
-    repository_url: https://repo1.maven.org/maven2
-    group_id: com.redhat.cloud.notifications
-    artifact_id: notifications-connector-common-http
-    version: 1.0.0-SNAPSHOT
-    type: jar
-  checksum: sha256:49354ea6a4301e201b6f2d7389fcbeb8c16bf28f75677cb873b33bb8129fbbb0
-- type: maven
-  filename: notifications-connector-common-1.0.0-SNAPSHOT.jar
-  attributes:
-    repository_url: https://repo1.maven.org/maven2
-    group_id: com.redhat.cloud.notifications
-    artifact_id: notifications-connector-common
-    version: 1.0.0-SNAPSHOT
-    type: jar
-  checksum: sha256:d222f944f29fa894bcb23bc712b706a626005a892e75c4ed18a152db9a9ed028
-- type: maven
   filename: camel-quarkus-http-3.26.0.jar
   attributes:
     repository_url: https://repo1.maven.org/maven2
@@ -154,15 +136,6 @@ artifacts:
     version: 5.3.4
     type: jar
   checksum: sha256:1d8f535f8bc0e027f8a99c3fe02d277a546dfe4a2faa9400076267a6a223b349
-- type: maven
-  filename: notifications-common-template-1.0.0-SNAPSHOT.jar
-  attributes:
-    repository_url: https://repo1.maven.org/maven2
-    group_id: com.redhat.cloud.notifications
-    artifact_id: notifications-common-template
-    version: 1.0.0-SNAPSHOT
-    type: jar
-  checksum: sha256:e107f6f6c1b3f95a1ba5c654faa73518f8132a14cbd8ffa1e2fc4202e7b5bfe9
 - type: maven
   filename: quarkus-qute-3.26.4.jar
   attributes:
@@ -2468,25 +2441,6 @@ artifacts:
     type: jar
   checksum: sha256:af3f9aa297c5bcd2fcb913b8a37b675cb8fcb614f10168fcd6333d015c8e8dcd
 - type: maven
-  filename: notifications-connector-common-1.0.0-SNAPSHOT-tests.test-jar
-  attributes:
-    repository_url: https://repo1.maven.org/maven2
-    group_id: com.redhat.cloud.notifications
-    artifact_id: notifications-connector-common
-    version: 1.0.0-SNAPSHOT
-    type: test-jar
-    classifier: tests
-  checksum: sha256:d222f944f29fa894bcb23bc712b706a626005a892e75c4ed18a152db9a9ed028
-- type: maven
-  filename: notifications-common-unleash-1.0.0-SNAPSHOT.jar
-  attributes:
-    repository_url: https://repo1.maven.org/maven2
-    group_id: com.redhat.cloud.notifications
-    artifact_id: notifications-common-unleash
-    version: 1.0.0-SNAPSHOT
-    type: jar
-  checksum: sha256:9f25c42edb3740034a4586af120eda03c1bda39a9650c8618df0e30b300d46f6
-- type: maven
   filename: microprofile-config-api-3.1.jar
   attributes:
     repository_url: https://repo1.maven.org/maven2
@@ -3359,16 +3313,6 @@ artifacts:
     version: 3.13.4
     type: jar
   checksum: sha256:958e11ef43cc4911441cf3a21ecd23a88a3da8d4b52eaa6b454ca95a62c16be8
-- type: maven
-  filename: notifications-common-1.0.0-SNAPSHOT-tests.test-jar
-  attributes:
-    repository_url: https://repo1.maven.org/maven2
-    group_id: com.redhat.cloud.notifications
-    artifact_id: notifications-common
-    version: 1.0.0-SNAPSHOT
-    type: test-jar
-    classifier: tests
-  checksum: sha256:67577736c773fadaa69d5da5cf7ed537a927d606c20814a71b278cea26c7e6d1
 - type: maven
   filename: quarkus-hibernate-orm-3.26.4.jar
   attributes:

--- a/connector-drawer/artifacts.lock.yaml
+++ b/connector-drawer/artifacts.lock.yaml
@@ -9,7 +9,7 @@ artifacts:
     artifact_id: camel-quarkus-http
     version: 3.26.0
     type: jar
-  checksum: sha256:a2ed1c8ed8156802dfcc7f396ad94bfd0ab56e8e3700abd5703ba3e52a5dce2a
+  checksum: sha256:8abb4a88902f23f374619894837cdf52341f63cc33880ecb0ff223aa1def3a3b
 - type: maven
   filename: camel-quarkus-http-common-3.26.0.jar
   attributes:
@@ -18,7 +18,7 @@ artifacts:
     artifact_id: camel-quarkus-http-common
     version: 3.26.0
     type: jar
-  checksum: sha256:2d75ddee101d7fbe627cf035c815eeecbd159bb1e52cf4d8d67e5b03533afbad
+  checksum: sha256:a5d19b97255da94ba3cde731f0195691b2a7b3a37f928e8eb2339493c852a823
 - type: maven
   filename: camel-quarkus-core-cloud-3.26.0.jar
   attributes:
@@ -27,7 +27,7 @@ artifacts:
     artifact_id: camel-quarkus-core-cloud
     version: 3.26.0
     type: jar
-  checksum: sha256:1ca42c6feecd26c2ee52c6108f98f19182a0cbd13a709151a99404351aa40881
+  checksum: sha256:22c89475494fd18285e31843f0259dc459df95d86ee62a36b05c8578e0dc9553
 - type: maven
   filename: camel-http-common-4.14.0.jar
   attributes:
@@ -36,7 +36,7 @@ artifacts:
     artifact_id: camel-http-common
     version: 4.14.0
     type: jar
-  checksum: sha256:996cef8df31d34a3ef95ff6ca01293b18ab2eb1627ce80a0ef0ec90b01502bde
+  checksum: sha256:f32100e9b63f3d774902f0aad63e55d3a731e1973525ff3b93b8e7c18881cb4c
 - type: maven
   filename: camel-http-base-4.14.0.jar
   attributes:
@@ -45,7 +45,7 @@ artifacts:
     artifact_id: camel-http-base
     version: 4.14.0
     type: jar
-  checksum: sha256:8763dd3f123d16af874432fe43214436841319a2d20afc6ba37f74b7fac2619f
+  checksum: sha256:1df5cb9ec621d9b82a12e90dcb246e267ce71f6fefbec1ae7b6957c84748c035
 - type: maven
   filename: camel-attachments-4.14.0.jar
   attributes:
@@ -54,7 +54,7 @@ artifacts:
     artifact_id: camel-attachments
     version: 4.14.0
     type: jar
-  checksum: sha256:d3274dd70a20bb33831c20d4cc544bda7035561e1766b190d78e8a70c37f28e4
+  checksum: sha256:a0db8725d126a90820248d2d82af1b6ff17f3f7fd46365ec1978d826ebcdb12e
 - type: maven
   filename: angus-activation-2.0.2.jar
   attributes:
@@ -63,7 +63,7 @@ artifacts:
     artifact_id: angus-activation
     version: 2.0.2
     type: jar
-  checksum: sha256:25d58710a35612a49949df7d6e0209853a5eb69362a01b197539207e050ed2df
+  checksum: sha256:6dd3bcffc22bce83b07376a0e2e094e4964a3195d4118fb43e380ef35436cc1e
 - type: maven
   filename: jakarta.servlet-api-6.0.0.jar
   attributes:
@@ -72,7 +72,7 @@ artifacts:
     artifact_id: jakarta.servlet-api
     version: 6.0.0
     type: jar
-  checksum: sha256:66ecc52d25f61859a3b8c6fe9e702738fc2c1bdc227862abe4b1ec43906b67c0
+  checksum: sha256:c034eb1afb158987dbb53a5fea0cadf611c8dae8daadd59c44d9d5ab70129cef
 - type: maven
   filename: camel-quarkus-support-httpclient5-3.26.0.jar
   attributes:
@@ -81,7 +81,7 @@ artifacts:
     artifact_id: camel-quarkus-support-httpclient5
     version: 3.26.0
     type: jar
-  checksum: sha256:225de9af788afcadd230e00b23f2eef0071e3fc4b580ba3b6837853d5118f97e
+  checksum: sha256:c3126bbb0193f99637426df9fdbb6ec2d6fd8585c295b94fdcc5debae6657b1e
 - type: maven
   filename: httpclient5-5.5.jar
   attributes:
@@ -90,7 +90,7 @@ artifacts:
     artifact_id: httpclient5
     version: '5.5'
     type: jar
-  checksum: sha256:6ba5eb0178a540f558facfbfc58af7c19dd75b8e3693c350a5c383263b92ea21
+  checksum: sha256:496b4b0e8d5f3a8139a5d2638486d304758bac3a9c39d76989f663cfd9354fc9
 - type: maven
   filename: camel-http-4.14.0.jar
   attributes:
@@ -99,7 +99,7 @@ artifacts:
     artifact_id: camel-http
     version: 4.14.0
     type: jar
-  checksum: sha256:44b08b6899ce3cb5fd7c71c609da5122852cf2d726f3f541a0bef3f5587c3899
+  checksum: sha256:0dc4683a244099b8a6cd84e91dbc9a9b4aaed43f268b173b400977bd56dd30cd
 - type: maven
   filename: camel-cloud-4.14.0.jar
   attributes:
@@ -108,7 +108,7 @@ artifacts:
     artifact_id: camel-cloud
     version: 4.14.0
     type: jar
-  checksum: sha256:6249381a48271b3cd96827644856c44a8887e1e0387cac3721710c21d00c368f
+  checksum: sha256:02ca863c3956ec3ca6199175c6a7d635fe6760df0e89000324240a8341c139eb
 - type: maven
   filename: camel-util-json-4.14.0.jar
   attributes:
@@ -117,7 +117,7 @@ artifacts:
     artifact_id: camel-util-json
     version: 4.14.0
     type: jar
-  checksum: sha256:1a82a88b0b634dacb79eb99783435fc09f21f61ae9164a0ce8671ecd8959cddb
+  checksum: sha256:6087ae62d3c16d8286694fc3be230a4256a3a3537ed98c2bb2c0d0c2a134eace
 - type: maven
   filename: httpcore5-5.3.4.jar
   attributes:
@@ -126,7 +126,7 @@ artifacts:
     artifact_id: httpcore5
     version: 5.3.4
     type: jar
-  checksum: sha256:38c8cae8b2efba33a1ffde9d8e88baa6d397c08fdf4dbed70e723e51ab57c9f9
+  checksum: sha256:f2b2fd7a0164e8c3120cd8437bc9fea439239e165c17262b3e907daa7e979f80
 - type: maven
   filename: httpcore5-h2-5.3.4.jar
   attributes:
@@ -135,7 +135,7 @@ artifacts:
     artifact_id: httpcore5-h2
     version: 5.3.4
     type: jar
-  checksum: sha256:1d8f535f8bc0e027f8a99c3fe02d277a546dfe4a2faa9400076267a6a223b349
+  checksum: sha256:1fb4f34e4b612e7c127ad693335583587850b17ce9b1c366f9de1ca49fe2c781
 - type: maven
   filename: quarkus-qute-3.26.4.jar
   attributes:
@@ -144,7 +144,7 @@ artifacts:
     artifact_id: quarkus-qute
     version: 3.26.4
     type: jar
-  checksum: sha256:cbd95fc040fd7716dd09d524aef409ca6d2c6da228991933eb1ddda4e3583482
+  checksum: sha256:8f2e5ac57162f7fb8fc93173af3d507712cc56a094c15082c9f69c3e69399a5e
 - type: maven
   filename: qute-core-3.26.4.jar
   attributes:
@@ -153,7 +153,7 @@ artifacts:
     artifact_id: qute-core
     version: 3.26.4
     type: jar
-  checksum: sha256:b88255d9bbcae976c4cf66c5de219a7ebfcc6e0a485e4b8be46c7a85273f08bb
+  checksum: sha256:c4f17c811d3c1445def832c276ff47cff2a2d216df76e4b6bb6e9aa19b1b44ff
 - type: maven
   filename: insights-notification-schemas-java-1.0.1.jar
   attributes:
@@ -162,7 +162,7 @@ artifacts:
     artifact_id: insights-notification-schemas-java
     version: 1.0.1
     type: jar
-  checksum: sha256:36365241c320e1a9e202de483488f54f6a6bf574b96f1588ffdc71ce2df5a11a
+  checksum: sha256:293e938941eedc0f45887372818d69f9a146a2202482fb845e041d2d92ea9897
 - type: maven
   filename: event-schemas-1.4.12.jar
   attributes:
@@ -171,7 +171,7 @@ artifacts:
     artifact_id: event-schemas
     version: 1.4.12
     type: jar
-  checksum: sha256:6d213bfa2352e9817c9259cdbb5466ff368bfc749d250713c30b26eb3dba9a66
+  checksum: sha256:09f78d6ba5d56111dbff3f3e197d965375c0a0c8fbd7038709184f5f73a3a2fa
 - type: maven
   filename: jackson-datatype-jsr310-2.19.2.jar
   attributes:
@@ -180,7 +180,7 @@ artifacts:
     artifact_id: jackson-datatype-jsr310
     version: 2.19.2
     type: jar
-  checksum: sha256:03afb33a075222bd94809bcf77b16f6f4b40fa1e2a1eef0386b9546434d6415c
+  checksum: sha256:9709f43e0fa5625633ee66db6c078fb1e8c7ca02092696ba95ea785dbf0fa6a1
 - type: maven
   filename: jackson-datatype-jdk8-2.19.2.jar
   attributes:
@@ -189,7 +189,7 @@ artifacts:
     artifact_id: jackson-datatype-jdk8
     version: 2.19.2
     type: jar
-  checksum: sha256:d1b64159854e20522ea0e201b562a500a1512eb137594a1c4e006d882dfb4192
+  checksum: sha256:6055fef10756e8bd1b0e8807aa1d881338c63ca95d59271e1da4922b9a17581e
 - type: maven
   filename: jackson-core-2.19.2.jar
   attributes:
@@ -198,7 +198,7 @@ artifacts:
     artifact_id: jackson-core
     version: 2.19.2
     type: jar
-  checksum: sha256:f108c0a9c7015e3b15f86716429e76a0ea2b1ab5feebef912431d962b6a3eb74
+  checksum: sha256:aa77eaf29293a868c47372194f7c5287d77d9370b04ea25d3fffc1e4904b5880
 - type: maven
   filename: quarkus-rest-client-jackson-3.26.4.jar
   attributes:
@@ -207,7 +207,7 @@ artifacts:
     artifact_id: quarkus-rest-client-jackson
     version: 3.26.4
     type: jar
-  checksum: sha256:aff35e94a11178d3954cdf9e1ac652bdbc4a2bb86d8f455a1e199153003fa2b8
+  checksum: sha256:424ebeb97a452b556c9bb81b44a32435bcbfc85db27fc5749a5bef0102571127
 - type: maven
   filename: resteasy-reactive-jackson-3.26.4.jar
   attributes:
@@ -216,7 +216,7 @@ artifacts:
     artifact_id: resteasy-reactive-jackson
     version: 3.26.4
     type: jar
-  checksum: sha256:269d16cbfd9658a503f7978ca730adadedf6b0cef913cb395c038f82a312b1cb
+  checksum: sha256:95fd5937141a9a345b4cee7ff05e3c409c3b51e444ec4af6e0b8b8d56f17b223
 - type: maven
   filename: resteasy-reactive-3.26.4.jar
   attributes:
@@ -225,7 +225,7 @@ artifacts:
     artifact_id: resteasy-reactive
     version: 3.26.4
     type: jar
-  checksum: sha256:595fae89f24a6bdd967b5500024cd5c450a9959eba41da91042b4e2df673f597
+  checksum: sha256:749c87d57f25643c4a7cce61e0689437b6b0fe9af62685c61f12fed2ce1c596e
 - type: maven
   filename: resteasy-reactive-common-3.26.4.jar
   attributes:
@@ -234,7 +234,7 @@ artifacts:
     artifact_id: resteasy-reactive-common
     version: 3.26.4
     type: jar
-  checksum: sha256:fd239c7780c1146150cdf8965ea4d39e44cd1680f623ab07696c374339f63fe3
+  checksum: sha256:4917bab471dc9394c71ab94ed2bef243aac863cc25bdc8799537b37506673982
 - type: maven
   filename: resteasy-reactive-common-types-3.26.4.jar
   attributes:
@@ -243,7 +243,7 @@ artifacts:
     artifact_id: resteasy-reactive-common-types
     version: 3.26.4
     type: jar
-  checksum: sha256:18df10e889284f1e301cc6a513741103a1e23192ee4d71bcab50a43968dc5c2b
+  checksum: sha256:a5bd83a42d143cd30019d9bdd4e85f04c3a8fa492eed82feb2e30ff9c921bf90
 - type: maven
   filename: commons-logging-jboss-logging-1.0.0.Final.jar
   attributes:
@@ -252,7 +252,7 @@ artifacts:
     artifact_id: commons-logging-jboss-logging
     version: 1.0.0.Final
     type: jar
-  checksum: sha256:fe37c37aa4f39e5a80bcf00808c4a11046831fcf51ebcf947daf7d45f2ab1a40
+  checksum: sha256:f12176263ea25f4e78bb4fa4b36d335a29738dde6a8123e1b6da89a655d150ff
 - type: maven
   filename: jakarta.xml.bind-api-4.0.2.jar
   attributes:
@@ -261,7 +261,7 @@ artifacts:
     artifact_id: jakarta.xml.bind-api
     version: 4.0.2
     type: jar
-  checksum: sha256:2d717f6d90e4668ad87b108ae9fd9d637dd7d2dd1fdd41cee99ec2a4a13c4c46
+  checksum: sha256:0d6bcfe47763e85047acf7c398336dc84ff85ebcad0a7cb6f3b9d3e981245406
 - type: maven
   filename: jakarta.activation-api-2.1.3.jar
   attributes:
@@ -270,7 +270,7 @@ artifacts:
     artifact_id: jakarta.activation-api
     version: 2.1.3
     type: jar
-  checksum: sha256:b2e22d55a51a42bb3163efdb570376854411399cc8d11658b59b54368dee66d1
+  checksum: sha256:01b176d718a169263e78290691fc479977186bcc6b333487325084d6586f4627
 - type: maven
   filename: quarkus-rest-jackson-common-3.26.4.jar
   attributes:
@@ -279,7 +279,7 @@ artifacts:
     artifact_id: quarkus-rest-jackson-common
     version: 3.26.4
     type: jar
-  checksum: sha256:099006fad97c770cd68e53e82989f0c4501099fd8195f71fd77d64f696927fb0
+  checksum: sha256:1af791941851a1f5d424bca40e714f966355fce20e3d8bc912bf123bac12d2cc
 - type: maven
   filename: quarkus-rest-common-3.26.4.jar
   attributes:
@@ -288,7 +288,7 @@ artifacts:
     artifact_id: quarkus-rest-common
     version: 3.26.4
     type: jar
-  checksum: sha256:9c176e241618d7443a571d0fa06f35c67ab4925f614dff47f386db5933aa3728
+  checksum: sha256:77d91e77c774cc05022a8bcceb8d51e7ca967d0c5ad65713ebadbd33cc1af575
 - type: maven
   filename: quarkus-jsonp-3.26.4.jar
   attributes:
@@ -297,7 +297,7 @@ artifacts:
     artifact_id: quarkus-jsonp
     version: 3.26.4
     type: jar
-  checksum: sha256:874574bffd9898a77002528c3b29c6355aa034f4b73efb4494ce635fc4c4ea08
+  checksum: sha256:b5bccce38c8a17cef8aee46a4e767163dbac63152efcdfb4fa25af62ee512c36
 - type: maven
   filename: parsson-1.1.7.jar
   attributes:
@@ -306,7 +306,7 @@ artifacts:
     artifact_id: parsson
     version: 1.1.7
     type: jar
-  checksum: sha256:1232df8ac25107e351b844c298d74f2bebe277e49e045ef7bc5de147c962c772
+  checksum: sha256:c21db018f8ac6cf79893f1af77f1cd337937bd12ae6fa3d4b10f5a00819ee56c
 - type: maven
   filename: quarkus-rest-client-3.26.4.jar
   attributes:
@@ -315,7 +315,7 @@ artifacts:
     artifact_id: quarkus-rest-client
     version: 3.26.4
     type: jar
-  checksum: sha256:2d7748386f846ac5b742c331b2bd408e7f276aa07d33706ca7652379d0de3241
+  checksum: sha256:8527dfde745f227e9685d935a8539ac491964b27d1c54be743041bbc6f3a93b3
 - type: maven
   filename: quarkus-rest-client-jaxrs-3.26.4.jar
   attributes:
@@ -324,7 +324,7 @@ artifacts:
     artifact_id: quarkus-rest-client-jaxrs
     version: 3.26.4
     type: jar
-  checksum: sha256:1e88ecbf681a11890101b7bbf9f9cea749d567f494726dd9e6bc22819bd01e47
+  checksum: sha256:bd3109039ae66c88bdffd3110d11726f0cb0b24c594c3bd152ed5fe0b2874a8f
 - type: maven
   filename: resteasy-reactive-client-3.26.4.jar
   attributes:
@@ -333,7 +333,7 @@ artifacts:
     artifact_id: resteasy-reactive-client
     version: 3.26.4
     type: jar
-  checksum: sha256:881c0d5456ae995430215a1a50fa7d641d60ddd81218909bca09aea42ec4a6b8
+  checksum: sha256:4e4527875781eca67797ad5a593c3b1900e44432377b78b9399fc64ce6c442ec
 - type: maven
   filename: stork-api-2.7.3.jar
   attributes:
@@ -342,7 +342,7 @@ artifacts:
     artifact_id: stork-api
     version: 2.7.3
     type: jar
-  checksum: sha256:6139ddb048f873dd623a9eaa136423b6972f1f69a45b0733403e32fee63128c8
+  checksum: sha256:5f94a09cdcd1a03be0a8771c8aae3f2ac3ab1b837088242318f48c2a60088e31
 - type: maven
   filename: vertx-web-client-4.5.21.jar
   attributes:
@@ -351,7 +351,7 @@ artifacts:
     artifact_id: vertx-web-client
     version: 4.5.21
     type: jar
-  checksum: sha256:55190fefaf36ebd14b6683a698a6573d3078ae4ae5e09ce77af7db3c50b47cab
+  checksum: sha256:e425ff063b20962ff3425a9e57f6a15875bc010cadb5b6413e9f0e70761c8a4b
 - type: maven
   filename: vertx-uri-template-4.5.21.jar
   attributes:
@@ -360,7 +360,7 @@ artifacts:
     artifact_id: vertx-uri-template
     version: 4.5.21
     type: jar
-  checksum: sha256:2a647d60050f943211f244fe4cfcf0e868f525ebeeaed024c0cae23f1c27ac0a
+  checksum: sha256:b6ad9e9e1793b7a208d72a4b4d8bf1e5b1bef69056ceddc6d4444a078309d53c
 - type: maven
   filename: quarkus-rest-client-config-3.26.4.jar
   attributes:
@@ -369,7 +369,7 @@ artifacts:
     artifact_id: quarkus-rest-client-config
     version: 3.26.4
     type: jar
-  checksum: sha256:61888e9237f59b3f90d307873da02abaf406a9b733c009ccc20758ef432788e6
+  checksum: sha256:158925d7b7fbe0274a10bde737a3c62c5024b98ba828e2023d3ac42d0e71d2b7
 - type: maven
   filename: jandex-3.4.0.jar
   attributes:
@@ -378,7 +378,7 @@ artifacts:
     artifact_id: jandex
     version: 3.4.0
     type: jar
-  checksum: sha256:5d288888e24ae43953cd4cc4d980decbe2e2f69bf72c47efa2c0584d7c23d445
+  checksum: sha256:6be417290a1d343dd27b45cbd12e273deb4af30a2df5cb9e4bad880fb63945b2
 - type: maven
   filename: quarkus-tls-registry-3.26.4.jar
   attributes:
@@ -387,7 +387,7 @@ artifacts:
     artifact_id: quarkus-tls-registry
     version: 3.26.4
     type: jar
-  checksum: sha256:c5cee5a31c3133f482e905d80467b65ffce2a04d10e21cf96de52de80f3bf2d0
+  checksum: sha256:5967193caedcba8656ce63f7dbae72780acc9204370ad8203db26073ba9fec33
 - type: maven
   filename: quarkus-tls-registry-spi-3.26.4.jar
   attributes:
@@ -396,7 +396,7 @@ artifacts:
     artifact_id: quarkus-tls-registry-spi
     version: 3.26.4
     type: jar
-  checksum: sha256:1fa41fcaeac018a8e42c7d1ef46599e37a0c5b32a9af55769735c755d79debd5
+  checksum: sha256:f808c21457cf21ce56ef95c60514740de94fd1a3cd787cd190c904162bb4b9a6
 - type: maven
   filename: quarkus-credentials-3.26.4.jar
   attributes:
@@ -405,7 +405,7 @@ artifacts:
     artifact_id: quarkus-credentials
     version: 3.26.4
     type: jar
-  checksum: sha256:0ac32b7a54027efdb360c67b0361c0a7bda6b140ac586f22bfa0d9918080085c
+  checksum: sha256:fa637e52afea693664189e807d5941a569c3e145f611ed36312948c5ab9547a5
 - type: maven
   filename: smallrye-private-key-pem-parser-0.9.2.jar
   attributes:
@@ -414,7 +414,7 @@ artifacts:
     artifact_id: smallrye-private-key-pem-parser
     version: 0.9.2
     type: jar
-  checksum: sha256:9d37ad326652ae59c1873dcd14df3139532e04f990697d2de463f7fdaee6e3d6
+  checksum: sha256:4ba98e92ed203593d87e384a1e09fa96c18c90173a6170fea71cf23a1c9c5286
 - type: maven
   filename: microprofile-rest-client-api-4.0.jar
   attributes:
@@ -423,7 +423,7 @@ artifacts:
     artifact_id: microprofile-rest-client-api
     version: '4.0'
     type: jar
-  checksum: sha256:83c7a63bd584b88e4250af4617e9205b17b86bf09ad2d6bf19c2ca5e35a62d85
+  checksum: sha256:61cddc4934d3c8413386210a21c83325a54a0afcd7388ed708b7bd21d8fd3d7d
 - type: maven
   filename: jakarta.validation-api-3.1.1.jar
   attributes:
@@ -432,7 +432,7 @@ artifacts:
     artifact_id: jakarta.validation-api
     version: 3.1.1
     type: jar
-  checksum: sha256:5ea88202c23bd9adde8f55c2ba307a2814ab14d992e01e39185a30f3d2d18ed3
+  checksum: sha256:63ce00156388c365f3ac1be71fcfaf114682fc0c452020b5df6e7ec236e142ab
 - type: maven
   filename: quarkus-messaging-kafka-3.26.4.jar
   attributes:
@@ -441,7 +441,7 @@ artifacts:
     artifact_id: quarkus-messaging-kafka
     version: 3.26.4
     type: jar
-  checksum: sha256:0e5f26c597fb75bb22f756c63286b70ced8a1ae6328642e1db64f93982210dcb
+  checksum: sha256:30bf4876877051d2338ac256516a76dd32e65f9131d8a040ab73789127d2cc63
 - type: maven
   filename: quarkus-kafka-client-3.26.4.jar
   attributes:
@@ -450,7 +450,7 @@ artifacts:
     artifact_id: quarkus-kafka-client
     version: 3.26.4
     type: jar
-  checksum: sha256:a6d1c3f1521de190643173c705210cb5eaefdb6e1bd9f741613d08e6e306dd81
+  checksum: sha256:676dd2b84106654b48d9d4f8883ab40b58637fe76f60de2640640445f1e31af9
 - type: maven
   filename: smallrye-reactive-messaging-kafka-4.28.0.jar
   attributes:
@@ -459,7 +459,7 @@ artifacts:
     artifact_id: smallrye-reactive-messaging-kafka
     version: 4.28.0
     type: jar
-  checksum: sha256:ccc2f4c2670bb8f6861c83190273186d7eb737fd5f96fcb5a8828e58505b1ab6
+  checksum: sha256:51ecde7389e250c93ab0f317962db1b72e22cb776e87f62ff7a60cca5fed2547
 - type: maven
   filename: smallrye-reactive-messaging-kafka-api-4.28.0.jar
   attributes:
@@ -468,7 +468,7 @@ artifacts:
     artifact_id: smallrye-reactive-messaging-kafka-api
     version: 4.28.0
     type: jar
-  checksum: sha256:b6ed33e645161f4b367e47daae349b4aacc8fab6dbd700faae39300be669286f
+  checksum: sha256:4b41a24f618a91e64b8f8f0e86a2eadcb9185047c0c9440cf7cc23a6a2000a4d
 - type: maven
   filename: smallrye-reactive-messaging-otel-4.28.0.jar
   attributes:
@@ -477,7 +477,7 @@ artifacts:
     artifact_id: smallrye-reactive-messaging-otel
     version: 4.28.0
     type: jar
-  checksum: sha256:efd7ecfb4d17cffca03bf4950608f5449825a0c52016fd5d8cfd39fc3775acfe
+  checksum: sha256:40e574c468523d9206ce61e41e1df74dcefa0627a64fc8492ba3944259a37a49
 - type: maven
   filename: opentelemetry-semconv-1.28.0-alpha.jar
   attributes:
@@ -486,7 +486,7 @@ artifacts:
     artifact_id: opentelemetry-semconv
     version: 1.28.0-alpha
     type: jar
-  checksum: sha256:a7e2c33d4df74b853f5af61ceeb09a0d90ffb4c509579720efb1a3b3647e6955
+  checksum: sha256:e8ab86e93cef09e421a6213f4cf18421fcc6e1f9cf0ab94b9a31ed4460ddf553
 - type: maven
   filename: opentelemetry-instrumentation-api-2.10.0.jar
   attributes:
@@ -495,7 +495,7 @@ artifacts:
     artifact_id: opentelemetry-instrumentation-api
     version: 2.10.0
     type: jar
-  checksum: sha256:5bf53d329b939822523244708a011a74b1b81cc8a3964f21de14933964c921d5
+  checksum: sha256:ab1535c29f92fcfcb755fdf96904d317161c6ae27d5385ebea8c8e394d29e6f6
 - type: maven
   filename: opentelemetry-api-incubator-1.44.1-alpha.jar
   attributes:
@@ -504,7 +504,7 @@ artifacts:
     artifact_id: opentelemetry-api-incubator
     version: 1.44.1-alpha
     type: jar
-  checksum: sha256:ebe4583773be0180ff4a9bf16822019ee0e1bbe5fdb9eb8ac6dad1c83f1b4122
+  checksum: sha256:8dbf451ce580fa0252ee9ca77331fd21710710ca9b735a1359241ead3be8ebe5
 - type: maven
   filename: opentelemetry-instrumentation-api-incubator-2.10.0-alpha.jar
   attributes:
@@ -513,7 +513,7 @@ artifacts:
     artifact_id: opentelemetry-instrumentation-api-incubator
     version: 2.10.0-alpha
     type: jar
-  checksum: sha256:ca0e61aa5673a2ed75862e5f674200486960779f96ffd5c214373c84823989d0
+  checksum: sha256:e6ad0bcee4674993f15fd672002090f7b108ffe95fe7da2d882989cbeb719a4c
 - type: maven
   filename: quarkus-jackson-3.26.4.jar
   attributes:
@@ -522,7 +522,7 @@ artifacts:
     artifact_id: quarkus-jackson
     version: 3.26.4
     type: jar
-  checksum: sha256:5a4077776abb6dc0586be77a380ee1dc9505013c22a819032293c733c8ff2a2d
+  checksum: sha256:213f62689933d55487cea2ab607b0fde52f7996815fefaa2fc8604da4259b93b
 - type: maven
   filename: jackson-module-parameter-names-2.19.2.jar
   attributes:
@@ -531,7 +531,7 @@ artifacts:
     artifact_id: jackson-module-parameter-names
     version: 2.19.2
     type: jar
-  checksum: sha256:13c6ff4b5852f206bff405b928b12e0f24192313824469b4ae105c8589adfa40
+  checksum: sha256:5cafef98759b40a418631e91257930a5e30abc162d9a690c1e365dbbdacdfecb
 - type: maven
   filename: kafka-clients-4.0.0.jar
   attributes:
@@ -540,7 +540,7 @@ artifacts:
     artifact_id: kafka-clients
     version: 4.0.0
     type: jar
-  checksum: sha256:077220c1ef6659e774d983eccb282c4f36ecffc0af5cc8c32e592b723afc23b5
+  checksum: sha256:8a8ad0ef4f7138b3f5c138ca4a921ba3cce5be64a82e82c370a9a134f31895a2
 - type: maven
   filename: zstd-jni-1.5.6-6.jar
   attributes:
@@ -549,7 +549,7 @@ artifacts:
     artifact_id: zstd-jni
     version: 1.5.6-6
     type: jar
-  checksum: sha256:fce58c298ac2cb44a134f20587f6bd077eefd5db91b286fbeb23663dceb7382d
+  checksum: sha256:1f85db623bf653860d10e13e7b1ca6609301f66994dc93784c92a66019516bb9
 - type: maven
   filename: lz4-java-1.8.0.jar
   attributes:
@@ -558,7 +558,7 @@ artifacts:
     artifact_id: lz4-java
     version: 1.8.0
     type: jar
-  checksum: sha256:2b8a1911400ff7f9954d2627479ab2100bc3ae12c008d0bad4e6053c4102f173
+  checksum: sha256:d74a3334fb35195009b338a951f918203d6bbca3d1d359033dc33edd1cadc9ef
 - type: maven
   filename: snappy-java-1.1.10.5.jar
   attributes:
@@ -567,7 +567,7 @@ artifacts:
     artifact_id: snappy-java
     version: 1.1.10.5
     type: jar
-  checksum: sha256:69dddd46d385ea848880e93f9e4d30efa58d25a3208f271cd742a9028a52fa2b
+  checksum: sha256:0f3f1857ed33116583f480b4df5c0218836c47bfbc9c6221c0d73f356decf37b
 - type: maven
   filename: quarkus-messaging-3.26.4.jar
   attributes:
@@ -576,7 +576,7 @@ artifacts:
     artifact_id: quarkus-messaging
     version: 3.26.4
     type: jar
-  checksum: sha256:04c0bdcc097514d53db42f9df1265520a6b429b351685f0ce03fac74450ff163
+  checksum: sha256:04c24e381530ea818f6a93c75e42b7210ec98c242149f58b63d2b45c13f00a09
 - type: maven
   filename: quarkus-mutiny-reactive-streams-operators-3.26.4.jar
   attributes:
@@ -585,7 +585,7 @@ artifacts:
     artifact_id: quarkus-mutiny-reactive-streams-operators
     version: 3.26.4
     type: jar
-  checksum: sha256:2e54c5e9b53faf5dc1778aeb082231e4cce839895280879f57e880974e9b17e1
+  checksum: sha256:4ae7c2e87300797b2c25e290d55956c4a69a97725a0243f486b3f8c1c5f9694c
 - type: maven
   filename: microprofile-reactive-streams-operators-api-3.0.1.jar
   attributes:
@@ -594,7 +594,7 @@ artifacts:
     artifact_id: microprofile-reactive-streams-operators-api
     version: 3.0.1
     type: jar
-  checksum: sha256:f04b4442e5759363a26e9594a3ac33c06e277d692659972564feb9c47cbc7932
+  checksum: sha256:2eb30081f2674e674c6587592747a81a4d92d2da1a735be5f645901de60f9f8d
 - type: maven
   filename: microprofile-reactive-streams-operators-core-3.0.1.jar
   attributes:
@@ -603,7 +603,7 @@ artifacts:
     artifact_id: microprofile-reactive-streams-operators-core
     version: 3.0.1
     type: jar
-  checksum: sha256:49ad66c31df3c889127a6c8dfcfc2f39711281092866c910893b4349e24a5bbc
+  checksum: sha256:276810a28dcab1ae1b929f0ade42581d6553847fc42acbf9b5d89904cf9c2f4a
 - type: maven
   filename: mutiny-reactive-streams-operators-2.9.4.jar
   attributes:
@@ -612,7 +612,7 @@ artifacts:
     artifact_id: mutiny-reactive-streams-operators
     version: 2.9.4
     type: jar
-  checksum: sha256:f071465401dcd53cbfacc35aa72502311c83d32e3250c365c1c6d637d68b559c
+  checksum: sha256:8867ac99d232566108c5dad04138663039bb4655b5a67edd870e7616cb4add30
 - type: maven
   filename: quarkus-messaging-kotlin-3.26.4.jar
   attributes:
@@ -621,7 +621,7 @@ artifacts:
     artifact_id: quarkus-messaging-kotlin
     version: 3.26.4
     type: jar
-  checksum: sha256:2ebf958fd05fa1d04e0ce47b8f309929e654b203c5a086b9eea4501344a3a2a0
+  checksum: sha256:972c90c9fa17d25c7b19b6fa628e6bca60f59a73a997a2df828075631ffd9d68
 - type: maven
   filename: vertx-web-4.5.21.jar
   attributes:
@@ -630,7 +630,7 @@ artifacts:
     artifact_id: vertx-web
     version: 4.5.21
     type: jar
-  checksum: sha256:0b46ad2977bf6845bb6e120275e015ccbb19826737e0406e4799f44765836419
+  checksum: sha256:9a4c2404827ca0000675d081d1603b9ceded93be2b04d7193bab49f25baba413
 - type: maven
   filename: vertx-web-common-4.5.21.jar
   attributes:
@@ -639,7 +639,7 @@ artifacts:
     artifact_id: vertx-web-common
     version: 4.5.21
     type: jar
-  checksum: sha256:1bd24fe5bf5c37d66a13f8a6e9d28b8712f02402e406b847f8c9ec6398ef1f2b
+  checksum: sha256:f1d6cfb1847bc99c8cd27c3045a43f8fe00c35df6589f7b29cf64babf78a0183
 - type: maven
   filename: vertx-auth-common-4.5.21.jar
   attributes:
@@ -648,7 +648,7 @@ artifacts:
     artifact_id: vertx-auth-common
     version: 4.5.21
     type: jar
-  checksum: sha256:0d28674ad56a19dfe29459edf34c386af51fa43981eca2f0c0edd631c26f8e87
+  checksum: sha256:6b0d6d06be5610e762396cebe84938848d1ddbba815b907da7f6171777f29a66
 - type: maven
   filename: vertx-bridge-common-4.5.21.jar
   attributes:
@@ -657,7 +657,7 @@ artifacts:
     artifact_id: vertx-bridge-common
     version: 4.5.21
     type: jar
-  checksum: sha256:241030bd4b69fcd9cbd1e7e1397d39b189ae7206cdb9cd96aee913b487725439
+  checksum: sha256:e67978c4a2ddf4fc85dfa82fc69e4c29453d982fe25b79e48a62e04e7bcb8c67
 - type: maven
   filename: quarkus-vertx-3.26.4.jar
   attributes:
@@ -666,7 +666,7 @@ artifacts:
     artifact_id: quarkus-vertx
     version: 3.26.4
     type: jar
-  checksum: sha256:1f98a7dac82ab402a7dc3b318f212c0016013aeaa0fc6f4df6ac2e621bf55e64
+  checksum: sha256:bfb94b7505c3b29e98ae782e22f3aaae464b4805df3eb0888d29c21ccfeb1031
 - type: maven
   filename: quarkus-netty-3.26.4.jar
   attributes:
@@ -675,7 +675,7 @@ artifacts:
     artifact_id: quarkus-netty
     version: 3.26.4
     type: jar
-  checksum: sha256:9f4cc536c0ca35cd90799cc55c2cc3ff730630acd433430e6a0964266e8c646d
+  checksum: sha256:5fd1af6cd458ab840dd05566c851b4ffd24e111ac8cba4b7ed4ecfb80ce810b7
 - type: maven
   filename: netty-codec-4.1.127.Final.jar
   attributes:
@@ -684,7 +684,7 @@ artifacts:
     artifact_id: netty-codec
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:4bcb5524f8c5e0325b4a37543e113355bb52b8ce7185e14cf7c6ccb0315c4193
+  checksum: sha256:187d21cee1a114f43b87be235f66c83828bdd0a3e0c1cdfebedaa37748e6e470
 - type: maven
   filename: netty-codec-http-4.1.127.Final.jar
   attributes:
@@ -693,7 +693,7 @@ artifacts:
     artifact_id: netty-codec-http
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:869646b60ccf63b46fd3e27bc569d46343b8879e22915576e1cefe2a169bc009
+  checksum: sha256:2408776c87c1808b5522298c25e8290427123763f4addfda02dff6a24a538f61
 - type: maven
   filename: netty-codec-http2-4.1.127.Final.jar
   attributes:
@@ -702,7 +702,7 @@ artifacts:
     artifact_id: netty-codec-http2
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:5698c7712cd1c149e229e13cef02207d9d8865d4c4b4ad8b431323c94bd84cf2
+  checksum: sha256:0eb1befa55f785b47729d58d4fce72abea73b7f48fc1c434d71953e6a558ffaa
 - type: maven
   filename: netty-handler-4.1.127.Final.jar
   attributes:
@@ -711,7 +711,7 @@ artifacts:
     artifact_id: netty-handler
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:931ac946186fbccdb3df84a704001d42219a52c662735e8dfac61a451e30080c
+  checksum: sha256:88b6892bc1321d32409392e5b9f94e59d8e800678c029c71e7c0d76daf6050d0
 - type: maven
   filename: netty-transport-native-unix-common-4.1.127.Final.jar
   attributes:
@@ -720,7 +720,7 @@ artifacts:
     artifact_id: netty-transport-native-unix-common
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:30bfdffac691ea0f7d3729dccf66fcb2de4bf8d4f5ca4c9ff808e372d47cd0cf
+  checksum: sha256:0e3a45e3ce1fe034ca8b32c1579afa5f06729ca6427b7b0610528c4ef37c6e50
 - type: maven
   filename: netty-codec-haproxy-4.1.127.Final.jar
   attributes:
@@ -729,7 +729,7 @@ artifacts:
     artifact_id: netty-codec-haproxy
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:6a8b695eabd26cbd16bef0cef5237e8d3fd5c4922eecadf4e0f096d41ad5bb34
+  checksum: sha256:4d08dffdac33cbdffbae328d03990a169a5e21b20e0f1ae3fcf73601d7d79594
 - type: maven
   filename: netty-buffer-4.1.127.Final.jar
   attributes:
@@ -738,7 +738,7 @@ artifacts:
     artifact_id: netty-buffer
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:3cf17e5a0c1f85bfc3cc18e90d428c76b6aacbdcc61fbcfed545643b2a760075
+  checksum: sha256:4a0a17dc5a58d910c56545be6912b9923cfe902522dc1df268e774bc22443eb6
 - type: maven
   filename: netty-transport-4.1.127.Final.jar
   attributes:
@@ -747,7 +747,7 @@ artifacts:
     artifact_id: netty-transport
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:5f3051c3609e61b11f960559db43101767d7ab1925fc8672168ed11fba2999c2
+  checksum: sha256:0d1ad82bc658f9919ca750cebe2571d4b0ae4514ec781964091f405343760e92
 - type: maven
   filename: quarkus-vertx-latebound-mdc-provider-3.26.4.jar
   attributes:
@@ -756,7 +756,7 @@ artifacts:
     artifact_id: quarkus-vertx-latebound-mdc-provider
     version: 3.26.4
     type: jar
-  checksum: sha256:239b349a512d966acb2744cf1258181cabf50133edf5a91e9f334ac1de8c9794
+  checksum: sha256:36dc34d9cff88633856404f650a640aea3dbf02860f2c8fab9270524fb60c078
 - type: maven
   filename: smallrye-fault-tolerance-vertx-6.9.3.jar
   attributes:
@@ -765,7 +765,7 @@ artifacts:
     artifact_id: smallrye-fault-tolerance-vertx
     version: 6.9.3
     type: jar
-  checksum: sha256:ccc18239ff2db41af90e4c282981549d23ad005d96d14c850b6032b502e2eddd
+  checksum: sha256:41087ca2ccf9c0f258df3639f6e4f959b7911596d0f175ee94278d59bc4884a0
 - type: maven
   filename: quarkus-virtual-threads-3.26.4.jar
   attributes:
@@ -774,7 +774,7 @@ artifacts:
     artifact_id: quarkus-virtual-threads
     version: 3.26.4
     type: jar
-  checksum: sha256:179c69f219fff9e01a241fb869eb05d8567036fe33ac44d07d3837a00c259d06
+  checksum: sha256:015a0ae14aeb76a804af0091129d58f01d3286643ba4792cedae6e633a84b38a
 - type: maven
   filename: vertx-core-4.5.21.jar
   attributes:
@@ -783,7 +783,7 @@ artifacts:
     artifact_id: vertx-core
     version: 4.5.21
     type: jar
-  checksum: sha256:cc33a39c9188d879903430af98d9a7655ddae58fe54d99224bb4ccaf057d2d39
+  checksum: sha256:a073006a8f8b71702fbb8375583b40d63b080b09884f62938446d581aeab256b
 - type: maven
   filename: netty-common-4.1.127.Final.jar
   attributes:
@@ -792,7 +792,7 @@ artifacts:
     artifact_id: netty-common
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:34713b155634e622a6a2c69568c78834c3dc259f7a98c018b866c332eb87381b
+  checksum: sha256:a6732bb70dc15ed96aa33ecca82c0d7b20f8ff41adf04f74f168f626adf359e8
 - type: maven
   filename: netty-handler-proxy-4.1.127.Final.jar
   attributes:
@@ -801,7 +801,7 @@ artifacts:
     artifact_id: netty-handler-proxy
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:0a2fb62083c651a52101b9fcefd534235e1527ccc1a96df670adeccb4e489cbb
+  checksum: sha256:2c0c8046e5d737e08f40a7c2907526648860d0434e125bd51de3c2cf390453fb
 - type: maven
   filename: netty-codec-socks-4.1.127.Final.jar
   attributes:
@@ -810,7 +810,7 @@ artifacts:
     artifact_id: netty-codec-socks
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:d5e6cb45837186ca977605531fbcbf7ffeeb6ea04aed97236ac1923c258981c6
+  checksum: sha256:d3d251f9239951a845f22e39191f95471fb2eb7951b9878ea4555ccac99529fb
 - type: maven
   filename: netty-resolver-4.1.127.Final.jar
   attributes:
@@ -819,7 +819,7 @@ artifacts:
     artifact_id: netty-resolver
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:b5ad214c49622147069e1ebbfc4d024599cc4c47d976ee2347830a9189450b02
+  checksum: sha256:a57ee62deb54ed99690db2696039f0f768a65c974677946ed48b2a2d8510ded3
 - type: maven
   filename: netty-resolver-dns-4.1.127.Final.jar
   attributes:
@@ -828,7 +828,7 @@ artifacts:
     artifact_id: netty-resolver-dns
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:8accd5344ecf0a90943ea8883c92fde626b2058f978265b379ebb9ade3e62083
+  checksum: sha256:a9b619a902ede5ced0579082734011111d099a52f512d03a17f9a7d79afa3c69
 - type: maven
   filename: netty-codec-dns-4.1.127.Final.jar
   attributes:
@@ -837,7 +837,7 @@ artifacts:
     artifact_id: netty-codec-dns
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:9d549d1738404e73929efca7f59a83fb35c094d047c3bb64a6faae15fa4d0481
+  checksum: sha256:4398b97193aad6bf2a9a90ad86a83b892b62589a4a2c90d0d0a3d94a71b47976
 - type: maven
   filename: smallrye-common-annotation-2.13.9.jar
   attributes:
@@ -846,7 +846,7 @@ artifacts:
     artifact_id: smallrye-common-annotation
     version: 2.13.9
     type: jar
-  checksum: sha256:09fc1e06ac5a0c19595a00bd35bdc49c1b5f9f3cbc6ddc7a9fef5ff9c6793a9c
+  checksum: sha256:ad3eff15b46fbf81bbc95315144640774bde7817c2e75981230a1fe39eb7429a
 - type: maven
   filename: smallrye-reactive-messaging-health-4.28.0.jar
   attributes:
@@ -855,7 +855,7 @@ artifacts:
     artifact_id: smallrye-reactive-messaging-health
     version: 4.28.0
     type: jar
-  checksum: sha256:2cdbbfcf509789c96e1ed7be97ca7a0346303b97400858114df9712acb0f692d
+  checksum: sha256:58686e60195d02d9542cbc690af7283c8dffbfe54b9a360e33afccdbc7463e54
 - type: maven
   filename: microprofile-health-api-4.0.1.jar
   attributes:
@@ -864,7 +864,7 @@ artifacts:
     artifact_id: microprofile-health-api
     version: 4.0.1
     type: jar
-  checksum: sha256:d600258ba46e4afbe4406c9093a8399819032281f5d66cbd8ecd33465b0fe70b
+  checksum: sha256:b89ca4b6c4f7a044250d31c0673f6bc221e40fd669fc5871dbad5e5a0769ca47
 - type: maven
   filename: smallrye-reactive-messaging-provider-4.28.0.jar
   attributes:
@@ -873,7 +873,7 @@ artifacts:
     artifact_id: smallrye-reactive-messaging-provider
     version: 4.28.0
     type: jar
-  checksum: sha256:77164d7aa971a5c02dc75cb53fc8364905cb62c1fefddb4ce120a29f3cdd00a2
+  checksum: sha256:3f996b327ddd5b651a5fb1cb8b5431c98a5497d58cae93ef364977c134a052b3
 - type: maven
   filename: smallrye-reactive-messaging-api-4.28.0.jar
   attributes:
@@ -882,7 +882,7 @@ artifacts:
     artifact_id: smallrye-reactive-messaging-api
     version: 4.28.0
     type: jar
-  checksum: sha256:b90862c6f5b8d11a56ea1fbe4e4c3683a0c01ee26eb05f794a6728e7fc5d8794
+  checksum: sha256:c6b655652d5d7eb44750acede128aba98f7aae5e2ee78b37d64405f5a6f4bd8c
 - type: maven
   filename: smallrye-common-vertx-context-2.13.9.jar
   attributes:
@@ -891,7 +891,7 @@ artifacts:
     artifact_id: smallrye-common-vertx-context
     version: 2.13.9
     type: jar
-  checksum: sha256:5509985e39e30d5e05217d7d9fdce1bacc08386fadc1618975fed68b3eb27f15
+  checksum: sha256:2f00c34a83458a2a505642593499e6e05c509694f2308732af5dd9160ad1054d
 - type: maven
   filename: smallrye-common-constraint-2.13.9.jar
   attributes:
@@ -900,7 +900,7 @@ artifacts:
     artifact_id: smallrye-common-constraint
     version: 2.13.9
     type: jar
-  checksum: sha256:f7f05fa358758ad08a56bcfec06e08713d36cc0a8ecb47597cf606ae071cbcec
+  checksum: sha256:c75d6fcecb867480106ed16607f03930788838c4fd959d11e05a916e5eae3a01
 - type: maven
   filename: smallrye-mutiny-vertx-core-3.19.2.jar
   attributes:
@@ -909,7 +909,7 @@ artifacts:
     artifact_id: smallrye-mutiny-vertx-core
     version: 3.19.2
     type: jar
-  checksum: sha256:98c6ef0d36ce782a0e1d93c568c257f10e72c4e1efb5df5f3d75115b995913e6
+  checksum: sha256:a9c7ca81bd5bdb460da42cc493d256049dc15442aa281ef3fa967ae88ac5e439
 - type: maven
   filename: smallrye-mutiny-vertx-runtime-3.19.2.jar
   attributes:
@@ -918,7 +918,7 @@ artifacts:
     artifact_id: smallrye-mutiny-vertx-runtime
     version: 3.19.2
     type: jar
-  checksum: sha256:4abe91ae588d22cdb0c059a68a7974c359a9eb6acc3363650c25cf22e2aabbec
+  checksum: sha256:b637b9b14d05436d2a361c7dbaffe52e0eed66805abc9921c1be538fcb975f95
 - type: maven
   filename: vertx-mutiny-generator-3.19.2.jar
   attributes:
@@ -927,7 +927,7 @@ artifacts:
     artifact_id: vertx-mutiny-generator
     version: 3.19.2
     type: jar
-  checksum: sha256:b067f15e6354663f1be1351ba934e7d22c0a0e7ae94872fc55441cd35f5d759f
+  checksum: sha256:59572433c8a7c72ae6df51df47d02da68d42c849dff51319d8210e2fe81fd657
 - type: maven
   filename: vertx-codegen-4.5.21.jar
   attributes:
@@ -936,7 +936,7 @@ artifacts:
     artifact_id: vertx-codegen
     version: 4.5.21
     type: jar
-  checksum: sha256:e727058b6015f413ad9c53efe2f11bd88ef332e8dba81a62357bff3814af2dc2
+  checksum: sha256:4261a187ce6a16e57b405ac824e4ec3fe9dc139c6a65e07ee321b0c7163bcd80
 - type: maven
   filename: jakarta.annotation-api-3.0.0.jar
   attributes:
@@ -945,7 +945,7 @@ artifacts:
     artifact_id: jakarta.annotation-api
     version: 3.0.0
     type: jar
-  checksum: sha256:adb1f9488132ff92720053e89e93736f4abd5dea880e4aa99b13924cae6324bd
+  checksum: sha256:b01f55552284cfb149411e64eabca75e942d26d2e1786b32914250e4330afaa2
 - type: maven
   filename: failsafe-3.3.2.jar
   attributes:
@@ -954,7 +954,7 @@ artifacts:
     artifact_id: failsafe
     version: 3.3.2
     type: jar
-  checksum: sha256:9dc38e91736588a85cfb196db044d65cb8c256d6d0ebd5240ea8919b4ea73406
+  checksum: sha256:2c5dc879a6dac7ea3a7b29d795e27bd49b8e7908b05c2f3e56053c19d79850f5
 - type: maven
   filename: camel-quarkus-junit5-3.26.0.jar
   attributes:
@@ -963,7 +963,7 @@ artifacts:
     artifact_id: camel-quarkus-junit5
     version: 3.26.0
     type: jar
-  checksum: sha256:68fa1103a92c91b5ff0864ddf5eb159f2e50816faa4b4dbbe0407d1963440700
+  checksum: sha256:fe4e448d56bf913d9d49f4a1963fc6a8ade39adc9fac3f04276c0e5bef65ee72
 - type: maven
   filename: quarkus-junit5-3.26.4.jar
   attributes:
@@ -972,7 +972,7 @@ artifacts:
     artifact_id: quarkus-junit5
     version: 3.26.4
     type: jar
-  checksum: sha256:669f8eed18f142aa9029a666e3fce9a1ef7a26a4be634166cc1185a80e3759ad
+  checksum: sha256:b7c71170ceb0aa20565195e8e63ba5eb8354be91ac80cf0ea3b52523ee3d378b
 - type: maven
   filename: quarkus-bootstrap-core-3.26.4.jar
   attributes:
@@ -981,7 +981,7 @@ artifacts:
     artifact_id: quarkus-bootstrap-core
     version: 3.26.4
     type: jar
-  checksum: sha256:508580dd821174c469c0e182a526b196c1a640db7d19749eeaaad13993e2f094
+  checksum: sha256:e8468455369a2c8b745669842d988370a01a73e20b6a5f58224b1a46641f921f
 - type: maven
   filename: quarkus-classloader-commons-3.26.4.jar
   attributes:
@@ -990,7 +990,7 @@ artifacts:
     artifact_id: quarkus-classloader-commons
     version: 3.26.4
     type: jar
-  checksum: sha256:faa037a9f55d1b311dd69b26754905ba6eff2c0b2d495d7f8f8e5953924215bc
+  checksum: sha256:415e58f75efccc8ebcace7b49694c7f23ed44157f58fd8787c0af81a0f13539c
 - type: maven
   filename: quarkus-bootstrap-app-model-3.26.4.jar
   attributes:
@@ -999,7 +999,7 @@ artifacts:
     artifact_id: quarkus-bootstrap-app-model
     version: 3.26.4
     type: jar
-  checksum: sha256:edd5ef432e925458e1d538b99f94f39704bf500f81ce655ba6092a068e50b195
+  checksum: sha256:2f622ed447efcfb3da53adc0fd09d0ed81acc3eb5c9f19389c1aaac232e3b01c
 - type: maven
   filename: smallrye-common-io-2.13.9.jar
   attributes:
@@ -1008,7 +1008,7 @@ artifacts:
     artifact_id: smallrye-common-io
     version: 2.13.9
     type: jar
-  checksum: sha256:8cb2c5d4a36bc96b4713396f0271ea002d12bb310c0f04d182e5aadbacf2b0d6
+  checksum: sha256:6132512fa1c32ea63b9f0dacb5fb85f5d418f25b7087d88db6ed294560a888eb
 - type: maven
   filename: org.eclipse.sisu.inject-0.9.0.M4.jar
   attributes:
@@ -1017,7 +1017,7 @@ artifacts:
     artifact_id: org.eclipse.sisu.inject
     version: 0.9.0.M4
     type: jar
-  checksum: sha256:76bc3fedd0ee3e1aad783400db2f4e4abae810abcef1b62ee2d85ce5c528eada
+  checksum: sha256:1cbd7a965a5e2a9ea823bab311962a4e5aa5c240705bdbad5a52b40ffdfa1004
 - type: maven
   filename: quarkus-test-common-3.26.4.jar
   attributes:
@@ -1026,7 +1026,7 @@ artifacts:
     artifact_id: quarkus-test-common
     version: 3.26.4
     type: jar
-  checksum: sha256:b76619c49e9422f051ebad1cc9f838f21f21d2749c0549b30b4dd6f014ac0739
+  checksum: sha256:fe4329a55a1a985404a5b088712072d7340e86ca85a401e4596453ea3e9c98b8
 - type: maven
   filename: quarkus-bootstrap-maven-resolver-3.26.4.jar
   attributes:
@@ -1035,7 +1035,7 @@ artifacts:
     artifact_id: quarkus-bootstrap-maven-resolver
     version: 3.26.4
     type: jar
-  checksum: sha256:d76269a50e3b2c8ec62a01413f4e300dcc97cbd1cabbe442d19255e4858bbca2
+  checksum: sha256:6e28f230a60771c4c78df7d9c5a5c774f2ff877a05aad1b29eb13695dc22a300
 - type: maven
   filename: smallrye-beanbag-maven-1.5.3.jar
   attributes:
@@ -1044,7 +1044,7 @@ artifacts:
     artifact_id: smallrye-beanbag-maven
     version: 1.5.3
     type: jar
-  checksum: sha256:5147ad9358259f138b4bc82ea58b6f5f19d37ff035d75d578700c975cf624663
+  checksum: sha256:8cc96b5a16bd7d99d8a933b74626d2abe71b0b629ace250f6e95201bdb9a80c5
 - type: maven
   filename: smallrye-beanbag-sisu-1.5.3.jar
   attributes:
@@ -1053,7 +1053,7 @@ artifacts:
     artifact_id: smallrye-beanbag-sisu
     version: 1.5.3
     type: jar
-  checksum: sha256:b14d68b36e193001705b550d3d54d637488a0e4fa46b01558d16e708fc13223b
+  checksum: sha256:5b709a4e0e62ce613550f3c9edaf7b2663fa797d5312eda7491f6837cd2fefad
 - type: maven
   filename: smallrye-beanbag-1.5.3.jar
   attributes:
@@ -1062,7 +1062,7 @@ artifacts:
     artifact_id: smallrye-beanbag
     version: 1.5.3
     type: jar
-  checksum: sha256:ad77021ad5a61760f46dce15705dc2617a7672884df34131af2630e90d46e101
+  checksum: sha256:a98a1df267cdef1b7f305fbeacfa7d51e423fe2d02596314877196f5ce29a578
 - type: maven
   filename: javax.inject-1.jar
   attributes:
@@ -1071,7 +1071,7 @@ artifacts:
     artifact_id: javax.inject
     version: '1'
     type: jar
-  checksum: sha256:ec1c09078365e6bee74521346a1f0916e937518d00656cb217cb6f5aba87908f
+  checksum: sha256:91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff
 - type: maven
   filename: maven-artifact-3.9.9.jar
   attributes:
@@ -1080,7 +1080,7 @@ artifacts:
     artifact_id: maven-artifact
     version: 3.9.9
     type: jar
-  checksum: sha256:3e654f82badca361a741c4d25cc08a62582df2f139ec804e5b5cefa47d5b33f7
+  checksum: sha256:30f015d1c1a393e19c18cd4f43532089c36d4ca328608ce3dda78b74d3d31515
 - type: maven
   filename: maven-builder-support-3.9.9.jar
   attributes:
@@ -1089,7 +1089,7 @@ artifacts:
     artifact_id: maven-builder-support
     version: 3.9.9
     type: jar
-  checksum: sha256:0fa4cc10dbe1b712bd0153a6b6a3e07fa74e8944ff6ada510928c40bc0474ec7
+  checksum: sha256:2ca4a967bdd12a9e85d40e012374f86e63d4a1030c199da4832e3d0a1c6770d8
 - type: maven
   filename: maven-model-3.9.9.jar
   attributes:
@@ -1098,7 +1098,7 @@ artifacts:
     artifact_id: maven-model
     version: 3.9.9
     type: jar
-  checksum: sha256:e604f4c0144b353573262e99c7a7965810b41ed3dcc957d54d387973d853d5d9
+  checksum: sha256:8f59b0a16fe9c933be749a60ae0705a0cb337bb5abaf38801b40b740ff775727
 - type: maven
   filename: maven-model-builder-3.9.9.jar
   attributes:
@@ -1107,7 +1107,7 @@ artifacts:
     artifact_id: maven-model-builder
     version: 3.9.9
     type: jar
-  checksum: sha256:0cf6ce048264a6af05403a5aee15a1cede098905da201a8c77fc88fab48fa2de
+  checksum: sha256:a4377182ac2e5adfe16be3b3c81981a5ecddab014184de72ae1e522f04a77602
 - type: maven
   filename: maven-repository-metadata-3.9.9.jar
   attributes:
@@ -1116,7 +1116,7 @@ artifacts:
     artifact_id: maven-repository-metadata
     version: 3.9.9
     type: jar
-  checksum: sha256:f6d65daf0e3f13278162cfdb1bdd351a68d3ca674c22443bbd94bb16e174ed4b
+  checksum: sha256:137c297e6a52d489b76663c82324d54e40f5d498a8fc015c0203fd91df8623b0
 - type: maven
   filename: maven-settings-3.9.9.jar
   attributes:
@@ -1125,7 +1125,7 @@ artifacts:
     artifact_id: maven-settings
     version: 3.9.9
     type: jar
-  checksum: sha256:0033f173b58f33214eff5b7e5db9d19c23598b8ada08a5149e95b73ae5894309
+  checksum: sha256:68edf1b510e0d759ec501271a5d05e3a6e425462fbb84126c16e8a6f89abdada
 - type: maven
   filename: maven-resolver-api-1.9.22.jar
   attributes:
@@ -1134,7 +1134,7 @@ artifacts:
     artifact_id: maven-resolver-api
     version: 1.9.22
     type: jar
-  checksum: sha256:5fad5efc5340b99065969c94f74da056e8edb3d5108773de655a561c089763f8
+  checksum: sha256:63f5f665e44a09ef55463b3b91fda0b78ff07dd24b1060d56e79c10b6e32cbfb
 - type: maven
   filename: maven-resolver-impl-1.9.22.jar
   attributes:
@@ -1143,7 +1143,7 @@ artifacts:
     artifact_id: maven-resolver-impl
     version: 1.9.22
     type: jar
-  checksum: sha256:2412329bad5c568024294bfce8dd31c4b3d0498149f1ac6b8aeb71f2607bb688
+  checksum: sha256:e4dafb8acc13d736377c02d2170d869438dd74b98b860745909d238726babcbb
 - type: maven
   filename: maven-resolver-named-locks-1.9.22.jar
   attributes:
@@ -1152,7 +1152,7 @@ artifacts:
     artifact_id: maven-resolver-named-locks
     version: 1.9.22
     type: jar
-  checksum: sha256:c3ab36325b0657774cede0aec31911e857c32336dc99047c407165855c57eb0e
+  checksum: sha256:0685f29ec3b548d9b6917c527f13c667685a3394b955aaa5b25d0559818b7fc5
 - type: maven
   filename: maven-resolver-spi-1.9.22.jar
   attributes:
@@ -1161,7 +1161,7 @@ artifacts:
     artifact_id: maven-resolver-spi
     version: 1.9.22
     type: jar
-  checksum: sha256:d3d3a77c84cfe35c0d83239fc412d7717a4d4f2cf2c8ed3d18c6391b905c44d7
+  checksum: sha256:99ad721e4631d9bd0c4f9e29c869672577c66f2a674a5723ce38eff13c75cbfd
 - type: maven
   filename: maven-resolver-util-1.9.22.jar
   attributes:
@@ -1170,7 +1170,7 @@ artifacts:
     artifact_id: maven-resolver-util
     version: 1.9.22
     type: jar
-  checksum: sha256:db6ba4387dadce9c4559d99fed223a69eb3dbf17f581fce3c8bebf6eaa145f74
+  checksum: sha256:4aaea1584c39294ca926fc474723d9684473609ef4490c4eb169d6ea7daca6b5
 - type: maven
   filename: maven-resolver-transport-http-1.9.23.jar
   attributes:
@@ -1179,7 +1179,7 @@ artifacts:
     artifact_id: maven-resolver-transport-http
     version: 1.9.23
     type: jar
-  checksum: sha256:687087612eb94d6829e228cc913a2d581548171b2a4f17d9898a697b14cde185
+  checksum: sha256:7c4d762c4c604db5c8a9eeadd5c98b8f2e03556b853b48aa3346eb8cef67b54d
 - type: maven
   filename: wagon-provider-api-3.5.3.jar
   attributes:
@@ -1188,7 +1188,7 @@ artifacts:
     artifact_id: wagon-provider-api
     version: 3.5.3
     type: jar
-  checksum: sha256:92d3525c0c9e40e0a95c079cf44d369fd84df8a3537cd5e3ed8e7af308f19363
+  checksum: sha256:5e72000338945ed3e96f8e4f578d1d0672e1af7e19c0e9014197ae5b31af3ef4
 - type: maven
   filename: wagon-http-shared-3.5.3.jar
   attributes:
@@ -1197,7 +1197,7 @@ artifacts:
     artifact_id: wagon-http-shared
     version: 3.5.3
     type: jar
-  checksum: sha256:3d94b78aaeabede117f2469dad5cda2c08f063f577abe3862d5ad9ea39a2d0f1
+  checksum: sha256:8e7da766f55164fde8779aaaa125832506c2848cab4876b5305138873e28037f
 - type: maven
   filename: plexus-interpolation-1.26.jar
   attributes:
@@ -1206,7 +1206,7 @@ artifacts:
     artifact_id: plexus-interpolation
     version: '1.26'
     type: jar
-  checksum: sha256:37d76529cd49645e5190cb4b723f33e5478a493703666f53b316cc8f3e910552
+  checksum: sha256:b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662
 - type: maven
   filename: plexus-utils-3.5.1.jar
   attributes:
@@ -1215,7 +1215,7 @@ artifacts:
     artifact_id: plexus-utils
     version: 3.5.1
     type: jar
-  checksum: sha256:f827ac02a4dc0f8d291558f370ba0cf18c85e564cfe23b852d69233db3cc51ba
+  checksum: sha256:86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b
 - type: maven
   filename: plexus-xml-4.0.2.jar
   attributes:
@@ -1224,7 +1224,7 @@ artifacts:
     artifact_id: plexus-xml
     version: 4.0.2
     type: jar
-  checksum: sha256:77c9f1133c86d6eeeef2b555b7f5a7101862ce071ffb0ce5ad798cfbfe136952
+  checksum: sha256:e55f26425ad1ce948e4fca7b0fde5ecc9b0ba90d326c6ecc25a8e0e56ccfb6fd
 - type: maven
   filename: maven-xml-impl-4.0.0-alpha-7.jar
   attributes:
@@ -1233,7 +1233,7 @@ artifacts:
     artifact_id: maven-xml-impl
     version: 4.0.0-alpha-7
     type: jar
-  checksum: sha256:592be20db238f22c0e8e706511de77a300fa034bfb010639db44ba68de3ce76a
+  checksum: sha256:c89323b70dd491a3ef21432dba4cad2b74e26caaafd77178b0f15313fe0bd5f0
 - type: maven
   filename: maven-api-xml-4.0.0-alpha-7.jar
   attributes:
@@ -1242,7 +1242,7 @@ artifacts:
     artifact_id: maven-api-xml
     version: 4.0.0-alpha-7
     type: jar
-  checksum: sha256:420060185f08528e9b5939e425a1fc1c5e2fcd412d6df58d697fe9edc2c00e70
+  checksum: sha256:3388f4d0465f5a7e9a6264baf506da1b052c51f7cc10b7ce73f09723e6cf1d92
 - type: maven
   filename: maven-api-meta-4.0.0-alpha-7.jar
   attributes:
@@ -1251,7 +1251,7 @@ artifacts:
     artifact_id: maven-api-meta
     version: 4.0.0-alpha-7
     type: jar
-  checksum: sha256:7dbc8aef4b262441b07ba75666a6fc94b2b3f3b5a1f4c6dc6b306ecdc8898168
+  checksum: sha256:c4f6f3868f5b280cc7e268f0f95e1bb1d2a824afe92a8029e861be7ec48b1272
 - type: maven
   filename: plexus-cipher-2.0.jar
   attributes:
@@ -1260,7 +1260,7 @@ artifacts:
     artifact_id: plexus-cipher
     version: '2.0'
     type: jar
-  checksum: sha256:d7f88bed366f899e5fa522e8904b54ff28449f455cf3b1a3354be6c1e2905d60
+  checksum: sha256:9a7f1b5c5a9effd61eadfd8731452a2f76a8e79111fac391ef75ea801bea203a
 - type: maven
   filename: plexus-sec-dispatcher-2.0.jar
   attributes:
@@ -1269,7 +1269,7 @@ artifacts:
     artifact_id: plexus-sec-dispatcher
     version: '2.0'
     type: jar
-  checksum: sha256:6bbb7d9c403f8badc15c4f0371a7a1cd5b17d82e655bc69cda69fdeba46e9830
+  checksum: sha256:873139960c4c780176dda580b003a2c4bf82188bdce5bb99234e224ef7acfceb
 - type: maven
   filename: quarkus-bootstrap-maven4-resolver-3.26.4.jar
   attributes:
@@ -1278,7 +1278,7 @@ artifacts:
     artifact_id: quarkus-bootstrap-maven4-resolver
     version: 3.26.4
     type: jar
-  checksum: sha256:28824a2dd61ec3603da06371396122415d20f8b8278d07cb198a1b8cb8390113
+  checksum: sha256:bac70d6575c134600a1e19989bafecc42568f7bc2c10f1482239e5caad9d9640
 - type: maven
   filename: maven-embedder-3.9.9.jar
   attributes:
@@ -1287,7 +1287,7 @@ artifacts:
     artifact_id: maven-embedder
     version: 3.9.9
     type: jar
-  checksum: sha256:9d43b52004d6a33480330de8df0f5a1b59cc5f130f176e596ec2f5ae2523a34e
+  checksum: sha256:2093565e8225ebebcdc0227ad0c56d3e87c892def87b5831dd1757a0eee65974
 - type: maven
   filename: maven-core-3.9.9.jar
   attributes:
@@ -1296,7 +1296,7 @@ artifacts:
     artifact_id: maven-core
     version: 3.9.9
     type: jar
-  checksum: sha256:96f7cc2a1e807a9f22a56432371c4ec7b5a9ccd094ef640745c79b752c2b38a8
+  checksum: sha256:7fab37fc6044f20ae004376ab8414373636cf51e26ad0b1efa6b3f1cd2bec503
 - type: maven
   filename: plexus-component-annotations-2.1.0.jar
   attributes:
@@ -1305,7 +1305,7 @@ artifacts:
     artifact_id: plexus-component-annotations
     version: 2.1.0
     type: jar
-  checksum: sha256:0221fa6eecf3f22f70bc4789a437e8971a37285d40af43ab0be0a69dc2fecba8
+  checksum: sha256:bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac
 - type: maven
   filename: maven-plugin-api-3.9.9.jar
   attributes:
@@ -1314,7 +1314,7 @@ artifacts:
     artifact_id: maven-plugin-api
     version: 3.9.9
     type: jar
-  checksum: sha256:b26c25ef1e18539c4d68f30fffd2381e79a5e475319da55e519be3dd2a457ffe
+  checksum: sha256:2b491d38db45b0e8eef522e8f7889a3366e546e58b376b07fcb56e34c424e932
 - type: maven
   filename: maven-shared-utils-3.4.2.jar
   attributes:
@@ -1323,7 +1323,7 @@ artifacts:
     artifact_id: maven-shared-utils
     version: 3.4.2
     type: jar
-  checksum: sha256:69385724f6abd9fa62f8e0f2c087f2e0df608585b8c955aeefdbcc3f6b5e4c12
+  checksum: sha256:b613357e1bad4dfc1dead801691c9460f9585fe7c6b466bc25186212d7d18487
 - type: maven
   filename: guice-5.1.0.jar
   attributes:
@@ -1332,7 +1332,7 @@ artifacts:
     artifact_id: guice
     version: 5.1.0
     type: jar
-  checksum: sha256:823580432156351b7688d58194c4ff000f9e1d808b20441f91c4c77a370286d3
+  checksum: sha256:4130e50bfac48099c860f0d903b91860c81a249c90f38245f8fed58fc817bc26
 - type: maven
   filename: aopalliance-1.0.jar
   attributes:
@@ -1341,7 +1341,7 @@ artifacts:
     artifact_id: aopalliance
     version: '1.0'
     type: jar
-  checksum: sha256:0e26e161ee03141cfadfd4eec6285eccc621a4877722bfb09a4ec2958e4dcf57
+  checksum: sha256:0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08
 - type: maven
   filename: guava-33.4.8-jre.jar
   attributes:
@@ -1350,7 +1350,7 @@ artifacts:
     artifact_id: guava
     version: 33.4.8-jre
     type: jar
-  checksum: sha256:0eb79503e1b485f929197441c7ac2c9cd23d49b4b3f2193ea8dc25e414e08ae3
+  checksum: sha256:f3d7f57f67fd622f4d468dfdd692b3a5e3909246c28017ac3263405f0fe617ed
 - type: maven
   filename: failureaccess-1.0.1.jar
   attributes:
@@ -1359,7 +1359,7 @@ artifacts:
     artifact_id: failureaccess
     version: 1.0.1
     type: jar
-  checksum: sha256:5712602179e2fd80579c2335abf044276be7ce38bd086bcf4c56b18966df6a2d
+  checksum: sha256:a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26
 - type: maven
   filename: javax.annotation-api-1.3.2.jar
   attributes:
@@ -1368,7 +1368,7 @@ artifacts:
     artifact_id: javax.annotation-api
     version: 1.3.2
     type: jar
-  checksum: sha256:555c559969eed438a8b5ee0143bd5a8637970857cc1ecb19d7ff68c54995cd2d
+  checksum: sha256:e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b
 - type: maven
   filename: plexus-classworlds-2.6.0.jar
   attributes:
@@ -1377,7 +1377,7 @@ artifacts:
     artifact_id: plexus-classworlds
     version: 2.6.0
     type: jar
-  checksum: sha256:0d458f6ef51992b68f3f67bcd2867f6231135e0ed885a94bd48e5c36d480a9b7
+  checksum: sha256:52f77c5ec49f787c9c417ebed5d6efd9922f44a202f217376e4f94c0d74f3549
 - type: maven
   filename: commons-cli-1.8.0.jar
   attributes:
@@ -1386,7 +1386,7 @@ artifacts:
     artifact_id: commons-cli
     version: 1.8.0
     type: jar
-  checksum: sha256:de6dade1e3bc60128e65418a05efff4d4e9fc0eb721fc98a6b34c4d5da107958
+  checksum: sha256:f94c98bbcfa1c1dac6956d6c3f494ec40265c67bf54ddefc95df4ffdd73ae6d5
 - type: maven
   filename: org.eclipse.sisu.plexus-0.9.0.M4.jar
   attributes:
@@ -1395,7 +1395,7 @@ artifacts:
     artifact_id: org.eclipse.sisu.plexus
     version: 0.9.0.M4
     type: jar
-  checksum: sha256:06ceac79802bb65309a8a6a3ae76554252e80e33e948e2bc1548292f1296f0f0
+  checksum: sha256:b90579bc652eac7331436e0a25533fce14130b9c6e015f2dd3a3d4bb07e942b7
 - type: maven
   filename: maven-settings-builder-3.9.9.jar
   attributes:
@@ -1404,7 +1404,7 @@ artifacts:
     artifact_id: maven-settings-builder
     version: 3.9.9
     type: jar
-  checksum: sha256:de43f1ac2f39ff4a6d7c9212e60c185a27c2e6a0a41ed9e935aafaf3799e2bc4
+  checksum: sha256:094640f3fdce47250cb06968a143f40c4e2f1c22be979c73caac2f49f3c38373
 - type: maven
   filename: maven-resolver-provider-3.9.9.jar
   attributes:
@@ -1413,7 +1413,7 @@ artifacts:
     artifact_id: maven-resolver-provider
     version: 3.9.9
     type: jar
-  checksum: sha256:6b9e04898c83ffdb9969e6ddfb7fe52fdb3e7198731d8a5b31daa25190751d19
+  checksum: sha256:5dea05049c94f952f48ce2bfe0111afdf986acc591fcc11d23fe3b8dcb70291e
 - type: maven
   filename: maven-resolver-connector-basic-1.9.22.jar
   attributes:
@@ -1422,7 +1422,7 @@ artifacts:
     artifact_id: maven-resolver-connector-basic
     version: 1.9.22
     type: jar
-  checksum: sha256:675d64f8f83ff9b94b5e52450dd39002633931a8cd6b2cab23a6038ca47afacb
+  checksum: sha256:4ab68bdec97eec318b2a3bd27e7c954e316f890df92d544b68afd0bf666c9588
 - type: maven
   filename: maven-resolver-transport-wagon-1.9.22.jar
   attributes:
@@ -1431,7 +1431,7 @@ artifacts:
     artifact_id: maven-resolver-transport-wagon
     version: 1.9.22
     type: jar
-  checksum: sha256:cd1c3d6a6c6a5b85bc748fe94b67de9bed9bf2c230aaf52eddc90d1820110d99
+  checksum: sha256:241e9d88d1d3ae242b0b7fe6ea822260590d7ad905bff1872138fbcde79cb21a
 - type: maven
   filename: wagon-http-3.5.3.jar
   attributes:
@@ -1440,7 +1440,7 @@ artifacts:
     artifact_id: wagon-http
     version: 3.5.3
     type: jar
-  checksum: sha256:af69dbfe06600cc0665a521125999fc710df675f8f429fc5d984837140ecf52a
+  checksum: sha256:d2b6e48c9fcbe579e1858c622d14464011ff265fa6e28e794004a6882154a509
 - type: maven
   filename: wagon-file-3.5.3.jar
   attributes:
@@ -1449,7 +1449,7 @@ artifacts:
     artifact_id: wagon-file
     version: 3.5.3
     type: jar
-  checksum: sha256:6555fb2589872a346588259868988f693b42d13c891ebc2fe6428aa084ae54c8
+  checksum: sha256:afc9216fa97b78dad227b4a8d4d67b9897bf113a57f80598d62993841113e103
 - type: maven
   filename: quarkus-bootstrap-gradle-resolver-3.26.4.jar
   attributes:
@@ -1458,7 +1458,7 @@ artifacts:
     artifact_id: quarkus-bootstrap-gradle-resolver
     version: 3.26.4
     type: jar
-  checksum: sha256:330c31c7587b9682e6fe8fb46eb83569d033839cc02b8174afec85dfd3f0029f
+  checksum: sha256:2caebc6fa88209ef396f4211a92200083f3ae118702886457523091b52df8194
 - type: maven
   filename: commons-io-2.20.0.jar
   attributes:
@@ -1467,7 +1467,7 @@ artifacts:
     artifact_id: commons-io
     version: 2.20.0
     type: jar
-  checksum: sha256:7e8d1d438d814afc84229e84f271b09ea2a84d6496d58d7473f3fe431e341bd8
+  checksum: sha256:df90bba0fe3cb586b7f164e78fe8f8f4da3f2dd5c27fa645f888100ccc25dd72
 - type: maven
   filename: quarkus-junit5-config-3.26.4.jar
   attributes:
@@ -1476,7 +1476,7 @@ artifacts:
     artifact_id: quarkus-junit5-config
     version: 3.26.4
     type: jar
-  checksum: sha256:2f609282c403dda4290f43b918213d1e5380adba9b40865c9ce393bc0849c3f9
+  checksum: sha256:5cc8bfae41feceb8ae1f26713122990f9b005b14acf1a55c1a543da11ac96a65
 - type: maven
   filename: junit-jupiter-5.13.4.jar
   attributes:
@@ -1485,7 +1485,7 @@ artifacts:
     artifact_id: junit-jupiter
     version: 5.13.4
     type: jar
-  checksum: sha256:2ecc26d18b9bb22e95072fb3e1212c71721f9fd011ac2719077c6f30ea98d163
+  checksum: sha256:b960f79217dd01c863031b678f07df4730bbf1eac650c74ad6b0c61faad78379
 - type: maven
   filename: camel-quarkus-core-3.26.0.jar
   attributes:
@@ -1494,7 +1494,7 @@ artifacts:
     artifact_id: camel-quarkus-core
     version: 3.26.0
     type: jar
-  checksum: sha256:8df747bae77b56c5647fa2b8916ee9027a856a7db00f15d31667358f207c4897
+  checksum: sha256:48fce70dfe188bb5250e95919d98c0c85fa891cd7a916a69031b3b10fa8857ae
 - type: maven
   filename: quarkus-development-mode-spi-3.26.4.jar
   attributes:
@@ -1503,7 +1503,7 @@ artifacts:
     artifact_id: quarkus-development-mode-spi
     version: 3.26.4
     type: jar
-  checksum: sha256:1cf9830dd9242e8abf0aeed7d37c532a688b3f4723092eb1dd46a6f038533874
+  checksum: sha256:29352ca4444805da0c652df2986e5088c3e3ce83007ef30759fa04dd8a4b05de
 - type: maven
   filename: camel-base-4.14.0.jar
   attributes:
@@ -1512,7 +1512,7 @@ artifacts:
     artifact_id: camel-base
     version: 4.14.0
     type: jar
-  checksum: sha256:70891e5f7cbfa5580718808a488d5aa5d6d7e2636c813079e8109f672ec50c26
+  checksum: sha256:a10a138e9a47de678e93ec84f072ab73383da2083ea8dc9678d1279ca0c0090e
 - type: maven
   filename: camel-api-4.14.0.jar
   attributes:
@@ -1521,7 +1521,7 @@ artifacts:
     artifact_id: camel-api
     version: 4.14.0
     type: jar
-  checksum: sha256:b404577efeffba5264e6a5c3ede6d7fcfc0eac67044c667b6e45a6d1ca6ea6d1
+  checksum: sha256:81e4cd8d655627b593f3a5061a273a56265173edc85880247bf1289c8f88c783
 - type: maven
   filename: camel-management-api-4.14.0.jar
   attributes:
@@ -1530,7 +1530,7 @@ artifacts:
     artifact_id: camel-management-api
     version: 4.14.0
     type: jar
-  checksum: sha256:61e9a68037b002759f0669d9ee0c9782c911732b9ba3a8ff2ea8d1f0a563d2b1
+  checksum: sha256:1d8ab85d9bc9e19136556b87fccf10da6ebe23bfacea479ba0844f578b691e6b
 - type: maven
   filename: camel-support-4.14.0.jar
   attributes:
@@ -1539,7 +1539,7 @@ artifacts:
     artifact_id: camel-support
     version: 4.14.0
     type: jar
-  checksum: sha256:4e45480a1653144fc8a8ea0ba9632925c8d569fb04508cc68f4078d262c177eb
+  checksum: sha256:6d4db7c0de36d7d2f3971b828f5b0ebc1f0c6b4723da02ea074ea09f7d118b47
 - type: maven
   filename: camel-util-4.14.0.jar
   attributes:
@@ -1548,7 +1548,7 @@ artifacts:
     artifact_id: camel-util
     version: 4.14.0
     type: jar
-  checksum: sha256:bba80508ed43b1ad4fe8e0441f6ade70aeae043e50bf80868f10797702d166c7
+  checksum: sha256:e4af208aec5d13f126c1177c7ba31ffdc7945ad2cf6d6150ab520ba86335ac49
 - type: maven
   filename: camel-componentdsl-4.14.0.jar
   attributes:
@@ -1557,7 +1557,7 @@ artifacts:
     artifact_id: camel-componentdsl
     version: 4.14.0
     type: jar
-  checksum: sha256:c42147e6a0db1fe6e1160c2c48ee6343772c87549fbdc027a352598f71d54a76
+  checksum: sha256:132adda3e51957c3271c0388c7c52e823a4f85979f4915db1c2b7bf512c25eb4
 - type: maven
   filename: camel-core-catalog-4.14.0.jar
   attributes:
@@ -1566,7 +1566,7 @@ artifacts:
     artifact_id: camel-core-catalog
     version: 4.14.0
     type: jar
-  checksum: sha256:8eda724642fdde3d4d0439162a3cb000d2ca555b76d490b4fbe5352ccf62c757
+  checksum: sha256:4816848f9ce9120454f0838ff383b5a83425f8964abd9d4bf37eacbbefdfedac
 - type: maven
   filename: camel-tooling-model-4.14.0.jar
   attributes:
@@ -1575,7 +1575,7 @@ artifacts:
     artifact_id: camel-tooling-model
     version: 4.14.0
     type: jar
-  checksum: sha256:5a8fe1ef4c8fc24c6abbd0840f0a36a4857872d779e4b61c7757f402fde87304
+  checksum: sha256:33ea4430c4d539f1933adf0047fba8285f3cfda3a099b17a98b2df3fe4cc3ea3
 - type: maven
   filename: camel-core-engine-4.14.0.jar
   attributes:
@@ -1584,7 +1584,7 @@ artifacts:
     artifact_id: camel-core-engine
     version: 4.14.0
     type: jar
-  checksum: sha256:c447e16d6f1bd0e6e3dc944122099f4057ea50d9603b082294746544aeceef30
+  checksum: sha256:68737a5eb8613cc74f18aaa826efa5ebf051606869ae84538aa116d8782f2191
 - type: maven
   filename: camel-base-engine-4.14.0.jar
   attributes:
@@ -1593,7 +1593,7 @@ artifacts:
     artifact_id: camel-base-engine
     version: 4.14.0
     type: jar
-  checksum: sha256:a5511343716c154e333ce4589e2b6328ac6e69b00a8a87474e6a0fd91311781a
+  checksum: sha256:334591c84b71029728b8a2a49aaa7d2e5f240bf18dbbff299563975801e241ec
 - type: maven
   filename: camel-core-reifier-4.14.0.jar
   attributes:
@@ -1602,7 +1602,7 @@ artifacts:
     artifact_id: camel-core-reifier
     version: 4.14.0
     type: jar
-  checksum: sha256:90b0878c62ee21a77011592a91f441cb9c911f3f3cc2a67c8130b034906179f4
+  checksum: sha256:5bde4f1d9603437e4e37d4bfb156b871f0e2f399f533c03b5d39e2b8a9c3dc71
 - type: maven
   filename: camel-core-languages-4.14.0.jar
   attributes:
@@ -1611,7 +1611,7 @@ artifacts:
     artifact_id: camel-core-languages
     version: 4.14.0
     type: jar
-  checksum: sha256:a29475cde62ff60ca89af409ddbfc7d98426f15cf0b2c4b5bd2a0ee337211e06
+  checksum: sha256:88759ddd872cb7014d5b5e2cfd55c2718751a3cbdfb0adb0867022901febd37b
 - type: maven
   filename: camel-core-model-4.14.0.jar
   attributes:
@@ -1620,7 +1620,7 @@ artifacts:
     artifact_id: camel-core-model
     version: 4.14.0
     type: jar
-  checksum: sha256:5b8c419ae726734528ceb3509b2b95cfc0cf89390023748bf56748285b00e69f
+  checksum: sha256:2bf2a118410803a92c0c8e7dc7201ff6ff49423268ab0bc354f69576ccfc7a9f
 - type: maven
   filename: camel-xml-jaxp-util-4.14.0.jar
   attributes:
@@ -1629,7 +1629,7 @@ artifacts:
     artifact_id: camel-xml-jaxp-util
     version: 4.14.0
     type: jar
-  checksum: sha256:cd07f37c7723aa2a7a6af4ed84ed37c4585ee115d8bcdc28a422d3805d75d8cb
+  checksum: sha256:65874996e1ba7ad046f4c3cb1edf5fa87aedf0df8db092067f5c65be9d925a9b
 - type: maven
   filename: camel-core-processor-4.14.0.jar
   attributes:
@@ -1638,7 +1638,7 @@ artifacts:
     artifact_id: camel-core-processor
     version: 4.14.0
     type: jar
-  checksum: sha256:b5e5546bf80a447fb50ebe8c7d53bc9df1b22ae5d7dc0a2071974d28ab49df1b
+  checksum: sha256:1e7a717ddeb56fbb73ce1f44bc2ea7e79fee3ede528d6fbb95549a5bc727ada3
 - type: maven
   filename: camel-endpointdsl-4.14.0.jar
   attributes:
@@ -1647,7 +1647,7 @@ artifacts:
     artifact_id: camel-endpointdsl
     version: 4.14.0
     type: jar
-  checksum: sha256:79d62524619d682cf9e33c16d4276f479f296852af2151b913703a1596b64fb4
+  checksum: sha256:27651b115e6ec2d032dfc2924a63f8839d66a38f8104bf8ea47001656fbbab38
 - type: maven
   filename: camel-main-4.14.0.jar
   attributes:
@@ -1656,7 +1656,7 @@ artifacts:
     artifact_id: camel-main
     version: 4.14.0
     type: jar
-  checksum: sha256:b6fc9f2a4c30d10d6ea5242c5d99546ef1fec8a428bdd7fb0d4d374f2811475d
+  checksum: sha256:61ae8ca66ab167806f2dd599dad650a4a0ef9999bb6338be65745754ccbbe898
 - type: maven
   filename: camel-microprofile-config-4.14.0.jar
   attributes:
@@ -1665,7 +1665,7 @@ artifacts:
     artifact_id: camel-microprofile-config
     version: 4.14.0
     type: jar
-  checksum: sha256:882a67715402ee242cc33b5b2229a91e81fe6a1d3f94ab6aa5e1e7caf2e180b5
+  checksum: sha256:08cf06396dcf6869d799ce97612e4149634baaa790fd19ba257d6e5c6df15f65
 - type: maven
   filename: camel-test-junit5-4.14.0.jar
   attributes:
@@ -1674,7 +1674,7 @@ artifacts:
     artifact_id: camel-test-junit5
     version: 4.14.0
     type: jar
-  checksum: sha256:4d611b8504290ebd9b1c715344da8e626f4de2eaee26fdf2b10032f405aa7505
+  checksum: sha256:af29ab3fa996eb7af44cc82733462460f596bf41c3ffe15e49c7a5a74ad524f6
 - type: maven
   filename: camel-bean-4.14.0.jar
   attributes:
@@ -1683,7 +1683,7 @@ artifacts:
     artifact_id: camel-bean
     version: 4.14.0
     type: jar
-  checksum: sha256:504b90dc2c1f0f1b4c6a065c21eb7d8030e5eda2edbe8e6b584a175ce72e963a
+  checksum: sha256:9da737a75bd90ed6a73c7364c1588fc108a5b823c28834f72e54357f5440413c
 - type: maven
   filename: camel-browse-4.14.0.jar
   attributes:
@@ -1692,7 +1692,7 @@ artifacts:
     artifact_id: camel-browse
     version: 4.14.0
     type: jar
-  checksum: sha256:d20ce23114fd8129d2923b17d711018830dba68473003b88721b49bca3cdeec6
+  checksum: sha256:b7b7335b0d1a6160cabc357b64c5322c6d35e3d5f618fbf7086f942256d8debd
 - type: maven
   filename: camel-controlbus-4.14.0.jar
   attributes:
@@ -1701,7 +1701,7 @@ artifacts:
     artifact_id: camel-controlbus
     version: 4.14.0
     type: jar
-  checksum: sha256:764f36ef93d7e40383ac98293b7af0f7f8d176c4712b8281170c979ef07eb018
+  checksum: sha256:9f948a1520be2edbdd47c84c45c30403f069f042a50d399b3a35a86e3d5b81d8
 - type: maven
   filename: camel-dataformat-4.14.0.jar
   attributes:
@@ -1710,7 +1710,7 @@ artifacts:
     artifact_id: camel-dataformat
     version: 4.14.0
     type: jar
-  checksum: sha256:d47d865d81d2a554a435e93ac4bddc8d08b80bba7aab15a27484651a037da216
+  checksum: sha256:b30a2a06611873918a5ce767dfe685f211ee01707c60f7a5af389e27e5e7853c
 - type: maven
   filename: camel-dataset-4.14.0.jar
   attributes:
@@ -1719,7 +1719,7 @@ artifacts:
     artifact_id: camel-dataset
     version: 4.14.0
     type: jar
-  checksum: sha256:ba213b3015b716b698209a9d873e2cb0a630a62f2ff5e00110713919075b1f98
+  checksum: sha256:c3fd942ef858a48390b3c8dcd572101bb431a79eeef7748c0d4a14d28a2b8185
 - type: maven
   filename: camel-direct-4.14.0.jar
   attributes:
@@ -1728,7 +1728,7 @@ artifacts:
     artifact_id: camel-direct
     version: 4.14.0
     type: jar
-  checksum: sha256:d19db6be610283f0efc76af9a3fa01765fe4c5cd2770083a325edd81fa04499b
+  checksum: sha256:301888249888f6e4cd56adaec3441dbaf6a79f71679117e0aae84b3ee27d30ab
 - type: maven
   filename: camel-file-4.14.0.jar
   attributes:
@@ -1737,7 +1737,7 @@ artifacts:
     artifact_id: camel-file
     version: 4.14.0
     type: jar
-  checksum: sha256:813a26dd9dd950f0f93952e25271de486a57775d7d7d1c75a9316c6436c53a09
+  checksum: sha256:c88e700f17e2b6830840a7937ed015d2b0eb3306a58468cb15b406f511c9623d
 - type: maven
   filename: camel-cluster-4.14.0.jar
   attributes:
@@ -1746,7 +1746,7 @@ artifacts:
     artifact_id: camel-cluster
     version: 4.14.0
     type: jar
-  checksum: sha256:d23122f8ff39e7aa0ae17a6a260aaa031526e9732255442f4b86337645263bc2
+  checksum: sha256:ea61aa601e61369e97846eedcf5064e2f6ade47b67597c3a937df2d74db7e552
 - type: maven
   filename: commons-codec-1.19.0.jar
   attributes:
@@ -1755,7 +1755,7 @@ artifacts:
     artifact_id: commons-codec
     version: 1.19.0
     type: jar
-  checksum: sha256:ca01f159884aea96b64a414b618b4c23b4b763efb72d56534413d8726ce1fed1
+  checksum: sha256:5c3881e4f556855e9c532927ee0c9dfde94cc66760d5805c031a59887070af5f
 - type: maven
   filename: camel-language-4.14.0.jar
   attributes:
@@ -1764,7 +1764,7 @@ artifacts:
     artifact_id: camel-language
     version: 4.14.0
     type: jar
-  checksum: sha256:c43cb8e1baf90991abef8978f3f9c161ff69f3e018c5156174ee287e612617db
+  checksum: sha256:5166b61e455f6cb83bfc7834588c23e6ced2d85307348c4a576d2d08da35547f
 - type: maven
   filename: camel-log-4.14.0.jar
   attributes:
@@ -1773,7 +1773,7 @@ artifacts:
     artifact_id: camel-log
     version: 4.14.0
     type: jar
-  checksum: sha256:d5d084f260f664b2cec4e500499ba398e63d0dc11f19df668ab3236865e6f1f2
+  checksum: sha256:bf23b8ea91b0864b9c6c9fce48413dc970de8058f42c9fa88d108dc31999dc03
 - type: maven
   filename: camel-mock-4.14.0.jar
   attributes:
@@ -1782,7 +1782,7 @@ artifacts:
     artifact_id: camel-mock
     version: 4.14.0
     type: jar
-  checksum: sha256:e07a5df66340a563b8909231c59e2a61e2e8fd0f87aa4814d7efbaa42bbdcc0d
+  checksum: sha256:657a0f5ad1aa4b4a3a0749b5fa9093396c1e06a95099dbfdddc4cb3bc32ffcb9
 - type: maven
   filename: camel-ref-4.14.0.jar
   attributes:
@@ -1791,7 +1791,7 @@ artifacts:
     artifact_id: camel-ref
     version: 4.14.0
     type: jar
-  checksum: sha256:3661b83be086501bed5f83c45a7e2135ecb65938b93264b6cdf56c534739b822
+  checksum: sha256:a7637f6c015a3457bc1dc540457b04850d82d009a1013736b862b756e10df65a
 - type: maven
   filename: camel-rest-4.14.0.jar
   attributes:
@@ -1800,7 +1800,7 @@ artifacts:
     artifact_id: camel-rest
     version: 4.14.0
     type: jar
-  checksum: sha256:d90829ca383fe373adde88c266bd956e93226981b2194872695ffb35f79f2b01
+  checksum: sha256:e69d105b44a4a84096a7b2d661331abc0f652ccc41bb894301becc42a87849dc
 - type: maven
   filename: camel-saga-4.14.0.jar
   attributes:
@@ -1809,7 +1809,7 @@ artifacts:
     artifact_id: camel-saga
     version: 4.14.0
     type: jar
-  checksum: sha256:5d0f84687a70276a78a66d8a64d21180a0bf12047e3cd0a68c5125a56290f4f5
+  checksum: sha256:5286e45a820833fcaccdb84684273a0c1bcc57ff5b00457b20c762436c0bc4be
 - type: maven
   filename: camel-scheduler-4.14.0.jar
   attributes:
@@ -1818,7 +1818,7 @@ artifacts:
     artifact_id: camel-scheduler
     version: 4.14.0
     type: jar
-  checksum: sha256:397024c8b2f950b789ef1bdaa667ff71e14ec5668de451c6907f94c37ec57622
+  checksum: sha256:33ce00626d795633141e08768655afff45efc799d1a5bab8d1f2ebafcb991b9a
 - type: maven
   filename: camel-seda-4.14.0.jar
   attributes:
@@ -1827,7 +1827,7 @@ artifacts:
     artifact_id: camel-seda
     version: 4.14.0
     type: jar
-  checksum: sha256:eff1a777d1d9350cf5b02ded869d6111656105b265664444d6aecf0573325e75
+  checksum: sha256:d40167afd4422da327451922879d3c62ec6f83904efc93075002c06825632ee5
 - type: maven
   filename: camel-stub-4.14.0.jar
   attributes:
@@ -1836,7 +1836,7 @@ artifacts:
     artifact_id: camel-stub
     version: 4.14.0
     type: jar
-  checksum: sha256:2a37cd5bec7eb29745711b122cb1bdcea58ac1cb20b7726f1378618c8e6e1c8c
+  checksum: sha256:4b5b6bac4a578313f27bf31ac9db71c87961882dfc66461df94dd9e4b49df38e
 - type: maven
   filename: camel-timer-4.14.0.jar
   attributes:
@@ -1845,7 +1845,7 @@ artifacts:
     artifact_id: camel-timer
     version: 4.14.0
     type: jar
-  checksum: sha256:9449cf0173088456b7bb8e915626b456a2aab14c0e19b368297a082975df88d4
+  checksum: sha256:6dba49d9684a02cb15fb61f960e4f41a5594a3d787fcddd872348eea2e71c66c
 - type: maven
   filename: camel-validator-4.14.0.jar
   attributes:
@@ -1854,7 +1854,7 @@ artifacts:
     artifact_id: camel-validator
     version: 4.14.0
     type: jar
-  checksum: sha256:84f3c22a4d0561594d5f7cc7a16877a5168f90aadad290af3864260669c4d07b
+  checksum: sha256:dcbdd3317fe6d69c8a1b70d2782e9dd778bd9374b405489792c8e9640aca1641
 - type: maven
   filename: camel-xml-jaxp-4.14.0.jar
   attributes:
@@ -1863,7 +1863,7 @@ artifacts:
     artifact_id: camel-xml-jaxp
     version: 4.14.0
     type: jar
-  checksum: sha256:abf7a9f26ff59ccf729b3abafa6f820752461d79bda990e7d03e8675a52d3fb3
+  checksum: sha256:429033e51bed8502a71e1af70837213fe1da47f222e4f171c351de9eaa6923ac
 - type: maven
   filename: camel-xml-io-util-4.14.0.jar
   attributes:
@@ -1872,7 +1872,7 @@ artifacts:
     artifact_id: camel-xml-io-util
     version: 4.14.0
     type: jar
-  checksum: sha256:481f450c30e963a21a5357e5f51d88648c82d4f04ca63861cdf628e2c345c066
+  checksum: sha256:d599f2da332b8566400901a173f3a2576406aba920e0d5181319533ca41c3dc2
 - type: maven
   filename: camel-xpath-4.14.0.jar
   attributes:
@@ -1881,7 +1881,7 @@ artifacts:
     artifact_id: camel-xpath
     version: 4.14.0
     type: jar
-  checksum: sha256:37faf129d1f8ba002f0746426de7df52e274f23f89089769f1f934c5b469a5da
+  checksum: sha256:219789edcf8869849cc68a6a8af42bb8438559c43c9d1c19d0c80aa2e4ffa446
 - type: maven
   filename: camel-xslt-4.14.0.jar
   attributes:
@@ -1890,7 +1890,7 @@ artifacts:
     artifact_id: camel-xslt
     version: 4.14.0
     type: jar
-  checksum: sha256:5aab4b30387f6d4ab768047979ec6f4ec0f9c1773e80c6b0c1f6f6cbafaa3c35
+  checksum: sha256:3c9f0e7fb7749994f656b56ba6d588f92666c30de1cc491f0f9ba1f812c55b03
 - type: maven
   filename: junit-jupiter-api-5.13.4.jar
   attributes:
@@ -1899,7 +1899,7 @@ artifacts:
     artifact_id: junit-jupiter-api
     version: 5.13.4
     type: jar
-  checksum: sha256:2e5cd081292e852734012b2a102f9e3ef823aa937cfa44d9b7bbf77cff70c122
+  checksum: sha256:d1bb81abfd9e03418306b4e6a3390c8db52c58372e749c2980ac29f0c08278f1
 - type: maven
   filename: opentest4j-1.3.0.jar
   attributes:
@@ -1908,7 +1908,7 @@ artifacts:
     artifact_id: opentest4j
     version: 1.3.0
     type: jar
-  checksum: sha256:7701c69bf433bf9fb132cb5e69b17f377ac3181e4c8979b5d3710a8864d947ba
+  checksum: sha256:48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b
 - type: maven
   filename: junit-platform-commons-1.13.4.jar
   attributes:
@@ -1917,7 +1917,7 @@ artifacts:
     artifact_id: junit-platform-commons
     version: 1.13.4
     type: jar
-  checksum: sha256:9986a9aff0328d4c64ee4cd9f6c5c2275624bb8ef23c84dd4a4dd5337f6a54d4
+  checksum: sha256:1c25ca641ebaae44ff3ad21ca1b2ef68d0dd84bfeb07c4805ba7840899b77408
 - type: maven
   filename: apiguardian-api-1.1.2.jar
   attributes:
@@ -1926,7 +1926,7 @@ artifacts:
     artifact_id: apiguardian-api
     version: 1.1.2
     type: jar
-  checksum: sha256:b2cdd163ebe760cb92147e499ebf65be392a8824298e690f959b1d4306a2b54a
+  checksum: sha256:b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38
 - type: maven
   filename: junit-jupiter-engine-5.13.4.jar
   attributes:
@@ -1935,7 +1935,7 @@ artifacts:
     artifact_id: junit-jupiter-engine
     version: 5.13.4
     type: jar
-  checksum: sha256:fc113a197642e766fcb0075a1e015e34b188a08cdf017e23f222ed9de35aa530
+  checksum: sha256:027404a92fe618b72465792a257951495c503a7d5751e2791e0f51c87f67f5bc
 - type: maven
   filename: junit-platform-engine-1.13.4.jar
   attributes:
@@ -1944,7 +1944,7 @@ artifacts:
     artifact_id: junit-platform-engine
     version: 1.13.4
     type: jar
-  checksum: sha256:be717997040d2072c6bf9fd89919a371c6fc7f1f29f1c6da31e1a6c8ba771d1e
+  checksum: sha256:390c5f77b84283a64b644f88251b397e0b0debb80bdcc50f899881aecff43a5a
 - type: maven
   filename: junit-jupiter-params-5.13.4.jar
   attributes:
@@ -1953,7 +1953,7 @@ artifacts:
     artifact_id: junit-jupiter-params
     version: 5.13.4
     type: jar
-  checksum: sha256:a2ebbd3cfdb9c156a9c9392b990a8eabd4718c51c58c5dca988743c676cdf3cd
+  checksum: sha256:3a8c6365716dbb698c0d49a05456c1e1ad05c406613c550f9dd50037872efc41
 - type: maven
   filename: mockserver-netty-no-dependencies-5.15.0.jar
   attributes:
@@ -1962,7 +1962,7 @@ artifacts:
     artifact_id: mockserver-netty-no-dependencies
     version: 5.15.0
     type: jar
-  checksum: sha256:4ac177b03d829ed35350b93bf79a60914dd46880cc06f556335ab0c95e1505da
+  checksum: sha256:866bd44bfda37a3dc7d95f89c3abb34175dab5014326cd74b3e03fd023eddebf
 - type: maven
   filename: json-schema-validator-1.5.9.jar
   attributes:
@@ -1971,7 +1971,7 @@ artifacts:
     artifact_id: json-schema-validator
     version: 1.5.9
     type: jar
-  checksum: sha256:340f5cd582df65f29aea7eb39e927013416882bd4f93ec2c3cf37657faeb9fd8
+  checksum: sha256:e0b8baeb78fd1ba027454ee3974d8a02f54447eaa510d3052820a7d2160d9ae4
 - type: maven
   filename: itu-1.14.0.jar
   attributes:
@@ -1980,7 +1980,7 @@ artifacts:
     artifact_id: itu
     version: 1.14.0
     type: jar
-  checksum: sha256:7e6507cd94410a7b9e75b61ddd1bfd0a60a6ca8f0b451e895ba193e1ada33f16
+  checksum: sha256:5cf40ab0cc77828ab2b875b1f3ecd71c8295d7721933476abc2e08fddcea164a
 - type: maven
   filename: jackson-databind-2.19.2.jar
   attributes:
@@ -1989,7 +1989,7 @@ artifacts:
     artifact_id: jackson-databind
     version: 2.19.2
     type: jar
-  checksum: sha256:e9a2dca72706bb86f0b5359c460a3cb8e48028132e4a799b6790b232d9a689f0
+  checksum: sha256:0a1bd4e9b0d670e632d40ee8c625ad376233502f03c2f5889baea95d025b47a7
 - type: maven
   filename: jackson-annotations-2.19.2.jar
   attributes:
@@ -1998,7 +1998,7 @@ artifacts:
     artifact_id: jackson-annotations
     version: 2.19.2
     type: jar
-  checksum: sha256:d0a5b356de397833b8d7feca968d0a32141bed14bdb019df6e300def385470e1
+  checksum: sha256:e516743a316dcf83c572ffc9cb6e8c5e8c134880c8c5155b02f7b34e9c5dc3cf
 - type: maven
   filename: jackson-dataformat-yaml-2.19.2.jar
   attributes:
@@ -2007,7 +2007,7 @@ artifacts:
     artifact_id: jackson-dataformat-yaml
     version: 2.19.2
     type: jar
-  checksum: sha256:1e2282ef6a6cf2be07651a3ac3652e7adb706ba3d4c3c30224c5c3e5b6551438
+  checksum: sha256:80a213e7d998244922ab7bcf0938ea03eb7868e88e2d05a8407c6228c885a37e
 - type: maven
   filename: snakeyaml-2.4.jar
   attributes:
@@ -2016,7 +2016,7 @@ artifacts:
     artifact_id: snakeyaml
     version: '2.4'
     type: jar
-  checksum: sha256:0af1fceb0feb93c31ea14eb2052a9109566cd34f97703f6cb2d163c315437c2c
+  checksum: sha256:ef779af5d29a9dde8cc70ce0341f5c6f7735e23edff9685ceaa9d35359b7bb7f
 - type: maven
   filename: slf4j-api-2.0.17.jar
   attributes:
@@ -2025,7 +2025,7 @@ artifacts:
     artifact_id: slf4j-api
     version: 2.0.17
     type: jar
-  checksum: sha256:156a204298f1630fef0901ab5d18c2ecbf451866e54896437de3df06d512a8c9
+  checksum: sha256:7b751d952061954d5abfed7181c1f645d336091b679891591d63329c622eb832
 - type: maven
   filename: quarkus-junit5-mockito-3.26.4.jar
   attributes:
@@ -2034,7 +2034,7 @@ artifacts:
     artifact_id: quarkus-junit5-mockito
     version: 3.26.4
     type: jar
-  checksum: sha256:863785bb20da1b0e39488df59032f055a45be373af66bc128d046e23caea64d4
+  checksum: sha256:9654e0922122c7aa0ee23a3afd1fcb01b541d8e3cd54ceba28006793f2d405c9
 - type: maven
   filename: mockito-junit-jupiter-5.18.0.jar
   attributes:
@@ -2043,7 +2043,7 @@ artifacts:
     artifact_id: mockito-junit-jupiter
     version: 5.18.0
     type: jar
-  checksum: sha256:6cb733452609c24e1db4e9d4a7ab4235b74d0dfab1118059e3717ef270e416e2
+  checksum: sha256:08811d2085deef83eecbbbc67885d7a6f6cef99ba72668280170aac6a4acd265
 - type: maven
   filename: quarkus-junit5-mockito-config-3.26.4.jar
   attributes:
@@ -2052,7 +2052,7 @@ artifacts:
     artifact_id: quarkus-junit5-mockito-config
     version: 3.26.4
     type: jar
-  checksum: sha256:69e61547cde755da6e2af3490497b70267be7f8f7903c5901a01126d7796eceb
+  checksum: sha256:6bf342df2c30bb2f4ca53cf812ffe00d291ffa5679a345aa1ea13ad4a05f1302
 - type: maven
   filename: quarkus-arc-deployment-3.26.4.jar
   attributes:
@@ -2061,7 +2061,7 @@ artifacts:
     artifact_id: quarkus-arc-deployment
     version: 3.26.4
     type: jar
-  checksum: sha256:e3602310ad0c4445c824a6f10ff42d5f9b88269291ed5d779894bc8ca439e58b
+  checksum: sha256:6f06d0987558fe0fba7ce2a7c1e9f1c7b1603ac8987f3cf42168030cb3f1a399
 - type: maven
   filename: quarkus-core-deployment-3.26.4.jar
   attributes:
@@ -2070,7 +2070,7 @@ artifacts:
     artifact_id: quarkus-core-deployment
     version: 3.26.4
     type: jar
-  checksum: sha256:c9ca93e72af5458af6034d47c60bf1ea0ee96f7cd81e113f7a0c6414d91ccbe8
+  checksum: sha256:94636d03ba1b8ed6f627927828a1cddef5c1ea2e8143586b180bcd6a3e33aab5
 - type: maven
   filename: readline-2.6.jar
   attributes:
@@ -2079,7 +2079,7 @@ artifacts:
     artifact_id: readline
     version: '2.6'
     type: jar
-  checksum: sha256:4228180fa44977b3405e5ddce8866ba53635aad13714e62663b3072d98666830
+  checksum: sha256:601eb6cbc77a8b07b8014ba89cf3fbdda20fcdb96493e57466d3753fa26accde
 - type: maven
   filename: jansi-2.4.0.jar
   attributes:
@@ -2088,7 +2088,7 @@ artifacts:
     artifact_id: jansi
     version: 2.4.0
     type: jar
-  checksum: sha256:79e80229c1abbb6538272b89747a2f7764b7a8e0297212e0ea4e9d0ce020b41b
+  checksum: sha256:6cd91991323dd7b2fb28ca93d7ac12af5a86a2f53279e2b35827b30313fd0b9f
 - type: maven
   filename: aesh-2.8.2.jar
   attributes:
@@ -2097,7 +2097,7 @@ artifacts:
     artifact_id: aesh
     version: 2.8.2
     type: jar
-  checksum: sha256:04291c7a22c7a221e059de238b51341c95ff588bf633effbc69acf700e62e992
+  checksum: sha256:8c1e17fd1ab9d3a736bdee7fbd649e174f7dc26c1ceeac6e9ea596a9d63fcffd
 - type: maven
   filename: commons-lang3-3.18.0.jar
   attributes:
@@ -2106,7 +2106,7 @@ artifacts:
     artifact_id: commons-lang3
     version: 3.18.0
     type: jar
-  checksum: sha256:a48ca0d7e086a30c9f3126d40523b29bbcaf4e27f6ed0b01af2fde98d2902cd9
+  checksum: sha256:4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720
 - type: maven
   filename: gizmo-1.9.0.jar
   attributes:
@@ -2115,7 +2115,7 @@ artifacts:
     artifact_id: gizmo
     version: 1.9.0
     type: jar
-  checksum: sha256:21c06d3b9735f476fc9815174a94cf47b3cd4a9df5a43829ef7078db5f89a52c
+  checksum: sha256:6d463d670ea45cb9a8241e99dd02c7e422d9982a2ff6e8623d338ac2a6c892b1
 - type: maven
   filename: asm-util-9.8.jar
   attributes:
@@ -2124,7 +2124,7 @@ artifacts:
     artifact_id: asm-util
     version: '9.8'
     type: jar
-  checksum: sha256:acd587927bfb6a3b8f8e560c7f4f99f28295184c44c387c4b709261db99a802a
+  checksum: sha256:8ba0460ecb28fd0e2980e5f3ef3433a513a457bc077f81a53bdc75b587a08d15
 - type: maven
   filename: asm-analysis-9.8.jar
   attributes:
@@ -2133,7 +2133,7 @@ artifacts:
     artifact_id: asm-analysis
     version: '9.8'
     type: jar
-  checksum: sha256:51d63687ff628a4951d4236128bde223438de9377224b6b02e9d76a21542e3c3
+  checksum: sha256:e640732fbcd3c6271925a504f125e38384688f4dfbbf92c8622dfcee0d09edb9
 - type: maven
   filename: gizmo2-2.0.0.Beta6.jar
   attributes:
@@ -2142,7 +2142,7 @@ artifacts:
     artifact_id: gizmo2
     version: 2.0.0.Beta6
     type: jar
-  checksum: sha256:12faa67c9ae16e31849ecf37c271eb27df89b531c3aa1670b7de496ed66ee273
+  checksum: sha256:bcb1ade9db85101dcd42cd81f5a0de2c15e50e696928957943723593ec719c70
 - type: maven
   filename: jdk-classfile-backport-24.0.jar
   attributes:
@@ -2151,7 +2151,7 @@ artifacts:
     artifact_id: jdk-classfile-backport
     version: '24.0'
     type: jar
-  checksum: sha256:cfa5bb606d2ee372e5af50bda0c7ba70426167c019be858248ad95b17562d4b7
+  checksum: sha256:34f5c9424d49bbfcc6277a28c3ac6da04520e8c6fcc49c59be7a2b1462ce5554
 - type: maven
   filename: smallrye-common-resource-2.13.9.jar
   attributes:
@@ -2160,7 +2160,7 @@ artifacts:
     artifact_id: smallrye-common-resource
     version: 2.13.9
     type: jar
-  checksum: sha256:fff5e5fd73663b95e2a2b60eb9817753705d7aecb523d1da12b71bbd25ed565e
+  checksum: sha256:9ba62b4cc6ae4cf2492966d19795cf3a150a4bcf8bc88d646b1d34b8c8019dc8
 - type: maven
   filename: jandex-gizmo2-3.4.0.jar
   attributes:
@@ -2169,7 +2169,7 @@ artifacts:
     artifact_id: jandex-gizmo2
     version: 3.4.0
     type: jar
-  checksum: sha256:b7896f4c85b93f30f156f4ffdb864d5bdea670ad07f11924cbbd2bda1c21be92
+  checksum: sha256:6df02b54b40fa1b8bb4e7b9f6856815a2242d2221760522ef975258b405d5c81
 - type: maven
   filename: smallrye-common-process-2.13.9.jar
   attributes:
@@ -2178,7 +2178,7 @@ artifacts:
     artifact_id: smallrye-common-process
     version: 2.13.9
     type: jar
-  checksum: sha256:d312bc391ce6048ebe0c4144126f1ca1a1e3013bdb373294947943df0445377f
+  checksum: sha256:5c9fae9b4e3cb8e84c8b211aacfd1919b3e2f5a6aaf9664f34e2b2fa5b386e17
 - type: maven
   filename: quarkus-hibernate-validator-spi-3.26.4.jar
   attributes:
@@ -2187,7 +2187,7 @@ artifacts:
     artifact_id: quarkus-hibernate-validator-spi
     version: 3.26.4
     type: jar
-  checksum: sha256:0158c9d6053d184981c07c8dd7fe565533f8213acc96faed82655cc1a40ed5a0
+  checksum: sha256:dd5a9dd4214893c1cc9084676aa0225c83dae1ada17d0d8fe84a42a1f83515b8
 - type: maven
   filename: quarkus-class-change-agent-3.26.4.jar
   attributes:
@@ -2196,7 +2196,7 @@ artifacts:
     artifact_id: quarkus-class-change-agent
     version: 3.26.4
     type: jar
-  checksum: sha256:1e3e1f0eaaa6f0590ab0aa157f2bd0407edd2e7dff945cda7098ea766cc8e90c
+  checksum: sha256:2af7cca236fddd0a38a28f6edf29134fd3690986b18cddb88d9e7381a2f33686
 - type: maven
   filename: quarkus-builder-3.26.4.jar
   attributes:
@@ -2205,7 +2205,7 @@ artifacts:
     artifact_id: quarkus-builder
     version: 3.26.4
     type: jar
-  checksum: sha256:100754104978ac616d7990dbfd96a5a90fa34e8d495a14abba5219c9f15d7aa5
+  checksum: sha256:fc8f58ee80f6ec772005b840fc5bc2563acd92a5dfebb471bc045a9cd8ecf71b
 - type: maven
   filename: nativeimage-23.1.2.jar
   attributes:
@@ -2214,7 +2214,7 @@ artifacts:
     artifact_id: nativeimage
     version: 23.1.2
     type: jar
-  checksum: sha256:af9172f67558a5f10bad9cf59e722bd154ed242c56317082de75a4cb12f9f9eb
+  checksum: sha256:b20c00823c194cadcafc8e853b96a5754e641b467dc56634e738d756b308ad9a
 - type: maven
   filename: junit-platform-launcher-1.13.4.jar
   attributes:
@@ -2223,7 +2223,7 @@ artifacts:
     artifact_id: junit-platform-launcher
     version: 1.13.4
     type: jar
-  checksum: sha256:1832d67f0420bb58738288d0be1cc4bc35a83ae76bd816791275638f36aef208
+  checksum: sha256:0b0beaeb6880a31149641d2d848b863712885469670c12099586d7f798522564
 - type: maven
   filename: quarkus-smallrye-context-propagation-spi-3.26.4.jar
   attributes:
@@ -2232,7 +2232,7 @@ artifacts:
     artifact_id: quarkus-smallrye-context-propagation-spi
     version: 3.26.4
     type: jar
-  checksum: sha256:a1ff9f0d9b4f877e6973214e9c5fbe1f3de644bbc08024c59d5c71f742138060
+  checksum: sha256:934b9935dbc185b0039d5a6bc066cb825716f9ba4af108b1fb5c2d981a443b9b
 - type: maven
   filename: quarkus-devui-deployment-spi-3.26.4.jar
   attributes:
@@ -2241,7 +2241,7 @@ artifacts:
     artifact_id: quarkus-devui-deployment-spi
     version: 3.26.4
     type: jar
-  checksum: sha256:19bb02c36423559c8e632f996dfd55d953ccba6e26ff25d8d0ef1eca7a2aadbf
+  checksum: sha256:6b3b2e9bb0d371f603adf9a0325b890e8cd173a857973ac8985829e49a7d2cfc
 - type: maven
   filename: quarkus-arc-dev-3.26.4.jar
   attributes:
@@ -2250,7 +2250,7 @@ artifacts:
     artifact_id: quarkus-arc-dev
     version: 3.26.4
     type: jar
-  checksum: sha256:0abb69cda22ae540a3f9d3d8b01304dac3b0dd50b4026092d2d772a23fc8112b
+  checksum: sha256:d154d7c87a6f87a94b94783714056faa2d0ffc4fbf3a6f7c3a2959cba1052ab1
 - type: maven
   filename: arc-processor-3.26.4.jar
   attributes:
@@ -2259,7 +2259,7 @@ artifacts:
     artifact_id: arc-processor
     version: 3.26.4
     type: jar
-  checksum: sha256:cef6377d96c610e552e6e71939fa6bcfe15b967ef67ea39bfb8338713f79b3b2
+  checksum: sha256:61e4ad5dd3c334717fffe22dee20b18a230d56b00f606e872a12852ec04b735d
 - type: maven
   filename: mockito-core-5.18.0.jar
   attributes:
@@ -2268,7 +2268,7 @@ artifacts:
     artifact_id: mockito-core
     version: 5.18.0
     type: jar
-  checksum: sha256:f2cebcf47277c498bbba0219621dd25aa12e751164afe8f327bcb248a2bb5201
+  checksum: sha256:a3d4e40f7fe66016fe42c00de4e343777d74132afc85018e0f03ac6334a60f29
 - type: maven
   filename: byte-buddy-1.17.6.jar
   attributes:
@@ -2277,7 +2277,7 @@ artifacts:
     artifact_id: byte-buddy
     version: 1.17.6
     type: jar
-  checksum: sha256:1ee12eb6dc6ecd600418efe9cf20991e54d444d164ea353488a8a3c3c751b6fe
+  checksum: sha256:d26382a839cb26d5c62a0b0f04715bcef55a531f96ac6ce40de452a1c0539e70
 - type: maven
   filename: byte-buddy-agent-1.17.5.jar
   attributes:
@@ -2286,7 +2286,7 @@ artifacts:
     artifact_id: byte-buddy-agent
     version: 1.17.5
     type: jar
-  checksum: sha256:ae848a76968722194729fa9eb3f1e5827039f7c4a16daa2b8b14d7f2494479a6
+  checksum: sha256:c5b9334ad82e632f6af60df22bbbdbbb62cee04877f4f43c38ba04aed9bd9901
 - type: maven
   filename: objenesis-3.3.jar
   attributes:
@@ -2295,7 +2295,7 @@ artifacts:
     artifact_id: objenesis
     version: '3.3'
     type: jar
-  checksum: sha256:f18edb0aa97817567e9b21337ddef5d2fd6fb15b00d1afd4bf63b266bbd524a5
+  checksum: sha256:02dfd0b0439a5591e35b708ed2f5474eb0948f53abf74637e959b8e4ef69bfeb
 - type: maven
   filename: quarkus-mutiny-3.26.4.jar
   attributes:
@@ -2304,7 +2304,7 @@ artifacts:
     artifact_id: quarkus-mutiny
     version: 3.26.4
     type: jar
-  checksum: sha256:42b80b39c87b5b3f208d079e5c6aab52abc17efb44f1fe1b54dfd3e6839b7b4e
+  checksum: sha256:b9db1e94f673d40ba059df8942b0e60dce06563447c2d9c909578133ddefa2ab
 - type: maven
   filename: quarkus-smallrye-context-propagation-3.26.4.jar
   attributes:
@@ -2313,7 +2313,7 @@ artifacts:
     artifact_id: quarkus-smallrye-context-propagation
     version: 3.26.4
     type: jar
-  checksum: sha256:3eaabf5d667b6d57229f774232c8749c1243bd4ead2ae150293989f9a8b4745e
+  checksum: sha256:3bd5f85d234e3c2e789a90480defef27361653a46d2b83ab64a64cb237c4fde2
 - type: maven
   filename: smallrye-context-propagation-2.2.1.jar
   attributes:
@@ -2322,7 +2322,7 @@ artifacts:
     artifact_id: smallrye-context-propagation
     version: 2.2.1
     type: jar
-  checksum: sha256:5ef7b5aab1cb104fa8dac8b167fbd9fc96074690256018ea5a4cb41b27359628
+  checksum: sha256:91fa253d8bd903672f30b9bcd03a97f03a73499f5a7ed1fd3d03d04f5348549a
 - type: maven
   filename: smallrye-context-propagation-api-2.2.1.jar
   attributes:
@@ -2331,7 +2331,7 @@ artifacts:
     artifact_id: smallrye-context-propagation-api
     version: 2.2.1
     type: jar
-  checksum: sha256:01d7060dcc4bacb1c4bd3b90602a4583e0ab83941d6ff700d5cc25ce2bb2149c
+  checksum: sha256:a13147f305d4879074c073adfd861d07076278b18f1f8010acd81fd8a21f5cb9
 - type: maven
   filename: smallrye-context-propagation-storage-2.2.1.jar
   attributes:
@@ -2340,7 +2340,7 @@ artifacts:
     artifact_id: smallrye-context-propagation-storage
     version: 2.2.1
     type: jar
-  checksum: sha256:d2f93d0d0dde19e4362e45ec52d9408b1821ec5ff9b22bcae47b310d1ec017f1
+  checksum: sha256:3b347bb57c8ec93ed2375ae78f24908fa0b541a110de80afdb63f325a5c8a705
 - type: maven
   filename: mutiny-smallrye-context-propagation-2.9.4.jar
   attributes:
@@ -2349,7 +2349,7 @@ artifacts:
     artifact_id: mutiny-smallrye-context-propagation
     version: 2.9.4
     type: jar
-  checksum: sha256:889b4f10a2c8979e57e770ac084f4903c611fc60e2e6eb07872ca7bd97b1729d
+  checksum: sha256:275f2b7fe675b31f4cbaddddd221fb1a4ca46c6beb586dad59f59a9252cf2d96
 - type: maven
   filename: smallrye-reactive-messaging-in-memory-4.28.0.jar
   attributes:
@@ -2358,7 +2358,7 @@ artifacts:
     artifact_id: smallrye-reactive-messaging-in-memory
     version: 4.28.0
     type: jar
-  checksum: sha256:12bbf2dfb93b98625d374982e91ade67d0da55fa0eac72ddbffa331d9fd940ad
+  checksum: sha256:dbe2636e4a2aa9d953795674b87cc175f4a1179cec8bb9f214afa62f9b04ebb3
 - type: maven
   filename: jboss-logging-3.6.1.Final.jar
   attributes:
@@ -2367,7 +2367,7 @@ artifacts:
     artifact_id: jboss-logging
     version: 3.6.1.Final
     type: jar
-  checksum: sha256:6b975fc1dee33d314ea689ee35f953df5e4c6b0a91ceea7f0d9fa53f010c2357
+  checksum: sha256:5e08a4b092dc85b337f0910a740571d8720cfa565fabd880a8caf94a657ca416
 - type: maven
   filename: smallrye-reactive-converter-api-3.0.3.jar
   attributes:
@@ -2376,7 +2376,7 @@ artifacts:
     artifact_id: smallrye-reactive-converter-api
     version: 3.0.3
     type: jar
-  checksum: sha256:f86f7ae383998086706894e366dc5c201cc35e588ccd38c61181bcc39c321220
+  checksum: sha256:8f47b3cbdef72c5875836011beb02f485918febbb73c15d51738c566eb669253
 - type: maven
   filename: reactive-streams-1.0.4.jar
   attributes:
@@ -2385,7 +2385,7 @@ artifacts:
     artifact_id: reactive-streams
     version: 1.0.4
     type: jar
-  checksum: sha256:fc221ffb44ee5c24579ed72448039c551dc9662cce89dd87f55b3d0f2b393684
+  checksum: sha256:f75ca597789b3dac58f61857b9ac2e1034a68fa672db35055a8fb4509e325f28
 - type: maven
   filename: mutiny-2.9.4.jar
   attributes:
@@ -2394,7 +2394,7 @@ artifacts:
     artifact_id: mutiny
     version: 2.9.4
     type: jar
-  checksum: sha256:06b31a4d5b8b92e3005a15feea4a013f5872ffe25dd326d9f5f896dbbf0ce15b
+  checksum: sha256:3a221ee1ef5bb624c87e5e2a38b60547320cc560f86088f25e1656c0f2620df3
 - type: maven
   filename: jctools-core-4.0.5.jar
   attributes:
@@ -2403,7 +2403,7 @@ artifacts:
     artifact_id: jctools-core
     version: 4.0.5
     type: jar
-  checksum: sha256:cb55fc042a1f581a7f9b61ebcf766dc1a5694def0e6b46b3040c50fb89d653cf
+  checksum: sha256:d65e5f38bcd0984e26f87187687f1f70dd52740c4d5e046f8d104e01ab5db95f
 - type: maven
   filename: mutiny-zero-1.1.1.jar
   attributes:
@@ -2412,7 +2412,7 @@ artifacts:
     artifact_id: mutiny-zero
     version: 1.1.1
     type: jar
-  checksum: sha256:77b3623dde4e657cc2c50e2ebf19dcd4cde694dde7119eb2b515cc3852582b03
+  checksum: sha256:2ba037374ea75e29921726d34a2ac426b88bd425a9e646802f905c117457a7a8
 - type: maven
   filename: mutiny-zero-flow-adapters-1.1.1.jar
   attributes:
@@ -2421,7 +2421,7 @@ artifacts:
     artifact_id: mutiny-zero-flow-adapters
     version: 1.1.1
     type: jar
-  checksum: sha256:6d3994d840721bb9609ab78ca6023fae162744636fb5065a40e4d96c8c7649d5
+  checksum: sha256:7e2576e235bcd277c52d67e11d70d1922040bc1b769883d985d68c60597a1ab2
 - type: maven
   filename: awaitility-4.3.0.jar
   attributes:
@@ -2430,7 +2430,7 @@ artifacts:
     artifact_id: awaitility
     version: 4.3.0
     type: jar
-  checksum: sha256:7da19fb40a8a90d3f6470483cdbc4f1b29153fbe2733db5975f21f7f7a3463cf
+  checksum: sha256:ee58568ea5945dcf988551501655183dc184e23e45a8e013fdfd9036194e6f7b
 - type: maven
   filename: hamcrest-2.2.jar
   attributes:
@@ -2439,7 +2439,7 @@ artifacts:
     artifact_id: hamcrest
     version: '2.2'
     type: jar
-  checksum: sha256:af3f9aa297c5bcd2fcb913b8a37b675cb8fcb614f10168fcd6333d015c8e8dcd
+  checksum: sha256:5e62846a89f05cd78cd9c1a553f340d002458380c320455dd1f8fc5497a8a1c1
 - type: maven
   filename: microprofile-config-api-3.1.jar
   attributes:
@@ -2448,7 +2448,7 @@ artifacts:
     artifact_id: microprofile-config-api
     version: '3.1'
     type: jar
-  checksum: sha256:2ef2fccd75421e5fc1fabef1be01c97c6fb4918837876ccad8d48d858a580958
+  checksum: sha256:dee277f81e1edfeafd5e43589441ecdf434500fe4a31d035e74b8e6d8e7bfd91
 - type: maven
   filename: quarkus-unleash-1.11.0.jar
   attributes:
@@ -2457,7 +2457,7 @@ artifacts:
     artifact_id: quarkus-unleash
     version: 1.11.0
     type: jar
-  checksum: sha256:99a567e482b5c901f5aa7e80651404f66e4f68048bf7f4b33331a8f140b0ad7f
+  checksum: sha256:f168fa4e9234fbefdb93d3ca8ef256bbbeb814ecfb7b8a28a6d397c044df9c2f
 - type: maven
   filename: unleash-client-java-11.0.2.jar
   attributes:
@@ -2466,7 +2466,7 @@ artifacts:
     artifact_id: unleash-client-java
     version: 11.0.2
     type: jar
-  checksum: sha256:865703159d1c8862badf64fdc52f2a5ebaf5c045245a54a18602c0fad5c10d10
+  checksum: sha256:76d861dc36acc94fcd96fd3b872eb9f5a3399c13a86e58c26a0819f4f97c578d
 - type: maven
   filename: yggdrasil-engine-0.3.2.jar
   attributes:
@@ -2475,7 +2475,7 @@ artifacts:
     artifact_id: yggdrasil-engine
     version: 0.3.2
     type: jar
-  checksum: sha256:ccff618645eb9adab960a0d304d1e54e6067909be60522257ddd80cf26f0f521
+  checksum: sha256:1a4b8c29ed2d72c6f119827711659f30becbdf7c0df5f08a1d230b4187c896f9
 - type: maven
   filename: runtime-1.5.1.jar
   attributes:
@@ -2484,7 +2484,7 @@ artifacts:
     artifact_id: runtime
     version: 1.5.1
     type: jar
-  checksum: sha256:03c88babd970998797b514c92f0af250b017933a33bc9b68d52988cb839c23ff
+  checksum: sha256:32fa6714208bf1d04d82a21714d14846fb7da4fdd47ae924ac3aa96cf0a3f068
 - type: maven
   filename: wasm-1.5.1.jar
   attributes:
@@ -2493,7 +2493,7 @@ artifacts:
     artifact_id: wasm
     version: 1.5.1
     type: jar
-  checksum: sha256:006333d7a318319a913d265c31bd8f614aff357f1928d4648a24765ac2f7ce35
+  checksum: sha256:5dc756da581c4684d0ff050049c185e6266d4339b6daca792b9b323a4079de13
 - type: maven
   filename: jna-5.8.0.jar
   attributes:
@@ -2502,7 +2502,7 @@ artifacts:
     artifact_id: jna
     version: 5.8.0
     type: jar
-  checksum: sha256:697749099bb7f454caebfe67e9845be6e7e85d266ebb2e500244f01c1743db94
+  checksum: sha256:930273cc1c492f25661ea62413a6da3fd7f6e01bf1c4dcc0817fc8696a7b07ac
 - type: maven
   filename: flatbuffers-java-23.1.21.jar
   attributes:
@@ -2511,7 +2511,7 @@ artifacts:
     artifact_id: flatbuffers-java
     version: 23.1.21
     type: jar
-  checksum: sha256:8380abca63eb25c8a3d02b56c39b092d36578ab98b6aaf941debcfa887353e57
+  checksum: sha256:6efcf86494327bfaedb32757018bc50a41c993a6aec7556801a0ef731d8c5c2e
 - type: maven
   filename: gson-2.13.2.jar
   attributes:
@@ -2520,7 +2520,7 @@ artifacts:
     artifact_id: gson
     version: 2.13.2
     type: jar
-  checksum: sha256:02e3e88b1f01d9ef61df06fe9ceda9e76dbedd50e01b88f51bdd53301cc150c2
+  checksum: sha256:dd0ce1b55a3ed2080cb70f9c655850cda86c206862310009dcb5e5c95265a5e0
 - type: maven
   filename: murmur-1.0.0.jar
   attributes:
@@ -2529,7 +2529,7 @@ artifacts:
     artifact_id: murmur
     version: 1.0.0
     type: jar
-  checksum: sha256:5700079ae217de75175937a90b59c9f7282471ecf340b13056d28d4a7eff284a
+  checksum: sha256:3268f5020fb9a22d2c940c1acc10e5963d88c452db31d9f4610a342ce7ed1a2a
 - type: maven
   filename: camel-quarkus-direct-3.26.0.jar
   attributes:
@@ -2538,7 +2538,7 @@ artifacts:
     artifact_id: camel-quarkus-direct
     version: 3.26.0
     type: jar
-  checksum: sha256:b654e63c40075b1cfc46690213b2dd2243df515d344c6984ab4ad4ee2063dd95
+  checksum: sha256:88d544a9885f80741eded63315c63ac2a87c770373670649832196083a31a26f
 - type: maven
   filename: camel-quarkus-kafka-3.26.0.jar
   attributes:
@@ -2547,7 +2547,7 @@ artifacts:
     artifact_id: camel-quarkus-kafka
     version: 3.26.0
     type: jar
-  checksum: sha256:9344fcc8f27870e821181508a4fbd7e2ed5b46543f4e1fa372af216a79794a0e
+  checksum: sha256:ca6473f9c57b8be1da7b1e394686ca679316429d9719c29aad94e1df5926318e
 - type: maven
   filename: camel-kafka-4.14.0.jar
   attributes:
@@ -2556,7 +2556,7 @@ artifacts:
     artifact_id: camel-kafka
     version: 4.14.0
     type: jar
-  checksum: sha256:5c6085cd3072757b394cc1bfa34e9fa9621f576d304cf1a8cef8f530b4f4b241
+  checksum: sha256:d92f3ee825210946fcc674c43c186f6865cc16eca53e1dabb19c11e666641ad6
 - type: maven
   filename: camel-health-4.14.0.jar
   attributes:
@@ -2565,7 +2565,7 @@ artifacts:
     artifact_id: camel-health
     version: 4.14.0
     type: jar
-  checksum: sha256:c9db62951faadf75f4e6364d2cc51ca62ddd4cdfced0f4ffd2ea0b5a103cca3f
+  checksum: sha256:612cdc4dd8cbd1d3c9b19bf5c5818365d4ad93066275b822fc49211ba92da27d
 - type: maven
   filename: camel-quarkus-log-3.26.0.jar
   attributes:
@@ -2574,7 +2574,7 @@ artifacts:
     artifact_id: camel-quarkus-log
     version: 3.26.0
     type: jar
-  checksum: sha256:dccf4a2071411fff525f1388503be4bb550d1c8e4b1efad28a5e2300fc2d8597
+  checksum: sha256:32c1ea53577a96cf37116a5fb5c6a8b780a8adebfffbafb73107014e20219a74
 - type: maven
   filename: camel-quarkus-micrometer-3.26.0.jar
   attributes:
@@ -2583,7 +2583,7 @@ artifacts:
     artifact_id: camel-quarkus-micrometer
     version: 3.26.0
     type: jar
-  checksum: sha256:cbae2fcd9364bd86b5962c7e10abe1191b9e8364ef551e472031ce336086186f
+  checksum: sha256:8e59a8e614bd22f6898f4c9dfc1a190b3afdf55b42243fa7b63beded7bdfcac1
 - type: maven
   filename: quarkus-micrometer-3.26.4.jar
   attributes:
@@ -2592,7 +2592,7 @@ artifacts:
     artifact_id: quarkus-micrometer
     version: 3.26.4
     type: jar
-  checksum: sha256:e414c9870ec8ed5a7c3e0e84f34fb3c35e08b5894cc5fb27ef73f21119b0995d
+  checksum: sha256:8c3da1fe2ed5a02929b137bfce7830c1b2efa30cd5b3cb2589f21e4ad3fd66bb
 - type: maven
   filename: micrometer-core-1.14.7.jar
   attributes:
@@ -2601,7 +2601,7 @@ artifacts:
     artifact_id: micrometer-core
     version: 1.14.7
     type: jar
-  checksum: sha256:9837519bd36326148db21ec649ea4152cade9f9c2ab3a06edb02c47f572ee2b5
+  checksum: sha256:250106bfd156efec888ceba9b4e8c94247276cc5ead97c0a6515a762f9029003
 - type: maven
   filename: micrometer-commons-1.14.7.jar
   attributes:
@@ -2610,7 +2610,7 @@ artifacts:
     artifact_id: micrometer-commons
     version: 1.14.7
     type: jar
-  checksum: sha256:e00b039cc2f195f105531aaeff130011f59897fd72af8b1403fc46c970157aa0
+  checksum: sha256:abaa708c886e8236bb5ec835db05e67b85aee369bddb34f5f5632b4c0bc4aee4
 - type: maven
   filename: micrometer-observation-1.14.7.jar
   attributes:
@@ -2619,7 +2619,7 @@ artifacts:
     artifact_id: micrometer-observation
     version: 1.14.7
     type: jar
-  checksum: sha256:1c99b740471e0f7a36bce792f2d47515cf8095c2d5f7f8d6670e1e124b1a4d5e
+  checksum: sha256:0f5ee6cbd8e8192b4bc383c3466fcbc86722c8d616e341a10a2f65138d9014fe
 - type: maven
   filename: HdrHistogram-2.2.2.jar
   attributes:
@@ -2628,7 +2628,7 @@ artifacts:
     artifact_id: HdrHistogram
     version: 2.2.2
     type: jar
-  checksum: sha256:77717d648429d1ab4034fc39fb3dfb9f6c576149210711258a8adb5e37eb6589
+  checksum: sha256:22d1d4316c4ec13a68b559e98c8256d69071593731da96136640f864fa14fad8
 - type: maven
   filename: LatencyUtils-2.0.3.jar
   attributes:
@@ -2637,7 +2637,7 @@ artifacts:
     artifact_id: LatencyUtils
     version: 2.0.3
     type: jar
-  checksum: sha256:d2e85b0d04f6f7840499db6f6bb4ac04ab2fca7a0f2aba127e4fea836990b1fc
+  checksum: sha256:a32a9ffa06b2f4e01c5360f8f9df7bc5d9454a5d373cd8f361347fa5a57165ec
 - type: maven
   filename: camel-micrometer-4.14.0.jar
   attributes:
@@ -2646,7 +2646,7 @@ artifacts:
     artifact_id: camel-micrometer
     version: 4.14.0
     type: jar
-  checksum: sha256:d29b1c9f82b7e4005d8ebc52985a46c24f00407b6e97e85b43f3bd1b0bedb47e
+  checksum: sha256:de21f0aed8776268480d161c08a7b0a133cff83edda116322d22c99f67f54285
 - type: maven
   filename: camel-quarkus-microprofile-health-3.26.0.jar
   attributes:
@@ -2655,7 +2655,7 @@ artifacts:
     artifact_id: camel-quarkus-microprofile-health
     version: 3.26.0
     type: jar
-  checksum: sha256:842cf4aa62888aa94f3027e7c865b16f53daeb52658e23c95a054d1785de3ada
+  checksum: sha256:8f3e1288822c17119d33e27b1cc907e522384fa51697d8f7893b8bb9a934cfc2
 - type: maven
   filename: quarkus-smallrye-health-3.26.4.jar
   attributes:
@@ -2664,7 +2664,7 @@ artifacts:
     artifact_id: quarkus-smallrye-health
     version: 3.26.4
     type: jar
-  checksum: sha256:86d8453cd1dcf551d9c7224ce7433413b846ac41e2434f788aed796fad6dc353
+  checksum: sha256:d33fc29f19b15b6560b9396357eb528a049a570dfc36f91496d69cf62dd70847
 - type: maven
   filename: smallrye-health-4.2.0.jar
   attributes:
@@ -2673,7 +2673,7 @@ artifacts:
     artifact_id: smallrye-health
     version: 4.2.0
     type: jar
-  checksum: sha256:e08db214bda6f7bd530ac55e2a4445de13295ee0423d0338f430527c41d21147
+  checksum: sha256:d8116d8ba03a41ff883959a56c29ac98fd503567f577470bf59237e9b1df748b
 - type: maven
   filename: smallrye-health-api-4.2.0.jar
   attributes:
@@ -2682,7 +2682,7 @@ artifacts:
     artifact_id: smallrye-health-api
     version: 4.2.0
     type: jar
-  checksum: sha256:e497fc33adb3a3e09e3011cb268646e79c0d92bab868c9e325f9e88e3f698201
+  checksum: sha256:a1766c6ae499bfe39ec53415917a2edacd221de9e264681a2f656223ab6fb694
 - type: maven
   filename: smallrye-health-provided-checks-4.2.0.jar
   attributes:
@@ -2691,7 +2691,7 @@ artifacts:
     artifact_id: smallrye-health-provided-checks
     version: 4.2.0
     type: jar
-  checksum: sha256:7e8c060fb85baa11afc421484968dfb5d7ae07c6e39f57517e1aad2cef39b385
+  checksum: sha256:a5ded00ec6cc359ceb0a23ac8f1461a823d7a33fe1927450b819db40ac4652cf
 - type: maven
   filename: camel-microprofile-health-4.14.0.jar
   attributes:
@@ -2700,7 +2700,7 @@ artifacts:
     artifact_id: camel-microprofile-health
     version: 4.14.0
     type: jar
-  checksum: sha256:7e2d606ebff6330245cafaac609932f6c7750135d75701e5add556afd7084b5d
+  checksum: sha256:7bdb7eafc6fee6950d3f0a3742ece066fc64903e6ae9b8f602ae9438451d23ba
 - type: maven
   filename: camel-quarkus-seda-3.26.0.jar
   attributes:
@@ -2709,7 +2709,7 @@ artifacts:
     artifact_id: camel-quarkus-seda
     version: 3.26.0
     type: jar
-  checksum: sha256:bffe12ad90a334b575c982b03eb994655a461bcc953135f88bb0eb7bf36a5bff
+  checksum: sha256:e06bce488953d3916b1e4b16c75b7de67f349eb30975e47fcf15043c62732473
 - type: maven
   filename: quarkus-micrometer-registry-prometheus-3.26.4.jar
   attributes:
@@ -2718,7 +2718,7 @@ artifacts:
     artifact_id: quarkus-micrometer-registry-prometheus
     version: 3.26.4
     type: jar
-  checksum: sha256:25caf78a3ed729f3b64f43736fb1b7ec5364248283bdf02ab9e07213021bfc8c
+  checksum: sha256:1e0a0a9335847ea574be872876835827c01ee8176443a0777760a739fc93057e
 - type: maven
   filename: micrometer-registry-prometheus-simpleclient-1.14.7.jar
   attributes:
@@ -2727,7 +2727,7 @@ artifacts:
     artifact_id: micrometer-registry-prometheus-simpleclient
     version: 1.14.7
     type: jar
-  checksum: sha256:b5c31c0d440d6ab14a611d25480edfc22cb10a4e128b2ea2c4d653dae7087734
+  checksum: sha256:74bf13b3c2cea4b26e1fdb162646ccc43f8e435e07f8ec987b1c06f8a747389f
 - type: maven
   filename: simpleclient_common-0.16.0.jar
   attributes:
@@ -2736,7 +2736,7 @@ artifacts:
     artifact_id: simpleclient_common
     version: 0.16.0
     type: jar
-  checksum: sha256:cde5a28685f9e2d9b56b05d5334d484b4afd19ff70e9513ea8b46c08183379ce
+  checksum: sha256:eba6ec26ce7e40cbb8725e05fb83247a9f4f44945b9e7522e3375dde67b9f059
 - type: maven
   filename: simpleclient-0.16.0.jar
   attributes:
@@ -2745,7 +2745,7 @@ artifacts:
     artifact_id: simpleclient
     version: 0.16.0
     type: jar
-  checksum: sha256:6992e6fec8d57006214dfb8c594a0a6eb62032260813f1ee676344f8351f6988
+  checksum: sha256:22c374f237f7bc4fdb1f0ec2da379c0ba00e69ad2ffe8b6ade543d73062d377f
 - type: maven
   filename: simpleclient_tracer_otel-0.16.0.jar
   attributes:
@@ -2754,7 +2754,7 @@ artifacts:
     artifact_id: simpleclient_tracer_otel
     version: 0.16.0
     type: jar
-  checksum: sha256:ac8121030200aa46e850e7a7d343acd8ac9caf6f1719ebddb820ec5cccaeef83
+  checksum: sha256:a2a84c59bef3796bb7f9c6f2ae8b7de8b905313ef28180ac3de7ff61dd68df3f
 - type: maven
   filename: simpleclient_tracer_common-0.16.0.jar
   attributes:
@@ -2763,7 +2763,7 @@ artifacts:
     artifact_id: simpleclient_tracer_common
     version: 0.16.0
     type: jar
-  checksum: sha256:6181f0662b4d3e4ffc299f50f2a0bc89251c8fb9eb505fd62c356ef0250c39c7
+  checksum: sha256:e84a784ac8e24f182ee62da80b6b5c8140774b75bfa4bf9cc3d3b8390db625f6
 - type: maven
   filename: simpleclient_tracer_otel_agent-0.16.0.jar
   attributes:
@@ -2772,7 +2772,7 @@ artifacts:
     artifact_id: simpleclient_tracer_otel_agent
     version: 0.16.0
     type: jar
-  checksum: sha256:17fa72121f3d8551b0c337d27e06b936d0a220761d9982ee19abdeb9a80afd6c
+  checksum: sha256:7ad2bb40df74a772d9f5445a3d03579b49d6b37a47d5e90f6cf3f59ecf41ad06
 - type: maven
   filename: quarkus-rest-3.26.4.jar
   attributes:
@@ -2781,7 +2781,7 @@ artifacts:
     artifact_id: quarkus-rest
     version: 3.26.4
     type: jar
-  checksum: sha256:b1c84711cdd21a6445c08ec1b87a9123dd7ba44a1b23f7bb4a45774503f14f57
+  checksum: sha256:346b6f4f939e57b3df8d25030ee19214dab4acae55a6d787b6774144b4ce62d4
 - type: maven
   filename: resteasy-reactive-vertx-3.26.4.jar
   attributes:
@@ -2790,7 +2790,7 @@ artifacts:
     artifact_id: resteasy-reactive-vertx
     version: 3.26.4
     type: jar
-  checksum: sha256:08dda7760c977c156893b5b58749f60e690346928907f8d48892d85f085aae3e
+  checksum: sha256:27abadedecb6d53c4e3e7145f8deeba19c1d68907c4529b1dd64ff6e2290b0e0
 - type: maven
   filename: quarkus-vertx-utils-3.26.4.jar
   attributes:
@@ -2799,7 +2799,7 @@ artifacts:
     artifact_id: quarkus-vertx-utils
     version: 3.26.4
     type: jar
-  checksum: sha256:3dbd9863055165b5dffa11d3f02d7bd089e5f7f061ff8dafcdde845ca8528c14
+  checksum: sha256:f77e70714c2ff2115c30405d8ee435303ca8b0eb705716bd0f40c49b17666833
 - type: maven
   filename: quarkus-vertx-http-3.26.4.jar
   attributes:
@@ -2808,7 +2808,7 @@ artifacts:
     artifact_id: quarkus-vertx-http
     version: 3.26.4
     type: jar
-  checksum: sha256:5375a7a2db5deb0f8718866c35c70787752b4215928e8b62692ff5d6246248f2
+  checksum: sha256:1394b6f6e6b914beaa92740e9069a7998b7ca877a614d0c1d8cbc5cb811e7ee6
 - type: maven
   filename: quarkus-security-runtime-spi-3.26.4.jar
   attributes:
@@ -2817,7 +2817,7 @@ artifacts:
     artifact_id: quarkus-security-runtime-spi
     version: 3.26.4
     type: jar
-  checksum: sha256:964bdb74b16d65892f06a9d0db9cad05a4c9ab0aaec6148416a521e2f068b53c
+  checksum: sha256:c150d002109cf8045ccf808c16be8ca01aab7531eddc8680d24dcb7c1961c8d3
 - type: maven
   filename: quarkus-security-2.2.1.jar
   attributes:
@@ -2826,7 +2826,7 @@ artifacts:
     artifact_id: quarkus-security
     version: 2.2.1
     type: jar
-  checksum: sha256:a5c073bead8e4eb612553cce53b34c8333c88fc98e14938219b70b343b414ef6
+  checksum: sha256:b5020f6fcc506d2db71c17ac6854cc3a9078c0b73952918048d1f2cbb4a7d8f8
 - type: maven
   filename: smallrye-mutiny-vertx-web-3.19.2.jar
   attributes:
@@ -2835,7 +2835,7 @@ artifacts:
     artifact_id: smallrye-mutiny-vertx-web
     version: 3.19.2
     type: jar
-  checksum: sha256:322469af8cde23afe993e57d5987edc2e6b07186ecf4890ec2c64b6d04365345
+  checksum: sha256:c3539c19e40ad25d38b3f870e07426030f3ef633e515eead6dd8ccb5642fc35c
 - type: maven
   filename: smallrye-mutiny-vertx-web-common-3.19.2.jar
   attributes:
@@ -2844,7 +2844,7 @@ artifacts:
     artifact_id: smallrye-mutiny-vertx-web-common
     version: 3.19.2
     type: jar
-  checksum: sha256:1d7bb58e67a4c97a2495ea7dd063d36405f8d3585db928a71dd97b327e58c917
+  checksum: sha256:55fbfac81e53e3b582cbd4204b2554f8e1b956ec242be909fd1edac3fdfe4810
 - type: maven
   filename: smallrye-mutiny-vertx-auth-common-3.19.2.jar
   attributes:
@@ -2853,7 +2853,7 @@ artifacts:
     artifact_id: smallrye-mutiny-vertx-auth-common
     version: 3.19.2
     type: jar
-  checksum: sha256:c534c1f6cbdff55699e0882d52f224d4adaa48fa57aed4397c9a8410222d91ac
+  checksum: sha256:52255a42d165fe95c20edf1115905d4899d45c218340e1a9865ef184eacb45ee
 - type: maven
   filename: smallrye-mutiny-vertx-bridge-common-3.19.2.jar
   attributes:
@@ -2862,7 +2862,7 @@ artifacts:
     artifact_id: smallrye-mutiny-vertx-bridge-common
     version: 3.19.2
     type: jar
-  checksum: sha256:2d5c4c20143dde76e08e83e53e6d4ea8bb8f7c131c6594404ea9f718a2fc09ea
+  checksum: sha256:66d5c887d86b92e1eb6fd9c25a0aca44309b4190d502ef56e5d3b587c77cda9e
 - type: maven
   filename: smallrye-mutiny-vertx-uri-template-3.19.2.jar
   attributes:
@@ -2871,7 +2871,7 @@ artifacts:
     artifact_id: smallrye-mutiny-vertx-uri-template
     version: 3.19.2
     type: jar
-  checksum: sha256:6570d769760f2c29bf02f8008f4653621609975cc5f5c3ef7c0c07d9d3a66645
+  checksum: sha256:181cf58d0e80d7269d33306cc47417663687351a3d821853b01a8f38d3bf3f32
 - type: maven
   filename: crac-1.5.0.jar
   attributes:
@@ -2880,7 +2880,7 @@ artifacts:
     artifact_id: crac
     version: 1.5.0
     type: jar
-  checksum: sha256:234fbffc04bdc3838707b64b1ba5e8252ec388262f529543775c478fa69235e1
+  checksum: sha256:f4426e1641c8f0fa2f025a4cd7c40c285abaf265930e6717adfcaef03d034850
 - type: maven
   filename: brotli4j-1.16.0.jar
   attributes:
@@ -2889,7 +2889,7 @@ artifacts:
     artifact_id: brotli4j
     version: 1.16.0
     type: jar
-  checksum: sha256:6b32dfe9519fd50073fadec48b3bf24cb1f817a9f6e3525ed0ba70e8e75c7078
+  checksum: sha256:285a0b96150649db6fd9d8a0a22ea98fc2b8a558fc924b21836a59550975485e
 - type: maven
   filename: service-1.16.0.jar
   attributes:
@@ -2898,7 +2898,7 @@ artifacts:
     artifact_id: service
     version: 1.16.0
     type: jar
-  checksum: sha256:249d862b1a5cd5fbad56d1239b5ebd8918ce2b28f4f3c10e32dbec4d957b6870
+  checksum: sha256:8e233823936a60d00b9d4434e733bd60aeaaac1c149ae5d9c9e7a49caecafa2d
 - type: maven
   filename: native-linux-x86_64-1.16.0.jar
   attributes:
@@ -2907,7 +2907,7 @@ artifacts:
     artifact_id: native-linux-x86_64
     version: 1.16.0
     type: jar
-  checksum: sha256:7c3ae2f100ad43c680c65d023386a6d8711a9a6f98e279dc54f2c97bb2674597
+  checksum: sha256:b6933c389857e1a7f400455096cec01ee76be73d51a9fb1164d2700d3d31054d
 - type: maven
   filename: quarkus-logging-cloudwatch-6.14.2.jar
   attributes:
@@ -2916,7 +2916,7 @@ artifacts:
     artifact_id: quarkus-logging-cloudwatch
     version: 6.14.2
     type: jar
-  checksum: sha256:6f4a02893cad55019093d38aafdfba6adba97251a503d19d7166994b75b9840c
+  checksum: sha256:4bc32d80d7d40e0d08201333f79f74e9117cc546cd68e852df90745088cd0b09
 - type: maven
   filename: quarkus-apache-httpclient-3.26.4.jar
   attributes:
@@ -2925,7 +2925,7 @@ artifacts:
     artifact_id: quarkus-apache-httpclient
     version: 3.26.4
     type: jar
-  checksum: sha256:2fdf3fee300f7245ba6ec60519bd0f7565621afcfb8475a765540ea6087a82dc
+  checksum: sha256:2b12b2cd7e5a84758a2ebb9f954ec3f3bdcf54a780348e32519bf140db3508a0
 - type: maven
   filename: httpclient-4.5.14.jar
   attributes:
@@ -2934,7 +2934,7 @@ artifacts:
     artifact_id: httpclient
     version: 4.5.14
     type: jar
-  checksum: sha256:7366b65252ab213fcfa86fa83928108c2c95c112dbccccb107d1fc00549f6070
+  checksum: sha256:c8bc7e1c51a6d4ce72f40d2ebbabf1c4b68bfe76e732104b04381b493478e9d6
 - type: maven
   filename: httpcore-4.4.16.jar
   attributes:
@@ -2943,7 +2943,7 @@ artifacts:
     artifact_id: httpcore
     version: 4.4.16
     type: jar
-  checksum: sha256:6e3736a65a5e83b672dacacd587750c19277612d8a6520cc7318d70e2c6029d6
+  checksum: sha256:6c9b3dd142a09dc468e23ad39aad6f75a0f2b85125104469f026e52a474e464f
 - type: maven
   filename: quarkus-amazon-common-3.9.0.jar
   attributes:
@@ -2952,7 +2952,7 @@ artifacts:
     artifact_id: quarkus-amazon-common
     version: 3.9.0
     type: jar
-  checksum: sha256:df3f66e689967dc0d0fd49fdb37813d16eb6830698c65ee0f57ceae80e989ef0
+  checksum: sha256:9221d57c19959e4b2f91b1592d82ecfdaa3df6f9e19e6e83c0cf6f30eb58e745
 - type: maven
   filename: sdk-core-2.32.4.jar
   attributes:
@@ -2961,7 +2961,7 @@ artifacts:
     artifact_id: sdk-core
     version: 2.32.4
     type: jar
-  checksum: sha256:b825cdc10c61ab37ee75171dfc599bc6aba50ae0eadbe2639e5072ba427d700c
+  checksum: sha256:4eaaf0527532c72a661bebaf8ece2766f9eff551510ffe09f914095c7b11de71
 - type: maven
   filename: checksums-spi-2.32.4.jar
   attributes:
@@ -2970,7 +2970,7 @@ artifacts:
     artifact_id: checksums-spi
     version: 2.32.4
     type: jar
-  checksum: sha256:57d636a4479d87c9f10676a565bce2354219af89eee0afea93cb60a583c1836e
+  checksum: sha256:d2e727263cf9ac757a5da1cd9a0d9f8654cdb05d109df14cd913b1e37a0d86d6
 - type: maven
   filename: checksums-2.32.4.jar
   attributes:
@@ -2979,7 +2979,7 @@ artifacts:
     artifact_id: checksums
     version: 2.32.4
     type: jar
-  checksum: sha256:7fba5c0ac8956b39b8c73efa3b5a03c0b0b8b1879e552cc41a8df8a902388024
+  checksum: sha256:74376d4088291ab84d6ac3c39741f6456e8e631912be579a7e4ad3a7cb52106b
 - type: maven
   filename: profiles-2.32.4.jar
   attributes:
@@ -2988,7 +2988,7 @@ artifacts:
     artifact_id: profiles
     version: 2.32.4
     type: jar
-  checksum: sha256:61d084dad36bee66e25eaf0d5c489d526f66d5737317e8ced22b9ee6048d4f2a
+  checksum: sha256:691aac1a4e60fad8506e67a34615465830f9da9ade9bce383a9ba976f47d754f
 - type: maven
   filename: retries-2.32.4.jar
   attributes:
@@ -2997,7 +2997,7 @@ artifacts:
     artifact_id: retries
     version: 2.32.4
     type: jar
-  checksum: sha256:6314208bbe4c558eb6332cfc13ebee22fb37eda126f6b3ce6bbbd113fe9fff5e
+  checksum: sha256:a14622f67284d6a41e4a7c4713329c097717c1ffa1dcf56a9783cf6f5033a66d
 - type: maven
   filename: aws-core-2.32.4.jar
   attributes:
@@ -3006,7 +3006,7 @@ artifacts:
     artifact_id: aws-core
     version: 2.32.4
     type: jar
-  checksum: sha256:447bc61b3da294e5d1973e2b6367f2f87932eb3df5f1c8a4b8d1adc95d085abd
+  checksum: sha256:38d80dfb3cfc30d9cf6f83e554f226554dea4dd5f769f1ebec5e9580d3711597
 - type: maven
   filename: eventstream-1.0.1.jar
   attributes:
@@ -3015,7 +3015,7 @@ artifacts:
     artifact_id: eventstream
     version: 1.0.1
     type: jar
-  checksum: sha256:395da98339731798a39ff271bc27d0def55003c4748a17ed64e8113d6382912e
+  checksum: sha256:0c37d8e696117f02c302191b8110b0d0eb20fa412fce34c3a269ec73c16ce822
 - type: maven
   filename: regions-2.32.4.jar
   attributes:
@@ -3024,7 +3024,7 @@ artifacts:
     artifact_id: regions
     version: 2.32.4
     type: jar
-  checksum: sha256:684d27c205358deb427502c51a540a4de41514e499807dafffbfcf1f7e8752d4
+  checksum: sha256:c0219ca8414423b8f272f2463f2266953ad3d2bca0b807acbe54515aa9316d56
 - type: maven
   filename: auth-2.32.4.jar
   attributes:
@@ -3033,7 +3033,7 @@ artifacts:
     artifact_id: auth
     version: 2.32.4
     type: jar
-  checksum: sha256:dc189ba85d8f8eee4f7f6ef9310a620a171ca482b43de28a04629d1176890996
+  checksum: sha256:d8edb5c109609c86180e894edb29dc7ce9652eb44d5f556dc8fce04518883899
 - type: maven
   filename: http-auth-aws-eventstream-2.32.4.jar
   attributes:
@@ -3042,7 +3042,7 @@ artifacts:
     artifact_id: http-auth-aws-eventstream
     version: 2.32.4
     type: jar
-  checksum: sha256:5346b0f7a0bfaf87f9ed7878658b84d218b1d0226ad61c94f5b6ad759d4d6f6b
+  checksum: sha256:bc1810ebc9920078340a2ab3d7324f01f548d0455ba34c0f656848e3ba109d35
 - type: maven
   filename: http-client-spi-2.32.4.jar
   attributes:
@@ -3051,7 +3051,7 @@ artifacts:
     artifact_id: http-client-spi
     version: 2.32.4
     type: jar
-  checksum: sha256:c07fa9b743701c45e949586c6bc5a61a2d1598ec9de94928f00f55fb680961a6
+  checksum: sha256:21be7ddd0d6355a4f87194a5e93a59708e6686c8973666c45e521177cc3a1162
 - type: maven
   filename: quarkus-amazon-common-spi-3.9.0.jar
   attributes:
@@ -3060,7 +3060,7 @@ artifacts:
     artifact_id: quarkus-amazon-common-spi
     version: 3.9.0
     type: jar
-  checksum: sha256:0e44f9744897a4bb9de517f0af87f8cf532916456b22db80eb8d204e3c7f6145
+  checksum: sha256:9004cbefa8f7bd07bd7fc60138026f93345252c0f8b2c97e503fb388afa91078
 - type: maven
   filename: cloudwatchlogs-2.32.3.jar
   attributes:
@@ -3069,7 +3069,7 @@ artifacts:
     artifact_id: cloudwatchlogs
     version: 2.32.3
     type: jar
-  checksum: sha256:7f87128ae768117a8105f02283e951f9e7bf7e4076533bf0f04d6b0ae610963b
+  checksum: sha256:e723f0b2e8fe0eef6da1f9634bd50420777110181d742a66608895258e91d54d
 - type: maven
   filename: aws-json-protocol-2.32.4.jar
   attributes:
@@ -3078,7 +3078,7 @@ artifacts:
     artifact_id: aws-json-protocol
     version: 2.32.4
     type: jar
-  checksum: sha256:0d7ec1f1f9f92441020d441bdbc8fa55ff22352d766cf4b558c4001dfef0f854
+  checksum: sha256:aa8f3f6cd3d96882f15b6a8c22df5553462661b6f81397f1d9101a948de93a78
 - type: maven
   filename: third-party-jackson-core-2.32.4.jar
   attributes:
@@ -3087,7 +3087,7 @@ artifacts:
     artifact_id: third-party-jackson-core
     version: 2.32.4
     type: jar
-  checksum: sha256:db0c542803c8d80c4cf9556c8c3b37b73f6fcddbe27f71f123916a63a217cf35
+  checksum: sha256:99b813a5c737100063b3e61c9cff3488b03063df262c497de3318d25be0fe84b
 - type: maven
   filename: protocol-core-2.32.4.jar
   attributes:
@@ -3096,7 +3096,7 @@ artifacts:
     artifact_id: protocol-core
     version: 2.32.4
     type: jar
-  checksum: sha256:5debf9df69ab20fa1bc61d89375078c0b78e4bfee6d94ca14b1689e0289f8075
+  checksum: sha256:a18e0355e85f4934c2c8942a9bfeca9672201e67672c1ed56138a0ba47f729e0
 - type: maven
   filename: http-auth-aws-2.32.4.jar
   attributes:
@@ -3105,7 +3105,7 @@ artifacts:
     artifact_id: http-auth-aws
     version: 2.32.4
     type: jar
-  checksum: sha256:d3950cf116747884a2ab998a6015001586b8e490bb9460f7b0c3f90e2d54d066
+  checksum: sha256:f3218bb0c3f68f5aa282331e07bc18bd4970a88cf333551a99d7c07575429675
 - type: maven
   filename: http-auth-spi-2.32.4.jar
   attributes:
@@ -3114,7 +3114,7 @@ artifacts:
     artifact_id: http-auth-spi
     version: 2.32.4
     type: jar
-  checksum: sha256:106bdd539909ae794bb40fc66019d9b9bec0775e94962af08eac956d291405a0
+  checksum: sha256:7364f09d94b1c2da9be5f03e2990fd8278d51cacb9a7eb479d17a0ca61f0b4b5
 - type: maven
   filename: http-auth-2.32.4.jar
   attributes:
@@ -3123,7 +3123,7 @@ artifacts:
     artifact_id: http-auth
     version: 2.32.4
     type: jar
-  checksum: sha256:22f1e55d981ce0bb58aa1d3c687f40e6d4bf9d94f270c1ec7be8e4628ad313db
+  checksum: sha256:c6493ad85d64408f32c5688130a5a5be406989ae3b04e12b3ab017d263866f1e
 - type: maven
   filename: identity-spi-2.32.4.jar
   attributes:
@@ -3132,7 +3132,7 @@ artifacts:
     artifact_id: identity-spi
     version: 2.32.4
     type: jar
-  checksum: sha256:31cd1604cb5c7e7ebd05149ca17f3716bd7de239bb48808b23327bb564c5fa8d
+  checksum: sha256:6322a9f1b75909c0046c149e56de70c3cd5fc58cc85c3eedbd8e429142255bdd
 - type: maven
   filename: annotations-2.32.4.jar
   attributes:
@@ -3141,7 +3141,7 @@ artifacts:
     artifact_id: annotations
     version: 2.32.4
     type: jar
-  checksum: sha256:468ed5fbf3af3f0ce447a914ef2505bef34f48f7b3006311a3f30eba45f29a18
+  checksum: sha256:c800b8869c6ce1e8209dc4fa434f95acba565d62c203b5eec2f1212397dc25e6
 - type: maven
   filename: utils-2.32.4.jar
   attributes:
@@ -3150,7 +3150,7 @@ artifacts:
     artifact_id: utils
     version: 2.32.4
     type: jar
-  checksum: sha256:bbac38f75f34ea43d5b17912a0016559fcbd329d6154d169bc09725589255702
+  checksum: sha256:05e1f8526a414c3cd1c57b57fd4e0004833708cfe9d89042fe9384955903ae7f
 - type: maven
   filename: metrics-spi-2.32.4.jar
   attributes:
@@ -3159,7 +3159,7 @@ artifacts:
     artifact_id: metrics-spi
     version: 2.32.4
     type: jar
-  checksum: sha256:ac1c5c4afaddaafc6e2e191fae5048996346784c811c17c82d207d84edc18724
+  checksum: sha256:54bb9173ab493d54a28e5a7f7ab6663b397b8f875fa31ace7402a361b74b773a
 - type: maven
   filename: json-utils-2.32.4.jar
   attributes:
@@ -3168,7 +3168,7 @@ artifacts:
     artifact_id: json-utils
     version: 2.32.4
     type: jar
-  checksum: sha256:2eb96885536b720134fd6ad74a664967c341e549bdbaf7fbd90b13a5b63aa99f
+  checksum: sha256:db46c23df910682c3a53b7ae2a053a869d7f80bcf05df34a3f26364dbd8fa225
 - type: maven
   filename: endpoints-spi-2.32.4.jar
   attributes:
@@ -3177,7 +3177,7 @@ artifacts:
     artifact_id: endpoints-spi
     version: 2.32.4
     type: jar
-  checksum: sha256:8819489cd6ee229f068ac18d26c57322a0e13f3dcaa782ef00c975a8c2200876
+  checksum: sha256:dd6cdbd8cdcc2608a2cfbcf91ae54beaed23cc954ba33de02731144f689dd532
 - type: maven
   filename: retries-spi-2.32.4.jar
   attributes:
@@ -3186,7 +3186,7 @@ artifacts:
     artifact_id: retries-spi
     version: 2.32.4
     type: jar
-  checksum: sha256:31b64625fa3cc531d9b5872d026504477c54f1e1a7e36772fca226c4b316af8a
+  checksum: sha256:490dc3554209735a63abe5d08c5cafa556f21007ce3bdb17b4975ecfae01b452
 - type: maven
   filename: apache-client-2.32.4.jar
   attributes:
@@ -3195,7 +3195,7 @@ artifacts:
     artifact_id: apache-client
     version: 2.32.4
     type: jar
-  checksum: sha256:0d4b956d5a1fec1210ba138fd0e4d8f06a33ce04e402d57895e6ddacd7a7edbe
+  checksum: sha256:1e3ed3cc5a5c56e3dce76f1c97d91b83a72fe0a38ef5a3b589f78ffbe943b296
 - type: maven
   filename: netty-nio-client-2.32.4.jar
   attributes:
@@ -3204,7 +3204,7 @@ artifacts:
     artifact_id: netty-nio-client
     version: 2.32.4
     type: jar
-  checksum: sha256:51f0bb3e0cd124fa12278cd0bc29f1303cb5396d0ec9b8f4b47527880b1a0610
+  checksum: sha256:c1bf0087e402546850c2e429f0cbfc18e13768b36cf87ebd586e22836303361f
 - type: maven
   filename: netty-transport-classes-epoll-4.1.127.Final.jar
   attributes:
@@ -3213,7 +3213,7 @@ artifacts:
     artifact_id: netty-transport-classes-epoll
     version: 4.1.127.Final
     type: jar
-  checksum: sha256:f825644a9c7af4ada7c365215770bb4d6ff4d00b73c78dd6f9f4ef753064af26
+  checksum: sha256:a39452eb911cb60068da6cdfd00e513b0a06e195b064fc44bd6fbfbc43c9527e
 - type: maven
   filename: ecs-logging-core-1.7.0.jar
   attributes:
@@ -3222,7 +3222,7 @@ artifacts:
     artifact_id: ecs-logging-core
     version: 1.7.0
     type: jar
-  checksum: sha256:a6e36b33d1bc4b47d09f615ffd6908cd58dcdf9cf9ea0be8ab08f14d4d9545ec
+  checksum: sha256:6431b4461025605ea26d8de2f8133a6178483522d0b9195f6445b693b524690b
 - type: maven
   filename: graal-sdk-23.1.2.jar
   attributes:
@@ -3231,7 +3231,7 @@ artifacts:
     artifact_id: graal-sdk
     version: 23.1.2
     type: jar
-  checksum: sha256:f2da6099fafd6c655e374a66a29888484ba9500dcbaf2ad629f349121bdba44e
+  checksum: sha256:a0dd3d7cfdee5dd069487d1f89e3fe985d06e362bf8abda1315a5b2bdc4d3ba0
 - type: maven
   filename: collections-23.1.2.jar
   attributes:
@@ -3240,7 +3240,7 @@ artifacts:
     artifact_id: collections
     version: 23.1.2
     type: jar
-  checksum: sha256:e2e230c5bd414b67c247eb6f68b3d3fcf505db2cedeab0cc49842826c85cc5ef
+  checksum: sha256:851a4052aaf916372c4fde2762c031446cd54fbf62ce7382a2ce08ab47fe33a8
 - type: maven
   filename: word-23.1.2.jar
   attributes:
@@ -3249,7 +3249,7 @@ artifacts:
     artifact_id: word
     version: 23.1.2
     type: jar
-  checksum: sha256:0e79b6fa11c0ab43831ebc1322d13ef4ce66aab2c2f024727a95f3652f0ef2b1
+  checksum: sha256:2ae7a71ff3f53f61d1d7360a6152f67ce3902ae86ca22b30b70208dc0cf4e039
 - type: maven
   filename: quarkus-logging-sentry-2.1.8.jar
   attributes:
@@ -3258,7 +3258,7 @@ artifacts:
     artifact_id: quarkus-logging-sentry
     version: 2.1.8
     type: jar
-  checksum: sha256:16b62fb3a218465a7080b986c0007fa5360a0455fb8c936dc1830da13ffbf613
+  checksum: sha256:ac7dc078d2d32fe12f356defd3420c2aeae69df505c2e606e6cfa6fc72a49eec
 - type: maven
   filename: sentry-jul-8.20.0.jar
   attributes:
@@ -3267,7 +3267,7 @@ artifacts:
     artifact_id: sentry-jul
     version: 8.20.0
     type: jar
-  checksum: sha256:08c57f97c6a6b5a8e73f6d90b69dec2d439e9ab9680f845d6e40716a069b66a9
+  checksum: sha256:243001b685cbae6dd47fa5cfc874579b36f40f1e30bfc2798f25da769bc712e2
 - type: maven
   filename: sentry-8.20.0.jar
   attributes:
@@ -3276,7 +3276,7 @@ artifacts:
     artifact_id: sentry
     version: 8.20.0
     type: jar
-  checksum: sha256:4a03e3e6abd4df63dbc582cb39a20b0ad9fd999e6698d08311c18a71c3955ec0
+  checksum: sha256:1b929906d11155b03d8306355eb1069562f67a5c258c5d11d21d2f9d3d4631b4
 - type: maven
   filename: clowder-quarkus-config-source-2.7.1.jar
   attributes:
@@ -3285,7 +3285,7 @@ artifacts:
     artifact_id: clowder-quarkus-config-source
     version: 2.7.1
     type: jar
-  checksum: sha256:4874819e8e8359fd0bec1ed9883cea9f53a457664b040bb3903860ccccdc63a3
+  checksum: sha256:9497426b6998a34111680319d4c67356b7ea159ba8735c036075c0f9dffedf54
 - type: maven
   filename: smallrye-config-3.13.4.jar
   attributes:
@@ -3294,7 +3294,7 @@ artifacts:
     artifact_id: smallrye-config
     version: 3.13.4
     type: jar
-  checksum: sha256:812e7585dafdf9b27c4a2f6783cecdb418cde11c8e4b3d1db63dcd1c46459326
+  checksum: sha256:ca8d6fb0b020d874b707f2c4a13d6492d62ea7fffa95fe03c040f553f77998f4
 - type: maven
   filename: smallrye-config-core-3.13.4.jar
   attributes:
@@ -3303,7 +3303,7 @@ artifacts:
     artifact_id: smallrye-config-core
     version: 3.13.4
     type: jar
-  checksum: sha256:613aef72889ae7926f8c535ec485357403772c49734c6689764241b28a7b1327
+  checksum: sha256:b2ac5384844bae798b40c57057f131eb72754fb68366fb092bda5d913ee4a35b
 - type: maven
   filename: smallrye-config-common-3.13.4.jar
   attributes:
@@ -3312,7 +3312,7 @@ artifacts:
     artifact_id: smallrye-config-common
     version: 3.13.4
     type: jar
-  checksum: sha256:958e11ef43cc4911441cf3a21ecd23a88a3da8d4b52eaa6b454ca95a62c16be8
+  checksum: sha256:fd3fb6f0609d2cb95d26119912165f89036120392ff79cabe0bc24cdb7acda51
 - type: maven
   filename: quarkus-hibernate-orm-3.26.4.jar
   attributes:
@@ -3321,7 +3321,7 @@ artifacts:
     artifact_id: quarkus-hibernate-orm
     version: 3.26.4
     type: jar
-  checksum: sha256:a6c44c82271d3cfc0372aa64432e95e38e86e37fc378c010399e5786906ee702
+  checksum: sha256:9263fb11fa4d341173718a41f12f9bdf36cebcaf940bcb04ab83f0dcd78b4c42
 - type: maven
   filename: quarkus-agroal-3.26.4.jar
   attributes:
@@ -3330,7 +3330,7 @@ artifacts:
     artifact_id: quarkus-agroal
     version: 3.26.4
     type: jar
-  checksum: sha256:0a5adb7e2d728a6a4b50f35b623cb64c24deb8415765fcb12eb1f909b36a0d9b
+  checksum: sha256:7bdd569f7202347dd8c9611d4c5907eeb2b64517dd0d1459f5c8bb5439d8d073
 - type: maven
   filename: quarkus-datasource-3.26.4.jar
   attributes:
@@ -3339,7 +3339,7 @@ artifacts:
     artifact_id: quarkus-datasource
     version: 3.26.4
     type: jar
-  checksum: sha256:ff5621474ba5203926417839b182fc4ab29567b89548ddff27d895ed9f95a105
+  checksum: sha256:98c8418a156e9aa8d7d60996faaf3fa232ee150f5f1464db2e0667866e04f56d
 - type: maven
   filename: agroal-api-2.8.jar
   attributes:
@@ -3348,7 +3348,7 @@ artifacts:
     artifact_id: agroal-api
     version: '2.8'
     type: jar
-  checksum: sha256:f53f5dc86496cf5529bdbcbebf39cd55b00cc4c6890091869880eb3ce48cf750
+  checksum: sha256:e5500e8fd736e749ec0373e8af3f2d2af8c37cf0d9eb73a35290b2dd2156421a
 - type: maven
   filename: agroal-narayana-2.8.jar
   attributes:
@@ -3357,7 +3357,7 @@ artifacts:
     artifact_id: agroal-narayana
     version: '2.8'
     type: jar
-  checksum: sha256:0c48697592ae641db81a8d9004404ee61544032b39459174e6f8e075e73a303b
+  checksum: sha256:0e7e658707a9bc3f857defc1005f649abbf010d54697ec7c66d7d43f39c3fe23
 - type: maven
   filename: jboss-transaction-spi-8.0.0.Final.jar
   attributes:
@@ -3366,7 +3366,7 @@ artifacts:
     artifact_id: jboss-transaction-spi
     version: 8.0.0.Final
     type: jar
-  checksum: sha256:82067fc0451a771377fcaad5dc6fc347da9b489417028052e47a5ca2bea2dc5a
+  checksum: sha256:07e4e62ceae075a8c11a715d89b19992c879f505b48be6b2727f5be798562ae1
 - type: maven
   filename: agroal-pool-2.8.jar
   attributes:
@@ -3375,7 +3375,7 @@ artifacts:
     artifact_id: agroal-pool
     version: '2.8'
     type: jar
-  checksum: sha256:2048ac8b29b83553980729243fd6f58256a48da9b647ee73c6ad759b54c09ec3
+  checksum: sha256:2964854555dab2c32b745b383ac13400396f827f35b2f12a2c984afacfe7523e
 - type: maven
   filename: quarkus-narayana-jta-3.26.4.jar
   attributes:
@@ -3384,7 +3384,7 @@ artifacts:
     artifact_id: quarkus-narayana-jta
     version: 3.26.4
     type: jar
-  checksum: sha256:d8529e24718c9b954e588efcb919b65f1098e534d4ec49140a93275a526d1260
+  checksum: sha256:9e986be4e48275763211e0e399c4576c50212f4d144d4e9b4b32f8ec61cfe5a6
 - type: maven
   filename: quarkus-transaction-annotations-3.26.4.jar
   attributes:
@@ -3393,7 +3393,7 @@ artifacts:
     artifact_id: quarkus-transaction-annotations
     version: 3.26.4
     type: jar
-  checksum: sha256:bcad8ac77779b1564bf8506809fd0ca6429d8ab334c9fd6ce45e958e3b423fd7
+  checksum: sha256:1a58d3a2eec29e7cb11b3beb8204e8d5ed9db864b88df74e38f36193509f9e12
 - type: maven
   filename: quarkus-datasource-common-3.26.4.jar
   attributes:
@@ -3402,7 +3402,7 @@ artifacts:
     artifact_id: quarkus-datasource-common
     version: 3.26.4
     type: jar
-  checksum: sha256:bf4145ffb11fbae1951c6cb7421d9a6342bf55ae321f4dbee625dea475a1725b
+  checksum: sha256:cef2f7475a5be092fc1120c77da2a80647ce53b4d08d3d0c22b7f77981fd177c
 - type: maven
   filename: smallrye-context-propagation-jta-2.2.1.jar
   attributes:
@@ -3411,7 +3411,7 @@ artifacts:
     artifact_id: smallrye-context-propagation-jta
     version: 2.2.1
     type: jar
-  checksum: sha256:51851bbc3275d91f482ff55e74a0d029c2316b1aec26768ea6dbe7ddac89885a
+  checksum: sha256:b4e2ec0db2911b83416cd5ade8dd3c77063eb8f6e7408927a32a4aa72fbeeb09
 - type: maven
   filename: smallrye-reactive-converter-mutiny-3.0.3.jar
   attributes:
@@ -3420,7 +3420,7 @@ artifacts:
     artifact_id: smallrye-reactive-converter-mutiny
     version: 3.0.3
     type: jar
-  checksum: sha256:c13b9db0130215392596503096a7e80e066ce9085bbcb33be2f3b237b917ae9a
+  checksum: sha256:5255e5e77d38b0bc166511c3ce7af3a97cf1edeaa19d2946102f929d99273111
 - type: maven
   filename: narayana-jta-7.2.2.Final.jar
   attributes:
@@ -3429,7 +3429,7 @@ artifacts:
     artifact_id: narayana-jta
     version: 7.2.2.Final
     type: jar
-  checksum: sha256:0a9b8031be91fd912fa7f9d33cb6f95073770c20d9c342e26cd1cd2f584a83ac
+  checksum: sha256:f5bf0b0561b408908a23db614b084f57f355a16bcf89e1f5b928bfab01e33a0c
 - type: maven
   filename: jakarta.resource-api-2.1.0.jar
   attributes:
@@ -3438,7 +3438,7 @@ artifacts:
     artifact_id: jakarta.resource-api
     version: 2.1.0
     type: jar
-  checksum: sha256:9eb332553beb6609219f5086cd6b5f12e784b3c047d4ee4d35b8fa0190d5680d
+  checksum: sha256:4d26ad86a5f72cd2f9c4a31cc4524f7bf3ec0ff74416f081f8642b7ce8041067
 - type: maven
   filename: jboss-invocation-2.0.0.Final.jar
   attributes:
@@ -3447,7 +3447,7 @@ artifacts:
     artifact_id: jboss-invocation
     version: 2.0.0.Final
     type: jar
-  checksum: sha256:c800942e81b345c1a3f6051e5347568efe2dcb41ac4c2dd1192f021f9cb7d76d
+  checksum: sha256:ef9beb3bff85930710b367b6f84d40bf72128898ca6ccdf3775537793b74b067
 - type: maven
   filename: narayana-jts-integration-7.2.2.Final.jar
   attributes:
@@ -3456,7 +3456,7 @@ artifacts:
     artifact_id: narayana-jts-integration
     version: 7.2.2.Final
     type: jar
-  checksum: sha256:e10fff0ab50cc59702b31ff14352f8022d2dd644cff5f71f5b20f155c44f8c7a
+  checksum: sha256:cba2351b5cf53ea21f40e70418b7c785f7c19171f2a4e2fc02ac5df6e728a164
 - type: maven
   filename: hibernate-core-7.1.0.Final.jar
   attributes:
@@ -3465,7 +3465,7 @@ artifacts:
     artifact_id: hibernate-core
     version: 7.1.0.Final
     type: jar
-  checksum: sha256:76975fe0db57f38505a6f13290c9f7caad5c313d68ded99907c8eb99597ef339
+  checksum: sha256:3d290966bbc074597c26cd2a975827fe37d5fe2951f3394a0cafe9ccf21eee3a
 - type: maven
   filename: hibernate-models-1.0.1.jar
   attributes:
@@ -3474,7 +3474,7 @@ artifacts:
     artifact_id: hibernate-models
     version: 1.0.1
     type: jar
-  checksum: sha256:0143a1ea5a0b5bb3ab3ea5032ab190a87d90e906e25cbe5ba21af25efd143ace
+  checksum: sha256:bdb42c4979001742ebc098f3b206dd1057dc93be55c50a31c3f027d3eed06412
 - type: maven
   filename: classmate-1.7.0.jar
   attributes:
@@ -3483,7 +3483,7 @@ artifacts:
     artifact_id: classmate
     version: 1.7.0
     type: jar
-  checksum: sha256:05865c4e2d731e7b01c67dd52e7c49c2110e38ebab2da25332bbecdf4bada493
+  checksum: sha256:cb868f231c5cceb89d795ea00e6e1b7a93b8f4ac1ce1d8be76dde322dff4a046
 - type: maven
   filename: antlr4-runtime-4.13.2.jar
   attributes:
@@ -3492,7 +3492,7 @@ artifacts:
     artifact_id: antlr4-runtime
     version: 4.13.2
     type: jar
-  checksum: sha256:5d8590a65e94b8a4d80d0ce6202f9abbe4dd518a6526d611007a81a1f00de7ee
+  checksum: sha256:dd3e8a13a2d669bf84fb8d834de35ce4875f27157698d206241ec8488aadcaf7
 - type: maven
   filename: hibernate-graalvm-7.1.0.Final.jar
   attributes:
@@ -3501,7 +3501,7 @@ artifacts:
     artifact_id: hibernate-graalvm
     version: 7.1.0.Final
     type: jar
-  checksum: sha256:0797d4353606d0da04e8d392a0ced238c0a49b284f6bfb59b97f18eff5859de6
+  checksum: sha256:00985dd35e2916ff93b564a3133d7b39a473b74c0e628972b1971ecbb440cc08
 - type: maven
   filename: jaxb-runtime-4.0.5.jar
   attributes:
@@ -3510,7 +3510,7 @@ artifacts:
     artifact_id: jaxb-runtime
     version: 4.0.5
     type: jar
-  checksum: sha256:4d3d11fd7740e9f87ee04fc60bee3636809cbfd00a66946e2dc0a8c673640e7b
+  checksum: sha256:485d8940e76373a7f300815ea5504bf5b726c234425ad30971019d133124cca4
 - type: maven
   filename: jaxb-core-4.0.5.jar
   attributes:
@@ -3519,7 +3519,7 @@ artifacts:
     artifact_id: jaxb-core
     version: 4.0.5
     type: jar
-  checksum: sha256:80a2cb260a26a0d70bb84c8157a5d1c00bed626a9d57a717f448b7988b048cf4
+  checksum: sha256:ad3fd9bf00de3eda9859f70b6cfb011e2fe9904804e16a2665092888ece0fdca
 - type: maven
   filename: txw2-4.0.5.jar
   attributes:
@@ -3528,7 +3528,7 @@ artifacts:
     artifact_id: txw2
     version: 4.0.5
     type: jar
-  checksum: sha256:fe0e592335f4f46cfa12aed8942b05bc5e75df92440ff01d84ce0c782ae0addf
+  checksum: sha256:917355bc451481f30d043b24d123110517966af34383901773882810dca480e5
 - type: maven
   filename: istack-commons-runtime-4.1.2.jar
   attributes:
@@ -3537,7 +3537,7 @@ artifacts:
     artifact_id: istack-commons-runtime
     version: 4.1.2
     type: jar
-  checksum: sha256:91706a6aa0450d2c51ba0c0b1d108acecdef36e834c50e69c1a0acd7ef02a77c
+  checksum: sha256:7fd6792361f4dd00f8c56af4a20cecc0066deea4a8f3dec38348af23fc2296ee
 - type: maven
   filename: jakarta.persistence-api-3.2.0.jar
   attributes:
@@ -3546,7 +3546,7 @@ artifacts:
     artifact_id: jakarta.persistence-api
     version: 3.2.0
     type: jar
-  checksum: sha256:480671d31fda1dfe0bf1c470731aadf347d7b91fba45e711886fc61a6aeda104
+  checksum: sha256:be8a26b0e75c84c1b7600f759256fbc68d60333d89ec0ce3f784fc3ffa09aa8c
 - type: maven
   filename: jakarta.transaction-api-2.0.1.jar
   attributes:
@@ -3555,7 +3555,7 @@ artifacts:
     artifact_id: jakarta.transaction-api
     version: 2.0.1
     type: jar
-  checksum: sha256:9b2f5f2ebb1cc32e644e611111df82da24307e09670679301c9d9fa3ee9619d1
+  checksum: sha256:50c0a7c760c13ae6c042acf182b28f0047413db95b4636fb8879bcffab5ba875
 - type: maven
   filename: quarkus-local-cache-0.3.1.jar
   attributes:
@@ -3564,7 +3564,7 @@ artifacts:
     artifact_id: quarkus-local-cache
     version: 0.3.1
     type: jar
-  checksum: sha256:015448f8a9b195d6a26187d4cd0ca3632a7f04b69552379b940770da1fc34cbc
+  checksum: sha256:a8feb703499dfaf129a364c84e1fb5f6c9738b96b6ac3e59dfc4697652a23d0b
 - type: maven
   filename: quarkus-caffeine-3.26.4.jar
   attributes:
@@ -3573,7 +3573,7 @@ artifacts:
     artifact_id: quarkus-caffeine
     version: 3.26.4
     type: jar
-  checksum: sha256:82b8ef8913dd974912e68672b30f63b9d76b70885acb2b03d4421486f79ae847
+  checksum: sha256:8a632a7059b3c305415a985e1c7c0e4aad2aa59d88346fe85823679091a100d4
 - type: maven
   filename: caffeine-3.2.2.jar
   attributes:
@@ -3582,7 +3582,7 @@ artifacts:
     artifact_id: caffeine
     version: 3.2.2
     type: jar
-  checksum: sha256:6953915abcb429848d58b7f9b7cd39772af3ade6819687be16f1c22efeec7c35
+  checksum: sha256:c74a6c72221dfb76eb92f2bb40108ea561a7da2f315dc3b1e64afa8f077f210c
 - type: maven
   filename: jspecify-1.0.0.jar
   attributes:
@@ -3591,7 +3591,7 @@ artifacts:
     artifact_id: jspecify
     version: 1.0.0
     type: jar
-  checksum: sha256:611b14d8d0410063ecadcfb348bca2abe63fbe5cff2279c0b7e72adb1c34d0ee
+  checksum: sha256:1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab
 - type: maven
   filename: error_prone_annotations-2.41.0.jar
   attributes:
@@ -3600,7 +3600,7 @@ artifacts:
     artifact_id: error_prone_annotations
     version: 2.41.0
     type: jar
-  checksum: sha256:8fcc485b5c57c19aafa1b0fd9d69c3c8a599e7dfd3e621c8b0f3170e60025c6a
+  checksum: sha256:a56e782b5b50811ac204073a355a21d915a2107fce13ec711331ad036f660fcc
 - type: maven
   filename: quarkus-hibernate-validator-3.26.4.jar
   attributes:
@@ -3609,7 +3609,7 @@ artifacts:
     artifact_id: quarkus-hibernate-validator
     version: 3.26.4
     type: jar
-  checksum: sha256:568fe0c108adb6b558545c8c9eabea8dffe3b60a391e1e1bcfc05d6205d65f8f
+  checksum: sha256:4a2a919d8b9bd4e6bf8fc8b0f59780bc727454d2a4c01c8448779825b0d87fc3
 - type: maven
   filename: hibernate-validator-9.0.1.Final.jar
   attributes:
@@ -3618,7 +3618,7 @@ artifacts:
     artifact_id: hibernate-validator
     version: 9.0.1.Final
     type: jar
-  checksum: sha256:de8fd1224d98bbcc8317caacef13d3084696f908a661fd50a7bbfed04857106b
+  checksum: sha256:25f40118fa4c50f8522d090d25d52d5a38953b0ccd1250835f052e7bd3164ce0
 - type: maven
   filename: expressly-6.0.0.jar
   attributes:
@@ -3627,7 +3627,7 @@ artifacts:
     artifact_id: expressly
     version: 6.0.0
     type: jar
-  checksum: sha256:becee0c3b5eb4c5df89cadb8e750ebcab982875a9faadb9fb9023b6a6ba9b677
+  checksum: sha256:86ee67c7040278bac5204b571f738b8b859f014ceb5f896bd935bacbdaf33cb9
 - type: maven
   filename: jakarta.el-api-6.0.1.jar
   attributes:
@@ -3636,7 +3636,7 @@ artifacts:
     artifact_id: jakarta.el-api
     version: 6.0.1
     type: jar
-  checksum: sha256:e7f43c47500302a58eaf85447f1e6ca28904b682c98c6b4c855a1ed4332aec1c
+  checksum: sha256:7e84b5bed49de32b79cc5e85d90b6f5adb1a953ac67283adbb41c1e297f9c605
 - type: maven
   filename: smallrye-config-validator-3.13.4.jar
   attributes:
@@ -3645,7 +3645,7 @@ artifacts:
     artifact_id: smallrye-config-validator
     version: 3.13.4
     type: jar
-  checksum: sha256:7e09740f7c81933e9c537aba73f3ff984cd958d2c437b267123c140235b62ca5
+  checksum: sha256:0a1aa2b774efef4df53a32b7566345d9a8744297c1cec1b1d9a682b1c40e69e9
 - type: maven
   filename: jakarta.ws.rs-api-3.1.0.jar
   attributes:
@@ -3654,7 +3654,7 @@ artifacts:
     artifact_id: jakarta.ws.rs-api
     version: 3.1.0
     type: jar
-  checksum: sha256:4fbad29647c74b2555aa80db638563673c9cabd52b5a10f76c3519146a6b5c51
+  checksum: sha256:6b3b3628b8b4aedda0d24c3354335e985497d8ef3c510b8f3028e920d5b8663d
 - type: maven
   filename: quarkus-rest-jackson-3.26.4.jar
   attributes:
@@ -3663,7 +3663,7 @@ artifacts:
     artifact_id: quarkus-rest-jackson
     version: 3.26.4
     type: jar
-  checksum: sha256:c985e3e8fa0406533fea5473125253973a9a57bd9318aa9ccf59801043bc7704
+  checksum: sha256:e5eb76318d76ea1eaf3115192293bd83885201682cc969ce34d5afbb7e32ff78
 - type: maven
   filename: quarkus-smallrye-openapi-3.26.4.jar
   attributes:
@@ -3672,7 +3672,7 @@ artifacts:
     artifact_id: quarkus-smallrye-openapi
     version: 3.26.4
     type: jar
-  checksum: sha256:22e3100e0f17aed02f80b76959c1071981ffe15a3518c452e617b6795abc72b7
+  checksum: sha256:80b3905ba1d6c58de27969f89de3b0502f4f59c537479bb35b518a03934d21f0
 - type: maven
   filename: smallrye-open-api-core-4.0.12.jar
   attributes:
@@ -3681,7 +3681,7 @@ artifacts:
     artifact_id: smallrye-open-api-core
     version: 4.0.12
     type: jar
-  checksum: sha256:453f6f964a96af285235000d6926a95d6794db1f8b488187b0800c1792a27211
+  checksum: sha256:2261cc22fe6b592a481032bb61c57080e30382841410cc40580e5ed75dac41e4
 - type: maven
   filename: microprofile-openapi-api-4.0.2.jar
   attributes:
@@ -3690,7 +3690,7 @@ artifacts:
     artifact_id: microprofile-openapi-api
     version: 4.0.2
     type: jar
-  checksum: sha256:aee62fff713aa0e8b01fb7a40203f583135e219adf77e8137c8697c592d0cad5
+  checksum: sha256:c6fca9913d7ecbdeb801d5e6c935988219f64a0eb8b17e23437ea0e01e7a10a9
 - type: maven
   filename: smallrye-open-api-model-4.0.12.jar
   attributes:
@@ -3699,7 +3699,7 @@ artifacts:
     artifact_id: smallrye-open-api-model
     version: 4.0.12
     type: jar
-  checksum: sha256:b129baddf50e11029d247ba768a477b197b9c9d7cf705d4fd012d34c4609f683
+  checksum: sha256:15a5b10f48fd79ef15535743965cfc17e090570f30480f0ac53d852ca2ea7c94
 - type: maven
   filename: smallrye-common-classloader-2.13.9.jar
   attributes:
@@ -3708,7 +3708,7 @@ artifacts:
     artifact_id: smallrye-common-classloader
     version: 2.13.9
     type: jar
-  checksum: sha256:e616fa17b8b559a678655e675066f5c3825d8a6f7accdd83138f64dc16932d29
+  checksum: sha256:27b7498b4d26e9288689570f8a859b08806d59f44fa0a4db03e60dd51d4d7884
 - type: maven
   filename: quarkus-swagger-ui-3.26.4.jar
   attributes:
@@ -3717,7 +3717,7 @@ artifacts:
     artifact_id: quarkus-swagger-ui
     version: 3.26.4
     type: jar
-  checksum: sha256:085add78bbea17a3c6f2c5981ee7460d70846d3c686ae8647b82dd8d215f80d3
+  checksum: sha256:5c4261b10fcaad0d081f03f1e31bcec9a20c51d2527dc8239563363680c7eb29
 - type: maven
   filename: quarkus-cache-3.26.4.jar
   attributes:
@@ -3726,7 +3726,7 @@ artifacts:
     artifact_id: quarkus-cache
     version: 3.26.4
     type: jar
-  checksum: sha256:0ac8deade5f27a2fc3e448f2a8d7485087321b68a8adb83cf6956bfc0e1a1d3e
+  checksum: sha256:0866b6d54f86f9558b2237585d6340072f8dd115f7355519ad9ec3656e7b7dfd
 - type: maven
   filename: quarkus-cache-runtime-spi-3.26.4.jar
   attributes:
@@ -3735,7 +3735,7 @@ artifacts:
     artifact_id: quarkus-cache-runtime-spi
     version: 3.26.4
     type: jar
-  checksum: sha256:7162ceb7b70493fba96a8792989bda8abe4df2f366dc7d223184daae5a84099a
+  checksum: sha256:69ffad5d2000aa037d938e05ced7beda67fec0ddba4860946ae0b8deefca2dbb
 - type: maven
   filename: quarkus-smallrye-fault-tolerance-3.26.4.jar
   attributes:
@@ -3744,7 +3744,7 @@ artifacts:
     artifact_id: quarkus-smallrye-fault-tolerance
     version: 3.26.4
     type: jar
-  checksum: sha256:ce95cb2f93dab69a8a026322f6183b3164958e563e3b0edf4fb410c483a450cb
+  checksum: sha256:7de6171eeecb664536686f4e3180d87cdb5861d7ce9ca556af6f08b2bb2e9331
 - type: maven
   filename: smallrye-fault-tolerance-6.9.3.jar
   attributes:
@@ -3753,7 +3753,7 @@ artifacts:
     artifact_id: smallrye-fault-tolerance
     version: 6.9.3
     type: jar
-  checksum: sha256:036fd6ca643238b1ee3ee51e3a5690b348e5e1991c38aa7f0bab4f7142540b3d
+  checksum: sha256:89a3750085656285844e7f416561cbd522974fb6bc49aa33c1aa928825ed8571
 - type: maven
   filename: microprofile-fault-tolerance-api-4.1.2.jar
   attributes:
@@ -3762,7 +3762,7 @@ artifacts:
     artifact_id: microprofile-fault-tolerance-api
     version: 4.1.2
     type: jar
-  checksum: sha256:b51745d46bf1235c8ae6f486539f1b7edde946208dd547993f779cfe3619b505
+  checksum: sha256:76c351922cbac8098e28bdc0431513992ff2468f24eb3b2e8f4ce500d460dfcc
 - type: maven
   filename: smallrye-fault-tolerance-api-6.9.3.jar
   attributes:
@@ -3771,7 +3771,7 @@ artifacts:
     artifact_id: smallrye-fault-tolerance-api
     version: 6.9.3
     type: jar
-  checksum: sha256:32a046179e1dda8b4f8f01308ceb358df63e579331fee2760670967c3eef64f5
+  checksum: sha256:f00651c083644bfa1a1d8c684c5ccaeba5779c1dab09c64e3ddb9f0114744364
 - type: maven
   filename: smallrye-fault-tolerance-core-6.9.3.jar
   attributes:
@@ -3780,7 +3780,7 @@ artifacts:
     artifact_id: smallrye-fault-tolerance-core
     version: 6.9.3
     type: jar
-  checksum: sha256:f2d30f794c9fa8b39ec69cbb77f72a48d7867b22e7a197c9e38fc4843e6a306e
+  checksum: sha256:309326f0ad9d4371e8c3c9b4fb1a4a276bd5345525e58c5eb8991ae342868120
 - type: maven
   filename: smallrye-fault-tolerance-autoconfig-core-6.9.3.jar
   attributes:
@@ -3789,7 +3789,7 @@ artifacts:
     artifact_id: smallrye-fault-tolerance-autoconfig-core
     version: 6.9.3
     type: jar
-  checksum: sha256:984cf319661fc442f09395a90d38668962bfe596da6bcf71ef4ad84ce214323b
+  checksum: sha256:998716d38bee13be83e96ff49f1777a022be22ad28edb4fcd269545a7040bc45
 - type: maven
   filename: smallrye-fault-tolerance-apiimpl-6.9.3.jar
   attributes:
@@ -3798,7 +3798,7 @@ artifacts:
     artifact_id: smallrye-fault-tolerance-apiimpl
     version: 6.9.3
     type: jar
-  checksum: sha256:ea79986aef9cf4445087b461df81a0f322a687996458ca49d630ca9186fe3b02
+  checksum: sha256:fd26af416751e7f7227daebfc2acfb3bb89d43e82ca85350361fbc6e9e5281cd
 - type: maven
   filename: jakarta.enterprise.cdi-api-4.1.0.jar
   attributes:
@@ -3807,7 +3807,7 @@ artifacts:
     artifact_id: jakarta.enterprise.cdi-api
     version: 4.1.0
     type: jar
-  checksum: sha256:cfe055c23a06ddba5482a6b17020bcf482fb6e705b31ba86a7e14088729d0e85
+  checksum: sha256:c42c808f17925129a0800f618febe050d966e181a4c7384c8a5e7a0283d68699
 - type: maven
   filename: jakarta.enterprise.lang-model-4.1.0.jar
   attributes:
@@ -3816,7 +3816,7 @@ artifacts:
     artifact_id: jakarta.enterprise.lang-model
     version: 4.1.0
     type: jar
-  checksum: sha256:e32c97dad3630270007291ae3fb76b2e2f23e69e61f4e98dcb2ba2eaef366dc3
+  checksum: sha256:bb56f571f60d2862b2387d5468fe8f5540f8094727283ed991f89082708095ee
 - type: maven
   filename: jakarta.interceptor-api-2.2.0.jar
   attributes:
@@ -3825,7 +3825,7 @@ artifacts:
     artifact_id: jakarta.interceptor-api
     version: 2.2.0
     type: jar
-  checksum: sha256:268d396c3af8ae79e9c8456a6680f78b7d83fb8b6d7779d41c94de8c7efe50ad
+  checksum: sha256:d240d72b4dd38a2e431c804079810010cb97903678fa5f987fb7434878b04398
 - type: maven
   filename: smallrye-fault-tolerance-context-propagation-6.9.3.jar
   attributes:
@@ -3834,7 +3834,7 @@ artifacts:
     artifact_id: smallrye-fault-tolerance-context-propagation
     version: 6.9.3
     type: jar
-  checksum: sha256:a07f66d5299dfc8016f1ebd0be6c3ea719d42d1628b3ea07f6ec467473e51103
+  checksum: sha256:cc328c174af35d271a118e1bc45f1261a49e691af35ab7e02b642b3fd3aa2ddf
 - type: maven
   filename: smallrye-fault-tolerance-mutiny-6.9.3.jar
   attributes:
@@ -3843,7 +3843,7 @@ artifacts:
     artifact_id: smallrye-fault-tolerance-mutiny
     version: 6.9.3
     type: jar
-  checksum: sha256:beeee1d0849c5b57a3c26780aac84f6b06278fbb05277f27eb9dde046864de32
+  checksum: sha256:062d6ff292fa90f7003972117f69869a960f945dd727ccbeb0106aea32389747
 - type: maven
   filename: mapstruct-1.6.3.jar
   attributes:
@@ -3852,7 +3852,7 @@ artifacts:
     artifact_id: mapstruct
     version: 1.6.3
     type: jar
-  checksum: sha256:4bb1f21f4f97e93065f4b2b05b15f2fc3458e2439c1d8f2b427038ed19dc6019
+  checksum: sha256:00b52467f31d482f8673b0b74306f4be0a305cdce31e587bc1b3d7bf779f1dbf
 - type: maven
   filename: opentelemetry-instrumentation-annotations-2.10.0.jar
   attributes:
@@ -3861,7 +3861,7 @@ artifacts:
     artifact_id: opentelemetry-instrumentation-annotations
     version: 2.10.0
     type: jar
-  checksum: sha256:4053b838660a14c81db6de4e99b3ab549e866d6d7f8f0c811e2fe873bb051ff6
+  checksum: sha256:906ba2ac747109e4540bd8723763fc1d0c51600b9fea203ba2276a42959bf6d3
 - type: maven
   filename: opentelemetry-api-1.44.1.jar
   attributes:
@@ -3870,7 +3870,7 @@ artifacts:
     artifact_id: opentelemetry-api
     version: 1.44.1
     type: jar
-  checksum: sha256:6892354faf0e666aaeb0b0e92b2265c177a22a27777f41fb7770cf39522a7e75
+  checksum: sha256:097e2e71c8b8c813f4a13176baafbbbb124b1253f5c9fffd110bc2add74ace93
 - type: maven
   filename: opentelemetry-context-1.44.1.jar
   attributes:
@@ -3879,7 +3879,7 @@ artifacts:
     artifact_id: opentelemetry-context
     version: 1.44.1
     type: jar
-  checksum: sha256:7765a56b8b1bb1fe831451344b4ae0c777f4fa39fb5c943745b61c8eb5e213b9
+  checksum: sha256:006b3f7c3880356a86f02c40eedeba124f226a2f145fe904cc1b7def0088bab0
 - type: maven
   filename: quarkus-jacoco-3.26.4.jar
   attributes:
@@ -3888,7 +3888,7 @@ artifacts:
     artifact_id: quarkus-jacoco
     version: 3.26.4
     type: jar
-  checksum: sha256:e78a508200914d8a5edcd5a4fb6c48859c67ce4abce4f0c02ffdd5659f1a301c
+  checksum: sha256:3e8ebd48e6b26ec6a68eb518418ba48e40bbca403f78675dcf858d16c6a9bdd0
 - type: maven
   filename: quarkus-core-3.26.4.jar
   attributes:
@@ -3897,7 +3897,7 @@ artifacts:
     artifact_id: quarkus-core
     version: 3.26.4
     type: jar
-  checksum: sha256:2985069fde37cc6d7081669dddd0a687e72f95c1a49a2d01b3bf744ac9b81f27
+  checksum: sha256:bafb94686c8a1764deb9fc98bff0aa900846e941b8c7cd063b3f913cd30f4c09
 - type: maven
   filename: jakarta.inject-api-2.0.1.jar
   attributes:
@@ -3906,7 +3906,7 @@ artifacts:
     artifact_id: jakarta.inject-api
     version: 2.0.1
     type: jar
-  checksum: sha256:a7f50c8949376ca5294485e3bc1493686afec8de5a9c66e0c3676c6b9cac40aa
+  checksum: sha256:f7dc98062fccf14126abb751b64fab12c312566e8cbdc8483598bffcea93af7c
 - type: maven
   filename: smallrye-common-os-2.13.9.jar
   attributes:
@@ -3915,7 +3915,7 @@ artifacts:
     artifact_id: smallrye-common-os
     version: 2.13.9
     type: jar
-  checksum: sha256:9857529546e39772dd9d4ff415e7a78dd9bdf4027a155ed8159ed0e80b389cf8
+  checksum: sha256:8de1846ca0674a299cd6c37f66914ce72569019b5706267aa3963ce68fd87b36
 - type: maven
   filename: quarkus-ide-launcher-3.26.4.jar
   attributes:
@@ -3924,7 +3924,7 @@ artifacts:
     artifact_id: quarkus-ide-launcher
     version: 3.26.4
     type: jar
-  checksum: sha256:caffbff67ba433925ba2ee0e76f9c3e7f2339c0769747d89733224bf7336d068
+  checksum: sha256:7deac72c7fc0ad612c34dd19d93a9a4c377705c0cb96968eeb35311ed4dd5c24
 - type: maven
   filename: jboss-logmanager-3.1.2.Final.jar
   attributes:
@@ -3933,7 +3933,7 @@ artifacts:
     artifact_id: jboss-logmanager
     version: 3.1.2.Final
     type: jar
-  checksum: sha256:3fdb82d094196554dfab499056e600e5a551035963ebf55cc5a556060c415699
+  checksum: sha256:c1e7de682a4871a8e4eefb26adaf0fcc63cd0913543c50aa6b7f46fa5ec151fe
 - type: maven
   filename: smallrye-common-cpu-2.13.9.jar
   attributes:
@@ -3942,7 +3942,7 @@ artifacts:
     artifact_id: smallrye-common-cpu
     version: 2.13.9
     type: jar
-  checksum: sha256:df8f0a29ac510b3e7b3a4f88998c889accb179dee9a3d0a483887515ca1d83f2
+  checksum: sha256:7ecaf8b4f048afb8a732fd798be4de29a33d9e01b58adce90fa22dfcedb6ef7c
 - type: maven
   filename: smallrye-common-expression-2.13.9.jar
   attributes:
@@ -3951,7 +3951,7 @@ artifacts:
     artifact_id: smallrye-common-expression
     version: 2.13.9
     type: jar
-  checksum: sha256:66c890c9f16d51426bccb3135d39638f2b5bbe8eba671ba621e1394e67b384d6
+  checksum: sha256:45f4f698e5f1daf239313616ede8faa0f1682dcb19b2ba6ae5750a6c1337d834
 - type: maven
   filename: smallrye-common-net-2.13.9.jar
   attributes:
@@ -3960,7 +3960,7 @@ artifacts:
     artifact_id: smallrye-common-net
     version: 2.13.9
     type: jar
-  checksum: sha256:67721209c7f61a9d1db07927c82ebe625a09e3d4122cb20e5ecb27dc4f968608
+  checksum: sha256:5825dbae884cb9cbde7a5e93025fd29caf3d0c4848a98b2fe049129e6b9587a7
 - type: maven
   filename: smallrye-common-ref-2.13.9.jar
   attributes:
@@ -3969,7 +3969,7 @@ artifacts:
     artifact_id: smallrye-common-ref
     version: 2.13.9
     type: jar
-  checksum: sha256:a71535388abbbbdbf4d61bbd9206bd7d221c2627f1eed265efeadb45a407a0de
+  checksum: sha256:72e147f76dc3a2d7aac9f18b812708390d1d8cf768ad32f556852068616575d7
 - type: maven
   filename: jakarta.json-api-2.1.3.jar
   attributes:
@@ -3978,7 +3978,7 @@ artifacts:
     artifact_id: jakarta.json-api
     version: 2.1.3
     type: jar
-  checksum: sha256:b463a982ba203889fe8926c8913ee22e917931677d06aee89b18edf49cc5879d
+  checksum: sha256:bc934142805ea1d794f1440563965a3861a2a9fb7414ecd3fe44f26500734414
 - type: maven
   filename: jboss-threads-3.9.1.jar
   attributes:
@@ -3987,7 +3987,7 @@ artifacts:
     artifact_id: jboss-threads
     version: 3.9.1
     type: jar
-  checksum: sha256:37103699442a434cc8aeb427f9642f625d0d97890eb568661bc4672fecada34e
+  checksum: sha256:d3af2f6b942eae683ff2de7dfe68467f8d570cbba8db37fe858977349c3bf2aa
 - type: maven
   filename: smallrye-common-function-2.13.9.jar
   attributes:
@@ -3996,7 +3996,7 @@ artifacts:
     artifact_id: smallrye-common-function
     version: 2.13.9
     type: jar
-  checksum: sha256:d8c52770a066828e5ac07e6bafcd2814d14d3319bfb5aca80a0eca9309f267f4
+  checksum: sha256:7f1fdd06f9201b00420569dbda7f5fc8c16b8ebc9e9c688f372709834804e3ca
 - type: maven
   filename: slf4j-jboss-logmanager-2.0.0.Final.jar
   attributes:
@@ -4005,7 +4005,7 @@ artifacts:
     artifact_id: slf4j-jboss-logmanager
     version: 2.0.0.Final
     type: jar
-  checksum: sha256:bc8caff4ab7a269b5167db81b193e912d0f8340df9d3da24766aee2a04ffac68
+  checksum: sha256:277885104b727a213ef784bab31499d23221074ded28b04827e809d2f5489693
 - type: maven
   filename: wildfly-common-2.0.1.jar
   attributes:
@@ -4014,7 +4014,7 @@ artifacts:
     artifact_id: wildfly-common
     version: 2.0.1
     type: jar
-  checksum: sha256:b96bfbfc1485de3b720830aeef904ce01f0958e559d88b1e7f24ec8f3d824c71
+  checksum: sha256:fa4a710db7ae3e598a5f41639eb54e9f7b09de5fd0f58f56bd6070f21d956374
 - type: maven
   filename: quarkus-bootstrap-runner-3.26.4.jar
   attributes:
@@ -4023,7 +4023,7 @@ artifacts:
     artifact_id: quarkus-bootstrap-runner
     version: 3.26.4
     type: jar
-  checksum: sha256:1170e0bdb7ea76eb916b8d4ad9f19c04cfdf64968e4bb699c04f0c54cfd74521
+  checksum: sha256:52ae904982bfea8d33bfaa54e851ad936a82add0030235f36d4f53063a2097d6
 - type: maven
   filename: quarkus-fs-util-1.1.0.jar
   attributes:
@@ -4032,7 +4032,7 @@ artifacts:
     artifact_id: quarkus-fs-util
     version: 1.1.0
     type: jar
-  checksum: sha256:072eb71d507ba81900ddbb00a9d8859e8335a713d77a5ade25cac85c20cc35d9
+  checksum: sha256:515792e2c261e704b5c052be21fdaa9cc43aa5fd8588df53cf2edd071fd9ee26
 - type: maven
   filename: quarkus-arc-3.26.4.jar
   attributes:
@@ -4041,7 +4041,7 @@ artifacts:
     artifact_id: quarkus-arc
     version: 3.26.4
     type: jar
-  checksum: sha256:c5b88a447f56bc20cc0b581dfe6f2479e0eb2c23ddd25bd8319acd7123c81428
+  checksum: sha256:fb0454db951947596cd4c7f8ba4eb8e978497011f3c55e3f4033cbe72e852f5a
 - type: maven
   filename: arc-3.26.4.jar
   attributes:
@@ -4050,7 +4050,7 @@ artifacts:
     artifact_id: arc
     version: 3.26.4
     type: jar
-  checksum: sha256:492668a69db9e8eac44a80ee9fa8f95fe4ac14e44c19910038180b161a9870ff
+  checksum: sha256:6356f9aadcfff417d1352cde1c64d611b7ad2cbe6a652a8553c9ebfdcfb5edc8
 - type: maven
   filename: microprofile-context-propagation-api-1.3.jar
   attributes:
@@ -4059,7 +4059,7 @@ artifacts:
     artifact_id: microprofile-context-propagation-api
     version: '1.3'
     type: jar
-  checksum: sha256:039a0b83a06108636482d2f9bbbc894ea6c6c0750034be7c486e06bacc559d8c
+  checksum: sha256:69ccc04487e87779d4970aa50c673cc34a9df080c1c0e8d8eab2e8b46f825cf4
 - type: maven
   filename: org.jacoco.core-0.8.13.jar
   attributes:
@@ -4068,7 +4068,7 @@ artifacts:
     artifact_id: org.jacoco.core
     version: 0.8.13
     type: jar
-  checksum: sha256:65ba20d07232b3e94909347af0f6e7e72f735e6873c5ece36ff323b78b40b1bb
+  checksum: sha256:514c23df6cfd015d7d83c10a792e35ab68a7b7e82f3d6a3a4481762c132e33a9
 - type: maven
   filename: asm-9.8.jar
   attributes:
@@ -4077,7 +4077,7 @@ artifacts:
     artifact_id: asm
     version: '9.8'
     type: jar
-  checksum: sha256:da765ca813a7a8a79cfe26df7da5c1cb8d8eb881b6f9baf714931db33b46958e
+  checksum: sha256:876eab6a83daecad5ca67eb9fcabb063c97b5aeb8cf1fca7a989ecde17522051
 - type: maven
   filename: asm-tree-9.8.jar
   attributes:
@@ -4086,7 +4086,7 @@ artifacts:
     artifact_id: asm-tree
     version: '9.8'
     type: jar
-  checksum: sha256:0820fa385cda532b4394599d09da29dad963085e7adf990d8150cdddb11b0f7f
+  checksum: sha256:14b7880cb7c85eed101e2710432fc3ffb83275532a6a894dc4c4095d49ad59f1
 - type: maven
   filename: org.jacoco.report-0.8.13.jar
   attributes:
@@ -4095,7 +4095,7 @@ artifacts:
     artifact_id: org.jacoco.report
     version: 0.8.13
     type: jar
-  checksum: sha256:fcae49c18f5d79e582c289ba3182e6c9d986c776937e2ce97d3ca94aaa80d14c
+  checksum: sha256:8133280a0aa44358be9d136b52370342f455ccb944aae07438220a77662578a2
 - type: maven
   filename: org.jacoco.agent-0.8.13.jar
   attributes:
@@ -4104,7 +4104,7 @@ artifacts:
     artifact_id: org.jacoco.agent
     version: 0.8.13
     type: jar
-  checksum: sha256:83c71118aa62e219ad07898b44b69e781911018e0d19ceff19b9a6008b81c426
+  checksum: sha256:9db3c9d5d74fa870b261b64a3082412e1bd6e22e9fa98f4737b1bff8af9cc64d
 - type: maven
   filename: org.jacoco.agent-0.8.13-runtime.jar
   attributes:
@@ -4114,7 +4114,7 @@ artifacts:
     version: 0.8.13
     type: jar
     classifier: runtime
-  checksum: sha256:83c71118aa62e219ad07898b44b69e781911018e0d19ceff19b9a6008b81c426
+  checksum: sha256:47e700ccb0fdb9e27c5241353f8161938f4e53c3561dd35e063c5fe88dc3349b
 - type: maven
   filename: asm-commons-9.8.jar
   attributes:
@@ -4123,4 +4123,4 @@ artifacts:
     artifact_id: asm-commons
     version: '9.8'
     type: jar
-  checksum: sha256:bc9000b77e26dd27870de3eb0c725e03d6eafff24b00704032ca7fe67f9130be
+  checksum: sha256:3301a1c1cb4c59fcc5292648dac1d7c5aed4c0f067dfbe88873b8cdfe77404f4

--- a/connector-drawer/artifacts.lock.yaml
+++ b/connector-drawer/artifacts.lock.yaml
@@ -1,0 +1,4182 @@
+metadata:
+  version: '1.0'
+artifacts:
+- type: maven
+  filename: notifications-connector-common-http-1.0.0-SNAPSHOT.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.redhat.cloud.notifications
+    artifact_id: notifications-connector-common-http
+    version: 1.0.0-SNAPSHOT
+    type: jar
+  checksum: sha256:49354ea6a4301e201b6f2d7389fcbeb8c16bf28f75677cb873b33bb8129fbbb0
+- type: maven
+  filename: notifications-connector-common-1.0.0-SNAPSHOT.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.redhat.cloud.notifications
+    artifact_id: notifications-connector-common
+    version: 1.0.0-SNAPSHOT
+    type: jar
+  checksum: sha256:d222f944f29fa894bcb23bc712b706a626005a892e75c4ed18a152db9a9ed028
+- type: maven
+  filename: camel-quarkus-http-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-http
+    version: 3.26.0
+    type: jar
+  checksum: sha256:a2ed1c8ed8156802dfcc7f396ad94bfd0ab56e8e3700abd5703ba3e52a5dce2a
+- type: maven
+  filename: camel-quarkus-http-common-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-http-common
+    version: 3.26.0
+    type: jar
+  checksum: sha256:2d75ddee101d7fbe627cf035c815eeecbd159bb1e52cf4d8d67e5b03533afbad
+- type: maven
+  filename: camel-quarkus-core-cloud-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-core-cloud
+    version: 3.26.0
+    type: jar
+  checksum: sha256:1ca42c6feecd26c2ee52c6108f98f19182a0cbd13a709151a99404351aa40881
+- type: maven
+  filename: camel-http-common-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-http-common
+    version: 4.14.0
+    type: jar
+  checksum: sha256:996cef8df31d34a3ef95ff6ca01293b18ab2eb1627ce80a0ef0ec90b01502bde
+- type: maven
+  filename: camel-http-base-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-http-base
+    version: 4.14.0
+    type: jar
+  checksum: sha256:8763dd3f123d16af874432fe43214436841319a2d20afc6ba37f74b7fac2619f
+- type: maven
+  filename: camel-attachments-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-attachments
+    version: 4.14.0
+    type: jar
+  checksum: sha256:d3274dd70a20bb33831c20d4cc544bda7035561e1766b190d78e8a70c37f28e4
+- type: maven
+  filename: angus-activation-2.0.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.angus
+    artifact_id: angus-activation
+    version: 2.0.2
+    type: jar
+  checksum: sha256:25d58710a35612a49949df7d6e0209853a5eb69362a01b197539207e050ed2df
+- type: maven
+  filename: jakarta.servlet-api-6.0.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.servlet
+    artifact_id: jakarta.servlet-api
+    version: 6.0.0
+    type: jar
+  checksum: sha256:66ecc52d25f61859a3b8c6fe9e702738fc2c1bdc227862abe4b1ec43906b67c0
+- type: maven
+  filename: camel-quarkus-support-httpclient5-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-support-httpclient5
+    version: 3.26.0
+    type: jar
+  checksum: sha256:225de9af788afcadd230e00b23f2eef0071e3fc4b580ba3b6837853d5118f97e
+- type: maven
+  filename: httpclient5-5.5.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.httpcomponents.client5
+    artifact_id: httpclient5
+    version: '5.5'
+    type: jar
+  checksum: sha256:6ba5eb0178a540f558facfbfc58af7c19dd75b8e3693c350a5c383263b92ea21
+- type: maven
+  filename: camel-http-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-http
+    version: 4.14.0
+    type: jar
+  checksum: sha256:44b08b6899ce3cb5fd7c71c609da5122852cf2d726f3f541a0bef3f5587c3899
+- type: maven
+  filename: camel-cloud-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-cloud
+    version: 4.14.0
+    type: jar
+  checksum: sha256:6249381a48271b3cd96827644856c44a8887e1e0387cac3721710c21d00c368f
+- type: maven
+  filename: camel-util-json-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-util-json
+    version: 4.14.0
+    type: jar
+  checksum: sha256:1a82a88b0b634dacb79eb99783435fc09f21f61ae9164a0ce8671ecd8959cddb
+- type: maven
+  filename: httpcore5-5.3.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.httpcomponents.core5
+    artifact_id: httpcore5
+    version: 5.3.4
+    type: jar
+  checksum: sha256:38c8cae8b2efba33a1ffde9d8e88baa6d397c08fdf4dbed70e723e51ab57c9f9
+- type: maven
+  filename: httpcore5-h2-5.3.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.httpcomponents.core5
+    artifact_id: httpcore5-h2
+    version: 5.3.4
+    type: jar
+  checksum: sha256:1d8f535f8bc0e027f8a99c3fe02d277a546dfe4a2faa9400076267a6a223b349
+- type: maven
+  filename: notifications-common-template-1.0.0-SNAPSHOT.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.redhat.cloud.notifications
+    artifact_id: notifications-common-template
+    version: 1.0.0-SNAPSHOT
+    type: jar
+  checksum: sha256:e107f6f6c1b3f95a1ba5c654faa73518f8132a14cbd8ffa1e2fc4202e7b5bfe9
+- type: maven
+  filename: quarkus-qute-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-qute
+    version: 3.26.4
+    type: jar
+  checksum: sha256:cbd95fc040fd7716dd09d524aef409ca6d2c6da228991933eb1ddda4e3583482
+- type: maven
+  filename: qute-core-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.qute
+    artifact_id: qute-core
+    version: 3.26.4
+    type: jar
+  checksum: sha256:b88255d9bbcae976c4cf66c5de219a7ebfcc6e0a485e4b8be46c7a85273f08bb
+- type: maven
+  filename: insights-notification-schemas-java-1.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.redhat.cloud.common
+    artifact_id: insights-notification-schemas-java
+    version: 1.0.1
+    type: jar
+  checksum: sha256:36365241c320e1a9e202de483488f54f6a6bf574b96f1588ffdc71ce2df5a11a
+- type: maven
+  filename: event-schemas-1.4.12.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.redhat.cloud.event
+    artifact_id: event-schemas
+    version: 1.4.12
+    type: jar
+  checksum: sha256:6d213bfa2352e9817c9259cdbb5466ff368bfc749d250713c30b26eb3dba9a66
+- type: maven
+  filename: jackson-datatype-jsr310-2.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.fasterxml.jackson.datatype
+    artifact_id: jackson-datatype-jsr310
+    version: 2.19.2
+    type: jar
+  checksum: sha256:03afb33a075222bd94809bcf77b16f6f4b40fa1e2a1eef0386b9546434d6415c
+- type: maven
+  filename: jackson-datatype-jdk8-2.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.fasterxml.jackson.datatype
+    artifact_id: jackson-datatype-jdk8
+    version: 2.19.2
+    type: jar
+  checksum: sha256:d1b64159854e20522ea0e201b562a500a1512eb137594a1c4e006d882dfb4192
+- type: maven
+  filename: jackson-core-2.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.fasterxml.jackson.core
+    artifact_id: jackson-core
+    version: 2.19.2
+    type: jar
+  checksum: sha256:f108c0a9c7015e3b15f86716429e76a0ea2b1ab5feebef912431d962b6a3eb74
+- type: maven
+  filename: quarkus-rest-client-jackson-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-rest-client-jackson
+    version: 3.26.4
+    type: jar
+  checksum: sha256:aff35e94a11178d3954cdf9e1ac652bdbc4a2bb86d8f455a1e199153003fa2b8
+- type: maven
+  filename: resteasy-reactive-jackson-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.resteasy.reactive
+    artifact_id: resteasy-reactive-jackson
+    version: 3.26.4
+    type: jar
+  checksum: sha256:269d16cbfd9658a503f7978ca730adadedf6b0cef913cb395c038f82a312b1cb
+- type: maven
+  filename: resteasy-reactive-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.resteasy.reactive
+    artifact_id: resteasy-reactive
+    version: 3.26.4
+    type: jar
+  checksum: sha256:595fae89f24a6bdd967b5500024cd5c450a9959eba41da91042b4e2df673f597
+- type: maven
+  filename: resteasy-reactive-common-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.resteasy.reactive
+    artifact_id: resteasy-reactive-common
+    version: 3.26.4
+    type: jar
+  checksum: sha256:fd239c7780c1146150cdf8965ea4d39e44cd1680f623ab07696c374339f63fe3
+- type: maven
+  filename: resteasy-reactive-common-types-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.resteasy.reactive
+    artifact_id: resteasy-reactive-common-types
+    version: 3.26.4
+    type: jar
+  checksum: sha256:18df10e889284f1e301cc6a513741103a1e23192ee4d71bcab50a43968dc5c2b
+- type: maven
+  filename: commons-logging-jboss-logging-1.0.0.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jboss.logging
+    artifact_id: commons-logging-jboss-logging
+    version: 1.0.0.Final
+    type: jar
+  checksum: sha256:fe37c37aa4f39e5a80bcf00808c4a11046831fcf51ebcf947daf7d45f2ab1a40
+- type: maven
+  filename: jakarta.xml.bind-api-4.0.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.xml.bind
+    artifact_id: jakarta.xml.bind-api
+    version: 4.0.2
+    type: jar
+  checksum: sha256:2d717f6d90e4668ad87b108ae9fd9d637dd7d2dd1fdd41cee99ec2a4a13c4c46
+- type: maven
+  filename: jakarta.activation-api-2.1.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.activation
+    artifact_id: jakarta.activation-api
+    version: 2.1.3
+    type: jar
+  checksum: sha256:b2e22d55a51a42bb3163efdb570376854411399cc8d11658b59b54368dee66d1
+- type: maven
+  filename: quarkus-rest-jackson-common-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-rest-jackson-common
+    version: 3.26.4
+    type: jar
+  checksum: sha256:099006fad97c770cd68e53e82989f0c4501099fd8195f71fd77d64f696927fb0
+- type: maven
+  filename: quarkus-rest-common-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-rest-common
+    version: 3.26.4
+    type: jar
+  checksum: sha256:9c176e241618d7443a571d0fa06f35c67ab4925f614dff47f386db5933aa3728
+- type: maven
+  filename: quarkus-jsonp-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-jsonp
+    version: 3.26.4
+    type: jar
+  checksum: sha256:874574bffd9898a77002528c3b29c6355aa034f4b73efb4494ce635fc4c4ea08
+- type: maven
+  filename: parsson-1.1.7.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.parsson
+    artifact_id: parsson
+    version: 1.1.7
+    type: jar
+  checksum: sha256:1232df8ac25107e351b844c298d74f2bebe277e49e045ef7bc5de147c962c772
+- type: maven
+  filename: quarkus-rest-client-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-rest-client
+    version: 3.26.4
+    type: jar
+  checksum: sha256:2d7748386f846ac5b742c331b2bd408e7f276aa07d33706ca7652379d0de3241
+- type: maven
+  filename: quarkus-rest-client-jaxrs-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-rest-client-jaxrs
+    version: 3.26.4
+    type: jar
+  checksum: sha256:1e88ecbf681a11890101b7bbf9f9cea749d567f494726dd9e6bc22819bd01e47
+- type: maven
+  filename: resteasy-reactive-client-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.resteasy.reactive
+    artifact_id: resteasy-reactive-client
+    version: 3.26.4
+    type: jar
+  checksum: sha256:881c0d5456ae995430215a1a50fa7d641d60ddd81218909bca09aea42ec4a6b8
+- type: maven
+  filename: stork-api-2.7.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.stork
+    artifact_id: stork-api
+    version: 2.7.3
+    type: jar
+  checksum: sha256:6139ddb048f873dd623a9eaa136423b6972f1f69a45b0733403e32fee63128c8
+- type: maven
+  filename: vertx-web-client-4.5.21.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.vertx
+    artifact_id: vertx-web-client
+    version: 4.5.21
+    type: jar
+  checksum: sha256:55190fefaf36ebd14b6683a698a6573d3078ae4ae5e09ce77af7db3c50b47cab
+- type: maven
+  filename: vertx-uri-template-4.5.21.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.vertx
+    artifact_id: vertx-uri-template
+    version: 4.5.21
+    type: jar
+  checksum: sha256:2a647d60050f943211f244fe4cfcf0e868f525ebeeaed024c0cae23f1c27ac0a
+- type: maven
+  filename: quarkus-rest-client-config-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-rest-client-config
+    version: 3.26.4
+    type: jar
+  checksum: sha256:61888e9237f59b3f90d307873da02abaf406a9b733c009ccc20758ef432788e6
+- type: maven
+  filename: jandex-3.4.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: jandex
+    version: 3.4.0
+    type: jar
+  checksum: sha256:5d288888e24ae43953cd4cc4d980decbe2e2f69bf72c47efa2c0584d7c23d445
+- type: maven
+  filename: quarkus-tls-registry-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-tls-registry
+    version: 3.26.4
+    type: jar
+  checksum: sha256:c5cee5a31c3133f482e905d80467b65ffce2a04d10e21cf96de52de80f3bf2d0
+- type: maven
+  filename: quarkus-tls-registry-spi-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-tls-registry-spi
+    version: 3.26.4
+    type: jar
+  checksum: sha256:1fa41fcaeac018a8e42c7d1ef46599e37a0c5b32a9af55769735c755d79debd5
+- type: maven
+  filename: quarkus-credentials-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-credentials
+    version: 3.26.4
+    type: jar
+  checksum: sha256:0ac32b7a54027efdb360c67b0361c0a7bda6b140ac586f22bfa0d9918080085c
+- type: maven
+  filename: smallrye-private-key-pem-parser-0.9.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.certs
+    artifact_id: smallrye-private-key-pem-parser
+    version: 0.9.2
+    type: jar
+  checksum: sha256:9d37ad326652ae59c1873dcd14df3139532e04f990697d2de463f7fdaee6e3d6
+- type: maven
+  filename: microprofile-rest-client-api-4.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.microprofile.rest.client
+    artifact_id: microprofile-rest-client-api
+    version: '4.0'
+    type: jar
+  checksum: sha256:83c7a63bd584b88e4250af4617e9205b17b86bf09ad2d6bf19c2ca5e35a62d85
+- type: maven
+  filename: jakarta.validation-api-3.1.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.validation
+    artifact_id: jakarta.validation-api
+    version: 3.1.1
+    type: jar
+  checksum: sha256:5ea88202c23bd9adde8f55c2ba307a2814ab14d992e01e39185a30f3d2d18ed3
+- type: maven
+  filename: quarkus-messaging-kafka-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-messaging-kafka
+    version: 3.26.4
+    type: jar
+  checksum: sha256:0e5f26c597fb75bb22f756c63286b70ced8a1ae6328642e1db64f93982210dcb
+- type: maven
+  filename: quarkus-kafka-client-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-kafka-client
+    version: 3.26.4
+    type: jar
+  checksum: sha256:a6d1c3f1521de190643173c705210cb5eaefdb6e1bd9f741613d08e6e306dd81
+- type: maven
+  filename: smallrye-reactive-messaging-kafka-4.28.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-reactive-messaging-kafka
+    version: 4.28.0
+    type: jar
+  checksum: sha256:ccc2f4c2670bb8f6861c83190273186d7eb737fd5f96fcb5a8828e58505b1ab6
+- type: maven
+  filename: smallrye-reactive-messaging-kafka-api-4.28.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-reactive-messaging-kafka-api
+    version: 4.28.0
+    type: jar
+  checksum: sha256:b6ed33e645161f4b367e47daae349b4aacc8fab6dbd700faae39300be669286f
+- type: maven
+  filename: smallrye-reactive-messaging-otel-4.28.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-reactive-messaging-otel
+    version: 4.28.0
+    type: jar
+  checksum: sha256:efd7ecfb4d17cffca03bf4950608f5449825a0c52016fd5d8cfd39fc3775acfe
+- type: maven
+  filename: opentelemetry-semconv-1.28.0-alpha.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.opentelemetry.semconv
+    artifact_id: opentelemetry-semconv
+    version: 1.28.0-alpha
+    type: jar
+  checksum: sha256:a7e2c33d4df74b853f5af61ceeb09a0d90ffb4c509579720efb1a3b3647e6955
+- type: maven
+  filename: opentelemetry-instrumentation-api-2.10.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.opentelemetry.instrumentation
+    artifact_id: opentelemetry-instrumentation-api
+    version: 2.10.0
+    type: jar
+  checksum: sha256:5bf53d329b939822523244708a011a74b1b81cc8a3964f21de14933964c921d5
+- type: maven
+  filename: opentelemetry-api-incubator-1.44.1-alpha.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.opentelemetry
+    artifact_id: opentelemetry-api-incubator
+    version: 1.44.1-alpha
+    type: jar
+  checksum: sha256:ebe4583773be0180ff4a9bf16822019ee0e1bbe5fdb9eb8ac6dad1c83f1b4122
+- type: maven
+  filename: opentelemetry-instrumentation-api-incubator-2.10.0-alpha.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.opentelemetry.instrumentation
+    artifact_id: opentelemetry-instrumentation-api-incubator
+    version: 2.10.0-alpha
+    type: jar
+  checksum: sha256:ca0e61aa5673a2ed75862e5f674200486960779f96ffd5c214373c84823989d0
+- type: maven
+  filename: quarkus-jackson-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-jackson
+    version: 3.26.4
+    type: jar
+  checksum: sha256:5a4077776abb6dc0586be77a380ee1dc9505013c22a819032293c733c8ff2a2d
+- type: maven
+  filename: jackson-module-parameter-names-2.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.fasterxml.jackson.module
+    artifact_id: jackson-module-parameter-names
+    version: 2.19.2
+    type: jar
+  checksum: sha256:13c6ff4b5852f206bff405b928b12e0f24192313824469b4ae105c8589adfa40
+- type: maven
+  filename: kafka-clients-4.0.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.kafka
+    artifact_id: kafka-clients
+    version: 4.0.0
+    type: jar
+  checksum: sha256:077220c1ef6659e774d983eccb282c4f36ecffc0af5cc8c32e592b723afc23b5
+- type: maven
+  filename: zstd-jni-1.5.6-6.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.github.luben
+    artifact_id: zstd-jni
+    version: 1.5.6-6
+    type: jar
+  checksum: sha256:fce58c298ac2cb44a134f20587f6bd077eefd5db91b286fbeb23663dceb7382d
+- type: maven
+  filename: lz4-java-1.8.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.lz4
+    artifact_id: lz4-java
+    version: 1.8.0
+    type: jar
+  checksum: sha256:2b8a1911400ff7f9954d2627479ab2100bc3ae12c008d0bad4e6053c4102f173
+- type: maven
+  filename: snappy-java-1.1.10.5.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.xerial.snappy
+    artifact_id: snappy-java
+    version: 1.1.10.5
+    type: jar
+  checksum: sha256:69dddd46d385ea848880e93f9e4d30efa58d25a3208f271cd742a9028a52fa2b
+- type: maven
+  filename: quarkus-messaging-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-messaging
+    version: 3.26.4
+    type: jar
+  checksum: sha256:04c0bdcc097514d53db42f9df1265520a6b429b351685f0ce03fac74450ff163
+- type: maven
+  filename: quarkus-mutiny-reactive-streams-operators-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-mutiny-reactive-streams-operators
+    version: 3.26.4
+    type: jar
+  checksum: sha256:2e54c5e9b53faf5dc1778aeb082231e4cce839895280879f57e880974e9b17e1
+- type: maven
+  filename: microprofile-reactive-streams-operators-api-3.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.microprofile.reactive-streams-operators
+    artifact_id: microprofile-reactive-streams-operators-api
+    version: 3.0.1
+    type: jar
+  checksum: sha256:f04b4442e5759363a26e9594a3ac33c06e277d692659972564feb9c47cbc7932
+- type: maven
+  filename: microprofile-reactive-streams-operators-core-3.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.microprofile.reactive-streams-operators
+    artifact_id: microprofile-reactive-streams-operators-core
+    version: 3.0.1
+    type: jar
+  checksum: sha256:49ad66c31df3c889127a6c8dfcfc2f39711281092866c910893b4349e24a5bbc
+- type: maven
+  filename: mutiny-reactive-streams-operators-2.9.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: mutiny-reactive-streams-operators
+    version: 2.9.4
+    type: jar
+  checksum: sha256:f071465401dcd53cbfacc35aa72502311c83d32e3250c365c1c6d637d68b559c
+- type: maven
+  filename: quarkus-messaging-kotlin-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-messaging-kotlin
+    version: 3.26.4
+    type: jar
+  checksum: sha256:2ebf958fd05fa1d04e0ce47b8f309929e654b203c5a086b9eea4501344a3a2a0
+- type: maven
+  filename: vertx-web-4.5.21.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.vertx
+    artifact_id: vertx-web
+    version: 4.5.21
+    type: jar
+  checksum: sha256:0b46ad2977bf6845bb6e120275e015ccbb19826737e0406e4799f44765836419
+- type: maven
+  filename: vertx-web-common-4.5.21.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.vertx
+    artifact_id: vertx-web-common
+    version: 4.5.21
+    type: jar
+  checksum: sha256:1bd24fe5bf5c37d66a13f8a6e9d28b8712f02402e406b847f8c9ec6398ef1f2b
+- type: maven
+  filename: vertx-auth-common-4.5.21.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.vertx
+    artifact_id: vertx-auth-common
+    version: 4.5.21
+    type: jar
+  checksum: sha256:0d28674ad56a19dfe29459edf34c386af51fa43981eca2f0c0edd631c26f8e87
+- type: maven
+  filename: vertx-bridge-common-4.5.21.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.vertx
+    artifact_id: vertx-bridge-common
+    version: 4.5.21
+    type: jar
+  checksum: sha256:241030bd4b69fcd9cbd1e7e1397d39b189ae7206cdb9cd96aee913b487725439
+- type: maven
+  filename: quarkus-vertx-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-vertx
+    version: 3.26.4
+    type: jar
+  checksum: sha256:1f98a7dac82ab402a7dc3b318f212c0016013aeaa0fc6f4df6ac2e621bf55e64
+- type: maven
+  filename: quarkus-netty-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-netty
+    version: 3.26.4
+    type: jar
+  checksum: sha256:9f4cc536c0ca35cd90799cc55c2cc3ff730630acd433430e6a0964266e8c646d
+- type: maven
+  filename: netty-codec-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-codec
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:4bcb5524f8c5e0325b4a37543e113355bb52b8ce7185e14cf7c6ccb0315c4193
+- type: maven
+  filename: netty-codec-http-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-codec-http
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:869646b60ccf63b46fd3e27bc569d46343b8879e22915576e1cefe2a169bc009
+- type: maven
+  filename: netty-codec-http2-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-codec-http2
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:5698c7712cd1c149e229e13cef02207d9d8865d4c4b4ad8b431323c94bd84cf2
+- type: maven
+  filename: netty-handler-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-handler
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:931ac946186fbccdb3df84a704001d42219a52c662735e8dfac61a451e30080c
+- type: maven
+  filename: netty-transport-native-unix-common-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-transport-native-unix-common
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:30bfdffac691ea0f7d3729dccf66fcb2de4bf8d4f5ca4c9ff808e372d47cd0cf
+- type: maven
+  filename: netty-codec-haproxy-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-codec-haproxy
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:6a8b695eabd26cbd16bef0cef5237e8d3fd5c4922eecadf4e0f096d41ad5bb34
+- type: maven
+  filename: netty-buffer-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-buffer
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:3cf17e5a0c1f85bfc3cc18e90d428c76b6aacbdcc61fbcfed545643b2a760075
+- type: maven
+  filename: netty-transport-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-transport
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:5f3051c3609e61b11f960559db43101767d7ab1925fc8672168ed11fba2999c2
+- type: maven
+  filename: quarkus-vertx-latebound-mdc-provider-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-vertx-latebound-mdc-provider
+    version: 3.26.4
+    type: jar
+  checksum: sha256:239b349a512d966acb2744cf1258181cabf50133edf5a91e9f334ac1de8c9794
+- type: maven
+  filename: smallrye-fault-tolerance-vertx-6.9.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-fault-tolerance-vertx
+    version: 6.9.3
+    type: jar
+  checksum: sha256:ccc18239ff2db41af90e4c282981549d23ad005d96d14c850b6032b502e2eddd
+- type: maven
+  filename: quarkus-virtual-threads-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-virtual-threads
+    version: 3.26.4
+    type: jar
+  checksum: sha256:179c69f219fff9e01a241fb869eb05d8567036fe33ac44d07d3837a00c259d06
+- type: maven
+  filename: vertx-core-4.5.21.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.vertx
+    artifact_id: vertx-core
+    version: 4.5.21
+    type: jar
+  checksum: sha256:cc33a39c9188d879903430af98d9a7655ddae58fe54d99224bb4ccaf057d2d39
+- type: maven
+  filename: netty-common-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-common
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:34713b155634e622a6a2c69568c78834c3dc259f7a98c018b866c332eb87381b
+- type: maven
+  filename: netty-handler-proxy-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-handler-proxy
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:0a2fb62083c651a52101b9fcefd534235e1527ccc1a96df670adeccb4e489cbb
+- type: maven
+  filename: netty-codec-socks-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-codec-socks
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:d5e6cb45837186ca977605531fbcbf7ffeeb6ea04aed97236ac1923c258981c6
+- type: maven
+  filename: netty-resolver-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-resolver
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:b5ad214c49622147069e1ebbfc4d024599cc4c47d976ee2347830a9189450b02
+- type: maven
+  filename: netty-resolver-dns-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-resolver-dns
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:8accd5344ecf0a90943ea8883c92fde626b2058f978265b379ebb9ade3e62083
+- type: maven
+  filename: netty-codec-dns-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-codec-dns
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:9d549d1738404e73929efca7f59a83fb35c094d047c3bb64a6faae15fa4d0481
+- type: maven
+  filename: smallrye-common-annotation-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-annotation
+    version: 2.13.9
+    type: jar
+  checksum: sha256:09fc1e06ac5a0c19595a00bd35bdc49c1b5f9f3cbc6ddc7a9fef5ff9c6793a9c
+- type: maven
+  filename: smallrye-reactive-messaging-health-4.28.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-reactive-messaging-health
+    version: 4.28.0
+    type: jar
+  checksum: sha256:2cdbbfcf509789c96e1ed7be97ca7a0346303b97400858114df9712acb0f692d
+- type: maven
+  filename: microprofile-health-api-4.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.microprofile.health
+    artifact_id: microprofile-health-api
+    version: 4.0.1
+    type: jar
+  checksum: sha256:d600258ba46e4afbe4406c9093a8399819032281f5d66cbd8ecd33465b0fe70b
+- type: maven
+  filename: smallrye-reactive-messaging-provider-4.28.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-reactive-messaging-provider
+    version: 4.28.0
+    type: jar
+  checksum: sha256:77164d7aa971a5c02dc75cb53fc8364905cb62c1fefddb4ce120a29f3cdd00a2
+- type: maven
+  filename: smallrye-reactive-messaging-api-4.28.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-reactive-messaging-api
+    version: 4.28.0
+    type: jar
+  checksum: sha256:b90862c6f5b8d11a56ea1fbe4e4c3683a0c01ee26eb05f794a6728e7fc5d8794
+- type: maven
+  filename: smallrye-common-vertx-context-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-vertx-context
+    version: 2.13.9
+    type: jar
+  checksum: sha256:5509985e39e30d5e05217d7d9fdce1bacc08386fadc1618975fed68b3eb27f15
+- type: maven
+  filename: smallrye-common-constraint-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-constraint
+    version: 2.13.9
+    type: jar
+  checksum: sha256:f7f05fa358758ad08a56bcfec06e08713d36cc0a8ecb47597cf606ae071cbcec
+- type: maven
+  filename: smallrye-mutiny-vertx-core-3.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-mutiny-vertx-core
+    version: 3.19.2
+    type: jar
+  checksum: sha256:98c6ef0d36ce782a0e1d93c568c257f10e72c4e1efb5df5f3d75115b995913e6
+- type: maven
+  filename: smallrye-mutiny-vertx-runtime-3.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-mutiny-vertx-runtime
+    version: 3.19.2
+    type: jar
+  checksum: sha256:4abe91ae588d22cdb0c059a68a7974c359a9eb6acc3363650c25cf22e2aabbec
+- type: maven
+  filename: vertx-mutiny-generator-3.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: vertx-mutiny-generator
+    version: 3.19.2
+    type: jar
+  checksum: sha256:b067f15e6354663f1be1351ba934e7d22c0a0e7ae94872fc55441cd35f5d759f
+- type: maven
+  filename: vertx-codegen-4.5.21.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.vertx
+    artifact_id: vertx-codegen
+    version: 4.5.21
+    type: jar
+  checksum: sha256:e727058b6015f413ad9c53efe2f11bd88ef332e8dba81a62357bff3814af2dc2
+- type: maven
+  filename: jakarta.annotation-api-3.0.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.annotation
+    artifact_id: jakarta.annotation-api
+    version: 3.0.0
+    type: jar
+  checksum: sha256:adb1f9488132ff92720053e89e93736f4abd5dea880e4aa99b13924cae6324bd
+- type: maven
+  filename: failsafe-3.3.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: dev.failsafe
+    artifact_id: failsafe
+    version: 3.3.2
+    type: jar
+  checksum: sha256:9dc38e91736588a85cfb196db044d65cb8c256d6d0ebd5240ea8919b4ea73406
+- type: maven
+  filename: camel-quarkus-junit5-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-junit5
+    version: 3.26.0
+    type: jar
+  checksum: sha256:68fa1103a92c91b5ff0864ddf5eb159f2e50816faa4b4dbbe0407d1963440700
+- type: maven
+  filename: quarkus-junit5-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-junit5
+    version: 3.26.4
+    type: jar
+  checksum: sha256:669f8eed18f142aa9029a666e3fce9a1ef7a26a4be634166cc1185a80e3759ad
+- type: maven
+  filename: quarkus-bootstrap-core-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-bootstrap-core
+    version: 3.26.4
+    type: jar
+  checksum: sha256:508580dd821174c469c0e182a526b196c1a640db7d19749eeaaad13993e2f094
+- type: maven
+  filename: quarkus-classloader-commons-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-classloader-commons
+    version: 3.26.4
+    type: jar
+  checksum: sha256:faa037a9f55d1b311dd69b26754905ba6eff2c0b2d495d7f8f8e5953924215bc
+- type: maven
+  filename: quarkus-bootstrap-app-model-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-bootstrap-app-model
+    version: 3.26.4
+    type: jar
+  checksum: sha256:edd5ef432e925458e1d538b99f94f39704bf500f81ce655ba6092a068e50b195
+- type: maven
+  filename: smallrye-common-io-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-io
+    version: 2.13.9
+    type: jar
+  checksum: sha256:8cb2c5d4a36bc96b4713396f0271ea002d12bb310c0f04d182e5aadbacf2b0d6
+- type: maven
+  filename: org.eclipse.sisu.inject-0.9.0.M4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.sisu
+    artifact_id: org.eclipse.sisu.inject
+    version: 0.9.0.M4
+    type: jar
+  checksum: sha256:76bc3fedd0ee3e1aad783400db2f4e4abae810abcef1b62ee2d85ce5c528eada
+- type: maven
+  filename: quarkus-test-common-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-test-common
+    version: 3.26.4
+    type: jar
+  checksum: sha256:b76619c49e9422f051ebad1cc9f838f21f21d2749c0549b30b4dd6f014ac0739
+- type: maven
+  filename: quarkus-bootstrap-maven-resolver-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-bootstrap-maven-resolver
+    version: 3.26.4
+    type: jar
+  checksum: sha256:d76269a50e3b2c8ec62a01413f4e300dcc97cbd1cabbe442d19255e4858bbca2
+- type: maven
+  filename: smallrye-beanbag-maven-1.5.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.beanbag
+    artifact_id: smallrye-beanbag-maven
+    version: 1.5.3
+    type: jar
+  checksum: sha256:5147ad9358259f138b4bc82ea58b6f5f19d37ff035d75d578700c975cf624663
+- type: maven
+  filename: smallrye-beanbag-sisu-1.5.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.beanbag
+    artifact_id: smallrye-beanbag-sisu
+    version: 1.5.3
+    type: jar
+  checksum: sha256:b14d68b36e193001705b550d3d54d637488a0e4fa46b01558d16e708fc13223b
+- type: maven
+  filename: smallrye-beanbag-1.5.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.beanbag
+    artifact_id: smallrye-beanbag
+    version: 1.5.3
+    type: jar
+  checksum: sha256:ad77021ad5a61760f46dce15705dc2617a7672884df34131af2630e90d46e101
+- type: maven
+  filename: javax.inject-1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: javax.inject
+    artifact_id: javax.inject
+    version: '1'
+    type: jar
+  checksum: sha256:ec1c09078365e6bee74521346a1f0916e937518d00656cb217cb6f5aba87908f
+- type: maven
+  filename: maven-artifact-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-artifact
+    version: 3.9.9
+    type: jar
+  checksum: sha256:3e654f82badca361a741c4d25cc08a62582df2f139ec804e5b5cefa47d5b33f7
+- type: maven
+  filename: maven-builder-support-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-builder-support
+    version: 3.9.9
+    type: jar
+  checksum: sha256:0fa4cc10dbe1b712bd0153a6b6a3e07fa74e8944ff6ada510928c40bc0474ec7
+- type: maven
+  filename: maven-model-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-model
+    version: 3.9.9
+    type: jar
+  checksum: sha256:e604f4c0144b353573262e99c7a7965810b41ed3dcc957d54d387973d853d5d9
+- type: maven
+  filename: maven-model-builder-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-model-builder
+    version: 3.9.9
+    type: jar
+  checksum: sha256:0cf6ce048264a6af05403a5aee15a1cede098905da201a8c77fc88fab48fa2de
+- type: maven
+  filename: maven-repository-metadata-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-repository-metadata
+    version: 3.9.9
+    type: jar
+  checksum: sha256:f6d65daf0e3f13278162cfdb1bdd351a68d3ca674c22443bbd94bb16e174ed4b
+- type: maven
+  filename: maven-settings-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-settings
+    version: 3.9.9
+    type: jar
+  checksum: sha256:0033f173b58f33214eff5b7e5db9d19c23598b8ada08a5149e95b73ae5894309
+- type: maven
+  filename: maven-resolver-api-1.9.22.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.resolver
+    artifact_id: maven-resolver-api
+    version: 1.9.22
+    type: jar
+  checksum: sha256:5fad5efc5340b99065969c94f74da056e8edb3d5108773de655a561c089763f8
+- type: maven
+  filename: maven-resolver-impl-1.9.22.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.resolver
+    artifact_id: maven-resolver-impl
+    version: 1.9.22
+    type: jar
+  checksum: sha256:2412329bad5c568024294bfce8dd31c4b3d0498149f1ac6b8aeb71f2607bb688
+- type: maven
+  filename: maven-resolver-named-locks-1.9.22.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.resolver
+    artifact_id: maven-resolver-named-locks
+    version: 1.9.22
+    type: jar
+  checksum: sha256:c3ab36325b0657774cede0aec31911e857c32336dc99047c407165855c57eb0e
+- type: maven
+  filename: maven-resolver-spi-1.9.22.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.resolver
+    artifact_id: maven-resolver-spi
+    version: 1.9.22
+    type: jar
+  checksum: sha256:d3d3a77c84cfe35c0d83239fc412d7717a4d4f2cf2c8ed3d18c6391b905c44d7
+- type: maven
+  filename: maven-resolver-util-1.9.22.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.resolver
+    artifact_id: maven-resolver-util
+    version: 1.9.22
+    type: jar
+  checksum: sha256:db6ba4387dadce9c4559d99fed223a69eb3dbf17f581fce3c8bebf6eaa145f74
+- type: maven
+  filename: maven-resolver-transport-http-1.9.23.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.resolver
+    artifact_id: maven-resolver-transport-http
+    version: 1.9.23
+    type: jar
+  checksum: sha256:687087612eb94d6829e228cc913a2d581548171b2a4f17d9898a697b14cde185
+- type: maven
+  filename: wagon-provider-api-3.5.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.wagon
+    artifact_id: wagon-provider-api
+    version: 3.5.3
+    type: jar
+  checksum: sha256:92d3525c0c9e40e0a95c079cf44d369fd84df8a3537cd5e3ed8e7af308f19363
+- type: maven
+  filename: wagon-http-shared-3.5.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.wagon
+    artifact_id: wagon-http-shared
+    version: 3.5.3
+    type: jar
+  checksum: sha256:3d94b78aaeabede117f2469dad5cda2c08f063f577abe3862d5ad9ea39a2d0f1
+- type: maven
+  filename: plexus-interpolation-1.26.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.codehaus.plexus
+    artifact_id: plexus-interpolation
+    version: '1.26'
+    type: jar
+  checksum: sha256:37d76529cd49645e5190cb4b723f33e5478a493703666f53b316cc8f3e910552
+- type: maven
+  filename: plexus-utils-3.5.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.codehaus.plexus
+    artifact_id: plexus-utils
+    version: 3.5.1
+    type: jar
+  checksum: sha256:f827ac02a4dc0f8d291558f370ba0cf18c85e564cfe23b852d69233db3cc51ba
+- type: maven
+  filename: plexus-xml-4.0.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.codehaus.plexus
+    artifact_id: plexus-xml
+    version: 4.0.2
+    type: jar
+  checksum: sha256:77c9f1133c86d6eeeef2b555b7f5a7101862ce071ffb0ce5ad798cfbfe136952
+- type: maven
+  filename: maven-xml-impl-4.0.0-alpha-7.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-xml-impl
+    version: 4.0.0-alpha-7
+    type: jar
+  checksum: sha256:592be20db238f22c0e8e706511de77a300fa034bfb010639db44ba68de3ce76a
+- type: maven
+  filename: maven-api-xml-4.0.0-alpha-7.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-api-xml
+    version: 4.0.0-alpha-7
+    type: jar
+  checksum: sha256:420060185f08528e9b5939e425a1fc1c5e2fcd412d6df58d697fe9edc2c00e70
+- type: maven
+  filename: maven-api-meta-4.0.0-alpha-7.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-api-meta
+    version: 4.0.0-alpha-7
+    type: jar
+  checksum: sha256:7dbc8aef4b262441b07ba75666a6fc94b2b3f3b5a1f4c6dc6b306ecdc8898168
+- type: maven
+  filename: plexus-cipher-2.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.codehaus.plexus
+    artifact_id: plexus-cipher
+    version: '2.0'
+    type: jar
+  checksum: sha256:d7f88bed366f899e5fa522e8904b54ff28449f455cf3b1a3354be6c1e2905d60
+- type: maven
+  filename: plexus-sec-dispatcher-2.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.codehaus.plexus
+    artifact_id: plexus-sec-dispatcher
+    version: '2.0'
+    type: jar
+  checksum: sha256:6bbb7d9c403f8badc15c4f0371a7a1cd5b17d82e655bc69cda69fdeba46e9830
+- type: maven
+  filename: quarkus-bootstrap-maven4-resolver-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-bootstrap-maven4-resolver
+    version: 3.26.4
+    type: jar
+  checksum: sha256:28824a2dd61ec3603da06371396122415d20f8b8278d07cb198a1b8cb8390113
+- type: maven
+  filename: maven-embedder-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-embedder
+    version: 3.9.9
+    type: jar
+  checksum: sha256:9d43b52004d6a33480330de8df0f5a1b59cc5f130f176e596ec2f5ae2523a34e
+- type: maven
+  filename: maven-core-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-core
+    version: 3.9.9
+    type: jar
+  checksum: sha256:96f7cc2a1e807a9f22a56432371c4ec7b5a9ccd094ef640745c79b752c2b38a8
+- type: maven
+  filename: plexus-component-annotations-2.1.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.codehaus.plexus
+    artifact_id: plexus-component-annotations
+    version: 2.1.0
+    type: jar
+  checksum: sha256:0221fa6eecf3f22f70bc4789a437e8971a37285d40af43ab0be0a69dc2fecba8
+- type: maven
+  filename: maven-plugin-api-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-plugin-api
+    version: 3.9.9
+    type: jar
+  checksum: sha256:b26c25ef1e18539c4d68f30fffd2381e79a5e475319da55e519be3dd2a457ffe
+- type: maven
+  filename: maven-shared-utils-3.4.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.shared
+    artifact_id: maven-shared-utils
+    version: 3.4.2
+    type: jar
+  checksum: sha256:69385724f6abd9fa62f8e0f2c087f2e0df608585b8c955aeefdbcc3f6b5e4c12
+- type: maven
+  filename: guice-5.1.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.google.inject
+    artifact_id: guice
+    version: 5.1.0
+    type: jar
+  checksum: sha256:823580432156351b7688d58194c4ff000f9e1d808b20441f91c4c77a370286d3
+- type: maven
+  filename: aopalliance-1.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: aopalliance
+    artifact_id: aopalliance
+    version: '1.0'
+    type: jar
+  checksum: sha256:0e26e161ee03141cfadfd4eec6285eccc621a4877722bfb09a4ec2958e4dcf57
+- type: maven
+  filename: guava-33.4.8-jre.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.google.guava
+    artifact_id: guava
+    version: 33.4.8-jre
+    type: jar
+  checksum: sha256:0eb79503e1b485f929197441c7ac2c9cd23d49b4b3f2193ea8dc25e414e08ae3
+- type: maven
+  filename: failureaccess-1.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.google.guava
+    artifact_id: failureaccess
+    version: 1.0.1
+    type: jar
+  checksum: sha256:5712602179e2fd80579c2335abf044276be7ce38bd086bcf4c56b18966df6a2d
+- type: maven
+  filename: javax.annotation-api-1.3.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: javax.annotation
+    artifact_id: javax.annotation-api
+    version: 1.3.2
+    type: jar
+  checksum: sha256:555c559969eed438a8b5ee0143bd5a8637970857cc1ecb19d7ff68c54995cd2d
+- type: maven
+  filename: plexus-classworlds-2.6.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.codehaus.plexus
+    artifact_id: plexus-classworlds
+    version: 2.6.0
+    type: jar
+  checksum: sha256:0d458f6ef51992b68f3f67bcd2867f6231135e0ed885a94bd48e5c36d480a9b7
+- type: maven
+  filename: commons-cli-1.8.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: commons-cli
+    artifact_id: commons-cli
+    version: 1.8.0
+    type: jar
+  checksum: sha256:de6dade1e3bc60128e65418a05efff4d4e9fc0eb721fc98a6b34c4d5da107958
+- type: maven
+  filename: org.eclipse.sisu.plexus-0.9.0.M4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.sisu
+    artifact_id: org.eclipse.sisu.plexus
+    version: 0.9.0.M4
+    type: jar
+  checksum: sha256:06ceac79802bb65309a8a6a3ae76554252e80e33e948e2bc1548292f1296f0f0
+- type: maven
+  filename: maven-settings-builder-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-settings-builder
+    version: 3.9.9
+    type: jar
+  checksum: sha256:de43f1ac2f39ff4a6d7c9212e60c185a27c2e6a0a41ed9e935aafaf3799e2bc4
+- type: maven
+  filename: maven-resolver-provider-3.9.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven
+    artifact_id: maven-resolver-provider
+    version: 3.9.9
+    type: jar
+  checksum: sha256:6b9e04898c83ffdb9969e6ddfb7fe52fdb3e7198731d8a5b31daa25190751d19
+- type: maven
+  filename: maven-resolver-connector-basic-1.9.22.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.resolver
+    artifact_id: maven-resolver-connector-basic
+    version: 1.9.22
+    type: jar
+  checksum: sha256:675d64f8f83ff9b94b5e52450dd39002633931a8cd6b2cab23a6038ca47afacb
+- type: maven
+  filename: maven-resolver-transport-wagon-1.9.22.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.resolver
+    artifact_id: maven-resolver-transport-wagon
+    version: 1.9.22
+    type: jar
+  checksum: sha256:cd1c3d6a6c6a5b85bc748fe94b67de9bed9bf2c230aaf52eddc90d1820110d99
+- type: maven
+  filename: wagon-http-3.5.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.wagon
+    artifact_id: wagon-http
+    version: 3.5.3
+    type: jar
+  checksum: sha256:af69dbfe06600cc0665a521125999fc710df675f8f429fc5d984837140ecf52a
+- type: maven
+  filename: wagon-file-3.5.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.maven.wagon
+    artifact_id: wagon-file
+    version: 3.5.3
+    type: jar
+  checksum: sha256:6555fb2589872a346588259868988f693b42d13c891ebc2fe6428aa084ae54c8
+- type: maven
+  filename: quarkus-bootstrap-gradle-resolver-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-bootstrap-gradle-resolver
+    version: 3.26.4
+    type: jar
+  checksum: sha256:330c31c7587b9682e6fe8fb46eb83569d033839cc02b8174afec85dfd3f0029f
+- type: maven
+  filename: commons-io-2.20.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: commons-io
+    artifact_id: commons-io
+    version: 2.20.0
+    type: jar
+  checksum: sha256:7e8d1d438d814afc84229e84f271b09ea2a84d6496d58d7473f3fe431e341bd8
+- type: maven
+  filename: quarkus-junit5-config-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-junit5-config
+    version: 3.26.4
+    type: jar
+  checksum: sha256:2f609282c403dda4290f43b918213d1e5380adba9b40865c9ce393bc0849c3f9
+- type: maven
+  filename: junit-jupiter-5.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.junit.jupiter
+    artifact_id: junit-jupiter
+    version: 5.13.4
+    type: jar
+  checksum: sha256:2ecc26d18b9bb22e95072fb3e1212c71721f9fd011ac2719077c6f30ea98d163
+- type: maven
+  filename: camel-quarkus-core-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-core
+    version: 3.26.0
+    type: jar
+  checksum: sha256:8df747bae77b56c5647fa2b8916ee9027a856a7db00f15d31667358f207c4897
+- type: maven
+  filename: quarkus-development-mode-spi-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-development-mode-spi
+    version: 3.26.4
+    type: jar
+  checksum: sha256:1cf9830dd9242e8abf0aeed7d37c532a688b3f4723092eb1dd46a6f038533874
+- type: maven
+  filename: camel-base-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-base
+    version: 4.14.0
+    type: jar
+  checksum: sha256:70891e5f7cbfa5580718808a488d5aa5d6d7e2636c813079e8109f672ec50c26
+- type: maven
+  filename: camel-api-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-api
+    version: 4.14.0
+    type: jar
+  checksum: sha256:b404577efeffba5264e6a5c3ede6d7fcfc0eac67044c667b6e45a6d1ca6ea6d1
+- type: maven
+  filename: camel-management-api-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-management-api
+    version: 4.14.0
+    type: jar
+  checksum: sha256:61e9a68037b002759f0669d9ee0c9782c911732b9ba3a8ff2ea8d1f0a563d2b1
+- type: maven
+  filename: camel-support-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-support
+    version: 4.14.0
+    type: jar
+  checksum: sha256:4e45480a1653144fc8a8ea0ba9632925c8d569fb04508cc68f4078d262c177eb
+- type: maven
+  filename: camel-util-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-util
+    version: 4.14.0
+    type: jar
+  checksum: sha256:bba80508ed43b1ad4fe8e0441f6ade70aeae043e50bf80868f10797702d166c7
+- type: maven
+  filename: camel-componentdsl-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-componentdsl
+    version: 4.14.0
+    type: jar
+  checksum: sha256:c42147e6a0db1fe6e1160c2c48ee6343772c87549fbdc027a352598f71d54a76
+- type: maven
+  filename: camel-core-catalog-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-core-catalog
+    version: 4.14.0
+    type: jar
+  checksum: sha256:8eda724642fdde3d4d0439162a3cb000d2ca555b76d490b4fbe5352ccf62c757
+- type: maven
+  filename: camel-tooling-model-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-tooling-model
+    version: 4.14.0
+    type: jar
+  checksum: sha256:5a8fe1ef4c8fc24c6abbd0840f0a36a4857872d779e4b61c7757f402fde87304
+- type: maven
+  filename: camel-core-engine-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-core-engine
+    version: 4.14.0
+    type: jar
+  checksum: sha256:c447e16d6f1bd0e6e3dc944122099f4057ea50d9603b082294746544aeceef30
+- type: maven
+  filename: camel-base-engine-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-base-engine
+    version: 4.14.0
+    type: jar
+  checksum: sha256:a5511343716c154e333ce4589e2b6328ac6e69b00a8a87474e6a0fd91311781a
+- type: maven
+  filename: camel-core-reifier-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-core-reifier
+    version: 4.14.0
+    type: jar
+  checksum: sha256:90b0878c62ee21a77011592a91f441cb9c911f3f3cc2a67c8130b034906179f4
+- type: maven
+  filename: camel-core-languages-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-core-languages
+    version: 4.14.0
+    type: jar
+  checksum: sha256:a29475cde62ff60ca89af409ddbfc7d98426f15cf0b2c4b5bd2a0ee337211e06
+- type: maven
+  filename: camel-core-model-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-core-model
+    version: 4.14.0
+    type: jar
+  checksum: sha256:5b8c419ae726734528ceb3509b2b95cfc0cf89390023748bf56748285b00e69f
+- type: maven
+  filename: camel-xml-jaxp-util-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-xml-jaxp-util
+    version: 4.14.0
+    type: jar
+  checksum: sha256:cd07f37c7723aa2a7a6af4ed84ed37c4585ee115d8bcdc28a422d3805d75d8cb
+- type: maven
+  filename: camel-core-processor-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-core-processor
+    version: 4.14.0
+    type: jar
+  checksum: sha256:b5e5546bf80a447fb50ebe8c7d53bc9df1b22ae5d7dc0a2071974d28ab49df1b
+- type: maven
+  filename: camel-endpointdsl-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-endpointdsl
+    version: 4.14.0
+    type: jar
+  checksum: sha256:79d62524619d682cf9e33c16d4276f479f296852af2151b913703a1596b64fb4
+- type: maven
+  filename: camel-main-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-main
+    version: 4.14.0
+    type: jar
+  checksum: sha256:b6fc9f2a4c30d10d6ea5242c5d99546ef1fec8a428bdd7fb0d4d374f2811475d
+- type: maven
+  filename: camel-microprofile-config-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-microprofile-config
+    version: 4.14.0
+    type: jar
+  checksum: sha256:882a67715402ee242cc33b5b2229a91e81fe6a1d3f94ab6aa5e1e7caf2e180b5
+- type: maven
+  filename: camel-test-junit5-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-test-junit5
+    version: 4.14.0
+    type: jar
+  checksum: sha256:4d611b8504290ebd9b1c715344da8e626f4de2eaee26fdf2b10032f405aa7505
+- type: maven
+  filename: camel-bean-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-bean
+    version: 4.14.0
+    type: jar
+  checksum: sha256:504b90dc2c1f0f1b4c6a065c21eb7d8030e5eda2edbe8e6b584a175ce72e963a
+- type: maven
+  filename: camel-browse-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-browse
+    version: 4.14.0
+    type: jar
+  checksum: sha256:d20ce23114fd8129d2923b17d711018830dba68473003b88721b49bca3cdeec6
+- type: maven
+  filename: camel-controlbus-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-controlbus
+    version: 4.14.0
+    type: jar
+  checksum: sha256:764f36ef93d7e40383ac98293b7af0f7f8d176c4712b8281170c979ef07eb018
+- type: maven
+  filename: camel-dataformat-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-dataformat
+    version: 4.14.0
+    type: jar
+  checksum: sha256:d47d865d81d2a554a435e93ac4bddc8d08b80bba7aab15a27484651a037da216
+- type: maven
+  filename: camel-dataset-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-dataset
+    version: 4.14.0
+    type: jar
+  checksum: sha256:ba213b3015b716b698209a9d873e2cb0a630a62f2ff5e00110713919075b1f98
+- type: maven
+  filename: camel-direct-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-direct
+    version: 4.14.0
+    type: jar
+  checksum: sha256:d19db6be610283f0efc76af9a3fa01765fe4c5cd2770083a325edd81fa04499b
+- type: maven
+  filename: camel-file-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-file
+    version: 4.14.0
+    type: jar
+  checksum: sha256:813a26dd9dd950f0f93952e25271de486a57775d7d7d1c75a9316c6436c53a09
+- type: maven
+  filename: camel-cluster-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-cluster
+    version: 4.14.0
+    type: jar
+  checksum: sha256:d23122f8ff39e7aa0ae17a6a260aaa031526e9732255442f4b86337645263bc2
+- type: maven
+  filename: commons-codec-1.19.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: commons-codec
+    artifact_id: commons-codec
+    version: 1.19.0
+    type: jar
+  checksum: sha256:ca01f159884aea96b64a414b618b4c23b4b763efb72d56534413d8726ce1fed1
+- type: maven
+  filename: camel-language-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-language
+    version: 4.14.0
+    type: jar
+  checksum: sha256:c43cb8e1baf90991abef8978f3f9c161ff69f3e018c5156174ee287e612617db
+- type: maven
+  filename: camel-log-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-log
+    version: 4.14.0
+    type: jar
+  checksum: sha256:d5d084f260f664b2cec4e500499ba398e63d0dc11f19df668ab3236865e6f1f2
+- type: maven
+  filename: camel-mock-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-mock
+    version: 4.14.0
+    type: jar
+  checksum: sha256:e07a5df66340a563b8909231c59e2a61e2e8fd0f87aa4814d7efbaa42bbdcc0d
+- type: maven
+  filename: camel-ref-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-ref
+    version: 4.14.0
+    type: jar
+  checksum: sha256:3661b83be086501bed5f83c45a7e2135ecb65938b93264b6cdf56c534739b822
+- type: maven
+  filename: camel-rest-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-rest
+    version: 4.14.0
+    type: jar
+  checksum: sha256:d90829ca383fe373adde88c266bd956e93226981b2194872695ffb35f79f2b01
+- type: maven
+  filename: camel-saga-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-saga
+    version: 4.14.0
+    type: jar
+  checksum: sha256:5d0f84687a70276a78a66d8a64d21180a0bf12047e3cd0a68c5125a56290f4f5
+- type: maven
+  filename: camel-scheduler-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-scheduler
+    version: 4.14.0
+    type: jar
+  checksum: sha256:397024c8b2f950b789ef1bdaa667ff71e14ec5668de451c6907f94c37ec57622
+- type: maven
+  filename: camel-seda-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-seda
+    version: 4.14.0
+    type: jar
+  checksum: sha256:eff1a777d1d9350cf5b02ded869d6111656105b265664444d6aecf0573325e75
+- type: maven
+  filename: camel-stub-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-stub
+    version: 4.14.0
+    type: jar
+  checksum: sha256:2a37cd5bec7eb29745711b122cb1bdcea58ac1cb20b7726f1378618c8e6e1c8c
+- type: maven
+  filename: camel-timer-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-timer
+    version: 4.14.0
+    type: jar
+  checksum: sha256:9449cf0173088456b7bb8e915626b456a2aab14c0e19b368297a082975df88d4
+- type: maven
+  filename: camel-validator-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-validator
+    version: 4.14.0
+    type: jar
+  checksum: sha256:84f3c22a4d0561594d5f7cc7a16877a5168f90aadad290af3864260669c4d07b
+- type: maven
+  filename: camel-xml-jaxp-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-xml-jaxp
+    version: 4.14.0
+    type: jar
+  checksum: sha256:abf7a9f26ff59ccf729b3abafa6f820752461d79bda990e7d03e8675a52d3fb3
+- type: maven
+  filename: camel-xml-io-util-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-xml-io-util
+    version: 4.14.0
+    type: jar
+  checksum: sha256:481f450c30e963a21a5357e5f51d88648c82d4f04ca63861cdf628e2c345c066
+- type: maven
+  filename: camel-xpath-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-xpath
+    version: 4.14.0
+    type: jar
+  checksum: sha256:37faf129d1f8ba002f0746426de7df52e274f23f89089769f1f934c5b469a5da
+- type: maven
+  filename: camel-xslt-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-xslt
+    version: 4.14.0
+    type: jar
+  checksum: sha256:5aab4b30387f6d4ab768047979ec6f4ec0f9c1773e80c6b0c1f6f6cbafaa3c35
+- type: maven
+  filename: junit-jupiter-api-5.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.junit.jupiter
+    artifact_id: junit-jupiter-api
+    version: 5.13.4
+    type: jar
+  checksum: sha256:2e5cd081292e852734012b2a102f9e3ef823aa937cfa44d9b7bbf77cff70c122
+- type: maven
+  filename: opentest4j-1.3.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.opentest4j
+    artifact_id: opentest4j
+    version: 1.3.0
+    type: jar
+  checksum: sha256:7701c69bf433bf9fb132cb5e69b17f377ac3181e4c8979b5d3710a8864d947ba
+- type: maven
+  filename: junit-platform-commons-1.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.junit.platform
+    artifact_id: junit-platform-commons
+    version: 1.13.4
+    type: jar
+  checksum: sha256:9986a9aff0328d4c64ee4cd9f6c5c2275624bb8ef23c84dd4a4dd5337f6a54d4
+- type: maven
+  filename: apiguardian-api-1.1.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apiguardian
+    artifact_id: apiguardian-api
+    version: 1.1.2
+    type: jar
+  checksum: sha256:b2cdd163ebe760cb92147e499ebf65be392a8824298e690f959b1d4306a2b54a
+- type: maven
+  filename: junit-jupiter-engine-5.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.junit.jupiter
+    artifact_id: junit-jupiter-engine
+    version: 5.13.4
+    type: jar
+  checksum: sha256:fc113a197642e766fcb0075a1e015e34b188a08cdf017e23f222ed9de35aa530
+- type: maven
+  filename: junit-platform-engine-1.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.junit.platform
+    artifact_id: junit-platform-engine
+    version: 1.13.4
+    type: jar
+  checksum: sha256:be717997040d2072c6bf9fd89919a371c6fc7f1f29f1c6da31e1a6c8ba771d1e
+- type: maven
+  filename: junit-jupiter-params-5.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.junit.jupiter
+    artifact_id: junit-jupiter-params
+    version: 5.13.4
+    type: jar
+  checksum: sha256:a2ebbd3cfdb9c156a9c9392b990a8eabd4718c51c58c5dca988743c676cdf3cd
+- type: maven
+  filename: mockserver-netty-no-dependencies-5.15.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.mock-server
+    artifact_id: mockserver-netty-no-dependencies
+    version: 5.15.0
+    type: jar
+  checksum: sha256:4ac177b03d829ed35350b93bf79a60914dd46880cc06f556335ab0c95e1505da
+- type: maven
+  filename: json-schema-validator-1.5.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.networknt
+    artifact_id: json-schema-validator
+    version: 1.5.9
+    type: jar
+  checksum: sha256:340f5cd582df65f29aea7eb39e927013416882bd4f93ec2c3cf37657faeb9fd8
+- type: maven
+  filename: itu-1.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.ethlo.time
+    artifact_id: itu
+    version: 1.14.0
+    type: jar
+  checksum: sha256:7e6507cd94410a7b9e75b61ddd1bfd0a60a6ca8f0b451e895ba193e1ada33f16
+- type: maven
+  filename: jackson-databind-2.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.fasterxml.jackson.core
+    artifact_id: jackson-databind
+    version: 2.19.2
+    type: jar
+  checksum: sha256:e9a2dca72706bb86f0b5359c460a3cb8e48028132e4a799b6790b232d9a689f0
+- type: maven
+  filename: jackson-annotations-2.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.fasterxml.jackson.core
+    artifact_id: jackson-annotations
+    version: 2.19.2
+    type: jar
+  checksum: sha256:d0a5b356de397833b8d7feca968d0a32141bed14bdb019df6e300def385470e1
+- type: maven
+  filename: jackson-dataformat-yaml-2.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.fasterxml.jackson.dataformat
+    artifact_id: jackson-dataformat-yaml
+    version: 2.19.2
+    type: jar
+  checksum: sha256:1e2282ef6a6cf2be07651a3ac3652e7adb706ba3d4c3c30224c5c3e5b6551438
+- type: maven
+  filename: snakeyaml-2.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.yaml
+    artifact_id: snakeyaml
+    version: '2.4'
+    type: jar
+  checksum: sha256:0af1fceb0feb93c31ea14eb2052a9109566cd34f97703f6cb2d163c315437c2c
+- type: maven
+  filename: slf4j-api-2.0.17.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.slf4j
+    artifact_id: slf4j-api
+    version: 2.0.17
+    type: jar
+  checksum: sha256:156a204298f1630fef0901ab5d18c2ecbf451866e54896437de3df06d512a8c9
+- type: maven
+  filename: quarkus-junit5-mockito-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-junit5-mockito
+    version: 3.26.4
+    type: jar
+  checksum: sha256:863785bb20da1b0e39488df59032f055a45be373af66bc128d046e23caea64d4
+- type: maven
+  filename: mockito-junit-jupiter-5.18.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.mockito
+    artifact_id: mockito-junit-jupiter
+    version: 5.18.0
+    type: jar
+  checksum: sha256:6cb733452609c24e1db4e9d4a7ab4235b74d0dfab1118059e3717ef270e416e2
+- type: maven
+  filename: quarkus-junit5-mockito-config-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-junit5-mockito-config
+    version: 3.26.4
+    type: jar
+  checksum: sha256:69e61547cde755da6e2af3490497b70267be7f8f7903c5901a01126d7796eceb
+- type: maven
+  filename: quarkus-arc-deployment-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-arc-deployment
+    version: 3.26.4
+    type: jar
+  checksum: sha256:e3602310ad0c4445c824a6f10ff42d5f9b88269291ed5d779894bc8ca439e58b
+- type: maven
+  filename: quarkus-core-deployment-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-core-deployment
+    version: 3.26.4
+    type: jar
+  checksum: sha256:c9ca93e72af5458af6034d47c60bf1ea0ee96f7cd81e113f7a0c6414d91ccbe8
+- type: maven
+  filename: readline-2.6.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.aesh
+    artifact_id: readline
+    version: '2.6'
+    type: jar
+  checksum: sha256:4228180fa44977b3405e5ddce8866ba53635aad13714e62663b3072d98666830
+- type: maven
+  filename: jansi-2.4.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.fusesource.jansi
+    artifact_id: jansi
+    version: 2.4.0
+    type: jar
+  checksum: sha256:79e80229c1abbb6538272b89747a2f7764b7a8e0297212e0ea4e9d0ce020b41b
+- type: maven
+  filename: aesh-2.8.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.aesh
+    artifact_id: aesh
+    version: 2.8.2
+    type: jar
+  checksum: sha256:04291c7a22c7a221e059de238b51341c95ff588bf633effbc69acf700e62e992
+- type: maven
+  filename: commons-lang3-3.18.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.commons
+    artifact_id: commons-lang3
+    version: 3.18.0
+    type: jar
+  checksum: sha256:a48ca0d7e086a30c9f3126d40523b29bbcaf4e27f6ed0b01af2fde98d2902cd9
+- type: maven
+  filename: gizmo-1.9.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.gizmo
+    artifact_id: gizmo
+    version: 1.9.0
+    type: jar
+  checksum: sha256:21c06d3b9735f476fc9815174a94cf47b3cd4a9df5a43829ef7078db5f89a52c
+- type: maven
+  filename: asm-util-9.8.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.ow2.asm
+    artifact_id: asm-util
+    version: '9.8'
+    type: jar
+  checksum: sha256:acd587927bfb6a3b8f8e560c7f4f99f28295184c44c387c4b709261db99a802a
+- type: maven
+  filename: asm-analysis-9.8.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.ow2.asm
+    artifact_id: asm-analysis
+    version: '9.8'
+    type: jar
+  checksum: sha256:51d63687ff628a4951d4236128bde223438de9377224b6b02e9d76a21542e3c3
+- type: maven
+  filename: gizmo2-2.0.0.Beta6.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.gizmo
+    artifact_id: gizmo2
+    version: 2.0.0.Beta6
+    type: jar
+  checksum: sha256:12faa67c9ae16e31849ecf37c271eb27df89b531c3aa1670b7de496ed66ee273
+- type: maven
+  filename: jdk-classfile-backport-24.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.github.dmlloyd
+    artifact_id: jdk-classfile-backport
+    version: '24.0'
+    type: jar
+  checksum: sha256:cfa5bb606d2ee372e5af50bda0c7ba70426167c019be858248ad95b17562d4b7
+- type: maven
+  filename: smallrye-common-resource-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-resource
+    version: 2.13.9
+    type: jar
+  checksum: sha256:fff5e5fd73663b95e2a2b60eb9817753705d7aecb523d1da12b71bbd25ed565e
+- type: maven
+  filename: jandex-gizmo2-3.4.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: jandex-gizmo2
+    version: 3.4.0
+    type: jar
+  checksum: sha256:b7896f4c85b93f30f156f4ffdb864d5bdea670ad07f11924cbbd2bda1c21be92
+- type: maven
+  filename: smallrye-common-process-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-process
+    version: 2.13.9
+    type: jar
+  checksum: sha256:d312bc391ce6048ebe0c4144126f1ca1a1e3013bdb373294947943df0445377f
+- type: maven
+  filename: quarkus-hibernate-validator-spi-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-hibernate-validator-spi
+    version: 3.26.4
+    type: jar
+  checksum: sha256:0158c9d6053d184981c07c8dd7fe565533f8213acc96faed82655cc1a40ed5a0
+- type: maven
+  filename: quarkus-class-change-agent-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-class-change-agent
+    version: 3.26.4
+    type: jar
+  checksum: sha256:1e3e1f0eaaa6f0590ab0aa157f2bd0407edd2e7dff945cda7098ea766cc8e90c
+- type: maven
+  filename: quarkus-builder-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-builder
+    version: 3.26.4
+    type: jar
+  checksum: sha256:100754104978ac616d7990dbfd96a5a90fa34e8d495a14abba5219c9f15d7aa5
+- type: maven
+  filename: nativeimage-23.1.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.graalvm.sdk
+    artifact_id: nativeimage
+    version: 23.1.2
+    type: jar
+  checksum: sha256:af9172f67558a5f10bad9cf59e722bd154ed242c56317082de75a4cb12f9f9eb
+- type: maven
+  filename: junit-platform-launcher-1.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.junit.platform
+    artifact_id: junit-platform-launcher
+    version: 1.13.4
+    type: jar
+  checksum: sha256:1832d67f0420bb58738288d0be1cc4bc35a83ae76bd816791275638f36aef208
+- type: maven
+  filename: quarkus-smallrye-context-propagation-spi-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-smallrye-context-propagation-spi
+    version: 3.26.4
+    type: jar
+  checksum: sha256:a1ff9f0d9b4f877e6973214e9c5fbe1f3de644bbc08024c59d5c71f742138060
+- type: maven
+  filename: quarkus-devui-deployment-spi-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-devui-deployment-spi
+    version: 3.26.4
+    type: jar
+  checksum: sha256:19bb02c36423559c8e632f996dfd55d953ccba6e26ff25d8d0ef1eca7a2aadbf
+- type: maven
+  filename: quarkus-arc-dev-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-arc-dev
+    version: 3.26.4
+    type: jar
+  checksum: sha256:0abb69cda22ae540a3f9d3d8b01304dac3b0dd50b4026092d2d772a23fc8112b
+- type: maven
+  filename: arc-processor-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.arc
+    artifact_id: arc-processor
+    version: 3.26.4
+    type: jar
+  checksum: sha256:cef6377d96c610e552e6e71939fa6bcfe15b967ef67ea39bfb8338713f79b3b2
+- type: maven
+  filename: mockito-core-5.18.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.mockito
+    artifact_id: mockito-core
+    version: 5.18.0
+    type: jar
+  checksum: sha256:f2cebcf47277c498bbba0219621dd25aa12e751164afe8f327bcb248a2bb5201
+- type: maven
+  filename: byte-buddy-1.17.6.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: net.bytebuddy
+    artifact_id: byte-buddy
+    version: 1.17.6
+    type: jar
+  checksum: sha256:1ee12eb6dc6ecd600418efe9cf20991e54d444d164ea353488a8a3c3c751b6fe
+- type: maven
+  filename: byte-buddy-agent-1.17.5.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: net.bytebuddy
+    artifact_id: byte-buddy-agent
+    version: 1.17.5
+    type: jar
+  checksum: sha256:ae848a76968722194729fa9eb3f1e5827039f7c4a16daa2b8b14d7f2494479a6
+- type: maven
+  filename: objenesis-3.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.objenesis
+    artifact_id: objenesis
+    version: '3.3'
+    type: jar
+  checksum: sha256:f18edb0aa97817567e9b21337ddef5d2fd6fb15b00d1afd4bf63b266bbd524a5
+- type: maven
+  filename: quarkus-mutiny-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-mutiny
+    version: 3.26.4
+    type: jar
+  checksum: sha256:42b80b39c87b5b3f208d079e5c6aab52abc17efb44f1fe1b54dfd3e6839b7b4e
+- type: maven
+  filename: quarkus-smallrye-context-propagation-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-smallrye-context-propagation
+    version: 3.26.4
+    type: jar
+  checksum: sha256:3eaabf5d667b6d57229f774232c8749c1243bd4ead2ae150293989f9a8b4745e
+- type: maven
+  filename: smallrye-context-propagation-2.2.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-context-propagation
+    version: 2.2.1
+    type: jar
+  checksum: sha256:5ef7b5aab1cb104fa8dac8b167fbd9fc96074690256018ea5a4cb41b27359628
+- type: maven
+  filename: smallrye-context-propagation-api-2.2.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-context-propagation-api
+    version: 2.2.1
+    type: jar
+  checksum: sha256:01d7060dcc4bacb1c4bd3b90602a4583e0ab83941d6ff700d5cc25ce2bb2149c
+- type: maven
+  filename: smallrye-context-propagation-storage-2.2.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-context-propagation-storage
+    version: 2.2.1
+    type: jar
+  checksum: sha256:d2f93d0d0dde19e4362e45ec52d9408b1821ec5ff9b22bcae47b310d1ec017f1
+- type: maven
+  filename: mutiny-smallrye-context-propagation-2.9.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: mutiny-smallrye-context-propagation
+    version: 2.9.4
+    type: jar
+  checksum: sha256:889b4f10a2c8979e57e770ac084f4903c611fc60e2e6eb07872ca7bd97b1729d
+- type: maven
+  filename: smallrye-reactive-messaging-in-memory-4.28.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-reactive-messaging-in-memory
+    version: 4.28.0
+    type: jar
+  checksum: sha256:12bbf2dfb93b98625d374982e91ade67d0da55fa0eac72ddbffa331d9fd940ad
+- type: maven
+  filename: jboss-logging-3.6.1.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jboss.logging
+    artifact_id: jboss-logging
+    version: 3.6.1.Final
+    type: jar
+  checksum: sha256:6b975fc1dee33d314ea689ee35f953df5e4c6b0a91ceea7f0d9fa53f010c2357
+- type: maven
+  filename: smallrye-reactive-converter-api-3.0.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-reactive-converter-api
+    version: 3.0.3
+    type: jar
+  checksum: sha256:f86f7ae383998086706894e366dc5c201cc35e588ccd38c61181bcc39c321220
+- type: maven
+  filename: reactive-streams-1.0.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.reactivestreams
+    artifact_id: reactive-streams
+    version: 1.0.4
+    type: jar
+  checksum: sha256:fc221ffb44ee5c24579ed72448039c551dc9662cce89dd87f55b3d0f2b393684
+- type: maven
+  filename: mutiny-2.9.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: mutiny
+    version: 2.9.4
+    type: jar
+  checksum: sha256:06b31a4d5b8b92e3005a15feea4a013f5872ffe25dd326d9f5f896dbbf0ce15b
+- type: maven
+  filename: jctools-core-4.0.5.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jctools
+    artifact_id: jctools-core
+    version: 4.0.5
+    type: jar
+  checksum: sha256:cb55fc042a1f581a7f9b61ebcf766dc1a5694def0e6b46b3040c50fb89d653cf
+- type: maven
+  filename: mutiny-zero-1.1.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: mutiny-zero
+    version: 1.1.1
+    type: jar
+  checksum: sha256:77b3623dde4e657cc2c50e2ebf19dcd4cde694dde7119eb2b515cc3852582b03
+- type: maven
+  filename: mutiny-zero-flow-adapters-1.1.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: mutiny-zero-flow-adapters
+    version: 1.1.1
+    type: jar
+  checksum: sha256:6d3994d840721bb9609ab78ca6023fae162744636fb5065a40e4d96c8c7649d5
+- type: maven
+  filename: awaitility-4.3.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.awaitility
+    artifact_id: awaitility
+    version: 4.3.0
+    type: jar
+  checksum: sha256:7da19fb40a8a90d3f6470483cdbc4f1b29153fbe2733db5975f21f7f7a3463cf
+- type: maven
+  filename: hamcrest-2.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.hamcrest
+    artifact_id: hamcrest
+    version: '2.2'
+    type: jar
+  checksum: sha256:af3f9aa297c5bcd2fcb913b8a37b675cb8fcb614f10168fcd6333d015c8e8dcd
+- type: maven
+  filename: notifications-connector-common-1.0.0-SNAPSHOT-tests.test-jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.redhat.cloud.notifications
+    artifact_id: notifications-connector-common
+    version: 1.0.0-SNAPSHOT
+    type: test-jar
+    classifier: tests
+  checksum: sha256:d222f944f29fa894bcb23bc712b706a626005a892e75c4ed18a152db9a9ed028
+- type: maven
+  filename: notifications-common-unleash-1.0.0-SNAPSHOT.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.redhat.cloud.notifications
+    artifact_id: notifications-common-unleash
+    version: 1.0.0-SNAPSHOT
+    type: jar
+  checksum: sha256:9f25c42edb3740034a4586af120eda03c1bda39a9650c8618df0e30b300d46f6
+- type: maven
+  filename: microprofile-config-api-3.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.microprofile.config
+    artifact_id: microprofile-config-api
+    version: '3.1'
+    type: jar
+  checksum: sha256:2ef2fccd75421e5fc1fabef1be01c97c6fb4918837876ccad8d48d858a580958
+- type: maven
+  filename: quarkus-unleash-1.11.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkiverse.unleash
+    artifact_id: quarkus-unleash
+    version: 1.11.0
+    type: jar
+  checksum: sha256:99a567e482b5c901f5aa7e80651404f66e4f68048bf7f4b33331a8f140b0ad7f
+- type: maven
+  filename: unleash-client-java-11.0.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.getunleash
+    artifact_id: unleash-client-java
+    version: 11.0.2
+    type: jar
+  checksum: sha256:865703159d1c8862badf64fdc52f2a5ebaf5c045245a54a18602c0fad5c10d10
+- type: maven
+  filename: yggdrasil-engine-0.3.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.getunleash
+    artifact_id: yggdrasil-engine
+    version: 0.3.2
+    type: jar
+  checksum: sha256:ccff618645eb9adab960a0d304d1e54e6067909be60522257ddd80cf26f0f521
+- type: maven
+  filename: runtime-1.5.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.dylibso.chicory
+    artifact_id: runtime
+    version: 1.5.1
+    type: jar
+  checksum: sha256:03c88babd970998797b514c92f0af250b017933a33bc9b68d52988cb839c23ff
+- type: maven
+  filename: wasm-1.5.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.dylibso.chicory
+    artifact_id: wasm
+    version: 1.5.1
+    type: jar
+  checksum: sha256:006333d7a318319a913d265c31bd8f614aff357f1928d4648a24765ac2f7ce35
+- type: maven
+  filename: jna-5.8.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: net.java.dev.jna
+    artifact_id: jna
+    version: 5.8.0
+    type: jar
+  checksum: sha256:697749099bb7f454caebfe67e9845be6e7e85d266ebb2e500244f01c1743db94
+- type: maven
+  filename: flatbuffers-java-23.1.21.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.google.flatbuffers
+    artifact_id: flatbuffers-java
+    version: 23.1.21
+    type: jar
+  checksum: sha256:8380abca63eb25c8a3d02b56c39b092d36578ab98b6aaf941debcfa887353e57
+- type: maven
+  filename: gson-2.13.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.google.code.gson
+    artifact_id: gson
+    version: 2.13.2
+    type: jar
+  checksum: sha256:02e3e88b1f01d9ef61df06fe9ceda9e76dbedd50e01b88f51bdd53301cc150c2
+- type: maven
+  filename: murmur-1.0.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.sangupta
+    artifact_id: murmur
+    version: 1.0.0
+    type: jar
+  checksum: sha256:5700079ae217de75175937a90b59c9f7282471ecf340b13056d28d4a7eff284a
+- type: maven
+  filename: camel-quarkus-direct-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-direct
+    version: 3.26.0
+    type: jar
+  checksum: sha256:b654e63c40075b1cfc46690213b2dd2243df515d344c6984ab4ad4ee2063dd95
+- type: maven
+  filename: camel-quarkus-kafka-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-kafka
+    version: 3.26.0
+    type: jar
+  checksum: sha256:9344fcc8f27870e821181508a4fbd7e2ed5b46543f4e1fa372af216a79794a0e
+- type: maven
+  filename: camel-kafka-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-kafka
+    version: 4.14.0
+    type: jar
+  checksum: sha256:5c6085cd3072757b394cc1bfa34e9fa9621f576d304cf1a8cef8f530b4f4b241
+- type: maven
+  filename: camel-health-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-health
+    version: 4.14.0
+    type: jar
+  checksum: sha256:c9db62951faadf75f4e6364d2cc51ca62ddd4cdfced0f4ffd2ea0b5a103cca3f
+- type: maven
+  filename: camel-quarkus-log-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-log
+    version: 3.26.0
+    type: jar
+  checksum: sha256:dccf4a2071411fff525f1388503be4bb550d1c8e4b1efad28a5e2300fc2d8597
+- type: maven
+  filename: camel-quarkus-micrometer-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-micrometer
+    version: 3.26.0
+    type: jar
+  checksum: sha256:cbae2fcd9364bd86b5962c7e10abe1191b9e8364ef551e472031ce336086186f
+- type: maven
+  filename: quarkus-micrometer-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-micrometer
+    version: 3.26.4
+    type: jar
+  checksum: sha256:e414c9870ec8ed5a7c3e0e84f34fb3c35e08b5894cc5fb27ef73f21119b0995d
+- type: maven
+  filename: micrometer-core-1.14.7.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.micrometer
+    artifact_id: micrometer-core
+    version: 1.14.7
+    type: jar
+  checksum: sha256:9837519bd36326148db21ec649ea4152cade9f9c2ab3a06edb02c47f572ee2b5
+- type: maven
+  filename: micrometer-commons-1.14.7.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.micrometer
+    artifact_id: micrometer-commons
+    version: 1.14.7
+    type: jar
+  checksum: sha256:e00b039cc2f195f105531aaeff130011f59897fd72af8b1403fc46c970157aa0
+- type: maven
+  filename: micrometer-observation-1.14.7.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.micrometer
+    artifact_id: micrometer-observation
+    version: 1.14.7
+    type: jar
+  checksum: sha256:1c99b740471e0f7a36bce792f2d47515cf8095c2d5f7f8d6670e1e124b1a4d5e
+- type: maven
+  filename: HdrHistogram-2.2.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.hdrhistogram
+    artifact_id: HdrHistogram
+    version: 2.2.2
+    type: jar
+  checksum: sha256:77717d648429d1ab4034fc39fb3dfb9f6c576149210711258a8adb5e37eb6589
+- type: maven
+  filename: LatencyUtils-2.0.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.latencyutils
+    artifact_id: LatencyUtils
+    version: 2.0.3
+    type: jar
+  checksum: sha256:d2e85b0d04f6f7840499db6f6bb4ac04ab2fca7a0f2aba127e4fea836990b1fc
+- type: maven
+  filename: camel-micrometer-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-micrometer
+    version: 4.14.0
+    type: jar
+  checksum: sha256:d29b1c9f82b7e4005d8ebc52985a46c24f00407b6e97e85b43f3bd1b0bedb47e
+- type: maven
+  filename: camel-quarkus-microprofile-health-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-microprofile-health
+    version: 3.26.0
+    type: jar
+  checksum: sha256:842cf4aa62888aa94f3027e7c865b16f53daeb52658e23c95a054d1785de3ada
+- type: maven
+  filename: quarkus-smallrye-health-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-smallrye-health
+    version: 3.26.4
+    type: jar
+  checksum: sha256:86d8453cd1dcf551d9c7224ce7433413b846ac41e2434f788aed796fad6dc353
+- type: maven
+  filename: smallrye-health-4.2.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-health
+    version: 4.2.0
+    type: jar
+  checksum: sha256:e08db214bda6f7bd530ac55e2a4445de13295ee0423d0338f430527c41d21147
+- type: maven
+  filename: smallrye-health-api-4.2.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-health-api
+    version: 4.2.0
+    type: jar
+  checksum: sha256:e497fc33adb3a3e09e3011cb268646e79c0d92bab868c9e325f9e88e3f698201
+- type: maven
+  filename: smallrye-health-provided-checks-4.2.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-health-provided-checks
+    version: 4.2.0
+    type: jar
+  checksum: sha256:7e8c060fb85baa11afc421484968dfb5d7ae07c6e39f57517e1aad2cef39b385
+- type: maven
+  filename: camel-microprofile-health-4.14.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel
+    artifact_id: camel-microprofile-health
+    version: 4.14.0
+    type: jar
+  checksum: sha256:7e2d606ebff6330245cafaac609932f6c7750135d75701e5add556afd7084b5d
+- type: maven
+  filename: camel-quarkus-seda-3.26.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.camel.quarkus
+    artifact_id: camel-quarkus-seda
+    version: 3.26.0
+    type: jar
+  checksum: sha256:bffe12ad90a334b575c982b03eb994655a461bcc953135f88bb0eb7bf36a5bff
+- type: maven
+  filename: quarkus-micrometer-registry-prometheus-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-micrometer-registry-prometheus
+    version: 3.26.4
+    type: jar
+  checksum: sha256:25caf78a3ed729f3b64f43736fb1b7ec5364248283bdf02ab9e07213021bfc8c
+- type: maven
+  filename: micrometer-registry-prometheus-simpleclient-1.14.7.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.micrometer
+    artifact_id: micrometer-registry-prometheus-simpleclient
+    version: 1.14.7
+    type: jar
+  checksum: sha256:b5c31c0d440d6ab14a611d25480edfc22cb10a4e128b2ea2c4d653dae7087734
+- type: maven
+  filename: simpleclient_common-0.16.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.prometheus
+    artifact_id: simpleclient_common
+    version: 0.16.0
+    type: jar
+  checksum: sha256:cde5a28685f9e2d9b56b05d5334d484b4afd19ff70e9513ea8b46c08183379ce
+- type: maven
+  filename: simpleclient-0.16.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.prometheus
+    artifact_id: simpleclient
+    version: 0.16.0
+    type: jar
+  checksum: sha256:6992e6fec8d57006214dfb8c594a0a6eb62032260813f1ee676344f8351f6988
+- type: maven
+  filename: simpleclient_tracer_otel-0.16.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.prometheus
+    artifact_id: simpleclient_tracer_otel
+    version: 0.16.0
+    type: jar
+  checksum: sha256:ac8121030200aa46e850e7a7d343acd8ac9caf6f1719ebddb820ec5cccaeef83
+- type: maven
+  filename: simpleclient_tracer_common-0.16.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.prometheus
+    artifact_id: simpleclient_tracer_common
+    version: 0.16.0
+    type: jar
+  checksum: sha256:6181f0662b4d3e4ffc299f50f2a0bc89251c8fb9eb505fd62c356ef0250c39c7
+- type: maven
+  filename: simpleclient_tracer_otel_agent-0.16.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.prometheus
+    artifact_id: simpleclient_tracer_otel_agent
+    version: 0.16.0
+    type: jar
+  checksum: sha256:17fa72121f3d8551b0c337d27e06b936d0a220761d9982ee19abdeb9a80afd6c
+- type: maven
+  filename: quarkus-rest-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-rest
+    version: 3.26.4
+    type: jar
+  checksum: sha256:b1c84711cdd21a6445c08ec1b87a9123dd7ba44a1b23f7bb4a45774503f14f57
+- type: maven
+  filename: resteasy-reactive-vertx-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.resteasy.reactive
+    artifact_id: resteasy-reactive-vertx
+    version: 3.26.4
+    type: jar
+  checksum: sha256:08dda7760c977c156893b5b58749f60e690346928907f8d48892d85f085aae3e
+- type: maven
+  filename: quarkus-vertx-utils-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.vertx.utils
+    artifact_id: quarkus-vertx-utils
+    version: 3.26.4
+    type: jar
+  checksum: sha256:3dbd9863055165b5dffa11d3f02d7bd089e5f7f061ff8dafcdde845ca8528c14
+- type: maven
+  filename: quarkus-vertx-http-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-vertx-http
+    version: 3.26.4
+    type: jar
+  checksum: sha256:5375a7a2db5deb0f8718866c35c70787752b4215928e8b62692ff5d6246248f2
+- type: maven
+  filename: quarkus-security-runtime-spi-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-security-runtime-spi
+    version: 3.26.4
+    type: jar
+  checksum: sha256:964bdb74b16d65892f06a9d0db9cad05a4c9ab0aaec6148416a521e2f068b53c
+- type: maven
+  filename: quarkus-security-2.2.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.security
+    artifact_id: quarkus-security
+    version: 2.2.1
+    type: jar
+  checksum: sha256:a5c073bead8e4eb612553cce53b34c8333c88fc98e14938219b70b343b414ef6
+- type: maven
+  filename: smallrye-mutiny-vertx-web-3.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-mutiny-vertx-web
+    version: 3.19.2
+    type: jar
+  checksum: sha256:322469af8cde23afe993e57d5987edc2e6b07186ecf4890ec2c64b6d04365345
+- type: maven
+  filename: smallrye-mutiny-vertx-web-common-3.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-mutiny-vertx-web-common
+    version: 3.19.2
+    type: jar
+  checksum: sha256:1d7bb58e67a4c97a2495ea7dd063d36405f8d3585db928a71dd97b327e58c917
+- type: maven
+  filename: smallrye-mutiny-vertx-auth-common-3.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-mutiny-vertx-auth-common
+    version: 3.19.2
+    type: jar
+  checksum: sha256:c534c1f6cbdff55699e0882d52f224d4adaa48fa57aed4397c9a8410222d91ac
+- type: maven
+  filename: smallrye-mutiny-vertx-bridge-common-3.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-mutiny-vertx-bridge-common
+    version: 3.19.2
+    type: jar
+  checksum: sha256:2d5c4c20143dde76e08e83e53e6d4ea8bb8f7c131c6594404ea9f718a2fc09ea
+- type: maven
+  filename: smallrye-mutiny-vertx-uri-template-3.19.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-mutiny-vertx-uri-template
+    version: 3.19.2
+    type: jar
+  checksum: sha256:6570d769760f2c29bf02f8008f4653621609975cc5f5c3ef7c0c07d9d3a66645
+- type: maven
+  filename: crac-1.5.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.crac
+    artifact_id: crac
+    version: 1.5.0
+    type: jar
+  checksum: sha256:234fbffc04bdc3838707b64b1ba5e8252ec388262f529543775c478fa69235e1
+- type: maven
+  filename: brotli4j-1.16.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.aayushatharva.brotli4j
+    artifact_id: brotli4j
+    version: 1.16.0
+    type: jar
+  checksum: sha256:6b32dfe9519fd50073fadec48b3bf24cb1f817a9f6e3525ed0ba70e8e75c7078
+- type: maven
+  filename: service-1.16.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.aayushatharva.brotli4j
+    artifact_id: service
+    version: 1.16.0
+    type: jar
+  checksum: sha256:249d862b1a5cd5fbad56d1239b5ebd8918ce2b28f4f3c10e32dbec4d957b6870
+- type: maven
+  filename: native-linux-x86_64-1.16.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.aayushatharva.brotli4j
+    artifact_id: native-linux-x86_64
+    version: 1.16.0
+    type: jar
+  checksum: sha256:7c3ae2f100ad43c680c65d023386a6d8711a9a6f98e279dc54f2c97bb2674597
+- type: maven
+  filename: quarkus-logging-cloudwatch-6.14.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkiverse.logging.cloudwatch
+    artifact_id: quarkus-logging-cloudwatch
+    version: 6.14.2
+    type: jar
+  checksum: sha256:6f4a02893cad55019093d38aafdfba6adba97251a503d19d7166994b75b9840c
+- type: maven
+  filename: quarkus-apache-httpclient-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-apache-httpclient
+    version: 3.26.4
+    type: jar
+  checksum: sha256:2fdf3fee300f7245ba6ec60519bd0f7565621afcfb8475a765540ea6087a82dc
+- type: maven
+  filename: httpclient-4.5.14.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.httpcomponents
+    artifact_id: httpclient
+    version: 4.5.14
+    type: jar
+  checksum: sha256:7366b65252ab213fcfa86fa83928108c2c95c112dbccccb107d1fc00549f6070
+- type: maven
+  filename: httpcore-4.4.16.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.apache.httpcomponents
+    artifact_id: httpcore
+    version: 4.4.16
+    type: jar
+  checksum: sha256:6e3736a65a5e83b672dacacd587750c19277612d8a6520cc7318d70e2c6029d6
+- type: maven
+  filename: quarkus-amazon-common-3.9.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkiverse.amazonservices
+    artifact_id: quarkus-amazon-common
+    version: 3.9.0
+    type: jar
+  checksum: sha256:df3f66e689967dc0d0fd49fdb37813d16eb6830698c65ee0f57ceae80e989ef0
+- type: maven
+  filename: sdk-core-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: sdk-core
+    version: 2.32.4
+    type: jar
+  checksum: sha256:b825cdc10c61ab37ee75171dfc599bc6aba50ae0eadbe2639e5072ba427d700c
+- type: maven
+  filename: checksums-spi-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: checksums-spi
+    version: 2.32.4
+    type: jar
+  checksum: sha256:57d636a4479d87c9f10676a565bce2354219af89eee0afea93cb60a583c1836e
+- type: maven
+  filename: checksums-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: checksums
+    version: 2.32.4
+    type: jar
+  checksum: sha256:7fba5c0ac8956b39b8c73efa3b5a03c0b0b8b1879e552cc41a8df8a902388024
+- type: maven
+  filename: profiles-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: profiles
+    version: 2.32.4
+    type: jar
+  checksum: sha256:61d084dad36bee66e25eaf0d5c489d526f66d5737317e8ced22b9ee6048d4f2a
+- type: maven
+  filename: retries-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: retries
+    version: 2.32.4
+    type: jar
+  checksum: sha256:6314208bbe4c558eb6332cfc13ebee22fb37eda126f6b3ce6bbbd113fe9fff5e
+- type: maven
+  filename: aws-core-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: aws-core
+    version: 2.32.4
+    type: jar
+  checksum: sha256:447bc61b3da294e5d1973e2b6367f2f87932eb3df5f1c8a4b8d1adc95d085abd
+- type: maven
+  filename: eventstream-1.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.eventstream
+    artifact_id: eventstream
+    version: 1.0.1
+    type: jar
+  checksum: sha256:395da98339731798a39ff271bc27d0def55003c4748a17ed64e8113d6382912e
+- type: maven
+  filename: regions-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: regions
+    version: 2.32.4
+    type: jar
+  checksum: sha256:684d27c205358deb427502c51a540a4de41514e499807dafffbfcf1f7e8752d4
+- type: maven
+  filename: auth-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: auth
+    version: 2.32.4
+    type: jar
+  checksum: sha256:dc189ba85d8f8eee4f7f6ef9310a620a171ca482b43de28a04629d1176890996
+- type: maven
+  filename: http-auth-aws-eventstream-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: http-auth-aws-eventstream
+    version: 2.32.4
+    type: jar
+  checksum: sha256:5346b0f7a0bfaf87f9ed7878658b84d218b1d0226ad61c94f5b6ad759d4d6f6b
+- type: maven
+  filename: http-client-spi-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: http-client-spi
+    version: 2.32.4
+    type: jar
+  checksum: sha256:c07fa9b743701c45e949586c6bc5a61a2d1598ec9de94928f00f55fb680961a6
+- type: maven
+  filename: quarkus-amazon-common-spi-3.9.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkiverse.amazonservices
+    artifact_id: quarkus-amazon-common-spi
+    version: 3.9.0
+    type: jar
+  checksum: sha256:0e44f9744897a4bb9de517f0af87f8cf532916456b22db80eb8d204e3c7f6145
+- type: maven
+  filename: cloudwatchlogs-2.32.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: cloudwatchlogs
+    version: 2.32.3
+    type: jar
+  checksum: sha256:7f87128ae768117a8105f02283e951f9e7bf7e4076533bf0f04d6b0ae610963b
+- type: maven
+  filename: aws-json-protocol-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: aws-json-protocol
+    version: 2.32.4
+    type: jar
+  checksum: sha256:0d7ec1f1f9f92441020d441bdbc8fa55ff22352d766cf4b558c4001dfef0f854
+- type: maven
+  filename: third-party-jackson-core-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: third-party-jackson-core
+    version: 2.32.4
+    type: jar
+  checksum: sha256:db0c542803c8d80c4cf9556c8c3b37b73f6fcddbe27f71f123916a63a217cf35
+- type: maven
+  filename: protocol-core-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: protocol-core
+    version: 2.32.4
+    type: jar
+  checksum: sha256:5debf9df69ab20fa1bc61d89375078c0b78e4bfee6d94ca14b1689e0289f8075
+- type: maven
+  filename: http-auth-aws-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: http-auth-aws
+    version: 2.32.4
+    type: jar
+  checksum: sha256:d3950cf116747884a2ab998a6015001586b8e490bb9460f7b0c3f90e2d54d066
+- type: maven
+  filename: http-auth-spi-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: http-auth-spi
+    version: 2.32.4
+    type: jar
+  checksum: sha256:106bdd539909ae794bb40fc66019d9b9bec0775e94962af08eac956d291405a0
+- type: maven
+  filename: http-auth-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: http-auth
+    version: 2.32.4
+    type: jar
+  checksum: sha256:22f1e55d981ce0bb58aa1d3c687f40e6d4bf9d94f270c1ec7be8e4628ad313db
+- type: maven
+  filename: identity-spi-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: identity-spi
+    version: 2.32.4
+    type: jar
+  checksum: sha256:31cd1604cb5c7e7ebd05149ca17f3716bd7de239bb48808b23327bb564c5fa8d
+- type: maven
+  filename: annotations-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: annotations
+    version: 2.32.4
+    type: jar
+  checksum: sha256:468ed5fbf3af3f0ce447a914ef2505bef34f48f7b3006311a3f30eba45f29a18
+- type: maven
+  filename: utils-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: utils
+    version: 2.32.4
+    type: jar
+  checksum: sha256:bbac38f75f34ea43d5b17912a0016559fcbd329d6154d169bc09725589255702
+- type: maven
+  filename: metrics-spi-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: metrics-spi
+    version: 2.32.4
+    type: jar
+  checksum: sha256:ac1c5c4afaddaafc6e2e191fae5048996346784c811c17c82d207d84edc18724
+- type: maven
+  filename: json-utils-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: json-utils
+    version: 2.32.4
+    type: jar
+  checksum: sha256:2eb96885536b720134fd6ad74a664967c341e549bdbaf7fbd90b13a5b63aa99f
+- type: maven
+  filename: endpoints-spi-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: endpoints-spi
+    version: 2.32.4
+    type: jar
+  checksum: sha256:8819489cd6ee229f068ac18d26c57322a0e13f3dcaa782ef00c975a8c2200876
+- type: maven
+  filename: retries-spi-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: retries-spi
+    version: 2.32.4
+    type: jar
+  checksum: sha256:31b64625fa3cc531d9b5872d026504477c54f1e1a7e36772fca226c4b316af8a
+- type: maven
+  filename: apache-client-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: apache-client
+    version: 2.32.4
+    type: jar
+  checksum: sha256:0d4b956d5a1fec1210ba138fd0e4d8f06a33ce04e402d57895e6ddacd7a7edbe
+- type: maven
+  filename: netty-nio-client-2.32.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: software.amazon.awssdk
+    artifact_id: netty-nio-client
+    version: 2.32.4
+    type: jar
+  checksum: sha256:51f0bb3e0cd124fa12278cd0bc29f1303cb5396d0ec9b8f4b47527880b1a0610
+- type: maven
+  filename: netty-transport-classes-epoll-4.1.127.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.netty
+    artifact_id: netty-transport-classes-epoll
+    version: 4.1.127.Final
+    type: jar
+  checksum: sha256:f825644a9c7af4ada7c365215770bb4d6ff4d00b73c78dd6f9f4ef753064af26
+- type: maven
+  filename: ecs-logging-core-1.7.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: co.elastic.logging
+    artifact_id: ecs-logging-core
+    version: 1.7.0
+    type: jar
+  checksum: sha256:a6e36b33d1bc4b47d09f615ffd6908cd58dcdf9cf9ea0be8ab08f14d4d9545ec
+- type: maven
+  filename: graal-sdk-23.1.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.graalvm.sdk
+    artifact_id: graal-sdk
+    version: 23.1.2
+    type: jar
+  checksum: sha256:f2da6099fafd6c655e374a66a29888484ba9500dcbaf2ad629f349121bdba44e
+- type: maven
+  filename: collections-23.1.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.graalvm.sdk
+    artifact_id: collections
+    version: 23.1.2
+    type: jar
+  checksum: sha256:e2e230c5bd414b67c247eb6f68b3d3fcf505db2cedeab0cc49842826c85cc5ef
+- type: maven
+  filename: word-23.1.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.graalvm.sdk
+    artifact_id: word
+    version: 23.1.2
+    type: jar
+  checksum: sha256:0e79b6fa11c0ab43831ebc1322d13ef4ce66aab2c2f024727a95f3652f0ef2b1
+- type: maven
+  filename: quarkus-logging-sentry-2.1.8.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkiverse.loggingsentry
+    artifact_id: quarkus-logging-sentry
+    version: 2.1.8
+    type: jar
+  checksum: sha256:16b62fb3a218465a7080b986c0007fa5360a0455fb8c936dc1830da13ffbf613
+- type: maven
+  filename: sentry-jul-8.20.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.sentry
+    artifact_id: sentry-jul
+    version: 8.20.0
+    type: jar
+  checksum: sha256:08c57f97c6a6b5a8e73f6d90b69dec2d439e9ab9680f845d6e40716a069b66a9
+- type: maven
+  filename: sentry-8.20.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.sentry
+    artifact_id: sentry
+    version: 8.20.0
+    type: jar
+  checksum: sha256:4a03e3e6abd4df63dbc582cb39a20b0ad9fd999e6698d08311c18a71c3955ec0
+- type: maven
+  filename: clowder-quarkus-config-source-2.7.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.redhat.cloud.common
+    artifact_id: clowder-quarkus-config-source
+    version: 2.7.1
+    type: jar
+  checksum: sha256:4874819e8e8359fd0bec1ed9883cea9f53a457664b040bb3903860ccccdc63a3
+- type: maven
+  filename: smallrye-config-3.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.config
+    artifact_id: smallrye-config
+    version: 3.13.4
+    type: jar
+  checksum: sha256:812e7585dafdf9b27c4a2f6783cecdb418cde11c8e4b3d1db63dcd1c46459326
+- type: maven
+  filename: smallrye-config-core-3.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.config
+    artifact_id: smallrye-config-core
+    version: 3.13.4
+    type: jar
+  checksum: sha256:613aef72889ae7926f8c535ec485357403772c49734c6689764241b28a7b1327
+- type: maven
+  filename: smallrye-config-common-3.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.config
+    artifact_id: smallrye-config-common
+    version: 3.13.4
+    type: jar
+  checksum: sha256:958e11ef43cc4911441cf3a21ecd23a88a3da8d4b52eaa6b454ca95a62c16be8
+- type: maven
+  filename: notifications-common-1.0.0-SNAPSHOT-tests.test-jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.redhat.cloud.notifications
+    artifact_id: notifications-common
+    version: 1.0.0-SNAPSHOT
+    type: test-jar
+    classifier: tests
+  checksum: sha256:67577736c773fadaa69d5da5cf7ed537a927d606c20814a71b278cea26c7e6d1
+- type: maven
+  filename: quarkus-hibernate-orm-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-hibernate-orm
+    version: 3.26.4
+    type: jar
+  checksum: sha256:a6c44c82271d3cfc0372aa64432e95e38e86e37fc378c010399e5786906ee702
+- type: maven
+  filename: quarkus-agroal-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-agroal
+    version: 3.26.4
+    type: jar
+  checksum: sha256:0a5adb7e2d728a6a4b50f35b623cb64c24deb8415765fcb12eb1f909b36a0d9b
+- type: maven
+  filename: quarkus-datasource-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-datasource
+    version: 3.26.4
+    type: jar
+  checksum: sha256:ff5621474ba5203926417839b182fc4ab29567b89548ddff27d895ed9f95a105
+- type: maven
+  filename: agroal-api-2.8.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.agroal
+    artifact_id: agroal-api
+    version: '2.8'
+    type: jar
+  checksum: sha256:f53f5dc86496cf5529bdbcbebf39cd55b00cc4c6890091869880eb3ce48cf750
+- type: maven
+  filename: agroal-narayana-2.8.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.agroal
+    artifact_id: agroal-narayana
+    version: '2.8'
+    type: jar
+  checksum: sha256:0c48697592ae641db81a8d9004404ee61544032b39459174e6f8e075e73a303b
+- type: maven
+  filename: jboss-transaction-spi-8.0.0.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jboss
+    artifact_id: jboss-transaction-spi
+    version: 8.0.0.Final
+    type: jar
+  checksum: sha256:82067fc0451a771377fcaad5dc6fc347da9b489417028052e47a5ca2bea2dc5a
+- type: maven
+  filename: agroal-pool-2.8.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.agroal
+    artifact_id: agroal-pool
+    version: '2.8'
+    type: jar
+  checksum: sha256:2048ac8b29b83553980729243fd6f58256a48da9b647ee73c6ad759b54c09ec3
+- type: maven
+  filename: quarkus-narayana-jta-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-narayana-jta
+    version: 3.26.4
+    type: jar
+  checksum: sha256:d8529e24718c9b954e588efcb919b65f1098e534d4ec49140a93275a526d1260
+- type: maven
+  filename: quarkus-transaction-annotations-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-transaction-annotations
+    version: 3.26.4
+    type: jar
+  checksum: sha256:bcad8ac77779b1564bf8506809fd0ca6429d8ab334c9fd6ce45e958e3b423fd7
+- type: maven
+  filename: quarkus-datasource-common-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-datasource-common
+    version: 3.26.4
+    type: jar
+  checksum: sha256:bf4145ffb11fbae1951c6cb7421d9a6342bf55ae321f4dbee625dea475a1725b
+- type: maven
+  filename: smallrye-context-propagation-jta-2.2.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-context-propagation-jta
+    version: 2.2.1
+    type: jar
+  checksum: sha256:51851bbc3275d91f482ff55e74a0d029c2316b1aec26768ea6dbe7ddac89885a
+- type: maven
+  filename: smallrye-reactive-converter-mutiny-3.0.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.reactive
+    artifact_id: smallrye-reactive-converter-mutiny
+    version: 3.0.3
+    type: jar
+  checksum: sha256:c13b9db0130215392596503096a7e80e066ce9085bbcb33be2f3b237b917ae9a
+- type: maven
+  filename: narayana-jta-7.2.2.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jboss.narayana.jta
+    artifact_id: narayana-jta
+    version: 7.2.2.Final
+    type: jar
+  checksum: sha256:0a9b8031be91fd912fa7f9d33cb6f95073770c20d9c342e26cd1cd2f584a83ac
+- type: maven
+  filename: jakarta.resource-api-2.1.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.resource
+    artifact_id: jakarta.resource-api
+    version: 2.1.0
+    type: jar
+  checksum: sha256:9eb332553beb6609219f5086cd6b5f12e784b3c047d4ee4d35b8fa0190d5680d
+- type: maven
+  filename: jboss-invocation-2.0.0.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jboss.invocation
+    artifact_id: jboss-invocation
+    version: 2.0.0.Final
+    type: jar
+  checksum: sha256:c800942e81b345c1a3f6051e5347568efe2dcb41ac4c2dd1192f021f9cb7d76d
+- type: maven
+  filename: narayana-jts-integration-7.2.2.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jboss.narayana.jts
+    artifact_id: narayana-jts-integration
+    version: 7.2.2.Final
+    type: jar
+  checksum: sha256:e10fff0ab50cc59702b31ff14352f8022d2dd644cff5f71f5b20f155c44f8c7a
+- type: maven
+  filename: hibernate-core-7.1.0.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.hibernate.orm
+    artifact_id: hibernate-core
+    version: 7.1.0.Final
+    type: jar
+  checksum: sha256:76975fe0db57f38505a6f13290c9f7caad5c313d68ded99907c8eb99597ef339
+- type: maven
+  filename: hibernate-models-1.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.hibernate.models
+    artifact_id: hibernate-models
+    version: 1.0.1
+    type: jar
+  checksum: sha256:0143a1ea5a0b5bb3ab3ea5032ab190a87d90e906e25cbe5ba21af25efd143ace
+- type: maven
+  filename: classmate-1.7.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.fasterxml
+    artifact_id: classmate
+    version: 1.7.0
+    type: jar
+  checksum: sha256:05865c4e2d731e7b01c67dd52e7c49c2110e38ebab2da25332bbecdf4bada493
+- type: maven
+  filename: antlr4-runtime-4.13.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.antlr
+    artifact_id: antlr4-runtime
+    version: 4.13.2
+    type: jar
+  checksum: sha256:5d8590a65e94b8a4d80d0ce6202f9abbe4dd518a6526d611007a81a1f00de7ee
+- type: maven
+  filename: hibernate-graalvm-7.1.0.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.hibernate.orm
+    artifact_id: hibernate-graalvm
+    version: 7.1.0.Final
+    type: jar
+  checksum: sha256:0797d4353606d0da04e8d392a0ced238c0a49b284f6bfb59b97f18eff5859de6
+- type: maven
+  filename: jaxb-runtime-4.0.5.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.glassfish.jaxb
+    artifact_id: jaxb-runtime
+    version: 4.0.5
+    type: jar
+  checksum: sha256:4d3d11fd7740e9f87ee04fc60bee3636809cbfd00a66946e2dc0a8c673640e7b
+- type: maven
+  filename: jaxb-core-4.0.5.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.glassfish.jaxb
+    artifact_id: jaxb-core
+    version: 4.0.5
+    type: jar
+  checksum: sha256:80a2cb260a26a0d70bb84c8157a5d1c00bed626a9d57a717f448b7988b048cf4
+- type: maven
+  filename: txw2-4.0.5.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.glassfish.jaxb
+    artifact_id: txw2
+    version: 4.0.5
+    type: jar
+  checksum: sha256:fe0e592335f4f46cfa12aed8942b05bc5e75df92440ff01d84ce0c782ae0addf
+- type: maven
+  filename: istack-commons-runtime-4.1.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.sun.istack
+    artifact_id: istack-commons-runtime
+    version: 4.1.2
+    type: jar
+  checksum: sha256:91706a6aa0450d2c51ba0c0b1d108acecdef36e834c50e69c1a0acd7ef02a77c
+- type: maven
+  filename: jakarta.persistence-api-3.2.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.persistence
+    artifact_id: jakarta.persistence-api
+    version: 3.2.0
+    type: jar
+  checksum: sha256:480671d31fda1dfe0bf1c470731aadf347d7b91fba45e711886fc61a6aeda104
+- type: maven
+  filename: jakarta.transaction-api-2.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.transaction
+    artifact_id: jakarta.transaction-api
+    version: 2.0.1
+    type: jar
+  checksum: sha256:9b2f5f2ebb1cc32e644e611111df82da24307e09670679301c9d9fa3ee9619d1
+- type: maven
+  filename: quarkus-local-cache-0.3.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.hibernate
+    artifact_id: quarkus-local-cache
+    version: 0.3.1
+    type: jar
+  checksum: sha256:015448f8a9b195d6a26187d4cd0ca3632a7f04b69552379b940770da1fc34cbc
+- type: maven
+  filename: quarkus-caffeine-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-caffeine
+    version: 3.26.4
+    type: jar
+  checksum: sha256:82b8ef8913dd974912e68672b30f63b9d76b70885acb2b03d4421486f79ae847
+- type: maven
+  filename: caffeine-3.2.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.github.ben-manes.caffeine
+    artifact_id: caffeine
+    version: 3.2.2
+    type: jar
+  checksum: sha256:6953915abcb429848d58b7f9b7cd39772af3ade6819687be16f1c22efeec7c35
+- type: maven
+  filename: jspecify-1.0.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jspecify
+    artifact_id: jspecify
+    version: 1.0.0
+    type: jar
+  checksum: sha256:611b14d8d0410063ecadcfb348bca2abe63fbe5cff2279c0b7e72adb1c34d0ee
+- type: maven
+  filename: error_prone_annotations-2.41.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: com.google.errorprone
+    artifact_id: error_prone_annotations
+    version: 2.41.0
+    type: jar
+  checksum: sha256:8fcc485b5c57c19aafa1b0fd9d69c3c8a599e7dfd3e621c8b0f3170e60025c6a
+- type: maven
+  filename: quarkus-hibernate-validator-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-hibernate-validator
+    version: 3.26.4
+    type: jar
+  checksum: sha256:568fe0c108adb6b558545c8c9eabea8dffe3b60a391e1e1bcfc05d6205d65f8f
+- type: maven
+  filename: hibernate-validator-9.0.1.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.hibernate.validator
+    artifact_id: hibernate-validator
+    version: 9.0.1.Final
+    type: jar
+  checksum: sha256:de8fd1224d98bbcc8317caacef13d3084696f908a661fd50a7bbfed04857106b
+- type: maven
+  filename: expressly-6.0.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.glassfish.expressly
+    artifact_id: expressly
+    version: 6.0.0
+    type: jar
+  checksum: sha256:becee0c3b5eb4c5df89cadb8e750ebcab982875a9faadb9fb9023b6a6ba9b677
+- type: maven
+  filename: jakarta.el-api-6.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.el
+    artifact_id: jakarta.el-api
+    version: 6.0.1
+    type: jar
+  checksum: sha256:e7f43c47500302a58eaf85447f1e6ca28904b682c98c6b4c855a1ed4332aec1c
+- type: maven
+  filename: smallrye-config-validator-3.13.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.config
+    artifact_id: smallrye-config-validator
+    version: 3.13.4
+    type: jar
+  checksum: sha256:7e09740f7c81933e9c537aba73f3ff984cd958d2c437b267123c140235b62ca5
+- type: maven
+  filename: jakarta.ws.rs-api-3.1.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.ws.rs
+    artifact_id: jakarta.ws.rs-api
+    version: 3.1.0
+    type: jar
+  checksum: sha256:4fbad29647c74b2555aa80db638563673c9cabd52b5a10f76c3519146a6b5c51
+- type: maven
+  filename: quarkus-rest-jackson-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-rest-jackson
+    version: 3.26.4
+    type: jar
+  checksum: sha256:c985e3e8fa0406533fea5473125253973a9a57bd9318aa9ccf59801043bc7704
+- type: maven
+  filename: quarkus-smallrye-openapi-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-smallrye-openapi
+    version: 3.26.4
+    type: jar
+  checksum: sha256:22e3100e0f17aed02f80b76959c1071981ffe15a3518c452e617b6795abc72b7
+- type: maven
+  filename: smallrye-open-api-core-4.0.12.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-open-api-core
+    version: 4.0.12
+    type: jar
+  checksum: sha256:453f6f964a96af285235000d6926a95d6794db1f8b488187b0800c1792a27211
+- type: maven
+  filename: microprofile-openapi-api-4.0.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.microprofile.openapi
+    artifact_id: microprofile-openapi-api
+    version: 4.0.2
+    type: jar
+  checksum: sha256:aee62fff713aa0e8b01fb7a40203f583135e219adf77e8137c8697c592d0cad5
+- type: maven
+  filename: smallrye-open-api-model-4.0.12.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-open-api-model
+    version: 4.0.12
+    type: jar
+  checksum: sha256:b129baddf50e11029d247ba768a477b197b9c9d7cf705d4fd012d34c4609f683
+- type: maven
+  filename: smallrye-common-classloader-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-classloader
+    version: 2.13.9
+    type: jar
+  checksum: sha256:e616fa17b8b559a678655e675066f5c3825d8a6f7accdd83138f64dc16932d29
+- type: maven
+  filename: quarkus-swagger-ui-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-swagger-ui
+    version: 3.26.4
+    type: jar
+  checksum: sha256:085add78bbea17a3c6f2c5981ee7460d70846d3c686ae8647b82dd8d215f80d3
+- type: maven
+  filename: quarkus-cache-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-cache
+    version: 3.26.4
+    type: jar
+  checksum: sha256:0ac8deade5f27a2fc3e448f2a8d7485087321b68a8adb83cf6956bfc0e1a1d3e
+- type: maven
+  filename: quarkus-cache-runtime-spi-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-cache-runtime-spi
+    version: 3.26.4
+    type: jar
+  checksum: sha256:7162ceb7b70493fba96a8792989bda8abe4df2f366dc7d223184daae5a84099a
+- type: maven
+  filename: quarkus-smallrye-fault-tolerance-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-smallrye-fault-tolerance
+    version: 3.26.4
+    type: jar
+  checksum: sha256:ce95cb2f93dab69a8a026322f6183b3164958e563e3b0edf4fb410c483a450cb
+- type: maven
+  filename: smallrye-fault-tolerance-6.9.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-fault-tolerance
+    version: 6.9.3
+    type: jar
+  checksum: sha256:036fd6ca643238b1ee3ee51e3a5690b348e5e1991c38aa7f0bab4f7142540b3d
+- type: maven
+  filename: microprofile-fault-tolerance-api-4.1.2.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.microprofile.fault-tolerance
+    artifact_id: microprofile-fault-tolerance-api
+    version: 4.1.2
+    type: jar
+  checksum: sha256:b51745d46bf1235c8ae6f486539f1b7edde946208dd547993f779cfe3619b505
+- type: maven
+  filename: smallrye-fault-tolerance-api-6.9.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-fault-tolerance-api
+    version: 6.9.3
+    type: jar
+  checksum: sha256:32a046179e1dda8b4f8f01308ceb358df63e579331fee2760670967c3eef64f5
+- type: maven
+  filename: smallrye-fault-tolerance-core-6.9.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-fault-tolerance-core
+    version: 6.9.3
+    type: jar
+  checksum: sha256:f2d30f794c9fa8b39ec69cbb77f72a48d7867b22e7a197c9e38fc4843e6a306e
+- type: maven
+  filename: smallrye-fault-tolerance-autoconfig-core-6.9.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-fault-tolerance-autoconfig-core
+    version: 6.9.3
+    type: jar
+  checksum: sha256:984cf319661fc442f09395a90d38668962bfe596da6bcf71ef4ad84ce214323b
+- type: maven
+  filename: smallrye-fault-tolerance-apiimpl-6.9.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-fault-tolerance-apiimpl
+    version: 6.9.3
+    type: jar
+  checksum: sha256:ea79986aef9cf4445087b461df81a0f322a687996458ca49d630ca9186fe3b02
+- type: maven
+  filename: jakarta.enterprise.cdi-api-4.1.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.enterprise
+    artifact_id: jakarta.enterprise.cdi-api
+    version: 4.1.0
+    type: jar
+  checksum: sha256:cfe055c23a06ddba5482a6b17020bcf482fb6e705b31ba86a7e14088729d0e85
+- type: maven
+  filename: jakarta.enterprise.lang-model-4.1.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.enterprise
+    artifact_id: jakarta.enterprise.lang-model
+    version: 4.1.0
+    type: jar
+  checksum: sha256:e32c97dad3630270007291ae3fb76b2e2f23e69e61f4e98dcb2ba2eaef366dc3
+- type: maven
+  filename: jakarta.interceptor-api-2.2.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.interceptor
+    artifact_id: jakarta.interceptor-api
+    version: 2.2.0
+    type: jar
+  checksum: sha256:268d396c3af8ae79e9c8456a6680f78b7d83fb8b6d7779d41c94de8c7efe50ad
+- type: maven
+  filename: smallrye-fault-tolerance-context-propagation-6.9.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-fault-tolerance-context-propagation
+    version: 6.9.3
+    type: jar
+  checksum: sha256:a07f66d5299dfc8016f1ebd0be6c3ea719d42d1628b3ea07f6ec467473e51103
+- type: maven
+  filename: smallrye-fault-tolerance-mutiny-6.9.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye
+    artifact_id: smallrye-fault-tolerance-mutiny
+    version: 6.9.3
+    type: jar
+  checksum: sha256:beeee1d0849c5b57a3c26780aac84f6b06278fbb05277f27eb9dde046864de32
+- type: maven
+  filename: mapstruct-1.6.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.mapstruct
+    artifact_id: mapstruct
+    version: 1.6.3
+    type: jar
+  checksum: sha256:4bb1f21f4f97e93065f4b2b05b15f2fc3458e2439c1d8f2b427038ed19dc6019
+- type: maven
+  filename: opentelemetry-instrumentation-annotations-2.10.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.opentelemetry.instrumentation
+    artifact_id: opentelemetry-instrumentation-annotations
+    version: 2.10.0
+    type: jar
+  checksum: sha256:4053b838660a14c81db6de4e99b3ab549e866d6d7f8f0c811e2fe873bb051ff6
+- type: maven
+  filename: opentelemetry-api-1.44.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.opentelemetry
+    artifact_id: opentelemetry-api
+    version: 1.44.1
+    type: jar
+  checksum: sha256:6892354faf0e666aaeb0b0e92b2265c177a22a27777f41fb7770cf39522a7e75
+- type: maven
+  filename: opentelemetry-context-1.44.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.opentelemetry
+    artifact_id: opentelemetry-context
+    version: 1.44.1
+    type: jar
+  checksum: sha256:7765a56b8b1bb1fe831451344b4ae0c777f4fa39fb5c943745b61c8eb5e213b9
+- type: maven
+  filename: quarkus-jacoco-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-jacoco
+    version: 3.26.4
+    type: jar
+  checksum: sha256:e78a508200914d8a5edcd5a4fb6c48859c67ce4abce4f0c02ffdd5659f1a301c
+- type: maven
+  filename: quarkus-core-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-core
+    version: 3.26.4
+    type: jar
+  checksum: sha256:2985069fde37cc6d7081669dddd0a687e72f95c1a49a2d01b3bf744ac9b81f27
+- type: maven
+  filename: jakarta.inject-api-2.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.inject
+    artifact_id: jakarta.inject-api
+    version: 2.0.1
+    type: jar
+  checksum: sha256:a7f50c8949376ca5294485e3bc1493686afec8de5a9c66e0c3676c6b9cac40aa
+- type: maven
+  filename: smallrye-common-os-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-os
+    version: 2.13.9
+    type: jar
+  checksum: sha256:9857529546e39772dd9d4ff415e7a78dd9bdf4027a155ed8159ed0e80b389cf8
+- type: maven
+  filename: quarkus-ide-launcher-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-ide-launcher
+    version: 3.26.4
+    type: jar
+  checksum: sha256:caffbff67ba433925ba2ee0e76f9c3e7f2339c0769747d89733224bf7336d068
+- type: maven
+  filename: jboss-logmanager-3.1.2.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jboss.logmanager
+    artifact_id: jboss-logmanager
+    version: 3.1.2.Final
+    type: jar
+  checksum: sha256:3fdb82d094196554dfab499056e600e5a551035963ebf55cc5a556060c415699
+- type: maven
+  filename: smallrye-common-cpu-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-cpu
+    version: 2.13.9
+    type: jar
+  checksum: sha256:df8f0a29ac510b3e7b3a4f88998c889accb179dee9a3d0a483887515ca1d83f2
+- type: maven
+  filename: smallrye-common-expression-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-expression
+    version: 2.13.9
+    type: jar
+  checksum: sha256:66c890c9f16d51426bccb3135d39638f2b5bbe8eba671ba621e1394e67b384d6
+- type: maven
+  filename: smallrye-common-net-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-net
+    version: 2.13.9
+    type: jar
+  checksum: sha256:67721209c7f61a9d1db07927c82ebe625a09e3d4122cb20e5ecb27dc4f968608
+- type: maven
+  filename: smallrye-common-ref-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-ref
+    version: 2.13.9
+    type: jar
+  checksum: sha256:a71535388abbbbdbf4d61bbd9206bd7d221c2627f1eed265efeadb45a407a0de
+- type: maven
+  filename: jakarta.json-api-2.1.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: jakarta.json
+    artifact_id: jakarta.json-api
+    version: 2.1.3
+    type: jar
+  checksum: sha256:b463a982ba203889fe8926c8913ee22e917931677d06aee89b18edf49cc5879d
+- type: maven
+  filename: jboss-threads-3.9.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jboss.threads
+    artifact_id: jboss-threads
+    version: 3.9.1
+    type: jar
+  checksum: sha256:37103699442a434cc8aeb427f9642f625d0d97890eb568661bc4672fecada34e
+- type: maven
+  filename: smallrye-common-function-2.13.9.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.smallrye.common
+    artifact_id: smallrye-common-function
+    version: 2.13.9
+    type: jar
+  checksum: sha256:d8c52770a066828e5ac07e6bafcd2814d14d3319bfb5aca80a0eca9309f267f4
+- type: maven
+  filename: slf4j-jboss-logmanager-2.0.0.Final.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jboss.slf4j
+    artifact_id: slf4j-jboss-logmanager
+    version: 2.0.0.Final
+    type: jar
+  checksum: sha256:bc8caff4ab7a269b5167db81b193e912d0f8340df9d3da24766aee2a04ffac68
+- type: maven
+  filename: wildfly-common-2.0.1.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.wildfly.common
+    artifact_id: wildfly-common
+    version: 2.0.1
+    type: jar
+  checksum: sha256:b96bfbfc1485de3b720830aeef904ce01f0958e559d88b1e7f24ec8f3d824c71
+- type: maven
+  filename: quarkus-bootstrap-runner-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-bootstrap-runner
+    version: 3.26.4
+    type: jar
+  checksum: sha256:1170e0bdb7ea76eb916b8d4ad9f19c04cfdf64968e4bb699c04f0c54cfd74521
+- type: maven
+  filename: quarkus-fs-util-1.1.0.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-fs-util
+    version: 1.1.0
+    type: jar
+  checksum: sha256:072eb71d507ba81900ddbb00a9d8859e8335a713d77a5ade25cac85c20cc35d9
+- type: maven
+  filename: quarkus-arc-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus
+    artifact_id: quarkus-arc
+    version: 3.26.4
+    type: jar
+  checksum: sha256:c5b88a447f56bc20cc0b581dfe6f2479e0eb2c23ddd25bd8319acd7123c81428
+- type: maven
+  filename: arc-3.26.4.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: io.quarkus.arc
+    artifact_id: arc
+    version: 3.26.4
+    type: jar
+  checksum: sha256:492668a69db9e8eac44a80ee9fa8f95fe4ac14e44c19910038180b161a9870ff
+- type: maven
+  filename: microprofile-context-propagation-api-1.3.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.eclipse.microprofile.context-propagation
+    artifact_id: microprofile-context-propagation-api
+    version: '1.3'
+    type: jar
+  checksum: sha256:039a0b83a06108636482d2f9bbbc894ea6c6c0750034be7c486e06bacc559d8c
+- type: maven
+  filename: org.jacoco.core-0.8.13.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jacoco
+    artifact_id: org.jacoco.core
+    version: 0.8.13
+    type: jar
+  checksum: sha256:65ba20d07232b3e94909347af0f6e7e72f735e6873c5ece36ff323b78b40b1bb
+- type: maven
+  filename: asm-9.8.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.ow2.asm
+    artifact_id: asm
+    version: '9.8'
+    type: jar
+  checksum: sha256:da765ca813a7a8a79cfe26df7da5c1cb8d8eb881b6f9baf714931db33b46958e
+- type: maven
+  filename: asm-tree-9.8.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.ow2.asm
+    artifact_id: asm-tree
+    version: '9.8'
+    type: jar
+  checksum: sha256:0820fa385cda532b4394599d09da29dad963085e7adf990d8150cdddb11b0f7f
+- type: maven
+  filename: org.jacoco.report-0.8.13.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jacoco
+    artifact_id: org.jacoco.report
+    version: 0.8.13
+    type: jar
+  checksum: sha256:fcae49c18f5d79e582c289ba3182e6c9d986c776937e2ce97d3ca94aaa80d14c
+- type: maven
+  filename: org.jacoco.agent-0.8.13.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jacoco
+    artifact_id: org.jacoco.agent
+    version: 0.8.13
+    type: jar
+  checksum: sha256:83c71118aa62e219ad07898b44b69e781911018e0d19ceff19b9a6008b81c426
+- type: maven
+  filename: org.jacoco.agent-0.8.13-runtime.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.jacoco
+    artifact_id: org.jacoco.agent
+    version: 0.8.13
+    type: jar
+    classifier: runtime
+  checksum: sha256:83c71118aa62e219ad07898b44b69e781911018e0d19ceff19b9a6008b81c426
+- type: maven
+  filename: asm-commons-9.8.jar
+  attributes:
+    repository_url: https://repo1.maven.org/maven2
+    group_id: org.ow2.asm
+    artifact_id: asm-commons
+    version: '9.8'
+    type: jar
+  checksum: sha256:bc9000b77e26dd27870de3eb0c725e03d6eafff24b00704032ca7fe67f9130be

--- a/docker/Dockerfile.notifications-connector-drawer.jvm
+++ b/docker/Dockerfile.notifications-connector-drawer.jvm
@@ -15,8 +15,8 @@ FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 # Update the base image packages
 USER root
 # See https://www.mankier.com/8/microdnf
-RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
-RUN microdnf clean all
+# RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+# RUN microdnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'


### PR DESCRIPTION
This PR enables hermetic builds in the Drawer connector by using a Maven artifacts file.
This is for science / spiking purposes, not intended to be in production usage

## Summary by Sourcery

Configure Drawer connector for hermetic Docker builds by adding a Maven artifacts lockfile and adjusting Tekton pipeline parameters; experimental usage only

New Features:
- Enable hermetic builds in Drawer connector using a Maven artifacts lock file

Enhancements:
- Update Tekton pipeline definitions to include hermetic flag and prefetch-input configuration
- Add artifacts.lock.yaml to pin Maven dependencies for reproducible Docker builds