### PR TITLE
RHCLOUD-45034 Prevent DB-related outages in .release-confidence-docs.md

### DIFF
--- a/.release-confidence-docs.md
+++ b/.release-confidence-docs.md
@@ -164,6 +164,27 @@ Red Hat services → Notifications Gateway REST API → platform.notifications.i
 - Multi-versioned API support (v1.0, v2.0) must maintain backward compatibility.
 - **Mitigation:** Extensive client coordination, version compatibility testing.
 
+**3. Index additions on large tables**
+- Adding indexes to large tables (e.g., `events` table with 15-day retention) can cause migrations to run longer than health check timeouts.
+- If OpenShift kills the `notifications-backend` pod before migration completes, the migration fails in an incomplete state.
+- **Risk indicators:** SQL migrations containing `CREATE INDEX` on high-volume tables.
+- **Mitigation:**
+  - Increase `failureThreshold` for liveness/readiness probes in ClowdApp configuration before deploying.
+  - Consider using `CREATE INDEX CONCURRENTLY` when possible (note: cannot run inside a transaction).
+  - Test migration duration against production-like data volumes.
+
+**4. New DB fields consumed by non-backend pods in same release**
+- Only `notifications-backend` runs Flyway migrations at startup; other pods (e.g., `notifications-engine`) do not.
+- If a release introduces a new DB field AND code in non-backend pods that consumes that field, those pods may start and process messages before the migration completes.
+- This causes failures when pods try to access columns that don't exist yet.
+- **Risk indicators:**
+  - SQL migration adding new columns (`ALTER TABLE ... ADD COLUMN`)
+  - Code changes in non-backend modules (e.g., `engine/`, `connector-*/`) referencing those new columns
+- **Mitigation:** Split into two releases:
+  1. **Release 1:** Add the DB field only (migration runs, no code consumes the new field)
+  2. **Release 2:** Add code that consumes the new field (field is guaranteed to exist)
+- **Critical:** This is an immediate deployment blocker if both changes are detected in the same release.
+
 ### 🟡 High-risk patterns requiring scrutiny
 
 **Known outage patterns:**
@@ -209,6 +230,8 @@ Red Hat services → Notifications Gateway REST API → platform.notifications.i
 
 **Automatic High Risk:**
 - Database schema migrations (Flyway Community Edition limitations)
+  - **Index on large tables:** `CREATE INDEX` on `events` or other high-volume tables requires extended health check timeouts or thresholds
+  - **New field + cross-pod consumption:** New columns consumed by non-backend pods in the same release is a **critical blocker** — must be split into two releases
 - Public API changes (affects frontend + multiple Red Hat services)
 - Authentication/authorization modifications (RBAC and Kessel)
 - Quarkus framework upgrades (historical outage source)


### PR DESCRIPTION
## Summary by Sourcery

Document additional database-related deployment risks and required mitigations for notifications service releases.

Documentation:
- Add guidance on risks and mitigations for adding indexes to large database tables during migrations.
- Add guidance on staggered releases when introducing new database fields used by non-backend pods in the same deployment.
- Highlight these new database migration patterns as automatic high-risk scenarios in the release confidence checklist.