### PR TITLE
RHCLOUD-45442 Reset Subscriptions dedup after customer configuration

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/DefaultEventDeduplicationConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/DefaultEventDeduplicationConfig.java
@@ -5,21 +5,17 @@ import com.redhat.cloud.notifications.models.Event;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-public class DefaultEventDeduplicationConfig extends EventDeduplicationConfig {
+public class DefaultEventDeduplicationConfig implements EventDeduplicationConfig {
 
     private static final int DEFAULT_RETENTION_DELAY_IN_DAYS = 1;
 
-    public DefaultEventDeduplicationConfig(Event event) {
-        super(event);
-    }
-
     @Override
-    public LocalDateTime getDeleteAfter() {
+    public LocalDateTime getDeleteAfter(Event event) {
         return event.getTimestamp().plusDays(DEFAULT_RETENTION_DELAY_IN_DAYS);
     }
 
     @Override
-    public Optional<String> getDeduplicationKey() {
+    public Optional<String> getDeduplicationKey(Event event) {
         if (event.getExternalId() != null) {
             return Optional.of(event.getExternalId().toString());
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicationConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicationConfig.java
@@ -5,15 +5,9 @@ import com.redhat.cloud.notifications.models.Event;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-public abstract class EventDeduplicationConfig {
+public interface EventDeduplicationConfig {
 
-    protected final Event event;
+    LocalDateTime getDeleteAfter(Event event);
 
-    public EventDeduplicationConfig(Event event) {
-        this.event = event;
-    }
-
-    public abstract LocalDateTime getDeleteAfter();
-
-    public abstract Optional<String> getDeduplicationKey();
+    Optional<String> getDeduplicationKey(Event event);
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.events.deduplication;
 
+import java.util.Optional;
+
 import com.redhat.cloud.notifications.models.Event;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -9,20 +11,24 @@ import jakarta.transaction.Transactional;
 @ApplicationScoped
 public class EventDeduplicator {
 
+    private static final DefaultEventDeduplicationConfig DEFAULT_DEDUPLICATION_CONFIG = new DefaultEventDeduplicationConfig();
     private static final String SUBSCRIPTION_SERVICES_BUNDLE = "subscription-services";
     private static final String SUBSCRIPTIONS_APP = "subscriptions";
 
     @Inject
     EntityManager entityManager;
 
+    @Inject
+    SubscriptionsDeduplicationConfig subscriptionsDeduplicationConfig;
+
     private EventDeduplicationConfig getEventDeduplicationConfig(Event event) {
         return switch (event.getEventType().getApplication().getBundle().getName()) {
             case SUBSCRIPTION_SERVICES_BUNDLE ->
                 switch (event.getEventType().getApplication().getName()) {
-                    case SUBSCRIPTIONS_APP -> new SubscriptionsDeduplicationConfig(event);
-                    default -> new DefaultEventDeduplicationConfig(event);
+                    case SUBSCRIPTIONS_APP -> subscriptionsDeduplicationConfig;
+                    default -> DEFAULT_DEDUPLICATION_CONFIG;
                 };
-            default -> new DefaultEventDeduplicationConfig(event);
+            default -> DEFAULT_DEDUPLICATION_CONFIG;
         };
     }
 
@@ -30,9 +36,10 @@ public class EventDeduplicator {
     public boolean isNew(Event event) {
 
         EventDeduplicationConfig eventDeduplicationConfig = getEventDeduplicationConfig(event);
+        Optional<String> deduplicationKey = eventDeduplicationConfig.getDeduplicationKey(event);
 
         // Events are always considered new if no deduplication key is available.
-        if (eventDeduplicationConfig.getDeduplicationKey().isEmpty()) {
+        if (deduplicationKey.isEmpty()) {
             return true;
         }
 
@@ -42,8 +49,8 @@ public class EventDeduplicator {
 
         int rowCount = entityManager.createNativeQuery(sql)
                 .setParameter("eventTypeId", event.getEventType().getId())
-                .setParameter("deduplicationKey", eventDeduplicationConfig.getDeduplicationKey().get())
-                .setParameter("deleteAfter", eventDeduplicationConfig.getDeleteAfter())
+                .setParameter("deduplicationKey", deduplicationKey.get())
+                .setParameter("deleteAfter", eventDeduplicationConfig.getDeleteAfter(event))
                 .executeUpdate();
         return rowCount > 0;
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfig.java
@@ -1,38 +1,49 @@
 package com.redhat.cloud.notifications.events.deduplication;
 
 import com.redhat.cloud.notifications.models.Event;
+import io.quarkus.cache.CacheResult;
 import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.UUID;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 
-public class SubscriptionsDeduplicationConfig extends EventDeduplicationConfig {
+@ApplicationScoped
+public class SubscriptionsDeduplicationConfig implements EventDeduplicationConfig {
 
     private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
 
-    public SubscriptionsDeduplicationConfig(Event event) {
-        super(event);
-    }
+    @Inject
+    EntityManager entityManager;
 
     @Override
-    public LocalDateTime getDeleteAfter() {
+    public LocalDateTime getDeleteAfter(Event event) {
         // The event_deduplication entries will be purged from the DB on the first day of the next month, when the first purge cronjob runs after midnight UTC.
         return event.getTimestamp().plusMonths(1).withDayOfMonth(1).truncatedTo(DAYS);
     }
 
     @Override
-    public Optional<String> getDeduplicationKey() {
+    public Optional<String> getDeduplicationKey(Event event) {
 
         JsonObject context = new JsonObject(event.getPayload()).getJsonObject("context");
         if (context == null) {
             Log.debug("Deduplication key could not be built because of a missing context");
             return Optional.empty();
         }
+
+        // Determine if the org will be notified based on behavior groups and subscriptions
+        boolean willBeNotified = willOrgBeNotified(
+                event.getOrgId(),
+                event.getEventType().getId()
+        );
 
         // TODO We could build a simpler String key with all field values concatenated. Check if the JSON data structure has a significant impact on the query performances.
         // Use TreeMap to ensure consistent alphabetical ordering of fields in the JSON output
@@ -42,7 +53,69 @@ public class SubscriptionsDeduplicationConfig extends EventDeduplicationConfig {
         deduplicationKey.put("metric_id", context.getString("metric_id"));
         deduplicationKey.put("billing_account_id", context.getString("billing_account_id"));
         deduplicationKey.put("month", event.getTimestamp().format(MONTH_FORMATTER));
+        deduplicationKey.put("will_be_notified", willBeNotified);
 
         return Optional.of(new JsonObject(deduplicationKey).encode());
+    }
+
+    /**
+     * Determines whether the given organization will be notified for the specified event type.
+     * An org will be notified if:
+     * <ol>
+     *   <li>A behavior group exists (org-specific or default) that is linked to the event type, AND
+     *       that behavior group has at least one enabled endpoint action, OR</li>
+     *   <li>At least one user in the org has an active email subscription for the event type</li>
+     * </ol>
+     *
+     * @param orgId the organization ID
+     * @param eventTypeId the event type ID
+     * @return true if the org will be notified, false otherwise
+     */
+    @CacheResult(cacheName = "org-notification-eligibility")
+    public boolean willOrgBeNotified(String orgId, UUID eventTypeId) {
+        Log.debugf("Checking notification eligibility for org %s and event type %s", orgId, eventTypeId);
+
+        // Check if there's a behavior group with enabled endpoints for this org and event type
+        String behaviorGroupQuery = """
+            SELECT COUNT(bga) > 0
+            FROM BehaviorGroupAction bga
+            JOIN bga.behaviorGroup bg
+            JOIN bg.behaviors b
+            WHERE b.eventType.id = :eventTypeId
+            AND (bg.orgId = :orgId OR bg.orgId IS NULL)
+            AND bga.endpoint.enabled = true
+            """;
+
+        boolean hasBehaviorGroupWithEndpoint = entityManager.createQuery(behaviorGroupQuery, Boolean.class)
+                .setParameter("eventTypeId", eventTypeId)
+                .setParameter("orgId", orgId)
+                .getSingleResult();
+
+        if (hasBehaviorGroupWithEndpoint) {
+            Log.debugf("Org %s has behavior group with enabled endpoint for event type %s", orgId, eventTypeId);
+            return true;
+        }
+
+        // Check if any user in the org has an active email subscription for this event type
+        String emailSubscriptionQuery = """
+            SELECT COUNT(es) > 0
+            FROM EventTypeEmailSubscription es
+            WHERE es.id.orgId = :orgId
+            AND es.id.eventTypeId = :eventTypeId
+            AND es.subscribed = true
+            """;
+
+        boolean hasEmailSubscription = entityManager.createQuery(emailSubscriptionQuery, Boolean.class)
+                .setParameter("orgId", orgId)
+                .setParameter("eventTypeId", eventTypeId)
+                .getSingleResult();
+
+        if (hasEmailSubscription) {
+            Log.debugf("Org %s has email subscription for event type %s", orgId, eventTypeId);
+            return true;
+        }
+
+        Log.debugf("Org %s will NOT be notified for event type %s", orgId, eventTypeId);
+        return false;
     }
 }

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -180,6 +180,7 @@ quarkus.cache.caffeine.recipients-resolver-results.expire-after-write=PT1M
 quarkus.cache.caffeine.get-bundle-by-id.expire-after-write=PT15M
 quarkus.cache.caffeine.get-app-by-name.expire-after-write=PT15M
 quarkus.cache.caffeine.aggregation-target-email-subscription-endpoints.expire-after-write=PT5M
+quarkus.cache.caffeine.org-notification-eligibility.expire-after-write=PT1M
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfigTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfigTest.java
@@ -2,18 +2,34 @@ package com.redhat.cloud.notifications.events.deduplication;
 
 import com.redhat.cloud.notifications.events.EventWrapperAction;
 import com.redhat.cloud.notifications.models.Event;
+import com.redhat.cloud.notifications.models.EventType;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 class SubscriptionsDeduplicationConfigTest {
+
+    private SubscriptionsDeduplicationConfig deduplicationConfig;
+
+    @BeforeEach
+    void setUp() {
+        deduplicationConfig = spy(new SubscriptionsDeduplicationConfig());
+        // Default: org will not be notified
+        doReturn(false).when(deduplicationConfig).willOrgBeNotified(anyString(), any(UUID.class));
+    }
 
     @Test
     void testGetDeleteAfter() {
@@ -21,8 +37,7 @@ class SubscriptionsDeduplicationConfigTest {
         Event event = new Event();
         event.setEventWrapper(new EventWrapperAction(ActionBuilder.build(LocalDateTime.of(2025, 11, 14, 10, 52))));
 
-        SubscriptionsDeduplicationConfig deduplicationConfig = new SubscriptionsDeduplicationConfig(event);
-        LocalDateTime deleteAfter = deduplicationConfig.getDeleteAfter();
+        LocalDateTime deleteAfter = deduplicationConfig.getDeleteAfter(event);
 
         assertNotNull(deleteAfter);
         assertEquals(LocalDateTime.of(2025, 12, 1, 0, 0), deleteAfter);
@@ -37,8 +52,7 @@ class SubscriptionsDeduplicationConfigTest {
         String billingAccountId = "billing-abc";
 
         Event event = givenSubscriptionEvent(orgId, productId, metricId, billingAccountId);
-        SubscriptionsDeduplicationConfig deduplicationConfig = new SubscriptionsDeduplicationConfig(event);
-        Optional<String> deduplicationKey = deduplicationConfig.getDeduplicationKey();
+        Optional<String> deduplicationKey = deduplicationConfig.getDeduplicationKey(event);
 
         assertTrue(deduplicationKey.isPresent());
 
@@ -49,18 +63,17 @@ class SubscriptionsDeduplicationConfigTest {
         assertEquals(metricId, deduplicationKeyJson.getString("metric_id"));
         assertEquals(billingAccountId, deduplicationKeyJson.getString("billing_account_id"));
         assertEquals("2025-11", deduplicationKeyJson.getString("month"));
+        assertEquals(false, deduplicationKeyJson.getBoolean("will_be_notified"));
     }
 
     @Test
     void testGetDeduplicationKeyDifferentEventsInSameMonth() {
 
         Event event1 = givenSubscriptionEvent("org-1", "product-1", "metric-1", "billing-1");
-        SubscriptionsDeduplicationConfig deduplicationConfig1 = new SubscriptionsDeduplicationConfig(event1);
-        Optional<String> deduplicationKey1 = deduplicationConfig1.getDeduplicationKey();
+        Optional<String> deduplicationKey1 = deduplicationConfig.getDeduplicationKey(event1);
 
         Event event2 = givenSubscriptionEvent("org-2", "product-2", "metric-2", "billing-2");
-        SubscriptionsDeduplicationConfig deduplicationConfig2 = new SubscriptionsDeduplicationConfig(event2);
-        Optional<String> deduplicationKey2 = deduplicationConfig2.getDeduplicationKey();
+        Optional<String> deduplicationKey2 = deduplicationConfig.getDeduplicationKey(event2);
 
         assertTrue(deduplicationKey1.isPresent());
         assertTrue(deduplicationKey2.isPresent());
@@ -76,12 +89,10 @@ class SubscriptionsDeduplicationConfigTest {
         String billingAccountId = "billing-789";
 
         Event event1 = givenSubscriptionEvent(orgId, productId, metricId, billingAccountId);
-        SubscriptionsDeduplicationConfig deduplicationConfig1 = new SubscriptionsDeduplicationConfig(event1);
-        Optional<String> deduplicationKey1 = deduplicationConfig1.getDeduplicationKey();
+        Optional<String> deduplicationKey1 = deduplicationConfig.getDeduplicationKey(event1);
 
         Event event2 = givenSubscriptionEvent(orgId, productId, metricId, billingAccountId);
-        SubscriptionsDeduplicationConfig deduplicationConfig2 = new SubscriptionsDeduplicationConfig(event2);
-        Optional<String> deduplicationKey2 = deduplicationConfig2.getDeduplicationKey();
+        Optional<String> deduplicationKey2 = deduplicationConfig.getDeduplicationKey(event2);
 
         assertTrue(deduplicationKey1.isPresent());
         assertTrue(deduplicationKey2.isPresent());
@@ -92,8 +103,7 @@ class SubscriptionsDeduplicationConfigTest {
     void testGetDeduplicationKeyIncludesCurrentMonth() {
 
         Event event = givenSubscriptionEvent("org", "product", "metric", "billing");
-        SubscriptionsDeduplicationConfig deduplicationConfig = new SubscriptionsDeduplicationConfig(event);
-        Optional<String> deduplicationKey = deduplicationConfig.getDeduplicationKey();
+        Optional<String> deduplicationKey = deduplicationConfig.getDeduplicationKey(event);
 
         assertTrue(deduplicationKey.isPresent());
 
@@ -104,16 +114,51 @@ class SubscriptionsDeduplicationConfigTest {
         assertTrue(month.matches("\\d{4}-\\d{2}"), "Month should be in yyyy-MM format");
     }
 
+    @Test
+    void testGetDeduplicationKeyWithNotificationEligibility() {
+
+        String orgId = "test-org";
+        String productId = "product-123";
+        String metricId = "metric-456";
+        String billingAccountId = "billing-789";
+
+        Event event = givenSubscriptionEvent(orgId, productId, metricId, billingAccountId);
+
+        // When org will be notified
+        doReturn(true).when(deduplicationConfig).willOrgBeNotified(anyString(), any(UUID.class));
+        Optional<String> deduplicationKey1 = deduplicationConfig.getDeduplicationKey(event);
+
+        assertTrue(deduplicationKey1.isPresent());
+        JsonObject keyJson1 = new JsonObject(deduplicationKey1.get());
+        assertEquals(true, keyJson1.getBoolean("will_be_notified"));
+
+        // When org will NOT be notified
+        doReturn(false).when(deduplicationConfig).willOrgBeNotified(anyString(), any(UUID.class));
+        Optional<String> deduplicationKey2 = deduplicationConfig.getDeduplicationKey(event);
+
+        assertTrue(deduplicationKey2.isPresent());
+        JsonObject keyJson2 = new JsonObject(deduplicationKey2.get());
+        assertEquals(false, keyJson2.getBoolean("will_be_notified"));
+
+        // Keys should be different based on notification eligibility
+        assertNotEquals(deduplicationKey1.get(), deduplicationKey2.get(),
+                "Deduplication keys should differ based on notification eligibility");
+    }
+
     private Event givenSubscriptionEvent(String orgId, String productId, String metricId, String billingAccountId) {
         JsonObject context = new JsonObject();
         context.put("product_id", productId);
         context.put("metric_id", metricId);
         context.put("billing_account_id", billingAccountId);
 
+        EventType eventType = new EventType();
+        eventType.setId(UUID.randomUUID());
+
         Event event = new Event();
         event.setOrgId(orgId);
         event.setPayload(JsonObject.of("context", context).encode());
         event.setEventWrapper(new EventWrapperAction(ActionBuilder.build(LocalDateTime.of(2025, 11, 14, 10, 52))));
+        event.setEventType(eventType);
         return event;
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Refine event deduplication for subscription-services events by incorporating notification eligibility into the dedup key and refactoring the dedup configuration to be stateless and injectable.

New Features:
- Include an organization’s notification eligibility in the subscriptions deduplication key to distinguish between events that will and will not trigger notifications.
- Cache organization notification eligibility based on behavior groups and email subscriptions to avoid repeated database checks.

Enhancements:
- Refactor event deduplication configuration into a stateless interface with injectable implementations, removing per-event config instantiation.
- Reuse a singleton default deduplication configuration across events to reduce object creation overhead.
- Update release confidence documentation to clarify the critical risk of deploying a new database column and matching shared JPA entity field in the same release.

Tests:
- Extend SubscriptionsDeduplicationConfig tests to cover notification eligibility in the dedup key and adapt them to the new stateless configuration API.