### PR TITLE
[RHCLOUD-45311] Implement engine gracefull shutdown

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -81,6 +81,7 @@ objects:
           timeoutSeconds: 1
           successThreshold: 1
           failureThreshold: 5
+        terminationGracePeriodSeconds: 75
         env:
         - name: ENV_BASE_URL
           value: ${ENV_BASE_URL}

--- a/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
@@ -56,11 +56,9 @@ public class GracefulShutdownManager {
      * and BEFORE Quarkus infrastructure (EntityManager, datasource) shutdown.
      *
      * The priority value of 100 ensures this executes early in the shutdown
-     * sequence (lower numbers = higher priority), giving us control over the
-     * shutdown order. Default is 2000 (APPLICATION level).
+     * sequence (lower numbers = higher priority). Default is 2500.
      */
-    @Priority(100)
-    void onShutdown(@Observes ShutdownEvent event) {
+    void onShutdown(@Observes @Priority(100) ShutdownEvent event) {
         Log.info("=== Starting graceful shutdown sequence ===");
 
         // Step 1: Stop all Kafka consumers from fetching new messages

--- a/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
@@ -1,0 +1,191 @@
+package com.redhat.cloud.notifications;
+
+import com.redhat.cloud.notifications.config.EngineConfig;
+import com.redhat.cloud.notifications.events.ConnectorReceiver;
+import com.redhat.cloud.notifications.events.EventConsumer;
+import com.redhat.cloud.notifications.events.ReplayEventConsumer;
+import com.redhat.cloud.notifications.exports.ExportEventListener;
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.ShutdownEvent;
+import io.smallrye.reactive.messaging.ChannelRegistry;
+import io.smallrye.reactive.messaging.PausableChannel;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages graceful shutdown of Kafka consumers and async processing to ensure
+ * all in-flight messages are processed before the EntityManager is closed.
+ *
+ * Shutdown sequence:
+ * 1. Pause all Kafka consumers (stop fetching new messages)
+ * 2. Drain the EventConsumer's ThreadPoolExecutor (wait for in-flight tasks)
+ * 3. @Blocking consumers naturally complete due to POST_PROCESSING acknowledgment
+ * 4. Only then does Quarkus shut down EntityManager/datasource
+ */
+@ApplicationScoped
+public class GracefulShutdownManager {
+
+    /**
+     * Maximum time (in seconds) to wait for executor tasks to complete.
+     * This should be less than quarkus.shutdown.timeout to leave buffer time.
+     */
+    private static final int EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 30;
+
+    /**
+     * Maximum time (in seconds) to forcefully terminate remaining tasks.
+     */
+    private static final int EXECUTOR_FORCE_SHUTDOWN_TIMEOUT_SECONDS = 5;
+
+    @Inject
+    ChannelRegistry channelRegistry;
+
+    @Inject
+    EventConsumer eventConsumer;
+
+    @Inject
+    EngineConfig engineConfig;
+
+    /**
+     * High-priority shutdown observer that runs BEFORE @PreDestroy methods
+     * and BEFORE Quarkus infrastructure (EntityManager, datasource) shutdown.
+     *
+     * The priority value of 100 ensures this executes early in the shutdown
+     * sequence (lower numbers = higher priority), giving us control over the
+     * shutdown order. Default is 2000 (APPLICATION level).
+     */
+    @Priority(100)
+    void onShutdown(@Observes ShutdownEvent event) {
+        Log.info("=== Starting graceful shutdown sequence ===");
+
+        // Step 1: Stop all Kafka consumers from fetching new messages
+        pauseAllKafkaConsumers();
+
+        // Step 2: Wait for EventConsumer's executor to drain (if async processing is enabled)
+        // This handles both EventConsumer and ReplayEventConsumer (which delegates to EventConsumer)
+        if (engineConfig.isAsyncEventProcessing()) {
+            Log.info("Async event processing is ENABLED - draining executor");
+            drainEventConsumerExecutor();
+        } else {
+            Log.info("Async event processing is DISABLED - EventConsumer processes synchronously");
+            Log.info("  Messages are fully processed before acknowledgment (already safe)");
+        }
+
+        // Step 3: @Blocking consumers (ConnectorReceiver, ExportEventListener) use POST_PROCESSING
+        // acknowledgment, so Quarkus will naturally wait for them to complete their current message
+        // No additional action needed - they're handled by the framework
+
+        Log.info("=== Graceful shutdown sequence completed ===");
+        Log.info("EntityManager and datasource can now safely shut down");
+    }
+
+    /**
+     * Pauses all Kafka consumer channels to prevent fetching new messages.
+     */
+    private void pauseAllKafkaConsumers() {
+        Log.info("Pausing all Kafka consumer channels...");
+
+        /**
+         * All pausable Kafka consumer channels in the application.
+         */
+        List<String> KAFKA_CHANNELS = List.of(
+            EventConsumer.INGRESS_CHANNEL,              // "ingress"
+            ReplayEventConsumer.INGRESS_REPLAY_CHANNEL, // "ingressreplay"
+            ConnectorReceiver.FROMCAMEL_CHANNEL,        // "fromcamel"
+            ExportEventListener.EXPORT_CHANNEL          // Export requests
+        );
+
+        int pausedCount = 0;
+        for (String channelName : KAFKA_CHANNELS) {
+            try {
+                PausableChannel channel = channelRegistry.getPausable(channelName);
+                if (channel != null) {
+                    if (!channel.isPaused()) {
+                        channel.pause();
+                        pausedCount++;
+                        Log.infof("  ✓ Paused channel: %s", channelName);
+                    } else {
+                        Log.debugf("  - Channel already paused: %s", channelName);
+                    }
+                } else {
+                    Log.debugf("  - Channel not found or not pausable: %s", channelName);
+                }
+            } catch (Exception e) {
+                Log.warnf(e, "  ✗ Failed to pause channel: %s", channelName);
+            }
+        }
+
+        Log.infof("Paused %d Kafka channel(s)", pausedCount);
+
+        // Give Kafka a brief moment to stop in-flight fetch requests
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Drains the EventConsumer's ThreadPoolExecutor, waiting for all submitted
+     * tasks to complete before allowing the shutdown to proceed.
+     *
+     * This is critical in async mode because EventConsumer acknowledges Kafka
+     * messages immediately after submitting them to the executor, so tasks may
+     * still be running even after Kafka thinks the messages are processed.
+     *
+     * Note: This method is only called when async processing is enabled.
+     */
+    private void drainEventConsumerExecutor() {
+        ExecutorService executor = eventConsumer.getExecutor();
+
+        if (executor == null) {
+            Log.warn("  ✗ EventConsumer executor is null (unexpected), skipping drain");
+            return;
+        }
+
+        Log.infof("  Draining EventConsumer executor (timeout: %ds)...", EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS);
+
+        // Prevent executor from accepting new tasks
+        executor.shutdown();
+
+        try {
+            // Wait for existing tasks to complete
+            boolean terminated = executor.awaitTermination(
+                EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS,
+                TimeUnit.SECONDS
+            );
+
+            if (terminated) {
+                Log.info("  ✓ EventConsumer executor drained successfully - all tasks completed");
+            } else {
+                // Timeout reached, force shutdown
+                Log.warnf("  ✗ Executor did not terminate within %ds, forcing shutdown...",
+                    EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS);
+
+                executor.shutdownNow();
+
+                // Wait a bit more for tasks to respond to interruption
+                boolean forcedTermination = executor.awaitTermination(
+                    EXECUTOR_FORCE_SHUTDOWN_TIMEOUT_SECONDS,
+                    TimeUnit.SECONDS
+                );
+
+                if (forcedTermination) {
+                    Log.info("  ✓ Executor terminated after forced shutdown");
+                } else {
+                    Log.error("  ✗ Executor did not terminate even after shutdownNow()");
+                    Log.error("  Some tasks may be left running - potential data inconsistency risk");
+                }
+            }
+        } catch (InterruptedException e) {
+            Log.error("  ✗ Shutdown interrupted, forcing immediate termination", e);
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
@@ -111,7 +111,7 @@ public class GracefulShutdownManager {
                         Log.debugf("  - Channel already paused: %s", channelName);
                     }
                 } else {
-                    Log.debugf("  - Channel not found or not pausable: %s", channelName);
+                    Log.debugf("  - Channel not found or not marked as pausable in application.properties: %s", channelName);
                 }
             } catch (Exception e) {
                 Log.warnf(e, "  ✗ Failed to pause channel: %s", channelName);

--- a/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
@@ -3,10 +3,10 @@ package com.redhat.cloud.notifications;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.events.EventConsumer;
 import io.quarkus.logging.Log;
-import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.ShutdownDelayInitiatedEvent;
 import io.smallrye.reactive.messaging.ChannelRegistry;
 import io.smallrye.reactive.messaging.PausableChannel;
-import jakarta.annotation.Priority;
+import io.smallrye.reactive.messaging.kafka.KafkaClientService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -48,6 +48,9 @@ public class GracefulShutdownManager {
     @Inject
     EngineConfig engineConfig;
 
+    @Inject
+    KafkaClientService kafkaClientService;
+
     /**
      * High-priority shutdown observer that runs BEFORE @PreDestroy methods
      * and BEFORE Quarkus infrastructure (EntityManager, datasource) shutdown.
@@ -55,7 +58,7 @@ public class GracefulShutdownManager {
      * The priority value of 100 ensures this executes early in the shutdown
      * sequence (lower numbers = higher priority). Default is 2500.
      */
-    void onShutdown(@Observes @Priority(100) ShutdownEvent event) {
+    void onShutdown(@Observes ShutdownDelayInitiatedEvent event) {
         Log.info("=== Starting graceful shutdown sequence ===");
 
         // Step 1: Stop all Kafka consumers from fetching new messages
@@ -67,13 +70,9 @@ public class GracefulShutdownManager {
             Log.info("Async event processing is ENABLED - draining executor");
             drainEventConsumerExecutor();
         } else {
-            Log.info("Async event processing is DISABLED - EventConsumer processes synchronously");
-            Log.info("  Messages are fully processed before acknowledgment (already safe)");
+            Log.debug("Async event processing is DISABLED - EventConsumer processes synchronously");
+            Log.debug("  Messages are fully processed before acknowledgment (already safe)");
         }
-
-        // Step 3: @Blocking consumers (ConnectorReceiver, ExportEventListener) use POST_PROCESSING
-        // acknowledgment, so Quarkus will naturally wait for them to complete their current message
-        // No additional action needed - they're handled by the framework
 
         Log.info("=== Graceful shutdown sequence completed ===");
         Log.info("EntityManager and datasource can now safely shut down");
@@ -87,13 +86,8 @@ public class GracefulShutdownManager {
     private void pauseAllKafkaConsumers() {
         Log.info("Pausing all Kafka consumer channels...");
 
-        // Get only emitter names (these are outgoing)
-        Set<String> emitterNames = channelRegistry.getEmitterNames();
-
         // Filter incoming names by excluding emitters
-        Set<String> incomingChannels = channelRegistry.getIncomingNames();
-        incomingChannels.removeAll(emitterNames);
-
+        Set<String> incomingChannels = kafkaClientService.getConsumerChannels();
         Log.infof("  Found %d incoming channel(s) to process", incomingChannels.size());
 
         int pausedCount = 0;
@@ -125,6 +119,7 @@ public class GracefulShutdownManager {
 
         // Give Kafka a brief moment to stop in-flight fetch requests
         try {
+            Log.infof("Waiting 5s to process already pulled messages", pausedCount, skippedCount);
             Thread.sleep(5000);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
@@ -1,10 +1,7 @@
 package com.redhat.cloud.notifications;
 
 import com.redhat.cloud.notifications.config.EngineConfig;
-import com.redhat.cloud.notifications.events.ConnectorReceiver;
 import com.redhat.cloud.notifications.events.EventConsumer;
-import com.redhat.cloud.notifications.events.ReplayEventConsumer;
-import com.redhat.cloud.notifications.exports.ExportEventListener;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.ShutdownEvent;
 import io.smallrye.reactive.messaging.ChannelRegistry;
@@ -14,7 +11,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -84,41 +81,47 @@ public class GracefulShutdownManager {
 
     /**
      * Pauses all Kafka consumer channels to prevent fetching new messages.
+     * Automatically discovers all incoming channels using the ChannelRegistry,
+     * but only pauses those that are actually pausable (Kafka consumers, not emitters).
      */
     private void pauseAllKafkaConsumers() {
         Log.info("Pausing all Kafka consumer channels...");
 
-        /**
-         * All pausable Kafka consumer channels in the application.
-         */
-        List<String> KAFKA_CHANNELS = List.of(
-            EventConsumer.INGRESS_CHANNEL,              // "ingress"
-            ReplayEventConsumer.INGRESS_REPLAY_CHANNEL, // "ingressreplay"
-            ConnectorReceiver.FROMCAMEL_CHANNEL,        // "fromcamel"
-            ExportEventListener.EXPORT_CHANNEL          // Export requests
-        );
+        // Get only emitter names (these are outgoing)
+        Set<String> emitterNames = channelRegistry.getEmitterNames();
+
+        // Filter incoming names by excluding emitters
+        Set<String> incomingChannels = channelRegistry.getIncomingNames();
+        incomingChannels.removeAll(emitterNames);
+
+        Log.infof("  Found %d incoming channel(s) to process", incomingChannels.size());
 
         int pausedCount = 0;
-        for (String channelName : KAFKA_CHANNELS) {
+        int skippedCount = 0;
+        for (String channelName : incomingChannels) {
             try {
                 PausableChannel channel = channelRegistry.getPausable(channelName);
                 if (channel != null) {
+                    // This is an actual pausable Kafka consumer channel
                     if (!channel.isPaused()) {
                         channel.pause();
                         pausedCount++;
-                        Log.infof("  ✓ Paused channel: %s", channelName);
+                        Log.infof("  ✓ Paused Kafka consumer: %s", channelName);
                     } else {
-                        Log.debugf("  - Channel already paused: %s", channelName);
+                        Log.infof("  - Channel already paused: %s", channelName);
                     }
                 } else {
-                    Log.debugf("  - Channel not found or not marked as pausable in application.properties: %s", channelName);
+                    // Not a pausable channel (e.g., emitter-based channels like toCamel)
+                    // These don't consume from Kafka, so no need to pause
+                    skippedCount++;
+                    Log.infof("  - Skipped non-pausable channel: %s (not configured as pausable in application.properties file)", channelName);
                 }
             } catch (Exception e) {
-                Log.warnf(e, "  ✗ Failed to pause channel: %s", channelName);
+                Log.warnf(e, "  ✗ Failed to pause channel: %s - Messages may be lost during shutdown!", channelName);
             }
         }
 
-        Log.infof("Paused %d Kafka channel(s)", pausedCount);
+        Log.infof("Successfully paused %d Kafka consumer(s), skipped %d non-pausable channel(s)", pausedCount, skippedCount);
 
         // Give Kafka a brief moment to stop in-flight fetch requests
         try {

--- a/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
@@ -1,12 +1,11 @@
 package com.redhat.cloud.notifications;
 
 import io.quarkus.logging.Log;
-import io.quarkus.runtime.ShutdownDelayInitiatedEvent;
+import io.quarkus.runtime.ShutdownDelayInitiated;
 import io.smallrye.reactive.messaging.ChannelRegistry;
 import io.smallrye.reactive.messaging.PausableChannel;
 import io.smallrye.reactive.messaging.kafka.KafkaClientService;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
 import java.util.Set;
@@ -29,7 +28,8 @@ public class GracefulShutdownManager {
     @Inject
     KafkaClientService kafkaClientService;
 
-    void onShutdown(@Observes ShutdownDelayInitiatedEvent event) {
+    @ShutdownDelayInitiated
+    void onShutdown() {
         Log.info("=== Starting graceful shutdown sequence ===");
 
         pauseAllKafkaConsumers();

--- a/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/GracefulShutdownManager.java
@@ -1,7 +1,5 @@
 package com.redhat.cloud.notifications;
 
-import com.redhat.cloud.notifications.config.EngineConfig;
-import com.redhat.cloud.notifications.events.EventConsumer;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.ShutdownDelayInitiatedEvent;
 import io.smallrye.reactive.messaging.ChannelRegistry;
@@ -12,8 +10,6 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Manages graceful shutdown of Kafka consumers and async processing to ensure
@@ -21,58 +17,22 @@ import java.util.concurrent.TimeUnit;
  *
  * Shutdown sequence:
  * 1. Pause all Kafka consumers (stop fetching new messages)
- * 2. Drain the EventConsumer's ThreadPoolExecutor (wait for in-flight tasks)
- * 3. @Blocking consumers naturally complete due to POST_PROCESSING acknowledgment
- * 4. Only then does Quarkus shut down EntityManager/datasource
+ * 2. @Blocking consumers naturally complete due to POST_PROCESSING acknowledgment
+ * 3. Only then does Quarkus shut down EntityManager/datasource
  */
 @ApplicationScoped
 public class GracefulShutdownManager {
-
-    /**
-     * Maximum time (in seconds) to wait for executor tasks to complete.
-     * This should be less than quarkus.shutdown.timeout to leave buffer time.
-     */
-    private static final int EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 30;
-
-    /**
-     * Maximum time (in seconds) to forcefully terminate remaining tasks.
-     */
-    private static final int EXECUTOR_FORCE_SHUTDOWN_TIMEOUT_SECONDS = 5;
 
     @Inject
     ChannelRegistry channelRegistry;
 
     @Inject
-    EventConsumer eventConsumer;
-
-    @Inject
-    EngineConfig engineConfig;
-
-    @Inject
     KafkaClientService kafkaClientService;
 
-    /**
-     * High-priority shutdown observer that runs BEFORE @PreDestroy methods
-     * and BEFORE Quarkus infrastructure (EntityManager, datasource) shutdown.
-     *
-     * The priority value of 100 ensures this executes early in the shutdown
-     * sequence (lower numbers = higher priority). Default is 2500.
-     */
     void onShutdown(@Observes ShutdownDelayInitiatedEvent event) {
         Log.info("=== Starting graceful shutdown sequence ===");
 
-        // Step 1: Stop all Kafka consumers from fetching new messages
         pauseAllKafkaConsumers();
-
-        // Step 2: Wait for EventConsumer's executor to drain (if async processing is enabled)
-        // This handles both EventConsumer and ReplayEventConsumer (which delegates to EventConsumer)
-        if (engineConfig.isAsyncEventProcessing()) {
-            Log.info("Async event processing is ENABLED - draining executor");
-            drainEventConsumerExecutor();
-        } else {
-            Log.debug("Async event processing is DISABLED - EventConsumer processes synchronously");
-            Log.debug("  Messages are fully processed before acknowledgment (already safe)");
-        }
 
         Log.info("=== Graceful shutdown sequence completed ===");
         Log.info("EntityManager and datasource can now safely shut down");
@@ -117,70 +77,11 @@ public class GracefulShutdownManager {
 
         Log.infof("Successfully paused %d Kafka consumer(s), skipped %d non-pausable channel(s)", pausedCount, skippedCount);
 
-        // Give Kafka a brief moment to stop in-flight fetch requests
+        // Give Kafka a brief moment to process in-flight fetch requests
         try {
             Log.infof("Waiting 5s to process already pulled messages", pausedCount, skippedCount);
             Thread.sleep(5000);
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    /**
-     * Drains the EventConsumer's ThreadPoolExecutor, waiting for all submitted
-     * tasks to complete before allowing the shutdown to proceed.
-     *
-     * This is critical in async mode because EventConsumer acknowledges Kafka
-     * messages immediately after submitting them to the executor, so tasks may
-     * still be running even after Kafka thinks the messages are processed.
-     *
-     * Note: This method is only called when async processing is enabled.
-     */
-    private void drainEventConsumerExecutor() {
-        ExecutorService executor = eventConsumer.getExecutor();
-
-        if (executor == null) {
-            Log.warn("  ✗ EventConsumer executor is null (unexpected), skipping drain");
-            return;
-        }
-
-        Log.infof("  Draining EventConsumer executor (timeout: %ds)...", EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS);
-
-        // Prevent executor from accepting new tasks
-        executor.shutdown();
-
-        try {
-            // Wait for existing tasks to complete
-            boolean terminated = executor.awaitTermination(
-                EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS,
-                TimeUnit.SECONDS
-            );
-
-            if (terminated) {
-                Log.info("  ✓ EventConsumer executor drained successfully - all tasks completed");
-            } else {
-                // Timeout reached, force shutdown
-                Log.warnf("  ✗ Executor did not terminate within %ds, forcing shutdown...",
-                    EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS);
-
-                executor.shutdownNow();
-
-                // Wait a bit more for tasks to respond to interruption
-                boolean forcedTermination = executor.awaitTermination(
-                    EXECUTOR_FORCE_SHUTDOWN_TIMEOUT_SECONDS,
-                    TimeUnit.SECONDS
-                );
-
-                if (forcedTermination) {
-                    Log.info("  ✓ Executor terminated after forced shutdown");
-                } else {
-                    Log.error("  ✗ Executor did not terminate even after shutdownNow()");
-                    Log.error("  Some tasks may be left running - potential data inconsistency risk");
-                }
-            }
-        } catch (InterruptedException e) {
-            Log.error("  ✗ Shutdown interrupted, forcing immediate termination", e);
-            executor.shutdownNow();
             Thread.currentThread().interrupt();
         }
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -370,4 +370,15 @@ public class EventConsumer {
 
         return messageId;
     }
+
+    /**
+     * Exposes the executor for graceful shutdown management.
+     * Used by GracefulShutdownManager to drain in-flight tasks before
+     * the EntityManager is closed during pod shutdown.
+     *
+     * @return the ThreadPoolExecutor instance, or null if async processing is disabled
+     */
+    public ExecutorService getExecutor() {
+        return executor;
+    }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -370,15 +370,4 @@ public class EventConsumer {
 
         return messageId;
     }
-
-    /**
-     * Exposes the executor for graceful shutdown management.
-     * Used by GracefulShutdownManager to drain in-flight tasks before
-     * the EntityManager is closed during pod shutdown.
-     *
-     * @return the ThreadPoolExecutor instance, or null if async processing is disabled
-     */
-    public ExecutorService getExecutor() {
-        return executor;
-    }
 }

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -201,6 +201,9 @@ quarkus.unleash.url=http://localhost:4242
 # Graceful shutdown configuration for pod rollouts
 # Ensures all Kafka messages are processed before EntityManager closes
 # Must be less than terminationGracePeriodSeconds value of clowdapp-engine.yaml (default value is 30s, current is 75s)
-quarkus.shutdown.timeout=60S
+quarkus.shutdown.timeout=PT60S
+quarkus.shutdown.delay-enabled=true
+%test.quarkus.shutdown.delay-enabled=false
+quarkus.shutdown.delay=PT15S
 
 %test.notifications.email.show.pendo.until.date=2000-01-01

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -196,4 +196,9 @@ quarkus.cache.caffeine.aggregation-target-email-subscription-endpoints.expire-af
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242
 
+# Graceful shutdown configuration for pod rollouts
+# Ensures all Kafka messages are processed before EntityManager closes
+# Must be less than Kubernetes terminationGracePeriodSeconds (typically 90s)
+quarkus.shutdown.timeout=60S
+
 %test.notifications.email.show.pendo.until.date=2000-01-01

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -31,6 +31,7 @@ mp.messaging.incoming.ingressreplay.value.deserializer=org.apache.kafka.common.s
 mp.messaging.incoming.ingressreplay.cloud-events=false
 mp.messaging.incoming.ingressreplay.auto.offset.reset=earliest
 mp.messaging.incoming.ingressreplay.enabled=false
+mp.messaging.incoming.ingressreplay.pausable=true
 
 # Output queue
 mp.messaging.outgoing.egress.connector=smallrye-kafka
@@ -74,6 +75,7 @@ mp.messaging.incoming.fromcamel.group.id=integrations
 mp.messaging.incoming.fromcamel.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.fromcamel.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.fromcamel.cloud-events=false
+mp.messaging.incoming.fromcamel.pausable=true
 
 # Input queue for the "export requests" coming from the export service.
 mp.messaging.incoming.exportrequests.connector=smallrye-kafka
@@ -198,7 +200,7 @@ quarkus.unleash.url=http://localhost:4242
 
 # Graceful shutdown configuration for pod rollouts
 # Ensures all Kafka messages are processed before EntityManager closes
-# Must be less than Kubernetes terminationGracePeriodSeconds (typically 90s)
+# Must be less than terminationGracePeriodSeconds value of clowdapp-engine.yaml (default value is 30s, current is 75s)
 quarkus.shutdown.timeout=60S
 
 %test.notifications.email.show.pendo.until.date=2000-01-01


### PR DESCRIPTION
## Why?
Currently, some Kafka messages could be lost during engine pod shutdown, because Quarkus may close database connection before ending processing Kafka events.

## Summary by Sourcery

Implement a graceful shutdown mechanism to ensure Kafka consumers and asynchronous event processing complete before engine resources are closed during pod termination.

Enhancements:
- Introduce a GracefulShutdownManager to coordinate pausing Kafka consumers and draining async executors during application shutdown.
- Expose the EventConsumer executor to allow controlled draining of in-flight tasks on shutdown.
- Configure a Quarkus shutdown timeout to align application shutdown behavior with Kubernetes pod termination timing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced graceful shutdown: consumer channels are paused and a short drain period allows in‑flight messages to complete, reducing potential message loss.
  * Added configurable shutdown timing and delay controls, providing a longer, adjustable shutdown window.
  * Improved shutdown logging to surface pause outcomes and warn on pause failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->