### PR TITLE
RHCLOUD-44150 Remove PSK/OIDC dead config in backend

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -136,11 +136,6 @@ objects:
           value: ${KESSEL_ENABLED}
         - name: NOTIFICATIONS_KESSEL_INSECURE_CLIENT_ENABLED
           value: ${KESSEL_INSECURE_CLIENT_ENABLED}
-        - name: NOTIFICATIONS_RBAC_PSKS
-          valueFrom:
-            secretKeyRef:
-              name: rbac-psks
-              key: psks.json
         - name: NOTIFICATIONS_UNLEASH_ENABLED
           value: ${NOTIFICATIONS_UNLEASH_ENABLED}
         - name: QUARKUS_REST_CLIENT_RBAC_AUTHENTICATION_READ_TIMEOUT


### PR DESCRIPTION
## Summary by Sourcery

Remove deprecated RBAC PSK and RBAC OIDC configuration from the backend service and deployment manifests.

Enhancements:
- Clean up backend configuration by removing unused RBAC PSK secrets and RBAC OIDC feature toggle handling.

Deployment:
- Remove the NOTIFICATIONS_RBAC_PSKS environment variable and associated secret reference from the backend ClowdApp deployment configuration.