### PR TITLE
RHCLOUD-45942 Update subscriptions endpoint to match willBeNotified logic

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/SubscriptionRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/SubscriptionRepository.java
@@ -272,11 +272,38 @@ public class SubscriptionRepository {
      * @return list of org id grouped by event types
      */
     public Map<String, List<String>> getOrgSubscriptionsPerEventType(String bundle, String application, List<String> eventTypes) {
-        final String query = "SELECT et.name, string_agg(DISTINCT org_id, ',') " +
-            "FROM email_subscriptions es JOIN event_type et ON event_type_id = et.id " +
-            "WHERE es.subscribed is true AND EXISTS " +
-            "(SELECT 1 FROM applications app JOIN bundles b ON app.bundle_id = b.id " +
-            "WHERE b.name = :bundleName AND app.name = :applicationName and et.application_id = app.id and et.name in (:eventTypeNames)) group by et.name";
+        /*
+         * This query mirrors the willBeNotified() logic from SubscriptionsDeduplicationConfig.
+         * An org is included if it has an enabled endpoint linked to the event type and either:
+         * - The endpoint is a machine-to-machine integration (not DRAWER or EMAIL_SUBSCRIPTION), OR
+         * - The endpoint is a recipient-based integration (DRAWER or EMAIL_SUBSCRIPTION) AND
+         *   at least one user in the org has an active subscription (via subscribed flag or severities)
+         */
+        final String query = "SELECT et.name, string_agg(DISTINCT derived.org_id, ',') " +
+            "FROM event_type et JOIN (" +
+                "SELECT ep.org_id, eet.event_type_id " +
+                "FROM endpoints ep " +
+                "JOIN endpoint_event_type eet ON ep.id = eet.endpoint_id " +
+                "WHERE ep.enabled = true " +
+                "AND ep.endpoint_type_v2 NOT IN ('DRAWER', 'EMAIL_SUBSCRIPTION') " +
+                "AND ep.org_id IS NOT NULL " +
+                "UNION " +
+                "SELECT es.org_id, es.event_type_id " +
+                "FROM email_subscriptions es " +
+                "WHERE (es.subscribed = true OR CAST(es.severities AS text) LIKE '%true%') " +
+                "AND EXISTS (" +
+                    "SELECT 1 FROM endpoints ep " +
+                    "JOIN endpoint_event_type eet ON ep.id = eet.endpoint_id " +
+                    "WHERE eet.event_type_id = es.event_type_id " +
+                    "AND (ep.org_id = es.org_id OR ep.org_id IS NULL) " +
+                    "AND ep.enabled = true " +
+                    "AND ep.endpoint_type_v2 IN ('DRAWER', 'EMAIL_SUBSCRIPTION')" +
+                ")" +
+            ") derived ON et.id = derived.event_type_id " +
+            "WHERE EXISTS (" +
+                "SELECT 1 FROM applications app JOIN bundles b ON app.bundle_id = b.id " +
+                "WHERE b.name = :bundleName AND app.name = :applicationName AND et.application_id = app.id AND et.name IN (:eventTypeNames)" +
+            ") GROUP BY et.name";
         List<Object[]> records = entityManager.createNativeQuery(query)
             .setParameter("bundleName", bundle)
             .setParameter("applicationName", application)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalGwResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalGwResourceTest.java
@@ -3,6 +3,9 @@ package com.redhat.cloud.notifications.routers.internal;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.EventType;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -24,6 +27,7 @@ import static com.redhat.cloud.notifications.models.SubscriptionType.INSTANT;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
@@ -35,6 +39,9 @@ public class InternalGwResourceTest extends DbIsolatedTest {
 
     @Inject
     EntityManager em;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
 
     @Test
     void testSubscriptionsList() {
@@ -54,6 +61,14 @@ public class InternalGwResourceTest extends DbIsolatedTest {
         eventType.setName("event2");
         eventType.setDisplayName("Event 2");
         String eventId2 = createEventType(adminIdentity, eventType, HttpStatus.SC_OK).get();
+
+        // Create enabled EMAIL_SUBSCRIPTION endpoints linked to event types for orgs 123456 and 654321
+        Endpoint emailEp1 = resourceHelpers.createEndpoint("account", "123456", EndpointType.EMAIL_SUBSCRIPTION, null, "email-ep-123456", "desc", null, true);
+        linkEndpointToEventType(emailEp1.getId(), UUID.fromString(eventId1));
+        linkEndpointToEventType(emailEp1.getId(), UUID.fromString(eventId2));
+        Endpoint emailEp2 = resourceHelpers.createEndpoint("account", "654321", EndpointType.EMAIL_SUBSCRIPTION, null, "email-ep-654321", "desc", null, true);
+        linkEndpointToEventType(emailEp2.getId(), UUID.fromString(eventId1));
+        linkEndpointToEventType(emailEp2.getId(), UUID.fromString(eventId2));
 
         // no subscriber yet
         Map<String, List<String>> mapOrgsByEventTypes = getSubscribedOrgs(adminIdentity, bundleName, applicationName, List.of("event1", "event2"));
@@ -97,6 +112,124 @@ public class InternalGwResourceTest extends DbIsolatedTest {
         assertEquals(0, mapOrgsByEventTypes.size());
     }
 
+    @Test
+    void testMachineToMachineEndpointReturnsOrg() {
+        Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
+
+        final String bundleName = "bundle-name-m2m";
+        final String applicationName = "application-name-m2m";
+        final String orgId = "org-m2m-1";
+        String bundleId = createBundle(adminIdentity, bundleName, RandomStringUtils.secure().nextAlphanumeric(10), HttpStatus.SC_OK).get();
+        String applicationId = createApp(adminIdentity, bundleId, applicationName, RandomStringUtils.secure().nextAlphanumeric(10), null, HttpStatus.SC_OK).get();
+        EventType eventType = new EventType();
+        eventType.setDescription(RandomStringUtils.secure().nextAlphanumeric(10));
+        eventType.setName("event-m2m");
+        eventType.setDisplayName("Event M2M");
+        eventType.setApplicationId(UUID.fromString(applicationId));
+        String eventId = createEventType(adminIdentity, eventType, HttpStatus.SC_OK).get();
+
+        // No endpoints yet — should be empty
+        Map<String, List<String>> result = getSubscribedOrgs(adminIdentity, bundleName, applicationName, List.of("event-m2m"));
+        assertTrue(result.isEmpty());
+
+        // Create an enabled WEBHOOK endpoint and link it to the event type
+        Endpoint webhookEndpoint = resourceHelpers.createEndpoint("account", orgId, EndpointType.WEBHOOK, null, "webhook-ep", "desc", null, true);
+        linkEndpointToEventType(webhookEndpoint.getId(), UUID.fromString(eventId));
+
+        // Org should now appear (machine-to-machine, no subscription needed)
+        result = getSubscribedOrgs(adminIdentity, bundleName, applicationName, List.of("event-m2m"));
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("event-m2m"));
+        assertTrue(result.get("event-m2m").contains(orgId));
+    }
+
+    @Test
+    void testRecipientEndpointWithoutSubscriptionDoesNotReturnOrg() {
+        Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
+
+        final String bundleName = "bundle-name-recip";
+        final String applicationName = "application-name-recip";
+        final String orgId = "org-recip-1";
+        String bundleId = createBundle(adminIdentity, bundleName, RandomStringUtils.secure().nextAlphanumeric(10), HttpStatus.SC_OK).get();
+        String applicationId = createApp(adminIdentity, bundleId, applicationName, RandomStringUtils.secure().nextAlphanumeric(10), null, HttpStatus.SC_OK).get();
+        EventType eventType = new EventType();
+        eventType.setDescription(RandomStringUtils.secure().nextAlphanumeric(10));
+        eventType.setName("event-recip");
+        eventType.setDisplayName("Event Recip");
+        eventType.setApplicationId(UUID.fromString(applicationId));
+        String eventId = createEventType(adminIdentity, eventType, HttpStatus.SC_OK).get();
+
+        // Create an enabled EMAIL_SUBSCRIPTION endpoint linked to the event type, but NO user subscription
+        Endpoint emailEndpoint = resourceHelpers.createEndpoint("account", orgId, EndpointType.EMAIL_SUBSCRIPTION, null, "email-ep", "desc", null, true);
+        linkEndpointToEventType(emailEndpoint.getId(), UUID.fromString(eventId));
+
+        // Org should NOT appear (recipient-based, no active subscription)
+        Map<String, List<String>> result = getSubscribedOrgs(adminIdentity, bundleName, applicationName, List.of("event-recip"));
+        assertFalse(result.containsKey("event-recip"));
+
+        // Now add a user subscription — org should appear
+        createUserSubscription(UUID.fromString(eventId), orgId);
+        result = getSubscribedOrgs(adminIdentity, bundleName, applicationName, List.of("event-recip"));
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("event-recip"));
+        assertTrue(result.get("event-recip").contains(orgId));
+    }
+
+    @Test
+    void testSeveritySubscriptionReturnsOrg() {
+        Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
+
+        final String bundleName = "bundle-name-sev";
+        final String applicationName = "application-name-sev";
+        final String orgId = "org-sev-1";
+        String bundleId = createBundle(adminIdentity, bundleName, RandomStringUtils.secure().nextAlphanumeric(10), HttpStatus.SC_OK).get();
+        String applicationId = createApp(adminIdentity, bundleId, applicationName, RandomStringUtils.secure().nextAlphanumeric(10), null, HttpStatus.SC_OK).get();
+        EventType eventType = new EventType();
+        eventType.setDescription(RandomStringUtils.secure().nextAlphanumeric(10));
+        eventType.setName("event-sev");
+        eventType.setDisplayName("Event Severity");
+        eventType.setApplicationId(UUID.fromString(applicationId));
+        String eventId = createEventType(adminIdentity, eventType, HttpStatus.SC_OK).get();
+
+        // Create an enabled DRAWER endpoint linked to the event type
+        Endpoint drawerEndpoint = resourceHelpers.createEndpoint("account", orgId, EndpointType.DRAWER, null, "drawer-ep", "desc", null, true);
+        linkEndpointToEventType(drawerEndpoint.getId(), UUID.fromString(eventId));
+
+        // Add a severity-based subscription (subscribed=false but severities has true)
+        createSeveritySubscription(UUID.fromString(eventId), orgId);
+
+        // Org should appear (severity-based subscription satisfies the condition)
+        Map<String, List<String>> result = getSubscribedOrgs(adminIdentity, bundleName, applicationName, List.of("event-sev"));
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("event-sev"));
+        assertTrue(result.get("event-sev").contains(orgId));
+    }
+
+    @Test
+    void testDisabledEndpointDoesNotReturnOrg() {
+        Header adminIdentity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
+
+        final String bundleName = "bundle-name-dis";
+        final String applicationName = "application-name-dis";
+        final String orgId = "org-dis-1";
+        String bundleId = createBundle(adminIdentity, bundleName, RandomStringUtils.secure().nextAlphanumeric(10), HttpStatus.SC_OK).get();
+        String applicationId = createApp(adminIdentity, bundleId, applicationName, RandomStringUtils.secure().nextAlphanumeric(10), null, HttpStatus.SC_OK).get();
+        EventType eventType = new EventType();
+        eventType.setDescription(RandomStringUtils.secure().nextAlphanumeric(10));
+        eventType.setName("event-dis");
+        eventType.setDisplayName("Event Disabled");
+        eventType.setApplicationId(UUID.fromString(applicationId));
+        String eventId = createEventType(adminIdentity, eventType, HttpStatus.SC_OK).get();
+
+        // Create a DISABLED WEBHOOK endpoint linked to the event type
+        Endpoint webhookEndpoint = resourceHelpers.createEndpoint("account", orgId, EndpointType.WEBHOOK, null, "webhook-disabled", "desc", null, false);
+        linkEndpointToEventType(webhookEndpoint.getId(), UUID.fromString(eventId));
+
+        // Org should NOT appear (endpoint is disabled)
+        Map<String, List<String>> result = getSubscribedOrgs(adminIdentity, bundleName, applicationName, List.of("event-dis"));
+        assertFalse(result.containsKey("event-dis"));
+    }
+
     private static Map<String, List<String>> getSubscribedOrgs(final Header adminIdentity, final String bundleName, final String applicationName, final List<String> event1) {
         return given()
             .contentType(JSON)
@@ -109,6 +242,32 @@ public class InternalGwResourceTest extends DbIsolatedTest {
             .then()
             .statusCode(HttpStatus.SC_OK).extract().as(new TypeRef<>() {
             });
+    }
+
+    @Transactional
+    protected void linkEndpointToEventType(UUID endpointId, UUID eventTypeId) {
+        em.createNativeQuery("INSERT INTO endpoint_event_type(endpoint_id, event_type_id) VALUES (:endpointId, :eventTypeId)")
+            .setParameter("endpointId", endpointId)
+            .setParameter("eventTypeId", eventTypeId)
+            .executeUpdate();
+        em.flush();
+    }
+
+    @Transactional
+    protected void createSeveritySubscription(UUID eventTypeId, String orgId) {
+        String sql = "INSERT INTO email_subscriptions(org_id, user_id, event_type_id, subscription_type, subscribed, severities) " +
+            "VALUES (:orgId, :userId, :eventTypeId, :subscriptionType, :subscribed, CAST(:severities AS jsonb)) " +
+            "ON CONFLICT (org_id, user_id, event_type_id, subscription_type) DO UPDATE SET subscribed = :subscribed, severities = CAST(:severities AS jsonb)";
+
+        em.createNativeQuery(sql)
+            .setParameter("orgId", orgId)
+            .setParameter("userId", "username")
+            .setParameter("eventTypeId", eventTypeId)
+            .setParameter("subscriptionType", INSTANT.name())
+            .setParameter("subscribed", false)
+            .setParameter("severities", "{\"CRITICAL\": true}")
+            .executeUpdate();
+        em.flush();
     }
 
     @Transactional


### PR DESCRIPTION
The `GET /notifications/subscriptions/{bundleName}/{applicationName}` endpoint previously only returned orgs with active email subscriptions.

It now also returns orgs with enabled machine-to-machine integrations (webhook, camel, ansible, pagerduty) linked to the event type, and checks severity-based subscriptions for recipient integrations (drawer, email).