### PR TITLE
Update .release-confidence-docs.md

### DIFF
--- a/.release-confidence-docs.md
+++ b/.release-confidence-docs.md
@@ -173,15 +173,16 @@ Red Hat services → Notifications Gateway REST API → platform.notifications.i
   - Consider using `CREATE INDEX CONCURRENTLY` when possible (note: cannot run inside a transaction).
   - Test migration duration against production-like data volumes.
 
-**4. New DB fields consumed by non-backend pods in same release**
-- Only `notifications-backend` runs Flyway migrations; other pods (`engine`, `aggregator`, `connector-*`) do not.
+**4. Database column + shared entity field in same release**
+- **Rule:** If a release adds BOTH a SQL column AND a corresponding JPA entity field in `common/`, flag as **CRITICAL BLOCKER**.
+- **Why:** Only `notifications-backend` runs Flyway migrations. Other pods (`engine`, `aggregator`, `connector-*`) load `common/` entities immediately. If the entity has a field mapped to a non-existent column, Hibernate crashes the pod.
 - **Detection:** Release contains BOTH:
-  1. SQL migration adding columns (`ALTER TABLE ... ADD COLUMN`) in `database/src/main/resources/db/migration/`
-  2. Code in `engine/`, `aggregator/`, or `connector-*/` referencing those new fields (getter/setter calls, JPQL queries)
-- **Failure mode:** Non-backend pods start before migration completes → `SQLException: column "X" does not exist` → crash loops, data loss.
-- **Mitigation:** Split into two releases:
-  1. Release 1: Migration + entity field in `common/` (no code using it yet)
-  2. Release 2: Code consuming the new field
+  1. SQL migration in `database/src/main/resources/db/migration/*.sql` adds a column
+  2. Entity in `common/src/main/java/**/models/*.java` adds a matching field
+- **Naming convention:** SQL `snake_case` → Java `camelCase` (e.g., `external_id` → `externalId`)
+- **Solution:** Split into two releases:
+  1. Release 1: SQL migration only (column exists after deploy)
+  2. Release 2: Entity field + code using it (column guaranteed to exist)
 
 ### 🟡 High-risk patterns requiring scrutiny
 
@@ -229,7 +230,7 @@ Red Hat services → Notifications Gateway REST API → platform.notifications.i
 **Automatic High Risk:**
 - Database schema migrations (Flyway Community Edition limitations)
   - **Index on large tables:** `CREATE INDEX` on `events` or other high-volume tables requires extended health check timeouts or thresholds
-  - **New field + cross-pod consumption:** Migration + non-backend code using new field in same release — **critical blocker**, must be split into two releases
+  - **Database column + shared entity field:** SQL column + matching JPA field in `common/` in same release — **critical blocker**, must be split into two releases
 - Public API changes (affects frontend + multiple Red Hat services)
 - Authentication/authorization modifications (RBAC and Kessel)
 - Quarkus framework upgrades (historical outage source)


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update guidance to treat adding a SQL column and corresponding shared JPA entity field in the same release as a critical blocker, with clearer detection, naming conventions, and a two-release mitigation pattern.