### PR TITLE
RHCLOUD-43595 Simplify Kessel permissions model

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselInventoryAuthorization.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselInventoryAuthorization.java
@@ -301,19 +301,12 @@ public class KesselInventoryAuthorization {
     CheckOperation getCheckOperation(KesselInventoryResourceType resourceType, KesselPermission permission) {
         if ((resourceType == KesselInventoryResourceType.WORKSPACE) && (permission instanceof WorkspacePermission workspacePermission)) {
             return switch (workspacePermission) {
-                case APPLICATIONS_VIEW,
-                     BUNDLES_VIEW,
-                     BEHAVIOR_GROUPS_VIEW,
-                     EVENT_LOG_VIEW,
-                     EVENT_TYPES_VIEW,
+                case EVENTS_VIEW,
                      INTEGRATIONS_VIEW,
-                     DAILY_DIGEST_PREFERENCE_VIEW
+                     NOTIFICATIONS_VIEW
                     -> CheckOperation.CHECK;
-                case BEHAVIOR_GROUPS_EDIT,
-                     CREATE_DRAWER_INTEGRATION,
-                     CREATE_EMAIL_SUBSCRIPTION_INTEGRATION,
-                     INTEGRATIONS_CREATE,
-                     DAILY_DIGEST_PREFERENCE_EDIT
+                case INTEGRATIONS_EDIT,
+                     NOTIFICATIONS_EDIT
                     -> CheckOperation.UPDATE;
             };
         } else {

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/permission/WorkspacePermission.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/permission/WorkspacePermission.java
@@ -1,19 +1,12 @@
 package com.redhat.cloud.notifications.auth.kessel.permission;
 
 public enum WorkspacePermission implements KesselPermission {
-    APPLICATIONS_VIEW("notifications_applications_view"),
-    BUNDLES_VIEW("notifications_bundles_view"),
-    BEHAVIOR_GROUPS_EDIT("notifications_behavior_groups_edit"),
-    BEHAVIOR_GROUPS_VIEW("notifications_behavior_groups_view"),
-    CREATE_DRAWER_INTEGRATION("notifications_integration_subscribe_drawer"),
-    CREATE_EMAIL_SUBSCRIPTION_INTEGRATION("notifications_integration_subscribe_email"),
-    EVENT_LOG_VIEW("notifications_event_log_view"),
-    EVENT_TYPES_VIEW("notifications_event_types_view"),
-    // TODO Replace with INTEGRATIONS_EDIT("notifications_integration_edit") - This requires a schema update in Kessel
-    INTEGRATIONS_CREATE("notifications_integration_create"),
-    INTEGRATIONS_VIEW("notifications_integration_view"),
-    DAILY_DIGEST_PREFERENCE_EDIT("notifications_daily_digest_preference_edit"),
-    DAILY_DIGEST_PREFERENCE_VIEW("notifications_daily_digest_preference_view");
+
+    EVENTS_VIEW("notifications_events_view"),
+    INTEGRATIONS_EDIT("integrations_endpoints_edit"),
+    INTEGRATIONS_VIEW("integrations_endpoints_view"),
+    NOTIFICATIONS_EDIT("notifications_notifications_edit"),
+    NOTIFICATIONS_VIEW("notifications_notifications_view");
 
     /**
      * The permission's name in Kessel's schema.

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
@@ -80,9 +80,7 @@ import java.util.UUID;
 import static com.redhat.cloud.notifications.Constants.API_INTEGRATIONS_V_1_0;
 import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_READ_INTEGRATIONS_ENDPOINTS;
 import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_WRITE_INTEGRATIONS_ENDPOINTS;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.CREATE_DRAWER_INTEGRATION;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.CREATE_EMAIL_SUBSCRIPTION_INTEGRATION;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_CREATE;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_EDIT;
 import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_VIEW;
 import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.models.EndpointType.ANSIBLE;
@@ -218,7 +216,7 @@ public class EndpointResource extends EndpointResourceCommon {
         @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = EndpointDTO.class))),
         @APIResponse(responseCode = "400", description = "Bad data passed, that does not correspond to the definition or Endpoint.properties are empty")
     })
-    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_EDIT)
     public EndpointDTO createEndpoint(
         @Context                        final SecurityContext sec,
         @NotNull @Valid @RequestBody    final EndpointDTO endpointDTO
@@ -329,7 +327,7 @@ public class EndpointResource extends EndpointResourceCommon {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Create an email subscription endpoint", description = "Adds the email subscription endpoint into the system and specifies the role-based access control (RBAC) group that will receive email notifications. Use this endpoint in behavior groups to send emails when an action linked to the behavior group is triggered.")
-    @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = CREATE_EMAIL_SUBSCRIPTION_INTEGRATION)
+    @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_VIEW)
     @Transactional
     public EndpointDTO getOrCreateEmailSubscriptionEndpoint(@Context SecurityContext sec, @NotNull @Valid @RequestBody(required = true) RequestSystemSubscriptionProperties requestProps) {
         return this.endpointMapper.toDTO(getOrCreateSystemSubscriptionEndpoint(sec, requestProps, EMAIL_SUBSCRIPTION));
@@ -340,7 +338,7 @@ public class EndpointResource extends EndpointResourceCommon {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Add a drawer endpoint", description = "Adds the drawer system endpoint into the system and specifies the role-based access control (RBAC) group that will receive notifications. Use this endpoint to add an animation as a notification in the UI.")
-    @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = CREATE_DRAWER_INTEGRATION)
+    @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_VIEW)
     @Transactional
     public EndpointDTO getOrCreateDrawerSubscriptionEndpoint(@Context SecurityContext sec, @NotNull @Valid @RequestBody(required = true) RequestSystemSubscriptionProperties requestProps) {
         return this.endpointMapper.toDTO(this.getOrCreateSystemSubscriptionEndpoint(sec, requestProps, DRAWER));
@@ -407,7 +405,7 @@ public class EndpointResource extends EndpointResourceCommon {
     @Path("/{id}")
     @Operation(summary = "Delete an endpoint", description = "Deletes an endpoint. Use this endpoint to delete an endpoint that is no longer needed. Deleting an endpoint that is already linked to a behavior group will unlink it from the behavior group. You cannot delete system endpoints.")
     @APIResponse(responseCode = "204", description = "The integration has been deleted", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_EDIT)
     @Transactional
     public Response deleteEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         String orgId = getOrgId(sec);
@@ -447,7 +445,7 @@ public class EndpointResource extends EndpointResourceCommon {
     @Produces(TEXT_PLAIN)
     @Operation(summary = "Enable an endpoint", description = "Enables an endpoint that is disabled so that the endpoint will be executed on the following operations that use the endpoint. An operation must be restarted to use the enabled endpoint.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
-    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_EDIT)
     @Transactional
     public Response enableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         String orgId = getOrgId(sec);
@@ -468,7 +466,7 @@ public class EndpointResource extends EndpointResourceCommon {
     @Operation(summary = "Disable an endpoint", description = "Disables an endpoint so that the endpoint will not be executed after an operation that uses the endpoint is started. An operation that is already running can still execute the endpoint. Disable an endpoint when you want to stop it from running and might want to re-enable it in the future.")
     @APIResponse(responseCode = "204", description = "The integration has been disabled", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
-    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_EDIT)
     public Response disableEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
         String orgId = getOrgId(sec);
         EndpointType endpointType = endpointRepository.getEndpointTypeById(orgId, id);
@@ -486,7 +484,7 @@ public class EndpointResource extends EndpointResourceCommon {
     @Produces(TEXT_PLAIN)
     @PUT
     @Transactional
-    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_EDIT)
     public Response updateEndpoint(
         @Context                                        SecurityContext securityContext,
         @PathParam("id")                                UUID id,
@@ -611,7 +609,7 @@ public class EndpointResource extends EndpointResourceCommon {
                 schema = @Schema(type = SchemaType.STRING)
             )
     })
-    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = RBAC_WRITE_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_EDIT)
     public void testEndpoint(@Context SecurityContext sec, @RestPath UUID uuid, @Valid @RequestBody final EndpointTestRequest requestBody) {
         if (!this.endpointRepository.existsByUuidAndOrgId(uuid, getOrgId(sec))) {
             throw new NotFoundException("integration not found");
@@ -672,7 +670,7 @@ public class EndpointResource extends EndpointResourceCommon {
     })
     @Tag(name = OApiFilter.PRIVATE)
     @Transactional
-    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = INTEGRATIONS_EDIT)
     public void deleteEventTypeFromEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID eventTypeId, @RestPath final UUID endpointId) {
         final String orgId = getOrgId(securityContext);
         endpointEventTypeRepository.deleteEndpointFromEventType(eventTypeId, endpointId, orgId);
@@ -700,7 +698,7 @@ public class EndpointResource extends EndpointResourceCommon {
     })
     @Tag(name = OApiFilter.PRIVATE)
     @Transactional
-    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = INTEGRATIONS_EDIT)
     public void addEventTypeToEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID eventTypeId, @RestPath final UUID endpointId) {
         final String orgId = getOrgId(securityContext);
         final String accountId = getAccountId(securityContext);
@@ -720,7 +718,7 @@ public class EndpointResource extends EndpointResourceCommon {
             description = "No event type or endpoint found with passed ids.")
     })
     @Transactional
-    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = INTEGRATIONS_EDIT)
     public void updateEventTypesLinkedToEndpoint(@Context final SecurityContext securityContext, @RestPath final UUID endpointId, @Parameter(description = "Set of event type ids to associate") Set<UUID> eventTypeIds) {
         internalUpdateEventTypesLinkedToEndpoint(securityContext, endpointId, eventTypeIds);
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
@@ -327,7 +327,7 @@ public class EndpointResource extends EndpointResourceCommon {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Create an email subscription endpoint", description = "Adds the email subscription endpoint into the system and specifies the role-based access control (RBAC) group that will receive email notifications. Use this endpoint in behavior groups to send emails when an action linked to the behavior group is triggered.")
-    @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_VIEW)
+    @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_EDIT)
     @Transactional
     public EndpointDTO getOrCreateEmailSubscriptionEndpoint(@Context SecurityContext sec, @NotNull @Valid @RequestBody(required = true) RequestSystemSubscriptionProperties requestProps) {
         return this.endpointMapper.toDTO(getOrCreateSystemSubscriptionEndpoint(sec, requestProps, EMAIL_SUBSCRIPTION));
@@ -338,7 +338,7 @@ public class EndpointResource extends EndpointResourceCommon {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Add a drawer endpoint", description = "Adds the drawer system endpoint into the system and specifies the role-based access control (RBAC) group that will receive notifications. Use this endpoint to add an animation as a notification in the UI.")
-    @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_VIEW)
+    @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_EDIT)
     @Transactional
     public EndpointDTO getOrCreateDrawerSubscriptionEndpoint(@Context SecurityContext sec, @NotNull @Valid @RequestBody(required = true) RequestSystemSubscriptionProperties requestProps) {
         return this.endpointMapper.toDTO(this.getOrCreateSystemSubscriptionEndpoint(sec, requestProps, DRAWER));

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceCommon.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceCommon.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.routers.handlers.endpoint;
 
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
 import com.redhat.cloud.notifications.auth.kessel.KesselInventoryAuthorization;
-import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
 import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.Query;
@@ -38,7 +37,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_EDIT;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 
 public class EndpointResourceCommon {
@@ -164,7 +163,7 @@ public class EndpointResourceCommon {
         if (this.backendConfig.isKesselEnabled(getOrgId(securityContext))) {
             final UUID workspaceId = this.workspaceUtils.getDefaultWorkspaceId(getOrgId(securityContext));
             try {
-                this.kesselInventoryAuthorization.hasPermissionOnWorkspace(securityContext, WorkspacePermission.INTEGRATIONS_CREATE, workspaceId);
+                this.kesselInventoryAuthorization.hasPermissionOnWorkspace(securityContext, INTEGRATIONS_EDIT, workspaceId);
                 shouldRedactSecrets = false;
             } catch (final ForbiddenException | NotFoundException e) {
                 shouldRedactSecrets = true;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -3,7 +3,6 @@ package com.redhat.cloud.notifications.routers.handlers.event;
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
 import com.redhat.cloud.notifications.auth.annotation.Authorization;
 import com.redhat.cloud.notifications.auth.kessel.KesselInventoryAuthorization;
-import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.repositories.EventRepository;
@@ -50,6 +49,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.EVENTS_VIEW;
 import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -81,7 +81,7 @@ public class EventResource {
         description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
         schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
     )
-    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS, workspacePermissions = {WorkspacePermission.EVENT_LOG_VIEW})
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS, workspacePermissions = EVENTS_VIEW)
     public Page<EventLogEntry> getEvents(@Context SecurityContext securityContext, @Context UriInfo uriInfo,
                                          @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
                                          @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResource.java
@@ -69,13 +69,8 @@ import java.util.stream.Stream;
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
 import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS;
 import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.APPLICATIONS_VIEW;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.BEHAVIOR_GROUPS_EDIT;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.BEHAVIOR_GROUPS_VIEW;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.BUNDLES_VIEW;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.EVENT_TYPES_VIEW;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_CREATE;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_VIEW;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_EDIT;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_VIEW;
 import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getAccountId;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
@@ -119,7 +114,7 @@ public class NotificationResource {
         description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
         schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
     )
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = {BEHAVIOR_GROUPS_VIEW, EVENT_TYPES_VIEW})
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public List<BehaviorGroup> getLinkedBehaviorGroups(
         @Context SecurityContext sec,
         @PathParam("eventTypeId") UUID eventTypeId,
@@ -140,7 +135,7 @@ public class NotificationResource {
         description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
         schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
     )
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = EVENT_TYPES_VIEW)
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public Page<EventType> getEventTypes(
         @Context SecurityContext securityContext, @Context UriInfo uriInfo, @BeanParam @Valid Query query, @QueryParam("applicationIds") Set<UUID> applicationIds,
         @QueryParam("bundleId") UUID bundleId, @QueryParam("eventTypeName") String eventTypeName, @QueryParam("excludeMutedTypes") boolean excludeMutedTypes
@@ -162,7 +157,7 @@ public class NotificationResource {
     @Path("/bundles/{bundleName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve a bundle by name", description = "Retrieves the details of a bundle by searching by its name.")
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = BUNDLES_VIEW)
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public Bundle getBundleByName(@Context final SecurityContext securityContext, @PathParam("bundleName") String bundleName) {
         Bundle bundle = bundleRepository.getBundle(bundleName);
         if (bundle == null) {
@@ -176,7 +171,7 @@ public class NotificationResource {
     @Path("/bundles/{bundleName}/applications/{applicationName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve an application by bundle and application names", description = "Retrieves an application by bundle and application names. Use this endpoint to  find an application by searching for the bundle that the application is part of. This is useful if you do not know the UUID of the bundle or application.")
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = {BUNDLES_VIEW, APPLICATIONS_VIEW})
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public Application getApplicationByNameAndBundleName(
         @Context SecurityContext securityContext,
         @PathParam("bundleName") String bundleName,
@@ -194,7 +189,7 @@ public class NotificationResource {
     @Path("/bundles/{bundleName}/applications/{applicationName}/eventTypes/{eventTypeName}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve an event type by bundle, application and event type names", description = "Retrieves the details of an event type by specifying the bundle name, the application name, and the event type name.")
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = {BUNDLES_VIEW, APPLICATIONS_VIEW, EVENT_TYPES_VIEW})
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public EventType getEventTypesByNameAndBundleAndApplicationName(
         @Context SecurityContext securityContext,
         @PathParam("bundleName") String bundleName,
@@ -218,7 +213,7 @@ public class NotificationResource {
     @Path("/eventTypes/affectedByRemovalOfBehaviorGroup/{behaviorGroupId}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List the event types affected by the removal of a behavior group", description = "Lists the event types that will be affected by the removal of a behavior group. Use this endpoint to see which event types will be removed if you delete a behavior group.")
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = {BEHAVIOR_GROUPS_VIEW, EVENT_TYPES_VIEW})
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public List<EventType> getEventTypesAffectedByRemovalOfBehaviorGroup(@Context SecurityContext sec,
                                                                          @Parameter(description = "The UUID of the behavior group to check") @PathParam("behaviorGroupId") UUID behaviorGroupId) {
         String orgId = getOrgId(sec);
@@ -233,7 +228,7 @@ public class NotificationResource {
     @Path("/behaviorGroups/affectedByRemovalOfEndpoint/{endpointId}")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List the behavior groups affected by the removal of an endpoint", description = "Lists the behavior groups that are affected by the removal of an endpoint. Use this endpoint to understand how removing an endpoint affects existing behavior groups.")
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = {INTEGRATIONS_VIEW, BEHAVIOR_GROUPS_VIEW})
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public List<BehaviorGroup> getBehaviorGroupsAffectedByRemovalOfEndpoint(@Context SecurityContext sec, @PathParam("endpointId") UUID endpointId) {
         String orgId = getOrgId(sec);
         return behaviorGroupRepository.findBehaviorGroupsByEndpointId(orgId, endpointId);
@@ -290,7 +285,7 @@ public class NotificationResource {
         @APIResponse(responseCode = "400", content = @Content(mediaType = TEXT_PLAIN, schema = @Schema(type = SchemaType.STRING)), description = "Bad or no content passed.")
     })
     @Transactional
-    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = BEHAVIOR_GROUPS_EDIT)
+    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)
     public CreateBehaviorGroupResponse createBehaviorGroup(
         @Context final SecurityContext sec,
         @NotNull @Valid @RequestBody(required = true) final CreateBehaviorGroupRequest request
@@ -351,7 +346,7 @@ public class NotificationResource {
     })
     @Operation(summary = "Update a behavior group", description = "Updates the details of a behavior group. Use this endpoint to update the list of related endpoints and event types associated with this behavior group.")
     @Transactional
-    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = BEHAVIOR_GROUPS_EDIT)
+    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)
     public Response updateBehaviorGroup(@Context SecurityContext sec,
                                         @Parameter(description = "The UUID of the behavior group to update") @PathParam("id") UUID id,
                                         @NotNull @RequestBody(description = "New parameters", required = true) @Valid UpdateBehaviorGroupRequest request) {
@@ -387,7 +382,7 @@ public class NotificationResource {
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Delete a behavior group", description = "Deletes a behavior group and all of its configured actions. Use this endpoint when you no longer need a behavior group.")
     @Transactional
-    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = BEHAVIOR_GROUPS_EDIT)
+    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)
     public Boolean deleteBehaviorGroup(@Context SecurityContext sec,
                                        @Parameter(description = "The UUID of the behavior group to delete") @PathParam("id") UUID behaviorGroupId) {
         String orgId = getOrgId(sec);
@@ -404,7 +399,7 @@ public class NotificationResource {
     @Operation(summary = "Update the list of behavior group actions", description = "Updates the list of actions to be executed in that particular behavior group after an event is received.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
-    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = BEHAVIOR_GROUPS_EDIT)
+    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)
     public Response updateBehaviorGroupActions(@Context SecurityContext sec,
                                                @Parameter(description = "The UUID of the behavior group to update") @PathParam("behaviorGroupId") UUID behaviorGroupId,
                                                @Parameter(description = "List of endpoint ids of the actions") List<UUID> endpointIds) {
@@ -435,7 +430,7 @@ public class NotificationResource {
     @Operation(summary = "Update the list of behavior groups for an event type", description = "Updates the list of behavior groups associated with an event type.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
-    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {BEHAVIOR_GROUPS_EDIT, EVENT_TYPES_VIEW})
+    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)
     public Response updateEventTypeBehaviors(@Context SecurityContext sec,
                                              @Parameter(description = "UUID of the eventType to associate with the behavior group(s)") @PathParam("eventTypeId") UUID eventTypeId,
                                              @Parameter(description = "Set of behavior group ids to associate") Set<UUID> behaviorGroupIds) {
@@ -464,7 +459,7 @@ public class NotificationResource {
     @Path("/eventTypes/{eventTypeUuid}/behaviorGroups/{behaviorGroupUuid}")
     @Operation(summary = "Add a behavior group to the given event type.")
     @APIResponse(responseCode = "204")
-    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {BEHAVIOR_GROUPS_EDIT, EVENT_TYPES_VIEW})
+    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)
     public void appendBehaviorGroupToEventType(
         @Context final SecurityContext securityContext,
         @RestPath final UUID behaviorGroupUuid,
@@ -482,7 +477,7 @@ public class NotificationResource {
     @Path("/eventTypes/{eventTypeId}/behaviorGroups/{behaviorGroupId}")
     @Operation(summary = "Delete a behavior group from an event type", description = "Delete a behavior group from the specified event type.")
     @APIResponse(responseCode = "204")
-    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {BEHAVIOR_GROUPS_EDIT, EVENT_TYPES_VIEW})
+    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)
     public void deleteBehaviorGroupFromEventType(
         @Context final SecurityContext securityContext,
         @RestPath final UUID eventTypeId,
@@ -500,7 +495,7 @@ public class NotificationResource {
     @Path("/bundles/{bundleId}/behaviorGroups")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List behavior groups in a bundle", description = "Lists the behavior groups associated with a bundle. Use this endpoint to see the behavior groups that are configured for a particular bundle for a particular tenant.")
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = {BUNDLES_VIEW, BEHAVIOR_GROUPS_VIEW})
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public List<BehaviorGroup> findBehaviorGroupsByBundleId(@Context SecurityContext sec,
                                                             @Parameter(description = "UUID of the bundle to retrieve the behavior groups for.") @PathParam("bundleId") UUID bundleId) {
         String orgId = getOrgId(sec);
@@ -527,7 +522,7 @@ public class NotificationResource {
             description = "No event type found with the passed id.")
     })
     @Tag(name = OApiFilter.PRIVATE)
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = {EVENT_TYPES_VIEW, INTEGRATIONS_VIEW})
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public Page<EndpointDTO> getLinkedEndpoints(@Context final SecurityContext sec, @RestPath("eventTypeId") final UUID eventTypeId, @BeanParam @Valid final Query query, @Context final UriInfo uriInfo) {
         String orgId = getOrgId(sec);
 
@@ -548,7 +543,7 @@ public class NotificationResource {
     @Operation(summary = "Update the list of endpoints for an event type", description = "Updates the list of endpoints associated with an event type.")
     @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.STRING)))
     @Transactional
-    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = INTEGRATIONS_CREATE)
+    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)
     public Response updateEventTypeEndpoints(@Context SecurityContext securityContext,
                                              @Parameter(description = "UUID of the eventType to associate with the endpoint(s)") @PathParam("eventTypeId") UUID eventTypeId,
                                              @Parameter(description = "Set of endpoint ids to associate") Set<UUID> endpointsIds) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResourceV2.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResourceV2.java
@@ -28,8 +28,7 @@ import java.util.UUID;
 
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_2_0;
 import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.BEHAVIOR_GROUPS_VIEW;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.EVENT_TYPES_VIEW;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_VIEW;
 import static com.redhat.cloud.notifications.db.Query.DEFAULT_RESULTS_PER_PAGE;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -53,7 +52,7 @@ public class NotificationResourceV2 {
         schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
     )
     @Operation(summary = "Retrieve the behavior groups linked to an event type.")
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = {EVENT_TYPES_VIEW, BEHAVIOR_GROUPS_VIEW})
+    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public Page<BehaviorGroup> getLinkedBehaviorGroups(
         @Context SecurityContext sec,
         @PathParam("eventTypeId") UUID eventTypeId,

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/orgconfig/OrgConfigResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/orgconfig/OrgConfigResource.java
@@ -2,7 +2,6 @@ package com.redhat.cloud.notifications.routers.handlers.orgconfig;
 
 import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
 import com.redhat.cloud.notifications.auth.annotation.Authorization;
-import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
 import com.redhat.cloud.notifications.db.repositories.AggregationOrgConfigRepository;
 import com.redhat.cloud.notifications.models.AggregationOrgConfig;
 import io.quarkus.logging.Log;
@@ -31,6 +30,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_1_0;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_EDIT;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_VIEW;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -55,7 +56,7 @@ public class OrgConfigResource {
     @Consumes(APPLICATION_JSON)
     @Transactional
     @Operation(summary = "Set the daily digest time", description = "Sets the daily digest UTC time. The accepted minute values are 00, 15, 30, and 45. Use this endpoint to set the time when daily emails are sent.")
-    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.DAILY_DIGEST_PREFERENCE_EDIT})
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)
     public void saveDailyDigestTimePreference(@Context SecurityContext sec, @NotNull LocalTime expectedTime) {
         String orgId = getOrgId(sec);
         if (!ALLOWED_MINUTES.contains(expectedTime.getMinute())) {
@@ -72,7 +73,7 @@ public class OrgConfigResource {
     @Path("/daily-digest/time-preference")
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve the daily digest time", description = "Retrieves the daily digest time setting. Use this endpoint to check the time that daily emails are sent.")
-    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = {WorkspacePermission.DAILY_DIGEST_PREFERENCE_VIEW})
+    @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW)
     public Response getDailyDigestTimePreference(@Context SecurityContext sec) {
         String orgId = getOrgId(sec);
         Log.infof("Get daily digest time preference for orgId %s", orgId);

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptorHelper.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptorHelper.java
@@ -1,9 +1,10 @@
 package com.redhat.cloud.notifications.auth.annotation;
 
-import com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission;
 import jakarta.ws.rs.core.SecurityContext;
 
 import java.util.UUID;
+
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_VIEW;
 
 /**
  * A simple helper class which defines a few methods for the {@link AuthorizationInterceptorTest}
@@ -20,7 +21,7 @@ public class AuthorizationInterceptorHelper {
 
     @Authorization(
         legacyRBACRole = AuthorizationInterceptorTest.LEGACY_RBAC_ROLE,
-        workspacePermissions = {WorkspacePermission.BUNDLES_VIEW, WorkspacePermission.APPLICATIONS_VIEW, WorkspacePermission.EVENT_TYPES_VIEW}
+        workspacePermissions = NOTIFICATIONS_VIEW
     )
     public void testMethodWithWorkspacePermissions(final SecurityContext ignored, final String ignoredTwo, final UUID ignoredThree) { }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptorTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/annotation/AuthorizationInterceptorTest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_VIEW;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.project_kessel.api.inventory.v1beta2.Allowed.ALLOWED_FALSE;
@@ -254,9 +255,7 @@ public class AuthorizationInterceptorTest {
         // Mock the Kessel checks to simulate that the principal has the
         // required workspace permissions.
         when(workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)).thenReturn(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID);
-        mockKesselPermission(WorkspacePermission.BUNDLES_VIEW, ALLOWED_TRUE);
-        mockKesselPermission(WorkspacePermission.APPLICATIONS_VIEW, ALLOWED_TRUE);
-        mockKesselPermission(WorkspacePermission.EVENT_TYPES_VIEW, ALLOWED_TRUE);
+        mockKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
 
         // Call the function under test which should not throw any exceptions.
         this.authorizationInterceptor.aroundInvoke(invocationContext);
@@ -291,9 +290,7 @@ public class AuthorizationInterceptorTest {
         // Mock the Kessel checks to simulate that the principal has the
         // required workspace permissions.
         when(workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)).thenReturn(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID);
-        mockKesselPermission(WorkspacePermission.BUNDLES_VIEW, ALLOWED_TRUE);
-        mockKesselPermission(WorkspacePermission.APPLICATIONS_VIEW, ALLOWED_FALSE);
-        mockKesselPermission(WorkspacePermission.EVENT_TYPES_VIEW, ALLOWED_TRUE);
+        mockKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_FALSE);
 
         // Call the function under test which should throw a ForbiddenException.
         Assertions.assertThrows(

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselInventoryAuthorizationTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselInventoryAuthorizationTest.java
@@ -70,7 +70,7 @@ public class KesselInventoryAuthorizationTest {
         // Call the function under test.
         this.kesselAuthorization.hasPermissionOnResource(
             mockedSecurityContext,
-            WorkspacePermission.EVENT_LOG_VIEW,
+            WorkspacePermission.EVENTS_VIEW,
             KesselInventoryResourceType.WORKSPACE,
             "workspace-uuid"
         );
@@ -99,7 +99,7 @@ public class KesselInventoryAuthorizationTest {
         Mockito.when(this.checkClient.check(Mockito.any())).thenReturn(positiveCheckResponse);
         RecipientsAuthorizationCriterion authorizationCriterion = new RecipientsAuthorizationCriterion();
         authorizationCriterion.setId("workspace-uuid");
-        authorizationCriterion.setRelation(WorkspacePermission.EVENT_LOG_VIEW.getKesselPermissionName());
+        authorizationCriterion.setRelation(WorkspacePermission.EVENTS_VIEW.getKesselPermissionName());
         Type t = new Type();
         t.setNamespace("rbac");
         t.setName("workspace");
@@ -135,7 +135,7 @@ public class KesselInventoryAuthorizationTest {
             RuntimeException.class,
             () -> this.kesselAuthorization.hasPermissionOnResource(
                     mockedSecurityContext,
-                    WorkspacePermission.EVENT_LOG_VIEW,
+                    WorkspacePermission.EVENTS_VIEW,
                     KesselInventoryResourceType.WORKSPACE,
                     "workspace-uuid"
             )
@@ -167,7 +167,7 @@ public class KesselInventoryAuthorizationTest {
             ForbiddenException.class,
             () -> this.kesselAuthorization.hasPermissionOnResource(
                 mockedSecurityContext,
-                WorkspacePermission.EVENT_LOG_VIEW,
+                WorkspacePermission.EVENTS_VIEW,
                 KesselInventoryResourceType.WORKSPACE,
                 "workspace-uuid"
             ),
@@ -199,7 +199,7 @@ public class KesselInventoryAuthorizationTest {
 
         RecipientsAuthorizationCriterion authorizationCriterion = new RecipientsAuthorizationCriterion();
         authorizationCriterion.setId("workspace-uuid");
-        authorizationCriterion.setRelation(WorkspacePermission.EVENT_LOG_VIEW.getKesselPermissionName());
+        authorizationCriterion.setRelation(WorkspacePermission.EVENTS_VIEW.getKesselPermissionName());
         Type t = new Type();
         t.setNamespace("rbac");
         t.setName("workspace");
@@ -236,7 +236,7 @@ public class KesselInventoryAuthorizationTest {
 
         RecipientsAuthorizationCriterion authorizationCriterion = new RecipientsAuthorizationCriterion();
         authorizationCriterion.setId("workspace-uuid");
-        authorizationCriterion.setRelation(WorkspacePermission.EVENT_LOG_VIEW.getKesselPermissionName());
+        authorizationCriterion.setRelation(WorkspacePermission.EVENTS_VIEW.getKesselPermissionName());
         Type t = new Type();
         t.setNamespace("rbac");
         t.setName("workspace");

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EmailsOnlyModeTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EmailsOnlyModeTest.java
@@ -33,7 +33,7 @@ import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.FULL_AC
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_CREATE;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_EDIT;
 import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
 import static com.redhat.cloud.notifications.routers.handlers.endpoint.EndpointResource.UNSUPPORTED_ENDPOINT_TYPE;
@@ -90,7 +90,7 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
@@ -123,7 +123,7 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
@@ -160,7 +160,7 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
@@ -192,7 +192,7 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);
@@ -224,7 +224,7 @@ public class EmailsOnlyModeTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         when(backendConfig.isEmailsOnlyModeEnabled()).thenReturn(true);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
@@ -1957,7 +1957,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final String endpointTypeUrl;
@@ -4314,7 +4314,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
@@ -76,6 +76,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.project_kessel.api.inventory.v1beta2.Allowed;
+import org.project_kessel.api.inventory.v1beta2.CheckForUpdateRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckRequest;
 
 import java.net.URI;
 import java.time.LocalDateTime;
@@ -97,9 +99,7 @@ import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockS
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.CREATE_DRAWER_INTEGRATION;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.CREATE_EMAIL_SUBSCRIPTION_INTEGRATION;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_CREATE;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_EDIT;
 import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_VIEW;
 import static com.redhat.cloud.notifications.models.EndpointStatus.READY;
 import static com.redhat.cloud.notifications.models.EndpointType.ANSIBLE;
@@ -143,6 +143,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         RestAssured.basePath = TestConstants.API_INTEGRATIONS_V_1_0;
         when(backendConfig.isInstantEmailsEnabled()).thenReturn(true);
         when(workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)).thenReturn(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID);
+        mockKesselDenyAll();
     }
 
     @Inject
@@ -235,7 +236,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -469,7 +470,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -609,7 +610,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -682,7 +683,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -759,7 +760,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -807,7 +808,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -904,7 +905,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         URI sNowUri = URI.create("http://redhat.com");
@@ -917,7 +918,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         URI splunkUri = URI.create("http://redhat.com");
@@ -1025,7 +1026,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -1116,7 +1117,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -1276,7 +1277,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -1404,7 +1405,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -1471,7 +1472,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -1563,7 +1564,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -1644,8 +1645,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -1759,10 +1759,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(CREATE_DRAWER_INTEGRATION, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(CREATE_DRAWER_INTEGRATION, ALLOWED_TRUE);
+            mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final String endpointTypeUrl;
@@ -1874,7 +1872,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
     void testAddEndpointEmailOrDrawerSubscriptionRbacAsRegularEndpoint(boolean kesselEnabled, EndpointType endpointType) {
 
         if (kesselEnabled) {
-            mockDefaultKesselPermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselPermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -1959,8 +1957,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(CREATE_DRAWER_INTEGRATION, ALLOWED_TRUE);
+            mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
         }
 
         final String endpointTypeUrl;
@@ -2094,7 +2091,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -2166,7 +2163,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -2229,7 +2226,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -2279,7 +2276,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -2336,7 +2333,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         // Set up the RBAC access for the test.
@@ -2468,7 +2465,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         // Set up the RBAC access for the test.
@@ -2556,7 +2553,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -2623,7 +2620,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, EndpointType.CAMEL);
@@ -2665,7 +2662,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -2699,7 +2696,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, EndpointType.CAMEL);
@@ -2745,7 +2742,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, EndpointType.CAMEL);
@@ -2790,7 +2787,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         CamelProperties camelProperties = new CamelProperties();
@@ -2838,7 +2835,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -2938,7 +2935,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -3033,7 +3030,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -3150,7 +3147,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -3236,7 +3233,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -3318,7 +3315,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         WebhookProperties properties = new WebhookProperties();
@@ -3402,9 +3399,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(true);
         mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_FALSE);
-        mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_FALSE);
-        mockDefaultKesselUpdatePermission(CREATE_DRAWER_INTEGRATION, ALLOWED_FALSE);
-        mockDefaultKesselUpdatePermission(CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, ALLOWED_FALSE);
+        mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_FALSE);
 
         // Create an identity header.
         final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -3466,6 +3461,8 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .then()
             .statusCode(HttpStatus.SC_FORBIDDEN);
 
+        mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_FALSE);
+
         // Create a drawer subscription.
         given()
             .header(identityHeader)
@@ -3485,8 +3482,6 @@ public class EndpointResourceTest extends DbIsolatedTest {
             .post("/endpoints/system/email_subscription")
             .then()
             .statusCode(HttpStatus.SC_FORBIDDEN);
-
-        mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_FALSE);
 
         try {
             RestAssured.basePath = TestConstants.API_INTEGRATIONS_V_2_0;
@@ -4155,7 +4150,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         // Add RBAC access.
@@ -4319,8 +4314,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(CREATE_DRAWER_INTEGRATION, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(CREATE_EMAIL_SUBSCRIPTION_INTEGRATION, ALLOWED_TRUE);
+            mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
         }
 
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
@@ -4377,7 +4371,7 @@ public class EndpointResourceTest extends DbIsolatedTest {
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
             mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(INTEGRATIONS_CREATE, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(INTEGRATIONS_EDIT, ALLOWED_TRUE);
         }
 
         // Create the integration we are going to attempt to delete.
@@ -4562,6 +4556,15 @@ public class EndpointResourceTest extends DbIsolatedTest {
                 Arguments.of(false, EndpointType.DRAWER), // Should use RBAC
                 Arguments.of(true, EndpointType.DRAWER) // Should use Kessel
         );
+    }
+
+    private void mockKesselDenyAll() {
+        when(kesselCheckClient
+            .check(any(CheckRequest.class)))
+            .thenReturn(kesselTestHelper.buildCheckResponse(ALLOWED_FALSE));
+        when(kesselCheckClient
+            .checkForUpdate(any(CheckForUpdateRequest.class)))
+            .thenReturn(kesselTestHelper.buildCheckForUpdateResponse(ALLOWED_FALSE));
     }
 
     private void mockDefaultKesselPermission(WorkspacePermission permission, Allowed allowed) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.project_kessel.api.inventory.v1beta2.Allowed;
+import org.project_kessel.api.inventory.v1beta2.CheckForUpdateRequest;
 import org.project_kessel.api.inventory.v1beta2.CheckRequest;
 import org.project_kessel.api.inventory.v1beta2.CheckResponse;
 
@@ -68,7 +69,7 @@ import static com.redhat.cloud.notifications.TestConstants.API_NOTIFICATIONS_V_1
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.EVENT_LOG_VIEW;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.EVENTS_VIEW;
 import static com.redhat.cloud.notifications.models.EndpointType.CAMEL;
 import static com.redhat.cloud.notifications.models.EndpointType.DRAWER;
 import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPTION;
@@ -152,6 +153,7 @@ public class EventResourceTest extends DbIsolatedTest {
         // disabled.
         Mockito.when(this.backendConfig.isRBACEnabled()).thenReturn(true);
         when(workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)).thenReturn(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID);
+        mockKesselDenyAll();
     }
 
     @ParameterizedTest
@@ -160,7 +162,7 @@ public class EventResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockKesselPermission(DEFAULT_ORG_ID, "non-default-user", EVENT_LOG_VIEW, ALLOWED_FALSE);
+            mockKesselPermission(DEFAULT_ORG_ID, "non-default-user", EVENTS_VIEW, ALLOWED_FALSE);
         }
 
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "non-default-user", NOTIFICATIONS_ACCESS_ONLY);
@@ -177,11 +179,11 @@ public class EventResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_LOG_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(EVENTS_VIEW, ALLOWED_TRUE);
             when(workspaceUtils.getDefaultWorkspaceId(OTHER_ORG_ID)).thenReturn(UUID.randomUUID());
-            mockKesselPermission(OTHER_ORG_ID, OTHER_USERNAME, EVENT_LOG_VIEW, ALLOWED_TRUE);
+            mockKesselPermission(OTHER_ORG_ID, OTHER_USERNAME, EVENTS_VIEW, ALLOWED_TRUE);
             when(workspaceUtils.getDefaultWorkspaceId("none")).thenReturn(UUID.randomUUID());
-            mockKesselPermission("none", OTHER_USERNAME, EVENT_LOG_VIEW, ALLOWED_TRUE);
+            mockKesselPermission("none", OTHER_USERNAME, EVENTS_VIEW, ALLOWED_TRUE);
         }
 
         /*
@@ -694,7 +696,7 @@ public class EventResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockKesselPermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", EVENT_LOG_VIEW, ALLOWED_FALSE);
+            mockKesselPermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", EVENTS_VIEW, ALLOWED_FALSE);
         }
 
         Header noAccessIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER + "no-access", NO_ACCESS);
@@ -711,7 +713,7 @@ public class EventResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_LOG_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(EVENTS_VIEW, ALLOWED_TRUE);
         }
 
         Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -731,7 +733,7 @@ public class EventResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_LOG_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(EVENTS_VIEW, ALLOWED_TRUE);
         }
 
         Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -758,7 +760,7 @@ public class EventResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_LOG_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(EVENTS_VIEW, ALLOWED_TRUE);
         }
 
         Header readAccessIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, NOTIFICATIONS_READ_ACCESS_ONLY);
@@ -991,11 +993,11 @@ public class EventResourceTest extends DbIsolatedTest {
 
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
 
-        mockDefaultKesselPermission(EVENT_LOG_VIEW, ALLOWED_TRUE);
+        mockDefaultKesselPermission(EVENTS_VIEW, ALLOWED_TRUE);
         when(workspaceUtils.getDefaultWorkspaceId(OTHER_ORG_ID)).thenReturn(UUID.randomUUID());
-        mockKesselPermission(OTHER_ORG_ID, OTHER_USERNAME, EVENT_LOG_VIEW, ALLOWED_TRUE);
+        mockKesselPermission(OTHER_ORG_ID, OTHER_USERNAME, EVENTS_VIEW, ALLOWED_TRUE);
         when(workspaceUtils.getDefaultWorkspaceId("none")).thenReturn(UUID.randomUUID());
-        mockKesselPermission("none", OTHER_USERNAME, EVENT_LOG_VIEW, ALLOWED_TRUE);
+        mockKesselPermission("none", OTHER_USERNAME, EVENTS_VIEW, ALLOWED_TRUE);
 
         Bundle bundle1 = resourceHelpers.createBundle("bundle-1", "Bundle 1");
         Bundle bundle2 = resourceHelpers.createBundle("bundle-2", "Bundle 2");
@@ -1082,6 +1084,15 @@ public class EventResourceTest extends DbIsolatedTest {
         assertSameEvent(page.getData().get(2), event1, history1, history2, history6);
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
+    }
+
+    private void mockKesselDenyAll() {
+        when(kesselCheckClient
+            .check(any(CheckRequest.class)))
+            .thenReturn(kesselTestHelper.buildCheckResponse(ALLOWED_FALSE));
+        when(kesselCheckClient
+            .checkForUpdate(any(CheckForUpdateRequest.class)))
+            .thenReturn(kesselTestHelper.buildCheckForUpdateResponse(ALLOWED_FALSE));
     }
 
     private void mockDefaultKesselPermission(WorkspacePermission permission, Allowed allowed) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResourceTest.java
@@ -50,6 +50,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.project_kessel.api.inventory.v1beta2.Allowed;
+import org.project_kessel.api.inventory.v1beta2.CheckForUpdateRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckRequest;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -70,12 +72,8 @@ import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
 import static com.redhat.cloud.notifications.auth.kessel.KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.APPLICATIONS_VIEW;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.BEHAVIOR_GROUPS_EDIT;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.BEHAVIOR_GROUPS_VIEW;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.BUNDLES_VIEW;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.EVENT_TYPES_VIEW;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.INTEGRATIONS_VIEW;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_EDIT;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_VIEW;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_APP_NAME;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_APP_NAME_2;
 import static com.redhat.cloud.notifications.db.ResourceHelpers.TEST_BUNDLE_2_NAME;
@@ -89,6 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.project_kessel.api.inventory.v1beta2.Allowed.ALLOWED_FALSE;
@@ -145,6 +144,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
         // disabled.
         Mockito.when(this.backendConfig.isRBACEnabled()).thenReturn(true);
         when(workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)).thenReturn(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID);
+        mockKesselDenyAll();
     }
 
     private Header initRbacMock(String accountId, String orgId, String username, RbacAccess access) {
@@ -159,7 +159,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         helpers.createTestAppAndEventTypes();
@@ -239,7 +239,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         helpers.createTestAppAndEventTypes();
@@ -275,7 +275,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         helpers.createTestAppAndEventTypes();
@@ -312,7 +312,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         helpers.createTestAppAndEventTypes();
@@ -352,7 +352,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         helpers.createTestAppAndEventTypes();
@@ -386,7 +386,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         helpers.createTestAppAndEventTypes();
@@ -428,7 +428,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         UUID bundleId = helpers.createTestAppAndEventTypes();
@@ -507,7 +507,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         UUID bundleId = helpers.createTestAppAndEventTypes();
@@ -599,7 +599,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
         if (kesselEnabled) {
             UUID otherOrganizationWorkspaceId = UUID.randomUUID();
             when(workspaceUtils.getDefaultWorkspaceId(otherOrganization)).thenReturn(otherOrganizationWorkspaceId);
-            mockKesselPermission(otherOrganization, DEFAULT_USER, EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockKesselPermission(otherOrganization, DEFAULT_USER, NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         Response otherOrgUnmatchedResponse = given()
@@ -651,8 +651,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(BEHAVIOR_GROUPS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -806,7 +805,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -880,7 +879,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -960,9 +959,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(BUNDLES_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselPermission(APPLICATIONS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -1079,13 +1076,9 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockKesselPermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", BUNDLES_VIEW, ALLOWED_FALSE);
-            mockKesselPermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", APPLICATIONS_VIEW, ALLOWED_FALSE);
-            mockKesselPermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", EVENT_TYPES_VIEW, ALLOWED_FALSE);
-            mockKesselPermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", BEHAVIOR_GROUPS_VIEW, ALLOWED_FALSE);
-            mockKesselPermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", INTEGRATIONS_VIEW, ALLOWED_FALSE);
-            mockKesselUpdatePermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", BEHAVIOR_GROUPS_EDIT, ALLOWED_FALSE);
-            mockKesselUpdatePermission(DEFAULT_ORG_ID, DEFAULT_USER + "read-access", BEHAVIOR_GROUPS_EDIT, ALLOWED_FALSE);
+            mockKesselPermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", NOTIFICATIONS_VIEW, ALLOWED_FALSE);
+            mockKesselUpdatePermission(DEFAULT_ORG_ID, DEFAULT_USER + "no-access", NOTIFICATIONS_EDIT, ALLOWED_FALSE);
+            mockKesselUpdatePermission(DEFAULT_ORG_ID, DEFAULT_USER + "read-access", NOTIFICATIONS_EDIT, ALLOWED_FALSE);
         }
 
         Header noAccessIdentityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER + "no-access", NO_ACCESS);
@@ -1259,7 +1252,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -1285,7 +1278,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -1305,8 +1298,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(BUNDLES_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselPermission(BEHAVIOR_GROUPS_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -1326,8 +1318,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(BEHAVIOR_GROUPS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -1347,8 +1338,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(BEHAVIOR_GROUPS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -1368,8 +1358,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(BEHAVIOR_GROUPS_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -1391,7 +1380,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final String BEHAVIOR_GROUP_1_NAME = "BehaviorGroup1";
@@ -1471,7 +1460,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final CreateBehaviorGroupRequest createBehaviorGroupRequest = new CreateBehaviorGroupRequest();
@@ -1515,7 +1504,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -1571,7 +1560,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final Bundle bundle = this.helpers.createBundle(TEST_BUNDLE_NAME, "Bundle-display-name");
@@ -1625,7 +1614,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         // Create the fixtures in the database.
@@ -1678,7 +1667,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         // Create the fixtures in the database.
@@ -1728,8 +1717,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final Bundle bundle = this.helpers.createBundle();
@@ -1760,8 +1748,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -1791,8 +1778,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final Bundle bundle = this.helpers.createBundle();
@@ -1828,8 +1814,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         // Create a bundle and a set of fixtures...
@@ -1866,8 +1851,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
         // Create the fixtures.
         final Bundle bundle = this.helpers.createBundle();
@@ -1911,8 +1895,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         // Create the fixtures.
@@ -2032,8 +2015,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselPermission(INTEGRATIONS_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
         }
 
         final Bundle bundle = helpers.createBundle();
@@ -2081,8 +2063,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(BEHAVIOR_GROUPS_EDIT, ALLOWED_TRUE);
-            mockDefaultKesselPermission(EVENT_TYPES_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         Header identityHeader = initRbacMock(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
@@ -2470,6 +2451,15 @@ public class NotificationResourceTest extends DbIsolatedTest {
         assertEquals(1, behaviorGroupList.size());
         assertEquals("behavior-group-ep-2", behaviorGroupList.get(0).getDisplayName());
         assertEquals(0, behaviorGroupList.get(0).getActions().size());
+    }
+
+    private void mockKesselDenyAll() {
+        when(kesselCheckClient
+            .check(any(CheckRequest.class)))
+            .thenReturn(kesselTestHelper.buildCheckResponse(ALLOWED_FALSE));
+        when(kesselCheckClient
+            .checkForUpdate(any(CheckForUpdateRequest.class)))
+            .thenReturn(kesselTestHelper.buildCheckForUpdateResponse(ALLOWED_FALSE));
     }
 
     private void mockDefaultKesselPermission(WorkspacePermission permission, Allowed allowed) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/orgconfig/OrgConfigResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/orgconfig/OrgConfigResourceTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.project_kessel.api.inventory.v1beta2.Allowed;
+import org.project_kessel.api.inventory.v1beta2.CheckForUpdateRequest;
+import org.project_kessel.api.inventory.v1beta2.CheckRequest;
 
 import java.time.LocalTime;
 
@@ -34,12 +36,13 @@ import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.READ_AC
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.DAILY_DIGEST_PREFERENCE_EDIT;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.DAILY_DIGEST_PREFERENCE_VIEW;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_EDIT;
+import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_VIEW;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static io.restassured.http.ContentType.TEXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.project_kessel.api.inventory.v1beta2.Allowed.ALLOWED_FALSE;
@@ -103,6 +106,7 @@ class OrgConfigResourceTest extends DbIsolatedTest {
         // disabled.
         when(backendConfig.isRBACEnabled()).thenReturn(true);
         when(workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)).thenReturn(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID);
+        mockKesselDenyAll();
     }
 
     @ParameterizedTest
@@ -111,7 +115,7 @@ class OrgConfigResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselUpdatePermission(DAILY_DIGEST_PREFERENCE_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         recordDefaultDailyDigestTimePreference();
@@ -132,7 +136,7 @@ class OrgConfigResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(isKesselEnabled);
         if (isKesselEnabled) {
-            mockDefaultKesselUpdatePermission(DAILY_DIGEST_PREFERENCE_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         final String ERROR_MESSAGE_WRONG_MINUTE_VALUE = "Accepted minute values are: 00, 15, 30, 45.";
@@ -153,8 +157,8 @@ class OrgConfigResourceTest extends DbIsolatedTest {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
         if (kesselEnabled) {
-            mockDefaultKesselPermission(DAILY_DIGEST_PREFERENCE_VIEW, ALLOWED_TRUE);
-            mockDefaultKesselUpdatePermission(DAILY_DIGEST_PREFERENCE_EDIT, ALLOWED_TRUE);
+            mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_TRUE);
+            mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_TRUE);
         }
 
         LocalTime foundedPreference = given()
@@ -239,8 +243,8 @@ class OrgConfigResourceTest extends DbIsolatedTest {
     void testKesselUnauthorized() {
 
         when(backendConfig.isKesselEnabled(anyString())).thenReturn(true);
-        mockDefaultKesselPermission(DAILY_DIGEST_PREFERENCE_VIEW, ALLOWED_FALSE);
-        mockDefaultKesselUpdatePermission(DAILY_DIGEST_PREFERENCE_EDIT, ALLOWED_FALSE);
+        mockDefaultKesselPermission(NOTIFICATIONS_VIEW, ALLOWED_FALSE);
+        mockDefaultKesselUpdatePermission(NOTIFICATIONS_EDIT, ALLOWED_FALSE);
 
         // Get the time preferences.
         given()
@@ -261,6 +265,15 @@ class OrgConfigResourceTest extends DbIsolatedTest {
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, username);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, access);
         return TestHelpers.createRHIdentityHeader(identityHeaderValue);
+    }
+
+    private void mockKesselDenyAll() {
+        when(kesselCheckClient
+            .check(any(CheckRequest.class)))
+            .thenReturn(kesselTestHelper.buildCheckResponse(ALLOWED_FALSE));
+        when(kesselCheckClient
+            .checkForUpdate(any(CheckForUpdateRequest.class)))
+            .thenReturn(kesselTestHelper.buildCheckForUpdateResponse(ALLOWED_FALSE));
     }
 
     private void mockDefaultKesselPermission(WorkspacePermission permission, Allowed allowed) {


### PR DESCRIPTION
Depends on https://github.com/RedHatInsights/rbac-config/pull/701.

## Summary by Sourcery

Simplify and consolidate Kessel workspace permissions across notifications, endpoints, events, and org-config APIs to use the new, coarse-grained EVENTS/INTEGRATIONS/NOTIFICATIONS permission set.

Enhancements:
- Replace granular workspace permissions (bundles, applications, behavior groups, event types, event log, daily digest, and integration create/subscribe) with the new NOTIFICATIONS_VIEW/EDIT, EVENTS_VIEW, and INTEGRATIONS_VIEW/EDIT permissions in API annotations and authorization logic.
- Update Kessel inventory authorization mapping to treat the new *_VIEW permissions as CHECK operations and *_EDIT permissions as UPDATE operations.
- Adjust endpoint, notification, event, org-config, and authorization interceptor helper code to rely on the new consolidated permissions for CRUD and linkage operations.
- Rename and simplify permission checks in shared endpoint logic so secret redaction decisions use INTEGRATIONS_EDIT instead of INTEGRATIONS_CREATE.

Tests:
- Update endpoint, notification, events, org-config, Kessel authorization, authorization interceptor, and emails-only mode tests to match the new consolidated workspace permissions and names.

## Summary by Sourcery

Consolidate Kessel workspace permissions for notifications, events, endpoints, and org-config APIs to use the new coarse-grained EVENTS/INTEGRATIONS/NOTIFICATIONS permissions.

Enhancements:
- Replace granular workspace permissions with new NOTIFICATIONS_VIEW/EDIT, EVENTS_VIEW, and INTEGRATIONS_VIEW/EDIT permissions across endpoint, notification, event, and org-config handlers.
- Update Kessel inventory authorization mapping and shared endpoint logic so edit vs. view permissions correctly gate mutation operations and secret redaction.
- Align authorization interceptor helper and related classes with the simplified permission model and workspace checks.

Tests:
- Update endpoint, notification, events, org-config, authorization interceptor, Kessel authorization, and emails-only mode tests to reflect the new consolidated workspace permissions and default deny-all Kessel behavior in test setup.