### PR TITLE
[RHCLOUD-44561] Add system endpoints on Endpoint Api V2

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -2,8 +2,6 @@ package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.Sort;
-import com.redhat.cloud.notifications.db.builder.QueryBuilder;
-import com.redhat.cloud.notifications.db.builder.WhereBuilder;
 import com.redhat.cloud.notifications.models.CamelProperties;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
 import com.redhat.cloud.notifications.models.Endpoint;
@@ -31,7 +29,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.models.EndpointStatus.READY;
@@ -99,25 +96,88 @@ public class EndpointRepository {
         Optional<Sort> sort = limiter == null ? Optional.empty() : Sort.getSort(limiter, null, Endpoint.SORT_FIELDS);
 
         Log.debugf("[org_id: %s][name: %s][composite_type: %s][active_only: %s][query: %s] Looking up endpoints in our database", orgId, name, type, activeOnly, limiter);
-        List<Endpoint> endpoints = EndpointRepository.queryBuilderEndpointsPerType(orgId, name, type, activeOnly)
-                .limit(limit)
-                .sort(sort)
-                .build(entityManager::createQuery)
-                .getResultList();
 
-        if (includeSystemIntegrations) {
-            endpoints.addAll(EndpointRepository.queryBuilderEndpointsPerType(null, name, type, activeOnly)
-                .limit(limit)
-                .sort(sort)
-                .build(entityManager::createQuery)
-                .getResultList());
-        }
+        List<Endpoint> endpoints = buildEndpointQuery(orgId, name, type, activeOnly, limit, sort, includeSystemIntegrations).getResultList();
 
         loadProperties(endpoints);
 
         Log.debugf("[org_id: %s] Returning list of endpoints: %s", orgId, endpoints);
 
         return endpoints;
+    }
+
+    protected TypedQuery<Endpoint> buildEndpointQuery(String orgId, String name, Set<CompositeEndpointType> type, Boolean activeOnly, Query.Limit limit, Optional<Sort> sort, boolean includeSystemIntegrations) {
+        Set<EndpointType> basicTypes = type.stream().filter(c -> c.getSubType() == null).map(CompositeEndpointType::getType).collect(Collectors.toSet());
+        Set<CompositeEndpointType> compositeTypes = type.stream().filter(c -> c.getSubType() != null).collect(Collectors.toSet());
+
+        StringBuilder hql = new StringBuilder("SELECT e FROM Endpoint e WHERE ");
+
+        // OrgId filter
+        if (orgId == null) {
+            hql.append("e.orgId IS NULL");
+        } else {
+            if (includeSystemIntegrations) {
+                // Build query for system integrations (orgId is null)
+                hql.append("(e.orgId = :orgId OR e.orgId IS NULL)");
+            } else {
+                hql.append("e.orgId = :orgId");
+            }
+        }
+
+        // Type filter
+        if (!basicTypes.isEmpty() || !compositeTypes.isEmpty()) {
+            hql.append(" AND (");
+            if (!basicTypes.isEmpty()) {
+                hql.append("e.compositeType.type IN (:endpointType)");
+                if (!compositeTypes.isEmpty()) {
+                    hql.append(" OR ");
+                }
+            }
+            if (!compositeTypes.isEmpty()) {
+                hql.append("e.compositeType IN (:compositeTypes)");
+            }
+            hql.append(")");
+        }
+
+        // Active filter
+        if (activeOnly != null) {
+            hql.append(" AND e.enabled = :enabled");
+        }
+
+        // Name filter
+        if (name != null && !name.isEmpty()) {
+            hql.append(" AND LOWER(e.name) LIKE :name");
+        }
+
+        // Sort
+        sort.ifPresent(value -> hql.append(" ").append(value.getSortQuery()));
+
+        TypedQuery<Endpoint> query = entityManager.createQuery(hql.toString(), Endpoint.class);
+
+        // Set parameters
+        if (orgId != null) {
+            query.setParameter("orgId", orgId);
+        }
+        if (!basicTypes.isEmpty()) {
+            query.setParameter("endpointType", basicTypes);
+        }
+        if (!compositeTypes.isEmpty()) {
+            query.setParameter("compositeTypes", compositeTypes);
+        }
+        if (activeOnly != null) {
+            query.setParameter("enabled", activeOnly);
+        }
+        if (name != null && !name.isEmpty()) {
+            query.setParameter("name", "%" + name.toLowerCase() + "%");
+        }
+
+        // Set limit and offset
+        if (limit != null) {
+            query.setFirstResult(limit.getOffset());
+            query.setMaxResults(limit.getLimit());
+        }
+
+        return query;
     }
 
     public EndpointType getEndpointTypeById(String orgId, UUID endpointId) {
@@ -178,16 +238,71 @@ public class EndpointRepository {
     }
 
     public Long getEndpointsCountPerCompositeType(String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly, boolean includeSystemIntegrations) {
-        Long count = EndpointRepository.queryBuilderEndpointsPerType(orgId, name, type, activeOnly)
-                .buildCount(entityManager::createQuery)
-                .getSingleResult();
+        Set<EndpointType> basicTypes = type.stream().filter(c -> c.getSubType() == null).map(CompositeEndpointType::getType).collect(Collectors.toSet());
+        Set<CompositeEndpointType> compositeTypes = type.stream().filter(c -> c.getSubType() != null).collect(Collectors.toSet());
 
-        if (includeSystemIntegrations) {
-            count += EndpointRepository.queryBuilderEndpointsPerType(null, name, type, activeOnly)
-                .buildCount(entityManager::createQuery)
-                .getSingleResult();
+        return buildAndExecuteEndpointCountQuery(orgId, name, basicTypes, compositeTypes, activeOnly, includeSystemIntegrations);
+    }
+
+    private Long buildAndExecuteEndpointCountQuery(String orgId, String name, Set<EndpointType> basicTypes, Set<CompositeEndpointType> compositeTypes, Boolean activeOnly, boolean includeSystemIntegrations) {
+        StringBuilder hql = new StringBuilder("SELECT COUNT(e) FROM Endpoint e WHERE ");
+
+        // OrgId filter
+        if (orgId == null) {
+            hql.append("e.orgId IS NULL");
+        } else {
+            if (includeSystemIntegrations) {
+                hql.append("(e.orgId = :orgId OR e.orgId IS NULL)");
+            } else {
+                hql.append("e.orgId = :orgId");
+            }
         }
-        return count;
+
+        // Type filter
+        if (!basicTypes.isEmpty() || !compositeTypes.isEmpty()) {
+            hql.append(" AND (");
+            if (!basicTypes.isEmpty()) {
+                hql.append("e.compositeType.type IN (:endpointType)");
+                if (!compositeTypes.isEmpty()) {
+                    hql.append(" OR ");
+                }
+            }
+            if (!compositeTypes.isEmpty()) {
+                hql.append("e.compositeType IN (:compositeTypes)");
+            }
+            hql.append(")");
+        }
+
+        // Active filter
+        if (activeOnly != null) {
+            hql.append(" AND e.enabled = :enabled");
+        }
+
+        // Name filter
+        if (name != null && !name.isEmpty()) {
+            hql.append(" AND LOWER(e.name) LIKE :name");
+        }
+
+        TypedQuery<Long> query = entityManager.createQuery(hql.toString(), Long.class);
+
+        // Set parameters
+        if (orgId != null) {
+            query.setParameter("orgId", orgId);
+        }
+        if (!basicTypes.isEmpty()) {
+            query.setParameter("endpointType", basicTypes);
+        }
+        if (!compositeTypes.isEmpty()) {
+            query.setParameter("compositeTypes", compositeTypes);
+        }
+        if (activeOnly != null) {
+            query.setParameter("enabled", activeOnly);
+        }
+        if (name != null && !name.isEmpty()) {
+            query.setParameter("name", "%" + name.toLowerCase() + "%");
+        }
+
+        return query.getSingleResult();
     }
 
     public Endpoint getEndpoint(String orgId, UUID id) {
@@ -348,33 +463,6 @@ public class EndpointRepository {
         }
     }
 
-    static QueryBuilder<Endpoint> queryBuilderEndpointsPerType(String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly) {
-        Set<EndpointType> basicTypes = type.stream().filter(c -> c.getSubType() == null).map(CompositeEndpointType::getType).collect(Collectors.toSet());
-        Set<CompositeEndpointType> compositeTypes = type.stream().filter(c -> c.getSubType() != null).collect(Collectors.toSet());
-        return QueryBuilder
-                .builder(Endpoint.class)
-                .alias("e")
-                .where(
-                        WhereBuilder.builder()
-                                .ifElse(
-                                        orgId == null,
-                                        WhereBuilder.builder().and("e.orgId IS NULL"),
-                                        WhereBuilder.builder().and("e.orgId = :orgId", "orgId", orgId)
-                                )
-                                .and(
-                                        WhereBuilder.builder()
-                                                .ifOr(basicTypes.size() > 0, "e.compositeType.type IN (:endpointType)", "endpointType", basicTypes)
-                                                .ifOr(compositeTypes.size() > 0, "e.compositeType IN (:compositeTypes)", "compositeTypes", compositeTypes)
-                                )
-                                .ifAnd(activeOnly != null, "e.enabled = :enabled", "enabled", activeOnly)
-                                .ifAnd(
-                                        name != null && !name.isEmpty(),
-                                        "LOWER(e.name) LIKE :name",
-                                        "name", (Supplier<String>) () -> "%" + name.toLowerCase() + "%"
-                                )
-                );
-    }
-
     public Endpoint loadProperties(Endpoint endpoint) {
         if (endpoint == null) {
             Log.warn("Endpoint properties loading attempt with a null endpoint. It should never happen, this is a bug.");
@@ -466,18 +554,4 @@ public class EndpointRepository {
             .setMaxResults(limit)
             .getResultList();
     }
-
-    public List<String> getOrgIdWithEndpoints() {
-        String query = "SELECT distinct(orgId) FROM Endpoint where orgId IS NOT null";
-        return entityManager.createQuery(query, String.class)
-                .getResultList();
-    }
-
-    public List<UUID> getEndpointsUUIDsByOrgId(final String orgId) {
-        String query = "SELECT id FROM Endpoint where orgId = :orgId ";
-        return entityManager.createQuery(query, UUID.class)
-            .setParameter("orgId", orgId)
-            .getResultList();
-    }
-
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -94,7 +94,7 @@ public class EndpointRepository {
         return endpoint;
     }
 
-    public List<Endpoint> getEndpointsPerCompositeType(String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly, Query limiter) {
+    public List<Endpoint> getEndpointsPerCompositeType(String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly, Query limiter, boolean includeSystemIntegrations) {
         Query.Limit limit = limiter == null ? null : limiter.getLimit();
         Optional<Sort> sort = limiter == null ? Optional.empty() : Sort.getSort(limiter, null, Endpoint.SORT_FIELDS);
 
@@ -104,6 +104,15 @@ public class EndpointRepository {
                 .sort(sort)
                 .build(entityManager::createQuery)
                 .getResultList();
+
+        if (includeSystemIntegrations) {
+            endpoints.addAll(EndpointRepository.queryBuilderEndpointsPerType(null, name, type, activeOnly)
+                .limit(limit)
+                .sort(sort)
+                .build(entityManager::createQuery)
+                .getResultList());
+        }
+
         loadProperties(endpoints);
 
         Log.debugf("[org_id: %s] Returning list of endpoints: %s", orgId, endpoints);
@@ -125,7 +134,7 @@ public class EndpointRepository {
 
     @Transactional
     public Optional<Endpoint> getSystemSubscriptionEndpoint(String orgId, SystemSubscriptionProperties properties, EndpointType endpointType) {
-        List<Endpoint> endpoints = getEndpointsPerCompositeType(orgId, null, Set.of(new CompositeEndpointType(endpointType)), null, null);
+        List<Endpoint> endpoints = getEndpointsPerCompositeType(orgId, null, Set.of(new CompositeEndpointType(endpointType)), null, null, false);
         loadProperties(endpoints);
         return endpoints
             .stream()
@@ -139,7 +148,7 @@ public class EndpointRepository {
         if (EndpointType.DRAWER == endpointType) {
             label = "Drawer";
         }
-        List<Endpoint> endpoints = getEndpointsPerCompositeType(orgId, null, Set.of(new CompositeEndpointType(endpointType)), null, null);
+        List<Endpoint> endpoints = getEndpointsPerCompositeType(orgId, null, Set.of(new CompositeEndpointType(endpointType)), null, null, false);
         loadProperties(endpoints);
         Optional<Endpoint> endpointOptional = endpoints
             .stream()
@@ -168,10 +177,17 @@ public class EndpointRepository {
         return createEndpoint(endpoint);
     }
 
-    public Long getEndpointsCountPerCompositeType(String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly) {
-        return EndpointRepository.queryBuilderEndpointsPerType(orgId, name, type, activeOnly)
+    public Long getEndpointsCountPerCompositeType(String orgId, @Nullable String name, Set<CompositeEndpointType> type, Boolean activeOnly, boolean includeSystemIntegrations) {
+        Long count = EndpointRepository.queryBuilderEndpointsPerType(orgId, name, type, activeOnly)
                 .buildCount(entityManager::createQuery)
                 .getSingleResult();
+
+        if (includeSystemIntegrations) {
+            count += EndpointRepository.queryBuilderEndpointsPerType(null, name, type, activeOnly)
+                .buildCount(entityManager::createQuery)
+                .getSingleResult();
+        }
+        return count;
     }
 
     public Endpoint getEndpoint(String orgId, UUID id) {
@@ -397,12 +413,19 @@ public class EndpointRepository {
         }
     }
 
-    public Optional<Endpoint> getEndpointWithLinkedEventTypes(String orgId, UUID id) {
+    public Optional<Endpoint> getEndpointWithLinkedEventTypes(String orgId, UUID id, boolean includeSystemIntegrationFlag) {
         String query = "SELECT e FROM Endpoint e " +
             "LEFT JOIN FETCH e.eventTypes ep " +
             "LEFT JOIN FETCH ep.application ap " +
             "LEFT JOIN FETCH ap.bundle " +
-            "WHERE e.orgId = :orgId AND e.id = :id";
+            "WHERE e.id = :id AND ";
+
+        String orgIdCriterion = "e.orgId = :orgId";
+        if (includeSystemIntegrationFlag) {
+            orgIdCriterion = "(e.orgId = :orgId or e.orgId is null)";
+        }
+        query += orgIdCriterion;
+
         try {
             Endpoint endpoint = entityManager.createQuery(query, Endpoint.class)
                 .setParameter("id", id)

--- a/backend/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/dto/v1/endpoint/EndpointDTO.java
@@ -97,6 +97,9 @@ public final class EndpointDTO {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Set<UUID> eventTypes;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean readOnly;
+
     public UUID getId() {
         return id;
     }
@@ -175,6 +178,14 @@ public final class EndpointDTO {
 
     public void setUpdated(final LocalDateTime updated) {
         this.updated = updated;
+    }
+
+    public Boolean getReadOnly() {
+        return readOnly;
+    }
+
+    public void setReadOnly(Boolean readOnly) {
+        this.readOnly = readOnly;
     }
 
     public EndpointPropertiesDTO getProperties() {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
@@ -209,7 +209,7 @@ public class EndpointResource extends EndpointResourceCommon {
         @QueryParam("active")   Boolean activeOnly,
         @QueryParam("name")     String name
     ) {
-        return internalGetEndpoints(sec, query, targetType, activeOnly, name, false);
+        return internalGetEndpoints(sec, query, targetType, activeOnly, name, false, false);
     }
 
     @POST
@@ -405,7 +405,7 @@ public class EndpointResource extends EndpointResourceCommon {
     @Operation(summary = "Retrieve an endpoint", description = "Retrieves the public information associated with an endpoint such as its description, name, and properties.")
     @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_VIEW)
     public EndpointDTO getEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
-        return internalGetEndpoint(sec, id, false);
+        return internalGetEndpoint(sec, id, false, false);
     }
 
     @DELETE

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceV2.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceV2.java
@@ -104,7 +104,7 @@ public class EndpointResourceV2 extends EndpointResourceCommon {
     @Operation(operationId = "EndpointResource$V2_getEndpoint", summary = "Retrieve an endpoint", description = "Retrieves the public information associated with an endpoint such as its description, name, and properties.")
     @Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_VIEW)
     public EndpointDTO getEndpoint(@Context SecurityContext sec, @PathParam("id") UUID id) {
-        return internalGetEndpoint(sec, id, true);
+        return internalGetEndpoint(sec, id, true, true);
     }
 
     @GET
@@ -134,6 +134,6 @@ public class EndpointResourceV2 extends EndpointResourceCommon {
         @QueryParam("active")   Boolean activeOnly,
         @QueryParam("name")     String name
     ) {
-        return internalGetEndpoints(sec, query, targetType, activeOnly, name, true);
+        return internalGetEndpoints(sec, query, targetType, activeOnly, name, true, true);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -76,7 +76,7 @@ public class EndpointRepositoryTest {
                 CompositeEndpointType.fromString("pagerduty")
         );
 
-        Function<Query, List<Endpoint>> provider = query -> endpointRepository.getEndpointsPerCompositeType(orgId, null, compositeEndpointTypes, null, query);
+        Function<Query, List<Endpoint>> provider = query -> endpointRepository.getEndpointsPerCompositeType(orgId, null, compositeEndpointTypes, null, query, false);
         TestHelpers.testSorting(
                 "id",
                 provider,

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResourceTest.java
@@ -3899,6 +3899,52 @@ public class EndpointResourceTest extends DbIsolatedTest {
     }
 
     @Test
+    void testSystemEndpointWriteOperationsBlocked() {
+        final Endpoint systemEndpoint = resourceHelpers.createEndpoint(null, null, EndpointType.EMAIL_SUBSCRIPTION);
+        final UUID systemEndpointId = systemEndpoint.getId();
+
+        final String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(TestConstants.DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "username");
+        final Header identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
+        MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
+
+        given()
+            .header(identityHeader)
+            .pathParam("id", systemEndpointId)
+            .when().delete("/endpoints/{id}")
+            .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+
+        given()
+            .header(identityHeader)
+            .pathParam("id", systemEndpointId)
+            .when().put("/endpoints/{id}/enable")
+            .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+
+        given()
+            .header(identityHeader)
+            .pathParam("id", systemEndpointId)
+            .when().delete("/endpoints/{id}/enable")
+            .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+
+        EndpointDTO updateRequest = new EndpointDTO();
+        updateRequest.setName("updated-name");
+        updateRequest.setDescription("updated-description");
+        updateRequest.setType(EndpointTypeDTO.EMAIL_SUBSCRIPTION);
+        updateRequest.setProperties(new SystemSubscriptionPropertiesDTO());
+
+        given()
+            .header(identityHeader)
+            .contentType(JSON)
+            .pathParam("id", systemEndpointId)
+            .body(Json.encode(updateRequest))
+            .when().put("/endpoints/{id}")
+            .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
     void testCreateThenDeleteEndpointToEventTypeRelationship() {
         final Bundle bundle1 = resourceHelpers.createBundle(RandomStringUtils.randomAlphabetic(10).toLowerCase(), "bundle 1");
 


### PR DESCRIPTION
## Why?

In order to be able to remove the Behavior Group management screen, we have to add system integration into regular integrations/endpoints apis.
Since end users will understand why they are notify even if they didn't configured such integration.
For UI purpose, those system integrations as to be flagged as read only.

## Summary by Sourcery

Expose system (org-less) endpoints via the v2 endpoints API while keeping them hidden in v1, and label them as read-only in responses.

New Features:
- Include system endpoints alongside regular endpoints in the v2 endpoints listing and single-endpoint retrieval APIs.
- Expose a readOnly flag on endpoint DTOs to indicate system-managed integrations.

Enhancements:
- Extend repository queries and counts to optionally include system endpoints in addition to org-scoped ones.
- Adjust endpoint retrieval helpers to support including linked event types and system endpoints with a single shared implementation.
- Remove obsolete endpoint test helper that asserted absence of integrations through the legacy /endpoints endpoint.

Tests:
- Add coverage ensuring v1 endpoints APIs ignore system endpoints while v2 endpoints APIs return them and correctly set the readOnly flag.
- Update repository tests to account for the new include-system-endpoints behavior in composite-type queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoint responses include a readOnly flag; V2 exposes system integration endpoints marked readOnly while V1 excludes them.

* **Bug Fixes**
  * Listing, counting and single-endpoint retrieval consistently honor inclusion of system integrations plus name/active/sort/pagination filters.
  * System endpoints are protected from modification (write operations rejected).

* **Tests**
  * Added tests for system endpoint visibility, filtering, readOnly behavior, sorting, and blocked writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->