### PR TITLE
[Do-Not-Merge] Test Hummingbird Base Images

### DIFF
--- a/.tekton/notifications-engine-pull-request.yaml
+++ b/.tekton/notifications-engine-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: ./docker/Dockerfile.notifications-engine.jvm
   - name: path-context
     value: .
+  - name: buildah-format
+    value: oci
   pipelineRef:
     name: docker-build
   taskRunTemplate:

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -17,8 +17,10 @@ FROM quay.io/hummingbird/openjdk:21-runtime
 # Update the base image packages
 USER root
 # See https://www.mankier.com/8/microdnf
-RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
-RUN microdnf clean all
+# RUN microdnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+# RUN microdnf clean all
+RUN dnf upgrade --refresh --nodocs --setopt=install_weak_deps=0 -y
+RUN dnf clean all
 USER jboss
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -8,7 +8,7 @@ FROM quay.io/hummingbird/openjdk:21-builder AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests -pl :notifications-engine -am --no-transfer-progress
+RUN JAVA_HOME=/usr/lib/jvm/java-21 ./mvnw clean package -DskipTests -pl :notifications-engine -am --no-transfer-progress
 
 # Build the container
 # FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -4,7 +4,7 @@
 
 # Build the project
 # FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
-FROM quay.io/hummingbird/openjdk:21 AS builder
+FROM quay.io/hummingbird/openjdk:21-builder AS builder
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
@@ -12,7 +12,7 @@ RUN ./mvnw clean package -DskipTests -pl :notifications-engine -am --no-transfer
 
 # Build the container
 # FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
-FROM quay.io/hummingbird/openjdk:21-runtime
+FROM quay.io/hummingbird/openjdk:21-runtime-builder
 
 # Update the base image packages
 USER root

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -3,14 +3,16 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
+# FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
+FROM quay.io/hummingbird/openjdk:21 AS builder
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -DskipTests -pl :notifications-engine -am --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
+# FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
+FROM quay.io/hummingbird/openjdk:21-runtime
 
 # Update the base image packages
 USER root

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -4,7 +4,7 @@
 
 # Build the project
 # FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
-FROM quay.io/hummingbird/openjdk:21-builder AS builder
+FROM quay.io/hummingbird/openjdk:21-builder AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss


### PR DESCRIPTION
Test if we can build Notifications (Java) images using Hummingbird  (distroless, 'no-CVEs') images.

## Summary by Sourcery

Build:
- Configure the notifications-engine pull request Tekton pipeline to pass buildah-format=oci to the docker-build pipeline.