### PR TITLE
Add domain-specific agent guidelines for 7 domains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+## Implementation And Review Guidelines
+- Security: docs/security-guidelines.md
+- Performance: docs/performance-guidelines.md
+- Error-handling: docs/error-handling-guidelines.md
+- Api-contracts: docs/api-contracts-guidelines.md
+- Database: docs/database-guidelines.md
+- Testing: docs/testing-guidelines.md
+- Integration: docs/integration-guidelines.md

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -12,8 +12,8 @@
 - Name V2 classes `{Domain}ResourceV2.java` (e.g., `EndpointResourceV2`, `NotificationResourceV2`)
 - Use a `{Domain}ResourceCommon.java` base class for shared logic between V1 and V2
 
-### 1.3 Versioned Inner Class Pattern (CRITICAL)
-Resources do NOT place `@Path` on the outer class. Instead, they use a **static inner class** to bind the version path:
+### 1.3 Versioned Inner Class Pattern (Preferred for Versioned Resources)
+Resources that exist in multiple API versions use a **static inner class** to bind the version path, keeping `@Path` off the outer class:
 ```java
 public class EndpointResource extends EndpointResourceCommon {
 
@@ -31,7 +31,15 @@ public class EndpointResourceV2 extends EndpointResourceCommon {
     }
 }
 ```
-Never put `@Path` with the base API path directly on the outer resource class. The inner class inherits all methods.
+Use this pattern for any new resource that needs V1/V2 versioning. The inner class inherits all methods from the outer class.
+
+### 1.4 Outer-Class `@Path` (Allowed for Single-Version Resources)
+Resources that exist in only one version place `@Path` directly on the class. This is common for:
+- **Internal API resources** (e.g., `InternalResource`, `TemplateResource`, `ValidationResource`) -- all use `@Path(API_INTERNAL + "/...")` on the class
+- **Single-version public handlers** (e.g., `StatusResource`, `UserConfigResource`, `OApiResource`) -- use `@Path(API_NOTIFICATIONS_V_1_0 + "/...")` on the class
+- **Utility resources** across modules (e.g., `HeapDumpResource`, `KafkaAdminResource`)
+
+When modifying an existing resource, follow the pattern it already uses. Only refactor to the inner-class pattern if adding a second API version.
 
 ## 2. API Path Constants
 
@@ -189,9 +197,3 @@ Use `@Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Dt
 - Use descriptive string messages in exceptions: `throw new BadRequestException("Properties is required")`
 - Define error message constants as `public static final String` in the resource class
 - Never return raw error maps; let the framework exception mappers handle error responses
-
-## 12. Transaction Management
-
-- Use `@Transactional` on methods that modify data (create, update, delete)
-- For operations requiring cleanup on failure (e.g., secrets), wrap in try/catch and clean up explicitly
-- Use `@TransactionConfiguration` only for extended timeout scenarios

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -1,0 +1,197 @@
+# API Contracts Guidelines
+
+## 1. Project Structure and Routing
+
+### 1.1 Resource Class Location
+- Public API resources live in `backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/`
+- Internal API resources live in `backend/src/main/java/com/redhat/cloud/notifications/routers/internal/`
+- Resources are organized by domain: `endpoint/`, `notification/`, `drawer/`, `event/`, `userconfig/`, `orgconfig/`
+
+### 1.2 Resource Class Naming
+- Name classes `{Domain}Resource.java` for V1 (e.g., `EndpointResource`, `NotificationResource`)
+- Name V2 classes `{Domain}ResourceV2.java` (e.g., `EndpointResourceV2`, `NotificationResourceV2`)
+- Use a `{Domain}ResourceCommon.java` base class for shared logic between V1 and V2
+
+### 1.3 Versioned Inner Class Pattern (CRITICAL)
+Resources do NOT place `@Path` on the outer class. Instead, they use a **static inner class** to bind the version path:
+```java
+public class EndpointResource extends EndpointResourceCommon {
+
+    @Path(API_INTEGRATIONS_V_1_0 + "/endpoints")
+    static class V1 extends EndpointResource {
+    }
+    // ... methods use relative @Path
+}
+```
+V2 resources follow the same pattern:
+```java
+public class EndpointResourceV2 extends EndpointResourceCommon {
+    @Path(API_INTEGRATIONS_V_2_0 + "/endpoints")
+    public static class V2 extends EndpointResourceV2 {
+    }
+}
+```
+Never put `@Path` with the base API path directly on the outer resource class. The inner class inherits all methods.
+
+## 2. API Path Constants
+
+### 2.1 All base paths are defined in `common/src/main/java/com/redhat/cloud/notifications/Constants.java`
+```
+API_INTEGRATIONS_V_1_0  = "/api/integrations/v1.0"
+API_INTEGRATIONS_V_2_0  = "/api/integrations/v2.0"
+API_NOTIFICATIONS_V_1_0 = "/api/notifications/v1.0"
+API_NOTIFICATIONS_V_2_0 = "/api/notifications/v2.0"
+API_INTERNAL            = "/internal"
+```
+
+### 2.2 Path Naming Rules
+- Use lowercase, plural nouns for resource paths: `/endpoints`, `/notifications`, `/eventTypes`
+- Use camelCase for composite path segments: `/eventTypes`, `/behaviorGroups` (not kebab-case)
+- Use `{id}` or `{descriptiveId}` for path parameters (e.g., `{endpointId}`, `{eventTypeId}`)
+- Sub-resources use nested paths: `/{id}/history`, `/{id}/history/{history_id}/details`
+
+## 3. API Versioning Strategy
+
+### 3.1 V1 vs V2 Differences
+- **V1** returns flat lists (`List<T>`) for collection endpoints
+- **V2** returns paginated `Page<T>` with `data`, `links`, and `meta` fields
+- V2 methods must set an explicit `operationId` via `@Operation(operationId = "ResourceName$V2_methodName")` to avoid OpenAPI ID collisions with V1
+- When adding a V2 endpoint, extract shared logic into the `*Common` base class
+
+### 3.2 Internal API
+- Internal endpoints use `@Path(API_INTERNAL)` directly on the class (not the inner-class pattern)
+- Secured with `@RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)` at class or method level
+- Never use the `@Authorization` annotation on internal endpoints
+
+## 4. Authorization
+
+### 4.1 Public API Endpoints
+Use the custom `@Authorization` annotation on every public endpoint method:
+```java
+@Authorization(legacyRBACRole = RBAC_READ_INTEGRATIONS_ENDPOINTS, workspacePermissions = INTEGRATIONS_VIEW)
+```
+- `legacyRBACRole`: RBAC role string used when Kessel is disabled
+- `workspacePermissions`: Kessel workspace permission(s) used when Kessel is enabled
+- Read operations use `*_VIEW` permissions; write operations use `*_EDIT` permissions
+- RBAC role constants are in `ConsoleIdentityProvider` (e.g., `RBAC_READ_INTEGRATIONS_ENDPOINTS`, `RBAC_WRITE_NOTIFICATIONS`)
+
+### 4.2 Private/Hidden Endpoints
+Tag with `@Tag(name = OApiFilter.PRIVATE)` to hide from the public OpenAPI spec while keeping them accessible.
+
+## 5. DTO Layer and MapStruct Mapping
+
+### 5.1 DTO Organization
+- DTOs live in `backend/.../models/dto/v1/` package, organized by domain (`endpoint/`, `endpoint/properties/`)
+- DTO classes are suffixed with `DTO` (e.g., `EndpointDTO`, `CamelPropertiesDTO`)
+- The `OApiFilter` strips the `DTO` suffix from schema names in the generated OpenAPI spec when there is no collision
+
+### 5.2 MapStruct Mappers
+- Use `@Mapper(componentModel = MappingConstants.ComponentModel.CDI)` for CDI injection
+- Define `toDTO(Entity)` and `toEntity(DTO)` methods
+- Use `@Named` qualified methods for polymorphic property mapping (see `EndpointMapper.mapEntityProperties`)
+- Ignore internal fields in entity-to-DTO mapping: `@Mapping(target = "orgId", ignore = true)`
+- Inject mappers via `@Inject` in resource classes
+
+### 5.3 CommonMapper
+`CommonMapper` handles cross-cutting mappings (Bundle, Application, EventType, NotificationHistory). Use it for shared DTO conversions rather than duplicating mapping logic.
+
+## 6. JSON Serialization (Jackson)
+
+### 6.1 Snake Case Convention
+All DTOs and request/response models MUST use `@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)`. This applies to:
+- DTO classes (`EndpointDTO`, `ApplicationDTO`, etc.)
+- Request models (`CreateBehaviorGroupRequest`, `UpdateBehaviorGroupRequest`)
+- Response models (`CreateBehaviorGroupResponse`, `EventLogEntry`)
+- Properties DTOs (via the abstract `EndpointPropertiesDTO` base class)
+
+### 6.2 Jackson Annotations
+- Use `@JsonProperty(access = READ_ONLY)` for server-generated fields (e.g., `created`, `updated`)
+- Use `@JsonInclude(NON_NULL)` for optional fields that should be omitted when null
+- Use `@JsonIgnore` for validation-only methods (e.g., `@AssertTrue` validators on DTOs)
+- Use `@JsonFormat(shape = Shape.STRING)` for `LocalDateTime` fields
+- Use `@JsonSubTypes` + `@JsonTypeInfo` for polymorphic deserialization (see `EndpointDTO.properties`)
+
+## 7. Request/Response Patterns
+
+### 7.1 Content Types
+- Produce and consume `APPLICATION_JSON` by default
+- Some update/enable endpoints produce `TEXT_PLAIN` for simple status responses
+- Always use static imports: `import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON`
+
+### 7.2 Request Bodies
+- Annotate with `@NotNull @Valid @RequestBody` for required bodies
+- Use `@RequestBody(required = true)` for OpenAPI documentation
+- Use Jakarta Validation annotations (`@NotNull`, `@Size`, `@Min`, `@Max`) on DTO fields
+
+### 7.3 Response Patterns
+- **200**: Return the DTO directly (Jackson serializes it)
+- **201**: Not used; creation returns 200 with the created object
+- **204**: Use `Response.noContent().build()` for delete/disable operations
+- **400**: Throw `BadRequestException` with a descriptive message
+- **404**: Throw `NotFoundException` (with or without a message)
+- Return `Response` only when you need custom status codes; otherwise return the DTO/entity type directly
+
+## 8. Pagination
+
+### 8.1 V1 Pagination (Legacy)
+V1 list endpoints return a flat `List<T>` or a specialized page class (`EndpointPage`). Pagination parameters are still accepted via `@BeanParam Query`.
+
+### 8.2 V2 Pagination (Standard)
+V2 returns `Page<T>` with three fields:
+- `data`: `List<T>` of results
+- `links`: `Map<String, String>` with `first`, `last`, `prev`, `next` URLs
+- `meta`: `Meta` object with `count` (total element count)
+
+### 8.3 Query Bean (`@BeanParam Query`)
+- `limit` (default 20, min 1, max 200): items per page
+- `pageNumber` (min 1): page number, converted to offset internally
+- `offset` (min 0): direct offset, takes precedence over `pageNumber`
+- `sort_by` / `sortBy`: sort field with optional `:asc`/`:desc` suffix
+- Use `PageLinksBuilder.build(uriInfo, count, query)` to generate pagination links (preserves query params)
+
+### 8.4 OpenAPI Pagination Documentation
+Document pagination parameters explicitly with `@Parameters` and `@Parameter` annotations on each list endpoint. Reference `DEFAULT_RESULTS_PER_PAGE` in descriptions.
+
+## 9. OpenAPI Annotations
+
+### 9.1 Required Annotations
+- `@Operation(summary = "...", description = "...")` on every public endpoint
+- `@APIResponse` / `@APIResponses` for non-200 responses, especially 400 and 404
+- `@Parameter` for query parameters with descriptions
+- `@Produces` and `@Consumes` on every endpoint
+
+### 9.2 OpenAPI Filtering
+The `OApiFilter` class splits the generated OpenAPI spec into four views: `notifications`, `integrations`, `private`, and `internal`. Endpoints are filtered by their base path. Private-tagged endpoints are excluded from the public specs but included in the `private` spec.
+
+### 9.3 Schema References
+Use `@Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = DtoClass.class))` in `@APIResponse` to explicitly reference the response DTO type.
+
+## 10. Backward Compatibility Rules
+
+### 10.1 Adding New Endpoints
+- Add new endpoints to V1 only if they follow V1 conventions (flat list returns)
+- Prefer adding to both V1 and V2, with V2 using `Page<T>` for collections
+- Extract shared logic into the `*Common` base class
+
+### 10.2 Deprecation Pattern
+- Use `@Deprecated(forRemoval = true)` on methods slated for removal
+- Both `sortBy` (camelCase) and `sort_by` (snake_case) query params are supported; `sortBy` is deprecated
+
+### 10.3 Non-Breaking Changes Only
+- Never remove or rename existing fields in DTOs
+- Never change the type of existing fields
+- New optional fields must use `@JsonInclude(NON_NULL)` to avoid breaking clients
+- Never change response status codes for existing endpoints
+
+## 11. Error Handling
+
+- Throw JAX-RS exceptions: `BadRequestException`, `NotFoundException`, `ForbiddenException`
+- Use descriptive string messages in exceptions: `throw new BadRequestException("Properties is required")`
+- Define error message constants as `public static final String` in the resource class
+- Never return raw error maps; let the framework exception mappers handle error responses
+
+## 12. Transaction Management
+
+- Use `@Transactional` on methods that modify data (create, update, delete)
+- For operations requiring cleanup on failure (e.g., secrets), wrap in try/catch and clean up explicitly
+- Use `@TransactionConfiguration` only for extended timeout scenarios

--- a/docs/database-guidelines.md
+++ b/docs/database-guidelines.md
@@ -1,0 +1,127 @@
+# Database Guidelines
+
+## Flyway Migrations
+
+### Location and Module Structure
+- All migration files live in `database/src/main/resources/db/migration/`.
+- The `database` module is a shared dependency; it contains no Java code, only SQL migrations.
+- Flyway runs at startup via `quarkus.flyway.migrate-at-start=true` (backend always; engine/aggregator in dev/test profiles only).
+
+### Versioning Scheme
+- Format: `V1.<sequence>.0__<JIRA-TICKET>_<description>.sql`
+- The major version is always `1`. The minor version is a monotonically increasing integer (currently up to 129). The patch is always `0` except for rare hotfix corrections (e.g., `V1.55.1`, `V1.55.2`).
+- To add a new migration, find the highest existing minor version and increment by 1. Example: if `V1.129.0` exists, create `V1.130.0__RHCLOUD-XXXXX_description.sql`.
+- Use double underscores `__` between the version and the description.
+- Description uses snake_case with a leading Jira ticket ID (e.g., `RHCLOUD-43290_event_deduplication`).
+
+### Migration Content Conventions
+- Use plain SQL, not Java-based migrations.
+- Always use `snake_case` for table names, column names, index names, and constraint names.
+- Name constraints explicitly with prefixes: `pk_` (primary key), `fk_` (foreign key), `ix_` (index), `uq_` (unique).
+- Foreign keys should specify `ON DELETE CASCADE` where child rows are owned by the parent.
+- PostgreSQL-specific features are allowed (see PostgreSQL section below).
+- Never modify data and schema in ways that break backward compatibility with the running application. Migrations run before new code deploys.
+
+## Database and Connection Configuration
+
+- Database: **PostgreSQL 16** (Testcontainers use `postgres:16`).
+- Database name: `notifications`.
+- Connection: `jdbc:postgresql://127.0.0.1:5432/notifications` (overridden by Clowder in production).
+- The `pgcrypto` extension is required and installed in test setup. The initial migration (`V1.0.0`) enables it for `gen_random_uuid()`.
+- Hibernate physical naming strategy: `SnakeCasePhysicalNamingStrategy` -- automatically converts camelCase Java field names to snake_case column names. You do NOT need `@Column(name=...)` for simple fields.
+
+## JPA Entity Conventions
+
+### Entity Structure
+- Entities live in `common/src/main/java/com/redhat/cloud/notifications/models/`.
+- Module-specific entities (rare) can live in their own module (e.g., `backend/.../models/`, `aggregator/.../models/`, `engine/.../models/`).
+- Always annotate with `@Entity` and `@Table(name = "table_name")` with an explicit table name.
+- Use `jakarta.persistence` annotations (Jakarta EE, not javax).
+
+### ID Generation
+- Primary keys are `UUID` type in nearly all entities.
+- Two patterns exist:
+  1. **`@GeneratedValue`** on UUID `@Id` -- Hibernate generates the UUID (used by `Event`, `BehaviorGroup`, `EventType`, `Application`, `Bundle`).
+  2. **Application-generated UUID** -- The entity sets `id = UUID.randomUUID()` in a `@PrePersist` or `additionalPrePersist()` hook (used by `Endpoint`, `NotificationHistory`).
+- For join/association tables, use `@EmbeddedId` with a composite key class implementing `Serializable` (e.g., `BehaviorGroupActionId`, `EventTypeBehaviorId`, `DrawerNotificationId`).
+
+### Audit Timestamps
+- Entities that need created/updated timestamps extend `CreationUpdateTimestamped` (which extends `CreationTimestamped`).
+- `CreationTimestamped`: sets `created` via `@PrePersist` using `LocalDateTime.now(UTC)`.
+- `CreationUpdateTimestamped`: sets `updated` via `@PreUpdate` using `LocalDateTime.now(UTC)`.
+- Some entities (e.g., `Event`) manage their own `created` timestamp via a local `@PrePersist`.
+
+### Multi-Tenancy Fields
+- Most tenant-scoped entities have both `accountId` (legacy, nullable `VARCHAR(50)`) and `orgId` (`VARCHAR(50)`) fields.
+- Always filter queries by `orgId`. The `accountId` field is legacy and being phased out.
+- Default behavior groups have `orgId = NULL` (shared across all orgs).
+
+### Relationship Mapping
+- Use `FetchType.LAZY` for `@ManyToOne` and `@OneToOne` relationships (explicitly specified as `fetch = LAZY`).
+- `@OneToMany` defaults to lazy (no explicit annotation needed, but the codebase sometimes states it).
+- Use `CascadeType.REMOVE` on `@OneToMany` for owned children (e.g., `Event.historyEntries`, `BehaviorGroup.actions`).
+- The `EndpointProperties` hierarchy uses `@MapsId` + `@OneToOne` to share the same UUID primary key as the parent `Endpoint`.
+- Properties are loaded in a separate step via `loadProperties()` because they are `@Transient` on `Endpoint` and loaded by type-specific batch queries.
+
+### Enums
+- Use `@Enumerated(EnumType.STRING)` (never ordinal).
+- Custom JPA `@Converter` classes exist in `common/.../db/converters/` for types like `HttpType`, `EndpointType`, `SubscriptionType`, and for JSON/Map fields.
+
+### Sort Fields
+- Entities expose a `public static final Map<String, String> SORT_FIELDS` mapping API sort parameter names to JPQL field expressions (e.g., `"created" -> "e.created"`).
+
+## Repository Pattern
+
+### Structure
+- Repository classes are `@ApplicationScoped` CDI beans in `<module>/src/main/java/com/redhat/cloud/notifications/db/repositories/`.
+- They inject `EntityManager` directly (not Spring Data or Panache).
+- Class naming: `<Entity>Repository` (e.g., `EndpointRepository`, `EventRepository`, `BehaviorGroupRepository`).
+- No repository interfaces or abstract base classes -- each repository is a concrete class.
+
+### Query Patterns
+- **Primary query language: HQL/JPQL** via `entityManager.createQuery(hql, ResultType.class)`.
+- **Native SQL** is used when PostgreSQL-specific features are needed (e.g., `ON CONFLICT`, `jsonb` casts, `string_agg`, stored procedure calls). Use `entityManager.createNativeQuery(sql)`.
+- **QueryBuilder**: A custom fluent query builder (`com.redhat.cloud.notifications.db.builder.QueryBuilder`) is available for dynamic WHERE clause composition with `WhereBuilder`. Use it for queries with many optional filters.
+- Dynamic HQL string concatenation is also common for complex filter queries (see `EventRepository`).
+- Always use named parameters (`:paramName`), never positional parameters.
+- For pagination, use `query.setMaxResults(limit)` and `query.setFirstResult(offset)`.
+
+### Upserts
+- Use PostgreSQL `INSERT ... ON CONFLICT ... DO UPDATE/DO NOTHING` via native queries for upsert operations (e.g., `SubscriptionRepository.updateSubscription`).
+
+### Locking
+- `PESSIMISTIC_WRITE` lock mode is used in `BehaviorGroupRepository` and engine's `EndpointRepository` for concurrent modification scenarios. Apply via `.setLockMode(PESSIMISTIC_WRITE)` on the query.
+
+## Transaction Management
+
+- Use `@Transactional` from `jakarta.transaction.Transactional` (JTA, not Spring).
+- Place `@Transactional` on repository methods that perform writes (`persist`, `executeUpdate`, `DELETE`, etc.).
+- Read-only queries do NOT need `@Transactional`.
+- For batch operations requiring manual transaction control, inject `StatelessSession` from Hibernate and manage transactions explicitly (`beginTransaction()` / `commit()` / `rollback()`).
+
+## PostgreSQL-Specific Features
+
+- **pgcrypto extension**: Used for `gen_random_uuid()` in early migrations.
+- **JSONB columns**: Used for payload data, notification details, and subscription severities. Cast with `CAST(:param AS jsonb)` in native queries. Use `@JdbcTypeCode(SqlTypes.JSON)` for Hibernate mapping.
+- **`ON CONFLICT` (upsert)**: Widely used for idempotent inserts.
+- **`string_agg()`**: Used for aggregating values in native queries.
+- **`jsonb_each_text()`, `jsonb_object_agg()`**: Used for JSONB manipulation in native queries.
+- **Stored procedures**: Defined in migrations for cleanup jobs (`cleanEventLog`, `cleanKafkaMessagesIds`, `cleanEventDeduplication`), executed by external CronJobs.
+- **Custom autovacuum settings**: Configured per-table in migrations for high-churn tables.
+- **Index comments**: Used to document the purpose of indexes (`COMMENT ON INDEX ...`).
+
+## Testing
+
+- Tests use **Testcontainers** with PostgreSQL 16 via `TestLifecycleManager`.
+- The pgcrypto extension is installed manually in the test setup.
+- Flyway migrations run automatically in test mode.
+- Test helper classes (`ResourceHelpers`) create test data; prefer using them over raw SQL in tests.
+
+## Key Schema Patterns
+
+- UUIDs for all primary keys (no integer sequences in modern tables).
+- Composite primary keys for join/association tables (never surrogate IDs).
+- Denormalization is used strategically (e.g., `Event` stores `bundleDisplayName`, `applicationDisplayName`, `eventTypeDisplayName` to avoid joins).
+- Soft references: `NotificationHistory` duplicates `endpointType`/`endpointSubType` so data survives endpoint deletion.
+- The `CompositeEndpointType` `@Embeddable` pattern encapsulates type + subtype as a reusable embedded component.
+- Foreign key constraints with `ON DELETE CASCADE` for owned relationships.

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -1,0 +1,164 @@
+# Error Handling Guidelines
+
+Rules and conventions for implementing and reviewing error handling in the notifications-backend repository.
+
+## 1. Exception Hierarchy
+
+### Custom Exceptions in This Repo
+- `DelayedException` (extends `RuntimeException`) -- Used by `DelayedThrower` to accumulate multiple exceptions from loop iterations and rethrow them all at the end. Individual exceptions are attached via `addSuppressed`.
+- `ActionParsingException` (extends `RuntimeException`) -- Thrown when Kafka message payload cannot be parsed as an Action. Always provide a message; include the cause when wrapping another exception.
+- `KesselTransientException` (extends `RuntimeException`) -- Marker for retryable gRPC failures from Kessel. Only wraps `StatusRuntimeException`. Used as `retryOn` target for `@Retry`.
+- `TemplateNotFoundException` (extends `RuntimeException`) -- Thrown when no Qute template is found for a given integration type / bundle / app / event type combination.
+- `FilterExtractionException` (checked `Exception`) -- Thrown when export filter parameters are invalid.
+- `TransformationException` / `UnsupportedFormatException` (checked `Exception`) -- Used in the export pipeline for data transformation errors.
+- `IllegalIdentityHeaderException` (checked `Exception`) -- Thrown during x-rh-identity header parsing.
+
+### When to Create a New Custom Exception
+- Only create one if callers need to distinguish it for retry logic, exception mapping, or conditional handling.
+- Prefer standard JAX-RS exceptions (`BadRequestException`, `NotFoundException`, `WebApplicationException`) for REST endpoint validation errors.
+- Extend `RuntimeException` for exceptions that propagate through framework boundaries (Kafka consumers, Camel processors). Use checked exceptions only in self-contained pipelines (exports).
+
+## 2. REST Exception Mappers (backend module)
+
+### Existing Mappers -- Do Not Duplicate
+| Mapper | Catches | Returns |
+|---|---|---|
+| `JaxRsExceptionMapper` | `WebApplicationException` | Preserves status; maps `BadRequestException` and wrapped `JsonParseException` to 400 |
+| `NotFoundExceptionMapper` | `NotFoundException` | Original status, `text/plain` body |
+| `ConstraintViolationExceptionMapper` | `ConstraintViolationException` | 400 with JSON body (`title`, `description`, `violations[]`) |
+| `JsonParseExceptionMapper` | `JsonParseException` | 400 (legacy, may be unused) |
+
+### Rules
+- Throw `BadRequestException` with a descriptive message for invalid input in REST handlers. The mapper preserves the message.
+- Throw `NotFoundException` when a looked-up entity does not exist. Do NOT return `Response.status(NOT_FOUND)` from public API endpoints -- throw the exception so the mapper handles it consistently.
+- For internal-only endpoints (`/internal/*`), returning `Response.status(NOT_FOUND).build()` directly is acceptable (existing pattern).
+- Use `@Valid` on request body parameters; the `ConstraintViolationExceptionMapper` handles the rest.
+- Never catch and swallow `WebApplicationException` in REST resource methods -- let it propagate to the mapper.
+
+### REST Client Exception Mappers
+- For `@RegisterRestClient` interfaces, use `@ClientExceptionMapper` (Quarkus style) or implement `ResponseExceptionMapper` and register it with `@RegisterProvider`.
+- Pattern: convert the response status + body into a `WebApplicationException` with a formatted message including the status code and response body text. See `ExportServicePsk` and `BadRequestExceptionMapper`.
+
+### recipients-resolver Module
+- Has its own `WebApplicationExceptionMapper` with similar logic to the backend's `JaxRsExceptionMapper`. Keep them consistent if modifying either.
+
+## 3. Retry Logic
+
+### MicroProfile @Retry -- Conventions
+- Standard pattern: `@Retry(maxRetries = 3)` for REST client calls to internal services (Sources, Export Service, Engine).
+- For Kessel gRPC: `@Retry(maxRetries = 3, delay = 100, retryOn = KesselTransientException.class)` -- only retry on the marker exception, not all failures.
+- For connector REST clients (v2): `@Retry(delay = 1, delayUnit = ChronoUnit.SECONDS, maxRetries = 2)` -- always add a comment clarifying total attempts (e.g., "1 initial + 2 retries = 3 attempts").
+- Never use `@Retry` without specifying `maxRetries`. The default is unbounded.
+
+### Mutiny Retry (ConsoleIdentityProvider)
+- Used for RBAC calls: `.onFailure(IOException | ConnectTimeoutException).retry().withBackOff(initial, max).atMost(n)`.
+- After retries exhausted, transform the failure into `AuthenticationFailedException`.
+- This pattern is specific to the authentication path; do not use Mutiny retry elsewhere unless the call is already reactive.
+
+### Camel Redelivery (connector-common, v1 connectors)
+- Configured in `EngineToConnectorRouteBuilder` via `onException(Throwable.class)`.
+- Two `onException` clauses: one with redelivery (when `RedeliveryPredicate.matches`), one without.
+- Default `RedeliveryPredicate`: retries on `IOException`. HTTP connectors extend this to also retry on 5xx and 429.
+- Config: `redelivery.max-attempts` (default 2), `redelivery.delay` (default 1000ms).
+- After redelivery exhaustion, the `ExceptionProcessor` handles the failure.
+
+### When to Add Retry
+- Add retry ONLY for transient, idempotent failures (network timeouts, 5xx, gRPC UNAVAILABLE/DEADLINE_EXCEEDED).
+- Never retry on 4xx (except 429), validation errors, or permission errors.
+- Always set a bounded `maxRetries`.
+
+## 4. Kafka Error Handling
+
+### Kafka Reinjection (v1 Camel Connectors)
+- When a connector fails to deliver to an external service, `ExceptionProcessor` decides: if `reinjectionCount < kafkaMaximumReinjections` (default 3), reinject the message back to the incoming Kafka topic; otherwise, report failure to the engine.
+- Reinjection delay uses exponential backoff: 10s, 30s, 1min, then half of `max.poll.interval.ms`.
+- The reinjection count is tracked in the Kafka header `x-rh-notifications-connector-reinjections-count`.
+- Email connector sets `kafka.maximum-reinjections=0` (no reinjection).
+
+### Kafka Consumer Error Handling (v2 Connectors, Engine)
+- v2 `MessageConsumer`: catches all exceptions, delegates to `ExceptionHandler.processException()`, sends failure response to engine via `OutgoingMessageSender.sendFailure()`, then ACKs the message. Messages are NEVER nacked.
+- Engine `EventConsumer`: catches all exceptions in a top-level try/catch, logs at INFO level with the payload, increments `input.processing.exception` counter. The message is always ACKed (`message.ack()` is called unconditionally).
+- Engine `ConnectorReceiver`: uses `@Acknowledgment(POST_PROCESSING)` -- the message is ACKed after `processAsync` returns. Errors in processing are caught, logged, and counted but do not prevent ACK.
+- No dead-letter-queue configuration exists; all Kafka failure strategies are handled in application code.
+
+### Rules for Kafka Consumers
+- Always ACK messages. Never let exceptions propagate past the `@Incoming` method unhandled -- this would trigger SmallRye's default failure strategy and potentially block the consumer.
+- Increment a counter on failure for observability.
+- Include `orgId` and `historyId` (or message ID) in error logs for traceability.
+
+## 5. Camel Connector Exception Handling
+
+### ExceptionProcessor (v1) / ExceptionHandler (v2)
+- Both are `@DefaultBean @ApplicationScoped` -- override by creating a subclass in the connector module.
+- `ExceptionProcessor` (v1): implements Camel `Processor`, sets `SUCCESSFUL=false` and `OUTCOME=exception message`, then decides between reinjection and reporting to engine.
+- `ExceptionHandler` (v2): returns `HandledExceptionDetails` with outcome message and optional connector-specific details.
+
+### HTTP Connector Exception Classification
+- `HttpExceptionProcessor` / `HttpExceptionHandler` classify exceptions by type and set `HTTP_ERROR_TYPE`:
+  - `HttpOperationFailedException` / `ClientWebApplicationException` -> classified by status code (3xx, 4xx, 5xx)
+  - `ConnectTimeoutException`, `SocketTimeoutException`, `HttpHostConnectException`, `SSLHandshakeException`, `UnknownHostException`, `SSLException` -> each gets a specific error type
+  - Anything else -> falls through to `logDefault`
+- HTTP 429 is grouped with 5xx (retryable), NOT with 4xx.
+- Log levels for HTTP errors are configurable: `serverErrorLogLevel` for 3xx/5xx/429, `clientErrorLogLevel` for 4xx.
+
+### Rules for New Connectors
+- Extend `ExceptionProcessor` (v1) or `ExceptionHandler` (v2) if the connector needs custom error classification.
+- Always call `logDefault(t, exchange)` as the fallback for unrecognized exceptions.
+- For HTTP-based connectors, extend `HttpExceptionProcessor` / `HttpExceptionHandler` rather than the base class.
+
+## 6. gRPC Error Handling (Kessel)
+
+### Status Code Classification
+- Transient (retryable): `UNAVAILABLE`, `DEADLINE_EXCEEDED`, `RESOURCE_EXHAUSTED`, `ABORTED` -> wrap in `KesselTransientException`, log at WARN.
+- Auth failure: `UNAUTHENTICATED` -> also transient, but additionally triggers channel recreation with fresh OAuth2 credentials.
+- Non-transient: `PERMISSION_DENIED`, `NOT_FOUND`, `INVALID_ARGUMENT`, etc. -> rethrow original `StatusRuntimeException`, log at ERROR.
+- All gRPC errors increment `notifications.kessel.grpc.error` counter with `error_type` tag.
+
+### Rules
+- Never catch `StatusRuntimeException` and return a default value. Always rethrow (directly or wrapped).
+- In REST-facing code that calls Kessel, catch `StatusRuntimeException` and convert to `WebApplicationException` with a descriptive message (see `RecipientsResolverResource`).
+
+## 7. DelayedThrower Pattern
+
+- Use `DelayedThrower.throwEventually(message, accumulator -> { ... })` when processing multiple items in a loop where one failure should NOT stop processing of the others.
+- Inside the loop, catch exceptions and call `accumulator.add(e)`.
+- After the loop, if any exceptions were accumulated, a single `DelayedException` is thrown with all failures as suppressed exceptions.
+- Used in `EndpointProcessor.process()` to ensure all endpoint types are attempted even if some fail.
+- Nested `DelayedException` instances are automatically flattened.
+
+## 8. Logging Conventions
+
+### Logger
+- Use `io.quarkus.logging.Log` (static import) everywhere. This is a compile-time generated logger -- no need to declare a `Logger` field. There are 120+ files using this pattern.
+- `org.jboss.logging.Logger` is used only in 2 connector files for level-parameterized logging (`Log.logf(level, ...)`). Use it only when the log level must be dynamic.
+
+### Log Levels for Errors
+- `Log.errorf(exception, formatString, args)` -- Non-transient, unexpected failures. Always include the exception as first argument.
+- `Log.warnf(formatString, args)` -- Transient failures that will be retried, or degraded-but-recoverable situations.
+- `Log.infof(exception, formatString, args)` -- Used in `EventConsumer` for payload processing failures (high volume, expected to happen).
+- Never use `Log.error(exception)` without context (message string). Always include identifying information.
+
+### Required Context in Error Logs
+- Always include: `orgId`, `historyId` (or event ID), and the operation being performed.
+- For connector errors, also include: `targetUrl`, `routeId`.
+- For HTTP errors, also include: `statusCode`, `responseBody`.
+- Format: `"Message sending failed [orgId=%s, historyId=%s, targetUrl=%s, statusCode=%d]"`.
+
+## 9. Metrics for Errors
+
+- Increment counters on all error paths. Existing counter naming conventions:
+  - `input.rejected` -- unparseable or unknown event types
+  - `input.processing.error` -- endpoint processing failures
+  - `input.processing.exception` -- any exception during Kafka message handling
+  - `camel.messages.error` -- connector return processing failures
+  - `notifications.kessel.grpc.error` (with `error_type` tag) -- gRPC failures
+- Use Micrometer `Counter` and `Timer` via injected `MeterRegistry`.
+
+## 10. Anti-Patterns to Avoid
+
+1. **Swallowing exceptions silently** -- Always log or count. Never write empty catch blocks.
+2. **Logging and rethrowing** -- Pick one. Log at the handling boundary, not at every layer.
+3. **Catching `Exception` too broadly** -- Prefer specific exception types when the handling differs.
+4. **Returning null on error** -- Throw an appropriate exception instead. The exception mappers will convert it to a proper HTTP response.
+5. **Using `e.printStackTrace()`** -- Use `Log.errorf(e, ...)` instead.
+6. **Interrupting threads without restoring the flag** -- When catching `InterruptedException`, always call `Thread.currentThread().interrupt()` (see `KesselCheckClient.preDestroy`).

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -48,7 +48,7 @@ Rules and conventions for implementing and reviewing error handling in the notif
 - Standard pattern: `@Retry(maxRetries = 3)` for REST client calls to internal services (Sources, Export Service, Engine).
 - For Kessel gRPC: `@Retry(maxRetries = 3, delay = 100, retryOn = KesselTransientException.class)` -- only retry on the marker exception, not all failures.
 - For connector REST clients (v2): `@Retry(delay = 1, delayUnit = ChronoUnit.SECONDS, maxRetries = 2)` -- always add a comment clarifying total attempts (e.g., "1 initial + 2 retries = 3 attempts").
-- Never use `@Retry` without specifying `maxRetries`. The default is unbounded.
+- The MicroProfile Fault Tolerance default for `maxRetries` is 3. Always specify `maxRetries` explicitly for clarity (`-1` would mean unbounded, but is never used in this repo).
 
 ### Mutiny Retry (ConsoleIdentityProvider)
 - Used for RBAC calls: `.onFailure(IOException | ConnectTimeoutException).retry().withBackOff(initial, max).atMost(n)`.

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -159,8 +159,8 @@ if (auth.isPresent() && BEARER == auth.get().authenticationType) {
 - Large email payloads exceeding `kafkaToCamelMaximumRequestSize` are stored in the database (`PayloadDetails`) and referenced by ID in the Kafka message.
 
 ## Testing Conventions
-- Use `@QuarkusTest` for all integration tests.
-- v2 connector tests extend `BaseConnectorIntegrationTest` (or `BaseHttpConnectorIntegrationTest` for HTTP connectors).
+- **v2 connector tests**: Use `@QuarkusTest` and extend `BaseConnectorIntegrationTest` (or `BaseHttpConnectorIntegrationTest` for HTTP connectors).
+- **v1 Camel connector tests**: Extend `ConnectorRoutesTest` (which extends `CamelQuarkusTestSupport`). Do not use `@QuarkusTest`.
+- **Backend/engine integration tests**: Use `@QuarkusTest` with `@QuarkusTestResource(TestLifecycleManager.class)`.
 - Use WireMock (`MockServerLifecycleManager`) for external service mocking.
 - Use `MicrometerAssertionHelper` for verifying metric values in tests.
-- Use `@QuarkusTestResource(TestLifecycleManager.class)` for lifecycle management.

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -1,0 +1,166 @@
+# Integration Guidelines
+
+## Architecture Overview
+
+This repo is a multi-module Quarkus application with an event-driven architecture. The primary flow is: **ingress Kafka topic -> engine -> connector Kafka topics -> connectors -> external services -> response Kafka topic -> engine**.
+
+There are two connector frameworks coexisting: **v1 (Apache Camel-based)** in `connector-common` and **v2 (SmallRye Reactive Messaging-based)** in `connector-common-v2`. New connectors should use v2.
+
+## Kafka Messaging
+
+### Topic Naming Convention
+- Ingress: `platform.notifications.ingress` (engine consumes events from producing applications)
+- Engine-to-connectors: `platform.notifications.tocamel` (engine sends to connectors)
+- Connectors-to-engine: `platform.notifications.fromcamel` (connectors report results back)
+- High-volume: `platform.notifications.connector.email.high.volume` (dedicated topic for high-traffic email)
+
+### Channel Constants
+- Define channel names as `public static final String` constants (e.g., `INGRESS_CHANNEL = "ingress"`, `TOCAMEL_CHANNEL = "tocamel"`).
+- Reference these constants in `@Incoming`, `@Channel`, and test overrides.
+- Channel names in `application.properties` must match the annotation values exactly.
+
+### SmallRye Reactive Messaging Patterns (v2 connectors)
+- Use `@Incoming("incomingmessages")` for consuming from Kafka.
+- Use `@Channel("outgoingmessages")` with `Emitter<String>` for producing to Kafka.
+- Annotate consumers with `@Blocking("connector-thread-pool")` and `@RunOnVirtualThread`.
+- Consumer methods return `CompletionStage<Void>` and must call `message.ack()`.
+- Outgoing messages use structured Cloud Events mode: `mp.messaging.outgoing.outgoingmessages.cloud-events-mode=structured`.
+
+### Kafka Configuration Rules
+- Serialization: always `StringSerializer`/`StringDeserializer` for both key and value.
+- Enable `snappy` compression for outgoing `tocamel` and `highvolume` topics (payloads can be large).
+- Set `mp.messaging.outgoing.egress.merge=true` when multiple emitters share a topic.
+- Use `pausable=true` for channels that support backpressure control.
+- Group IDs use the pattern `notifications-connector-{name}` for connectors or `integrations` for the engine.
+
+### Test Configuration
+- Override connectors with `smallrye-in-memory` in `src/test/resources/application.properties`:
+  ```
+  mp.messaging.incoming.incomingmessages.connector=smallrye-in-memory
+  mp.messaging.outgoing.outgoingmessages.connector=smallrye-in-memory
+  ```
+- Inject `InMemoryConnector` with `@Any` qualifier in tests.
+- Use `InMemorySource<Message<JsonObject>>` to send and `InMemorySink<String>` to receive.
+
+## Cloud Events
+
+### Format
+- Spec version: `1.0`.
+- Engine-to-connector type: `com.redhat.console.notification.toCamel.{connector}` (e.g., `com.redhat.console.notification.toCamel.webhook`).
+- Connector-to-engine type: `com.redhat.console.notifications.history`.
+- Cloud Event ID = `historyId` (UUID), used to correlate the outgoing request with the return notification.
+- Data content type: `application/json`.
+
+### Building Outgoing Cloud Events (Engine)
+- Attach three metadata objects to each `Message`: `OutgoingKafkaRecordMetadata` (with `x-rh-notifications-connector` header), `OutgoingCloudEventMetadata`, and `TracingMetadata`.
+- The `x-rh-notifications-connector` Kafka header routes messages to the correct connector.
+
+### Parsing Incoming Events (Engine)
+- The engine tries to parse payloads as `Action` first, then as `ConsoleCloudEvent`.
+- `EventWrapperAction` and `EventWrapperCloudEvent` are the two wrapper types.
+- Cloud Events can be transformed to Actions via `CloudEventTransformerFactory`.
+
+## Connector Architecture
+
+### v2 Connectors (preferred for new work)
+Located in `connector-common-v2`, `connector-common-http-v2`, and `connector-common-authentication-v2`.
+
+**Key classes to extend/override (all use `@DefaultBean` + `@Priority`):**
+1. `MessageHandler` -- override `handle(IncomingCloudEventMetadata<JsonObject>)` to implement connector logic. Return `HandledMessageDetails`.
+2. `ExceptionHandler` -- override `process(Throwable, IncomingCloudEventMetadata)` to customize error handling. Return `HandledExceptionDetails`.
+3. `OutgoingCloudEventBuilder` -- override `buildSuccess`/`buildFailure` to add custom metadata to responses.
+4. `ConnectorConfig` -- extend to add connector-specific configuration. Use `@Priority(BASE_CONFIG_PRIORITY + 1)`.
+
+**HTTP connectors** additionally depend on `connector-common-http-v2`:
+- Use `HttpNotificationValidator` to parse and validate incoming payloads with Bean Validation.
+- Use `HttpRestClient` (or define a custom `@RegisterRestClient`) for outgoing HTTP calls.
+- Extend `HttpExceptionHandler` for HTTP-specific error classification (3xx/4xx/5xx, SSL, timeout, DNS).
+
+**Message flow in v2:** `MessageConsumer.processMessage()` -> filters by `x-rh-notifications-connector` header -> calls `MessageHandler.handle()` -> `OutgoingMessageSender.sendSuccess/sendFailure()`.
+
+### v1 Connectors (Camel-based, legacy)
+Located in `connector-common`. Used by: Slack, Teams, Google Chat, PagerDuty, ServiceNow, Splunk.
+
+**Key classes to extend:**
+1. `EngineToConnectorRouteBuilder` -- override `configureRoutes()` to define the Camel route from `seda(ENGINE_TO_CONNECTOR)` to external service, ending with `to(direct(SUCCESS))`.
+2. `CloudEventDataExtractor` -- override `extract(Exchange, JsonObject)` to extract data from Cloud Event payload into Camel exchange properties.
+3. `ConnectorConfig` / `HttpConnectorConfig` -- extend for connector-specific settings.
+
+**Camel route structure:**
+- Kafka consumer -> `IncomingCloudEventFilter` (header check) -> `IncomingCloudEventProcessor` (extracts CE fields) -> SEDA queue -> connector route -> `ConnectorToEngineRouteBuilder` (sends result back).
+- Error handling uses Camel's `onException` with configurable redelivery (default: 2 retries, 1s delay).
+- Camel supports message reinjection back to Kafka with async delay for retry scenarios.
+
+### Required Configuration Per Connector
+In `application.properties`, every connector must set:
+```
+notifications.connector.name={name}
+notifications.connector.supported-connector-headers={comma-separated-headers}
+notifications.connector.kafka.incoming.topic=${mp.messaging.tocamel.topic}
+notifications.connector.kafka.outgoing.topic=${mp.messaging.fromcamel.topic}
+```
+
+### Connector Header Routing
+- The engine sets `x-rh-notifications-connector` Kafka header to the connector name.
+- Both v1 and v2 connectors filter messages by checking this header against `supportedConnectorHeaders`.
+- A connector can handle multiple header values (e.g., webhook handles both `ansible` and `webhook`).
+
+## Authentication
+
+### Sources API Integration
+- Use `AuthenticationLoader.fetchAuthenticationData(orgId, authenticationData)` to retrieve secrets.
+- Supports two auth types: `BEARER` and `SECRET_TOKEN` (via `AuthenticationType` enum).
+- Secrets are fetched from the Sources API, with a transition from PSK to OIDC authentication controlled by the `sources-oidc-auth` Unleash toggle.
+- REST clients: `SourcesPskClient` (configKey `sources`) and `SourcesOidcClient` (configKey `sources-oidc`).
+
+### Webhook Authentication Pattern
+```java
+Optional<AuthenticationResult> auth = authenticationLoader.fetchAuthenticationData(orgId, notification.getAuthentication());
+if (auth.isPresent() && BEARER == auth.get().authenticationType) {
+    response = client.postWithBearer("Bearer " + auth.get().password, url, body);
+}
+```
+
+## Event Deduplication
+
+### Kafka-Level (deprecated)
+- `KafkaMessageDeduplicator` validates the `rh-message-id` Kafka header (must be UUID v4).
+- Being replaced by the `id` field in the Action/CloudEvent payload.
+
+### Application-Level
+- `EventDeduplicator.isNew(Event)` uses DB-backed deduplication with `event_deduplication` table.
+- Deduplication is configurable per bundle/application via `EventDeduplicationConfig` implementations.
+- Uses `INSERT ... ON CONFLICT DO NOTHING` for atomic duplicate detection.
+- Events without a deduplication key are always treated as new.
+
+## REST Client Patterns
+- All external service clients use `@RegisterRestClient(configKey = "...")`.
+- Configure URL, timeouts, and TLS in `application.properties` under `quarkus.rest-client.{configKey}.*`.
+- Use `@Retry` from MicroProfile Fault Tolerance for retries (e.g., webhook: 1s delay, 2 retries).
+- Dynamic URLs use `@Url String url` parameter with `quarkus-rest-client-reactive`.
+
+## Metrics and Observability
+- Use Micrometer (`MeterRegistry`) for all metrics -- never raw Prometheus.
+- Name counters/timers with dot-separated names (e.g., `input.consumed`, `camel.messages.processed`).
+- Tag metrics with `bundle`, `application`, `event-type`, and `connector` where applicable.
+- Initialize counters in `@PostConstruct` methods for counters used in hot paths.
+- Use `Timer.Sample` pattern: `Timer.start(registry)` at beginning, `sample.stop(registry.timer(...))` at end.
+- Track payload sizes with `DistributionSummary`.
+
+## Feature Flags
+- Feature toggles use Unleash via `ToggleRegistry.register(toggleName, defaultValue)`.
+- Build `UnleashContext` with `UnleashContextBuilder.buildUnleashContextWithOrgId(orgId)` for org-scoped toggles.
+- Config classes expose toggle state via methods like `isFeatureEnabled(String orgId)`.
+
+## High Volume Traffic
+- Events from `errata-notifications` application are routed to a dedicated `highvolume` Kafka topic.
+- Only the email connector (`email_subscription`) is compatible with the high-volume topic.
+- Controlled by `engineConfig.isOutgoingKafkaHighVolumeTopicEnabled()`.
+- Large email payloads exceeding `kafkaToCamelMaximumRequestSize` are stored in the database (`PayloadDetails`) and referenced by ID in the Kafka message.
+
+## Testing Conventions
+- Use `@QuarkusTest` for all integration tests.
+- v2 connector tests extend `BaseConnectorIntegrationTest` (or `BaseHttpConnectorIntegrationTest` for HTTP connectors).
+- Use WireMock (`MockServerLifecycleManager`) for external service mocking.
+- Use `MicrometerAssertionHelper` for verifying metric values in tests.
+- Use `@QuarkusTestResource(TestLifecycleManager.class)` for lifecycle management.

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -1,0 +1,151 @@
+# Performance Guidelines
+
+Rules for AI agents implementing or reviewing code in the notifications-backend repository.
+
+## 1. Caching with Quarkus Cache (Caffeine)
+
+### 1.1 Use `@CacheResult` for repetitive external lookups
+This repo caches DB lookups (event types, templates, bundles), RBAC calls, and recipients-resolver results using `io.quarkus.cache.CacheResult`. When adding a new cacheable method, follow these conventions:
+- The method **must be on an `@ApplicationScoped` CDI bean** (not `@Dependent`), and calls must go through the CDI proxy (no `this.method()` calls to cached methods).
+- Define the TTL in the relevant module's `application.properties` using `quarkus.cache.caffeine.<cache-name>.expire-after-write`.
+- Always set `quarkus.cache.caffeine.<cache-name>.metrics-enabled=true` so the cache is observable.
+- Use short TTLs for volatile data (e.g., `PT1M` for recipients-resolver results) and longer TTLs for stable reference data (e.g., `PT15M` for bundles/apps).
+
+### 1.2 Existing cache TTL conventions
+| Cache | TTL | Module |
+|---|---|---|
+| `event-types-from-baet` / `event-types-from-fqn` | 5 min | engine |
+| `recipients-resolver-results` | 1 min | engine |
+| `recipients-users-provider-get-users` | 10 min | recipients-resolver |
+| `find-recipients` | 10 min | recipients-resolver |
+| `rbac-cache` | 2 min | backend |
+| `kessel-oauth2-client-credentials` | 7 days | backend |
+| `get-bundle-by-id` / `get-app-by-name` | 15 min | engine |
+
+### 1.3 Provide cache invalidation
+When a cache wraps credentials or tokens (see `OAuth2ClientCredentialsCache`), provide a `@CacheInvalidateAll` method so the cache can be cleared on auth failures.
+
+### 1.4 Test with cache disabled
+Engine tests set `quarkus.cache.enabled=false`. Ensure new cached methods work correctly in both cached and uncached modes.
+
+## 2. Kafka Consumer and Producer Patterns
+
+### 2.1 Consumer method signature
+Kafka consumers use `@Incoming("channel-name")` with `@Blocking` annotation. They return `CompletionStage<Void>` and call `message.ack()`. Follow the pattern in `EventConsumer` and `ConnectorReceiver`.
+
+### 2.2 Use `@ActivateRequestContext` on message processors
+Methods that access JPA entities from Kafka consumer threads **must** be annotated with `@ActivateRequestContext` to ensure a CDI request context is active. See `EventConsumer.process()` and `ConnectorReceiver.processAsync()`.
+
+### 2.3 Enable Snappy compression for large outgoing messages
+Outgoing Kafka topics carrying potentially large payloads (e.g., rendered emails) must set `mp.messaging.outgoing.<channel>.compression.type=snappy`. Both `tocamel` and `highvolume` channels do this.
+
+### 2.4 High-volume traffic separation
+Route high-volume applications (currently `errata-notifications`) to a dedicated `highvolume` Kafka channel. Check `ConnectorSender.isEventFromHighVolumeApplication()` before adding new routing rules.
+
+### 2.5 Large payload offloading
+When Kafka message payload exceeds `mp.messaging.outgoing.tocamel.max.request.size` (default 10MB), the payload is stored in the database and a reference ID is sent instead. Follow the pattern in `ConnectorSender.send()`.
+
+### 2.6 Pausable channels
+Mark Kafka incoming channels that need runtime control as `pausable=true` in `application.properties`. Use `KafkaChannelManager` and Unleash feature flags to pause/resume channels per host.
+
+### 2.7 Connector message filtering
+In connector-common-v2, `MessageConsumer` filters messages by the `x-rh-notifications-connector` Kafka header. Ack and skip messages not matching the connector's supported headers -- never process them.
+
+### 2.8 Virtual threads in connectors
+Connector-v2 `MessageConsumer` uses `@RunOnVirtualThread` with `@Blocking("connector-thread-pool")`. The pool concurrency is configured via `smallrye.messaging.worker.connector-thread-pool.max-concurrency` (default 20 for drawer).
+
+## 3. Concurrency and Thread Safety
+
+### 3.1 EventConsumer thread pool
+`EventConsumer` uses a custom `ThreadPoolExecutor` with a blocking `LinkedBlockingQueue` that overrides `offer()` to call `put()`, creating **back-pressure** from the thread pool to the Kafka consumer. Configurable via:
+- `notifications.event-consumer.core-thread-pool-size` (default 10)
+- `notifications.event-consumer.max-thread-pool-size` (default 10)
+- `notifications.event-consumer.queue-capacity` (default 1)
+
+Do not increase queue capacity without understanding the back-pressure implications.
+
+### 3.2 Volatile fields for shared mutable state
+Use `volatile` for fields written during initialization and read by multiple request threads. See `KesselCheckClient.grpcClient` and `grpcChannel`. Do not use `volatile` for immutable or CDI-injected fields.
+
+### 3.3 ConcurrentHashMap for dynamic registrations
+Use `ConcurrentHashMap` with `computeIfAbsent` for lazily-initialized, thread-safe registries (e.g., `FetchUsersFromExternalServices.rbacUsers` gauge map).
+
+### 3.4 Pessimistic locking for atomic DB operations
+Use `PESSIMISTIC_WRITE` (`SELECT FOR UPDATE`) when an operation must be atomic across pods/threads. See `EndpointRepository.lockEndpoint()` for the endpoint server-errors counter pattern. Always keep the locked transaction short.
+
+## 4. gRPC Channel Management (Kessel)
+
+### 4.1 Channel lifecycle
+- Initialize in `@PostConstruct`, shut down in `@PreDestroy` with `awaitTermination`.
+- On `UNAUTHENTICATED` errors, recreate the channel with fresh OAuth2 credentials.
+- On `SHUTDOWN` state, recreate the channel (terminal state, cannot recover).
+- When replacing a channel, call `shutdown()` on the old channel without waiting.
+
+### 4.2 Timeouts and retries
+- Set `withDeadlineAfter` on every gRPC call using a configurable timeout (`notifications.kessel.timeout-ms`).
+- Use `@Retry(maxRetries = 3, delay = 100, retryOn = KesselTransientException.class)` for transient gRPC errors (UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, ABORTED).
+
+### 4.3 Error classification
+Distinguish transient errors (retry) from permanent errors (propagate immediately). Track all gRPC errors with Micrometer counters tagged by error code.
+
+## 5. Database Query Optimization
+
+### 5.1 Use JOIN FETCH for entity graphs
+Always use `JOIN FETCH` in JPQL when you need associated entities to avoid N+1 queries. See `EventTypeRepository.getEventType()` which fetches application and bundle in one query.
+
+### 5.2 Batch-load properties by type
+`EndpointRepository.loadProperties()` groups endpoints by type and loads all properties per type in a single `IN` query. Follow this pattern instead of loading properties one-by-one.
+
+### 5.3 Pagination for external service calls
+Use offset-based pagination with configurable page size (`recipientsResolverConfig.getMaxResultsPerPage()`). Loop until the returned page is smaller than the max page size. See `FetchUsersFromExternalServices.getWithPagination()`.
+
+### 5.4 Flyway migrations
+Never run Flyway migrations in production (`%prod` profile). Migrations are the responsibility of `notifications-backend`. Only `%dev` and `%test` profiles auto-migrate.
+
+## 6. Retry and Resilience Patterns
+
+### 6.1 Failsafe retry policy
+Use `dev.failsafe.RetryPolicy` with exponential backoff for external service calls. Configure via properties:
+- `max-attempts` (default 3)
+- `initial-backoff` / `max-backoff`
+- Handle only `IOException` (or specific transient exceptions)
+- Log on `onRetriesExceeded`, not on every retry
+
+### 6.2 MicroProfile Fault Tolerance
+Use `@Retry` from MicroProfile for CDI-proxied methods (e.g., `KesselCheckClient`). Specify `retryOn` with a custom transient exception class to avoid retrying permanent failures.
+
+### 6.3 RBAC call resilience
+RBAC calls in `ConsoleIdentityProvider` use Mutiny `.retry().withBackOff().atMost()` chaining. Retry only on `IOException` and `ConnectTimeoutException`.
+
+## 7. Metrics and Monitoring
+
+### 7.1 Counter initialization
+Initialize `Counter` instances in `@PostConstruct` and store as fields when the counter has static tags. See `EventConsumer.init()`.
+
+### 7.2 Dynamic tags
+For counters/timers with dynamic tags (bundle, application, event-type), create them inline with `registry.counter(name, tagKey, tagValue, ...)`. Use `tags.getOrDefault(key, "")` -- Micrometer throws NPE on null tag values.
+
+### 7.3 Timer.Sample for elapsed time
+Use `Timer.start(registry)` at the beginning and `sample.stop(registry.timer(...))` at the end. Do not use `System.currentTimeMillis()` for metrics (only for non-metric timing).
+
+### 7.4 Distribution summaries for payload sizes
+Use `DistributionSummary` with `baseUnit("bytes")` for measuring payload sizes. See `ConnectorSender.recordMetrics()`.
+
+### 7.5 Prometheus PushGateway
+The aggregator job uses `PushGateway` for batch job metrics. Only push in non-dev/test environments.
+
+## 8. Feature Flags (Unleash)
+
+### 8.1 Toggle registration pattern
+Register toggles in `@PostConstruct` via `ToggleRegistry.register()` with a default value. Check with `unleash.isEnabled(toggleName, context, fallback)`. Always provide an env-var fallback for non-Unleash environments.
+
+### 8.2 Blacklisting via Unleash context
+Endpoint and event-type blacklisting uses `UnleashContext` with custom properties (`endpointId`, `eventTypeId`). New feature flags that target specific entities should follow this pattern.
+
+## 9. Reactive Patterns (Mutiny)
+
+Mutiny (`Uni`/`Multi`) is used sparingly and only in the backend module for authentication flows. The engine and connectors use blocking/imperative style with `@Blocking`. Do not introduce Mutiny in modules that currently use imperative patterns.
+
+## 10. Log-Level Guards
+
+Use `Log.isDebugEnabled()` before constructing expensive debug log messages (e.g., joining user lists). See `FetchUsersFromExternalServices.getUsers()`. Prefer `Log.infof`/`Log.debugf` with format strings over string concatenation.

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -100,7 +100,7 @@ Always use `JOIN FETCH` in JPQL when you need associated entities to avoid N+1 q
 Use offset-based pagination with configurable page size (`recipientsResolverConfig.getMaxResultsPerPage()`). Loop until the returned page is smaller than the max page size. See `FetchUsersFromExternalServices.getWithPagination()`.
 
 ### 5.4 Flyway migrations
-Never run Flyway migrations in production (`%prod` profile). Migrations are the responsibility of `notifications-backend`. Only `%dev` and `%test` profiles auto-migrate.
+The backend service runs Flyway migrations at startup in all profiles (including prod). Engine and aggregator only auto-migrate in `%dev`/`%test` profiles. See `docs/database-guidelines.md` for migration conventions.
 
 ## 6. Retry and Resilience Patterns
 

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -12,6 +12,7 @@ This repo caches DB lookups (event types, templates, bundles), RBAC calls, and r
 - Use short TTLs for volatile data (e.g., `PT1M` for recipients-resolver results) and longer TTLs for stable reference data (e.g., `PT15M` for bundles/apps).
 
 ### 1.2 Existing cache TTL conventions
+
 | Cache | TTL | Module |
 |---|---|---|
 | `event-types-from-baet` / `event-types-from-fqn` | 5 min | engine |

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -1,0 +1,101 @@
+# Security Guidelines
+
+Rules for AI agents implementing or reviewing code in the notifications-backend repository.
+
+## 1. Authentication: x-rh-identity Header
+
+- All external requests are authenticated via the `x-rh-identity` Base64-encoded header (`Constants.X_RH_IDENTITY_HEADER`).
+- The header is decoded and deserialized into a `ConsoleIdentity` subtype using Jackson polymorphic deserialization in `ConsoleIdentityProvider.getRhIdentityFromString()`.
+- Supported identity types: `User` (`RhUserIdentity`), `ServiceAccount` (`RhServiceAccountIdentity`), `Associate/SAML` (`TurnpikeSamlIdentity`), `X509` (`TurnpikeX509Identity`).
+- Never process requests without verifying that `org_id` is present and non-blank for `RhIdentity` types. The existing code rejects null/blank `org_id` with `AuthenticationFailedException`.
+- Never expose authentication failure details in response bodies. Tests explicitly assert `body(emptyString())` on 401 responses. Follow this pattern: throw `AuthenticationFailedException()` without a message that reaches the client.
+- The `ConsoleAuthMechanism` whitelists unauthenticated paths (OpenAPI specs, health, metrics, validation endpoints). Do not add new unauthenticated paths without security review.
+
+## 2. Authorization: Dual RBAC/Kessel System
+
+### 2.1 Legacy RBAC (role-based)
+- RBAC permissions are fetched from an external RBAC server via `RbacServer` REST client at authentication time and cached (`@CacheResult(cacheName = "rbac-cache")`).
+- Roles are mapped to constants in `ConsoleIdentityProvider`: `RBAC_READ_NOTIFICATIONS`, `RBAC_WRITE_NOTIFICATIONS`, `RBAC_READ_INTEGRATIONS_ENDPOINTS`, `RBAC_WRITE_INTEGRATIONS_ENDPOINTS`, `RBAC_READ_NOTIFICATIONS_EVENTS`.
+- Internal API endpoints use `@RolesAllowed` with `RBAC_INTERNAL_USER` (read) or `RBAC_INTERNAL_ADMIN` (write). Apply these annotations consistently to all internal endpoints.
+
+### 2.2 Kessel (relationship-based)
+- Kessel is the newer authorization backend and takes priority when enabled for an org (`backendConfig.isKesselEnabled(orgId)`).
+- When Kessel is enabled, no RBAC roles are attached to the `SecurityIdentity`; authorization happens at request time via gRPC calls to Kessel Inventory.
+- Use the `@Authorization` annotation on endpoint methods for declarative permission checks. Always specify both `legacyRBACRole` (for RBAC fallback) and `workspacePermissions` (for Kessel).
+- Example: `@Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT)`.
+- The `AuthorizationInterceptor` requires a `SecurityContext` parameter on annotated methods. Omitting it causes an `IllegalStateException` at runtime.
+- For Kessel, use `CheckOperation.CHECK` for read-only operations and `CheckOperation.UPDATE` (via `checkForUpdate`) for write operations. This distinction matters for side effects in the inventory system.
+- Kessel `WorkspacePermission` values: `EVENTS_VIEW`, `INTEGRATIONS_VIEW`, `INTEGRATIONS_EDIT`, `NOTIFICATIONS_VIEW`, `NOTIFICATIONS_EDIT`.
+
+### 2.3 Critical Rules
+- Never bypass authorization checks. Every public-facing endpoint must have either `@Authorization` or `@RolesAllowed`.
+- When both RBAC and Kessel are disabled in a non-local environment, authentication must fail. The code enforces this: `if (!this.environment.isLocal()) { throw AuthenticationFailedException }`.
+- Development-mode full-privilege identity (`buildDevelopmentSecurityIdentity`) must only be reachable in local environments.
+
+## 3. Tenant Isolation (orgId)
+
+- Every database query for tenant-scoped data MUST filter by `orgId`. This is the primary tenant isolation mechanism.
+- Extract `orgId` from the security context using `SecurityContextUtil.getOrgId(securityContext)`, which casts the principal to `RhIdPrincipal`.
+- Never trust `orgId` from request parameters or path variables for data owned by the requesting user. Always derive it from the authenticated identity.
+- Repository methods consistently include `WHERE ... orgId = :orgId` or `WHERE ... e.orgId = :orgId` clauses. Maintain this pattern in all new queries.
+- Some resources (like default behavior groups) use `orgId IS NULL` to indicate system-wide resources. Queries that mix tenant and system resources must explicitly handle both: `(etb.behaviorGroup.orgId is NULL OR etb.behaviorGroup.orgId = :orgId)`.
+
+## 4. Internal API Security
+
+- Internal APIs are under `Constants.API_INTERNAL` path prefix.
+- Turnpike (SAML Associate) identities are used for internal API access. The `RBAC_INTERNAL_USER` role is always added for Turnpike identities.
+- The `RBAC_INTERNAL_ADMIN` role is granted only when the identity's roles include the configured `internal.admin-role`.
+- Fine-grained internal access control uses `InternalRoleAccess` to restrict operations to specific applications. Use `SecurityContextUtil.hasPermissionForRole()`, `hasPermissionForApplication()`, or `hasPermissionForEventType()` for internal endpoints that need app-level scoping.
+- When `internal-rbac.enabled` is false, all internal requests get full admin access. This must only be used in development/ephemeral environments.
+
+## 5. Principal and Identity Handling
+
+- Use `SecurityContextUtil` static methods to extract identity details: `getOrgId()`, `getAccountId()`, `getUsername()`, `isServiceAccountAuthentication()`, `extractRhIdentity()`.
+- For Kessel authorization, the `user_id` field from the identity is required (used as the subject in permission checks). The code rejects identities with missing `user_id` when Kessel is enabled.
+- Never construct identity objects from untrusted input in production code. The `TestHelpers` class provides `encodeRHIdentityInfo()`, `encodeRHServiceAccountIdentityInfo()`, and `encodeTurnpikeIdentityInfo()` for test-only identity construction.
+- The Kessel subject reference format is: `{kesselDomain}/{userId}` with resource type `principal` and namespace `rbac`.
+
+## 6. Secrets Management
+
+- Secrets (API tokens, passwords, bearer tokens) are stored in the external Sources service, not in the notifications database. Endpoint properties store only Sources secret IDs (e.g., `secretTokenSourcesId`, `bearerAuthenticationSourcesId`).
+- Use `SecretUtils` to create, read, update, and delete secrets in Sources. It supports both PSK and OIDC authentication to Sources.
+- The Sources PSK is injected via `@ConfigProperty(name = "sources.psk")`. Never log or expose PSK values. The `RbacClientResponseFilter` explicitly redacts headers containing "psk".
+- OIDC client secrets use placeholder values in `application.properties` (e.g., `REPLACE_ME_FROM_ENV_VAR`) and must be overridden via environment variables or Clowder config.
+- Never hardcode real secrets in `application.properties`. Use `${clowder.endpoints.*}` property references for production values.
+
+## 7. Input Validation
+
+- Use Jakarta Bean Validation annotations on DTOs and request parameters: `@NotNull`, `@NotBlank`, `@Valid`, `@Size`, `@Min`.
+- Apply `@Valid` on method parameters that are request bodies to trigger nested validation (e.g., `@NotNull @Valid EventType eventType`).
+- Use `@JsonIgnoreProperties(ignoreUnknown = true)` on deserialized request models to prevent unexpected fields from being processed.
+- Mark server-controlled fields with `@JsonProperty(access = JsonProperty.Access.READ_ONLY)` to prevent client-side manipulation (e.g., `created`, `updated` timestamps on `EndpointDTO`).
+- Use `@JsonIgnore` on internal/computed fields that should not be serialized to API responses (e.g., `InternalRoleAccess.getInternalRole()`).
+
+## 8. TLS Configuration
+
+- All inter-service REST client communication uses TLS trust stores provided by Clowder: `trust-store`, `trust-store-password`, `trust-store-type` properties.
+- The Kessel gRPC client supports both secure (OAuth2 + TLS) and insecure modes. Insecure mode (`notifications.kessel.insecure-client.enabled`) disables OAuth2 and TLS verification. It must only be enabled in development. The code logs a warning when insecure mode is active.
+- gRPC connections to Kessel use configurable timeouts (`notifications.kessel.timeout-ms`) with `withDeadlineAfter()`.
+
+## 9. Error Handling and Logging
+
+- Never log the decoded contents of `x-rh-identity` headers at INFO level or above. Use DEBUG/TRACE for identity details.
+- The `RbacClientResponseFilter` logs RBAC failures at WARN level and full request/response details only at TRACE level, with PSK headers redacted.
+- Throw `ForbiddenException` (403) for authorization failures, `AuthenticationFailedException` (401) for authentication failures. Never return detailed error messages that reveal the authorization backend in use.
+- RBAC server call failures are retried with exponential backoff (`rbac.retry.max-attempts`, `rbac.retry.back-off.*`). After exhausting retries, they result in `AuthenticationFailedException`.
+- Kessel gRPC errors are classified as transient (UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, ABORTED) and retried via `@Retry(maxRetries = 3)`, or non-transient and propagated immediately. UNAUTHENTICATED triggers channel recreation with fresh OAuth2 credentials.
+
+## 10. Testing Security
+
+- Use `MockServerConfig.addMockRbacAccess()` with WireMock to simulate RBAC responses in tests. Available access levels: `FULL_ACCESS`, `NOTIFICATIONS_READ_ACCESS_ONLY`, `NOTIFICATIONS_ACCESS_ONLY`, `READ_ACCESS`, `NO_ACCESS`.
+- Always test both authorized and unauthorized scenarios. Verify that 401/403 responses have empty bodies.
+- Use `TestHelpers.encodeRHIdentityInfo()` and related methods to create test identity headers. Never reuse identity headers across tests that require different org isolation.
+- For Kessel tests, use `KesselTestHelper` and mock `BackendConfig.isKesselEnabled()` via `@InjectSpy`.
+- Test Turnpike identity handling separately, verifying that roles are correctly mapped through `InternalRoleAccess.getInternalRole()`.
+- The `AuthorizationInterceptorTest` validates the interceptor behavior. When adding new `@Authorization`-annotated endpoints, add corresponding interceptor tests.
+
+## 11. Feature Toggles (Unleash)
+
+- Security-affecting features (Kessel enablement, drawer, Sources OIDC auth) are controlled via Unleash feature toggles with org-level context.
+- `isKesselEnabled(orgId)` checks both the config property and the Unleash toggle, using orgId as context. This allows gradual rollout per organization.
+- Never assume a feature toggle state. Always check via `BackendConfig` methods, which encapsulate the Unleash logic.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -17,7 +17,7 @@ class MyResourceTest extends DbIsolatedTest {
 }
 ```
 
-- Always annotate with `@QuarkusTest` for integration tests.
+- Annotate integration tests with `@QuarkusTest`, except v1 Camel connector tests which extend `CamelQuarkusTestSupport` instead (see section 11).
 - Always add `@QuarkusTestResource(TestLifecycleManager.class)` -- each module has its own `TestLifecycleManager`.
 - For tests touching the database (backend, engine, aggregator), extend `DbIsolatedTest` to get automatic before/after cleanup.
 
@@ -180,26 +180,11 @@ Header header = TestHelpers.createRHIdentityHeader(identity);
 
 - **JaCoCo** (`0.8.x`) via `quarkus-jacoco` extension. Reports go to `target/jacoco-report/jacoco.xml`.
 - **SonarQube** reads from `sonar.coverage.jacoco.xmlReportPaths`.
-- **Checkstyle** rules enforced at build time:
-  - No tabs, no trailing whitespace, newline at end of file.
-  - No star imports (except static).
-  - No JUnit 4 imports.
-  - No `@author` tags.
-  - Braces required, EOL style.
-  - 4-space indentation.
+- **Checkstyle** rules enforced at build time: no tabs, no trailing whitespace, no star imports (except static), no JUnit 4 imports, no `@author` tags, braces required (EOL style), 4-space indentation.
 
 ## 17. Running Tests
 
-```bash
-# Run all tests for a specific module
-./mvnw test -pl backend
-
-# Run a single test class
-./mvnw test -pl backend -Dtest=EndpointResourceTest
-
-# Run all tests
-./mvnw verify
-```
+- Single module: `./mvnw test -pl backend`; single class: `./mvnw test -pl backend -Dtest=EndpointResourceTest`; all: `./mvnw verify`.
 
 ## 18. Common Pitfalls
 

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -1,0 +1,211 @@
+# Testing Guidelines
+
+## 1. Framework and Dependencies
+
+- **Java 21**, **Quarkus 3.x**, **JUnit 5** (Jupiter). JUnit 4 imports are banned by checkstyle (`org.junit.Test`, `org.junit.Assert`, etc.).
+- Key test dependencies: `quarkus-junit5`, `rest-assured`, WireMock (`3.13.x`), Testcontainers (`2.0.x`), Mockito (via Quarkus), Awaitility, SmallRye InMemoryConnector.
+- Camel-based connectors (v1) use `CamelQuarkusTestSupport` as base class instead of `@QuarkusTest`.
+
+## 2. Test Class Structure
+
+### Integration Tests (most common pattern)
+```java
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+class MyResourceTest extends DbIsolatedTest {
+    // ...
+}
+```
+
+- Always annotate with `@QuarkusTest` for integration tests.
+- Always add `@QuarkusTestResource(TestLifecycleManager.class)` -- each module has its own `TestLifecycleManager`.
+- For tests touching the database (backend, engine, aggregator), extend `DbIsolatedTest` to get automatic before/after cleanup.
+
+### Unit Tests (no Quarkus context)
+```java
+class BaseTransformerTest {
+    private final BaseTransformer baseTransformer = new BaseTransformer();
+}
+```
+- Pure unit tests do NOT use `@QuarkusTest`. Instantiate the class under test directly.
+- Use `package-private` visibility for test classes and methods (no `public` modifier). Checkstyle enforces `RedundantModifier`.
+
+## 3. Test Naming Conventions
+
+- Test classes: `<ClassUnderTest>Test.java` (e.g., `EmailActorsResolverTest`, `ConnectorSenderTest`).
+- Integration tests for routes/resources: `<ResourceName>ResourceTest.java` or `<Feature>IntegrationTest.java`.
+- Test methods: descriptive camelCase, often prefixed with `test` (e.g., `testDefaultEmailSenderHCC`, `testOpenshiftClusterManagerStageEmailSender`).
+- No `@author` javadoc tags (banned by checkstyle).
+
+## 4. TestLifecycleManager (QuarkusTestResourceLifecycleManager)
+
+Each module has its own `TestLifecycleManager` implementing `QuarkusTestResourceLifecycleManager`:
+
+| Module | What it starts |
+|---|---|
+| `backend` | PostgreSQL (Testcontainers) + WireMock |
+| `engine` | PostgreSQL (Testcontainers) + WireMock + InMemoryConnector cleanup |
+| `aggregator` | PostgreSQL (Testcontainers) + WireMock |
+| `connector-common` | WireMock only (no database) |
+| `connector-common-v2` | WireMock only (no database) |
+| `connector-email`, `connector-drawer` | Module-specific WireMock setup |
+
+- PostgreSQL version is pinned via `TestConstants.POSTGRES_MAJOR_VERSION` (currently `"16"`).
+- The `pgcrypto` extension is installed during test setup.
+- WireMock is managed via `MockServerLifecycleManager` in the `common` test module.
+
+## 5. Database Test Isolation
+
+- **Extend `DbIsolatedTest`** for any test that reads/writes database records. It injects `DbCleaner` and calls `clean()` in both `@BeforeEach` and `@AfterEach`.
+- `DbCleaner` deletes all entity records in dependency order, then re-creates a default Bundle ("rhel"), Application ("policies"), and EventType ("policy-triggered").
+- Do NOT manually truncate tables or rely on test ordering.
+
+## 6. Test Data Setup
+
+- **`ResourceHelpers`**: an `@ApplicationScoped` CDI bean (in `backend/src/test`) providing transactional methods to create Bundles, Applications, EventTypes, Endpoints, Events, etc. Inject it with `@Inject ResourceHelpers`.
+- The `common` module has an abstract `ResourceHelpers` base class with shared entity creation methods (`createBundle`, `createApp`, `createEventType`, `createEvent`).
+- **`TestHelpers`**: static utility methods for encoding `x-rh-identity` headers (User, ServiceAccount, Turnpike/Associate). Each module (backend, engine) has its own version.
+- **`CrudTestHelpers`**: static methods in `backend` for CRUD operations via REST-Assured against internal API endpoints.
+- Use `TestConstants.DEFAULT_ACCOUNT_ID`, `DEFAULT_ORG_ID`, `DEFAULT_USER` for standard test identities.
+
+## 7. Identity Headers for REST Tests
+
+```java
+String identity = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
+Header header = TestHelpers.createRHIdentityHeader(identity);
+```
+
+- For internal/Turnpike endpoints: `TestHelpers.createTurnpikeIdentityHeader("user@example.com", "role1")`.
+- For service accounts: `TestHelpers.encodeRHServiceAccountIdentityInfo(orgId, username, uuid)`.
+
+## 8. WireMock Usage
+
+- `MockServerLifecycleManager` (in `common/src/test`) wraps a `WireMockServer` with dynamic HTTP and HTTPS ports.
+- Access the server via `MockServerLifecycleManager.getClient()` to stub endpoints.
+- `MockServerConfig` in `backend` provides helper methods for common RBAC stubs:
+  ```java
+  MockServerConfig.addMockRbacAccess(xRhIdentity, RbacAccess.FULL_ACCESS);
+  ```
+- RBAC mock payloads are stored as JSON files in `backend/src/test/resources/rbac-examples/`.
+- For OIDC mocking, use `OidcServerMockResource` (implements `QuarkusTestResourceLifecycleManager`) which stubs discovery and token endpoints.
+- `SourcesServerMockResource` exists for mocking Sources API. Combine multiple resources:
+  ```java
+  @QuarkusTestResource(OidcServerMockResource.class)
+  @QuarkusTestResource(SourcesServerMockResource.class)
+  ```
+
+## 9. Mocking Patterns
+
+### `@InjectMock` (Quarkus Mockito)
+- Replaces a CDI bean entirely with a Mockito mock for the test class. Use for external service clients:
+  ```java
+  @InjectMock
+  @RestClient
+  SourcesPskClient sourcesClient;
+  ```
+
+### `@InjectSpy` (Quarkus Mockito)
+- Wraps a real CDI bean with a Mockito spy (partial mock). Use when you need the real behavior but want to verify calls or stub specific methods:
+  ```java
+  @InjectSpy
+  DailyEmailAggregationJob dailyEmailAggregationJob;
+  ```
+
+### Kessel Authorization Mocking
+- Use `KesselTestHelper` (`@ApplicationScoped`) to build Kessel check requests/responses:
+  ```java
+  @Inject KesselTestHelper kesselTestHelper;
+  @InjectMock KesselCheckClient kesselCheckClient;
+  // then: when(kesselCheckClient.check(...)).thenReturn(...)
+  ```
+
+## 10. Kafka/Messaging in Tests
+
+- Use SmallRye `InMemoryConnector` to replace Kafka in tests. Configure in `src/test/resources/application.properties`:
+  ```properties
+  mp.messaging.outgoing.tocamel.connector=smallrye-in-memory
+  mp.messaging.incoming.fromcamel.connector=smallrye-in-memory
+  ```
+- Inject and use:
+  ```java
+  @Inject @Any InMemoryConnector connector;
+  InMemorySink<String> sink = connector.sink("channelName");
+  InMemorySource<Message<JsonObject>> source = connector.source("channelName");
+  ```
+- Call `sink.clear()` in `@BeforeEach` and `InMemoryConnector.clear()` on stop.
+
+## 11. Connector Tests (v1 Camel-based)
+
+- Extend `ConnectorRoutesTest` (which extends `CamelQuarkusTestSupport`).
+- Override abstract methods: `getMockEndpointPattern()`, `getMockEndpointUri()`, `buildIncomingPayload()`, `checkOutgoingPayload()`.
+- Uses Camel `AdviceWith` and `MockEndpoint` for route testing.
+
+## 12. Connector Tests (v2)
+
+- Extend `BaseConnectorIntegrationTest` (annotated with `@QuarkusTest`).
+- Override: `buildIncomingPayload(String targetUrl)`, `getConnectorSpecificTargetUrl()`.
+- Uses `InMemoryConnector` for messaging and WireMock for HTTP targets.
+- Uses `Awaitility` for async assertions on outgoing messages.
+
+## 13. Metrics Testing
+
+- Use `MicrometerAssertionHelper` (`@ApplicationScoped` in `common/src/test`):
+  ```java
+  @Inject MicrometerAssertionHelper micrometerAssertionHelper;
+
+  @BeforeEach
+  void setup() {
+      micrometerAssertionHelper.saveCounterValuesBeforeTest("counter.name");
+  }
+
+  // In test:
+  micrometerAssertionHelper.assertCounterIncrement("counter.name", 1.0);
+  micrometerAssertionHelper.awaitAndAssertCounterIncrement("counter.name", 1.0); // async
+  ```
+- Do NOT call `MeterRegistry.clear()` between tests -- it breaks `@ApplicationScoped` bean references.
+
+## 14. REST API Testing
+
+- Use REST-Assured (statically imported `given()`).
+- Set identity headers via `TestHelpers.createRHIdentityHeader()`.
+- Use API path constants from `TestConstants` (`API_INTEGRATIONS_V_1_0`, `API_NOTIFICATIONS_V_1_0`, etc.) and `Constants.API_INTERNAL`.
+- Always assert response status and content type.
+
+## 15. Test Profiles
+
+- `ProdTestProfile` activates the `prod` Quarkus config profile. Apply with `@TestProfile(ProdTestProfile.class)`.
+- Custom profiles can be created as inner classes implementing `QuarkusTestProfile` for test-specific configuration overrides.
+
+## 16. Coverage and Quality
+
+- **JaCoCo** (`0.8.x`) via `quarkus-jacoco` extension. Reports go to `target/jacoco-report/jacoco.xml`.
+- **SonarQube** reads from `sonar.coverage.jacoco.xmlReportPaths`.
+- **Checkstyle** rules enforced at build time:
+  - No tabs, no trailing whitespace, newline at end of file.
+  - No star imports (except static).
+  - No JUnit 4 imports.
+  - No `@author` tags.
+  - Braces required, EOL style.
+  - 4-space indentation.
+
+## 17. Running Tests
+
+```bash
+# Run all tests for a specific module
+./mvnw test -pl backend
+
+# Run a single test class
+./mvnw test -pl backend -Dtest=EndpointResourceTest
+
+# Run all tests
+./mvnw verify
+```
+
+## 18. Common Pitfalls
+
+- Do NOT create a new `TestLifecycleManager` -- reuse the one in the module you are testing.
+- Do NOT use `@Mock` from plain Mockito in `@QuarkusTest` classes -- use `@InjectMock` or `@InjectSpy` instead.
+- Do NOT forget `@QuarkusTestResource(TestLifecycleManager.class)` on `@QuarkusTest` classes that need database or WireMock.
+- Do NOT skip extending `DbIsolatedTest` for database tests -- test pollution will cause intermittent failures.
+- When testing async message processing, always use `Awaitility.await()` with a timeout rather than `Thread.sleep()`.
+- Clean WireMock stubs between tests using `getClient().resetAll()` in `@BeforeEach` when tests configure different stubs.


### PR DESCRIPTION
Create guideline files for security, performance, error-handling, api-contracts, database, testing, and integration domains. These guidelines capture repo-specific conventions and patterns that specialized AI agents can reference when implementing or reviewing code in this repository.

Also add CLAUDE.md with an index linking to all guideline files.