### PR TITLE
[RHCLOUD-46428] Filter drawer entries from event log and behavior group apis

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -51,6 +51,7 @@ public class BackendConfig {
     private String sourcesOidcAuthToggle;
     private String toggleUseBetaTemplatesEnabled;
     private String showHiddenEventTypesToggle;
+    private String useDrawerfilteredQuery;
 
     @ConfigProperty(name = UNLEASH, defaultValue = "false")
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
@@ -130,6 +131,7 @@ public class BackendConfig {
         sourcesOidcAuthToggle = toggleRegistry.register("sources-oidc-auth", true);
         toggleUseBetaTemplatesEnabled = toggleRegistry.register("use-beta-templates", true);
         showHiddenEventTypesToggle = toggleRegistry.register("show-hidden-event-types", true);
+        useDrawerfilteredQuery = toggleRegistry.register("remove-drawer-endpoint-from-behavior-group", true);
     }
 
     void logConfigAtStartup(@Observes Startup event) {
@@ -151,6 +153,7 @@ public class BackendConfig {
         config.put(UNLEASH, unleashEnabled);
         config.put(sourcesOidcAuthToggle, isSourcesOidcAuthEnabled(null));
         config.put(showHiddenEventTypesToggle, isShowHiddenEventTypes(null));
+        config.put(useDrawerfilteredQuery, isUseDrawerfilteredQuery(null));
 
         Log.info("=== Startup configuration ===");
         config.forEach((key, value) -> {
@@ -315,6 +318,14 @@ public class BackendConfig {
     public boolean isShowHiddenEventTypes(String orgId) {
         if (unleashEnabled) {
             return unleash.isEnabled(showHiddenEventTypesToggle, buildUnleashContextWithOrgId(orgId), false);
+        } else {
+            return false;
+        }
+    }
+
+    public boolean isUseDrawerfilteredQuery(String orgId) {
+        if (unleashEnabled) {
+            return unleash.isEnabled(useDrawerfilteredQuery, buildUnleashContextWithOrgId(orgId), false);
         } else {
             return false;
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -51,7 +51,7 @@ public class BackendConfig {
     private String sourcesOidcAuthToggle;
     private String toggleUseBetaTemplatesEnabled;
     private String showHiddenEventTypesToggle;
-    private String useDrawerfilteredQuery;
+    private String useDrawerFilteredQuery;
 
     @ConfigProperty(name = UNLEASH, defaultValue = "false")
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
@@ -131,7 +131,7 @@ public class BackendConfig {
         sourcesOidcAuthToggle = toggleRegistry.register("sources-oidc-auth", true);
         toggleUseBetaTemplatesEnabled = toggleRegistry.register("use-beta-templates", true);
         showHiddenEventTypesToggle = toggleRegistry.register("show-hidden-event-types", true);
-        useDrawerfilteredQuery = toggleRegistry.register("remove-drawer-endpoint-from-behavior-group", true);
+        useDrawerFilteredQuery = toggleRegistry.register("remove-drawer-endpoint-from-behavior-group", true);
     }
 
     void logConfigAtStartup(@Observes Startup event) {
@@ -153,7 +153,7 @@ public class BackendConfig {
         config.put(UNLEASH, unleashEnabled);
         config.put(sourcesOidcAuthToggle, isSourcesOidcAuthEnabled(null));
         config.put(showHiddenEventTypesToggle, isShowHiddenEventTypes(null));
-        config.put(useDrawerfilteredQuery, isUseDrawerfilteredQuery(null));
+        config.put(useDrawerFilteredQuery, isUseDrawerFilteredQuery(null));
 
         Log.info("=== Startup configuration ===");
         config.forEach((key, value) -> {
@@ -323,9 +323,9 @@ public class BackendConfig {
         }
     }
 
-    public boolean isUseDrawerfilteredQuery(String orgId) {
+    public boolean isUseDrawerFilteredQuery(String orgId) {
         if (unleashEnabled) {
-            return unleash.isEnabled(useDrawerfilteredQuery, buildUnleashContextWithOrgId(orgId), false);
+            return unleash.isEnabled(useDrawerFilteredQuery, buildUnleashContextWithOrgId(orgId), false);
         } else {
             return false;
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -51,6 +51,7 @@ public class BackendConfig {
     private String sourcesHccClusterToggle;
     private String toggleUseBetaTemplatesEnabled;
     private String showHiddenEventTypesToggle;
+    private String useDrawerfilteredQuery;
     private String normalizedQueriesToggle;
 
     @ConfigProperty(name = UNLEASH, defaultValue = "false")
@@ -131,6 +132,7 @@ public class BackendConfig {
         sourcesHccClusterToggle = toggleRegistry.register("sources-hcc-cluster", true);
         toggleUseBetaTemplatesEnabled = toggleRegistry.register("use-beta-templates", true);
         showHiddenEventTypesToggle = toggleRegistry.register("show-hidden-event-types", true);
+        useDrawerfilteredQuery = toggleRegistry.register("remove-drawer-endpoint-from-behavior-group", true);
         normalizedQueriesToggle = toggleRegistry.register("normalized-queries", true);
     }
 
@@ -153,6 +155,7 @@ public class BackendConfig {
         config.put(UNLEASH, unleashEnabled);
         config.put(sourcesHccClusterToggle, isSourcesHccClusterEnabled(null));
         config.put(showHiddenEventTypesToggle, isShowHiddenEventTypes(null));
+        config.put(useDrawerfilteredQuery, isUseDrawerfilteredQuery(null));
 
         Log.info("=== Startup configuration ===");
         config.forEach((key, value) -> {
@@ -325,6 +328,14 @@ public class BackendConfig {
     public boolean isNormalizedQueriesEnabled(String orgId) {
         if (unleashEnabled) {
             return unleash.isEnabled(normalizedQueriesToggle, buildUnleashContextWithOrgId(orgId), false);
+        } else {
+            return false;
+        }
+    }
+
+    public boolean isUseDrawerfilteredQuery(String orgId) {
+        if (unleashEnabled) {
+            return unleash.isEnabled(useDrawerfilteredQuery, buildUnleashContextWithOrgId(orgId), false);
         } else {
             return false;
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -165,30 +165,42 @@ public class BehaviorGroupRepository {
             throw new NotFoundException("Bundle not found");
         }
 
-        /*
-         * When PostgreSQL sorts a BOOLEAN column in DESC order, true comes first. That's not true for all DBMS.
-         */
-        String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+        List<BehaviorGroup> behaviorGroups;
+        if (backendConfig.isUseDrawerfilteredQuery(orgId)) {
+            String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
                 "LEFT JOIN FETCH a.endpoint e " +
                 "WHERE (b.orgId = :orgId OR b.orgId IS NULL) AND b.bundle.id = :bundleId " +
                 "ORDER BY b.created DESC, a.position ASC";
 
-        List<BehaviorGroup> behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
+            behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
                 .setParameter("orgId", orgId)
                 .setParameter("bundleId", bundleId)
                 .getResultList();
 
-        if (!backendConfig.isDrawerEnabled()) {
-            for (BehaviorGroup behaviorGroup : behaviorGroups) {
-                if (behaviorGroup.getActions() != null) {
-                    behaviorGroup.setActions(
+            if (!backendConfig.isDrawerEnabled()) {
+                for (BehaviorGroup behaviorGroup : behaviorGroups) {
+                    if (behaviorGroup.getActions() != null) {
+                        behaviorGroup.setActions(
                             behaviorGroup.getActions().stream()
-                                    .filter(action -> action.getEndpoint() == null
-                                            || EndpointType.DRAWER != action.getEndpoint().getType())
-                                    .collect(Collectors.toList())
-                    );
+                                .filter(action -> action.getEndpoint() == null
+                                    || EndpointType.DRAWER != action.getEndpoint().getType())
+                                .collect(Collectors.toList())
+                        );
+                    }
                 }
             }
+        } else {
+            /*
+             * When PostgreSQL sorts a BOOLEAN column in DESC order, true comes first. That's not true for all DBMS.
+             */
+            String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+                "WHERE (b.orgId = :orgId OR b.orgId IS NULL) AND b.bundle.id = :bundleId " +
+                "ORDER BY b.created DESC, a.position ASC";
+
+            behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
+                .setParameter("orgId", orgId)
+                .setParameter("bundleId", bundleId)
+                .getResultList();
         }
 
         for (BehaviorGroup behaviorGroup : behaviorGroups) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.BehaviorGroupAction;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.EventTypeBehavior;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static jakarta.persistence.LockModeType.PESSIMISTIC_WRITE;
 
@@ -167,12 +169,28 @@ public class BehaviorGroupRepository {
          * When PostgreSQL sorts a BOOLEAN column in DESC order, true comes first. That's not true for all DBMS.
          */
         String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+                "LEFT JOIN FETCH a.endpoint e " +
                 "WHERE (b.orgId = :orgId OR b.orgId IS NULL) AND b.bundle.id = :bundleId " +
                 "ORDER BY b.created DESC, a.position ASC";
+
         List<BehaviorGroup> behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
                 .setParameter("orgId", orgId)
                 .setParameter("bundleId", bundleId)
                 .getResultList();
+
+        if (!backendConfig.isDrawerEnabled()) {
+            for (BehaviorGroup behaviorGroup : behaviorGroups) {
+                if (behaviorGroup.getActions() != null) {
+                    behaviorGroup.setActions(
+                            behaviorGroup.getActions().stream()
+                                    .filter(action -> action.getEndpoint() == null
+                                            || EndpointType.DRAWER != action.getEndpoint().getType())
+                                    .collect(Collectors.toList())
+                    );
+                }
+            }
+        }
+
         for (BehaviorGroup behaviorGroup : behaviorGroups) {
             behaviorGroup.filterOutBundle();
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -166,7 +166,9 @@ public class BehaviorGroupRepository {
         }
 
         List<BehaviorGroup> behaviorGroups;
-        if (backendConfig.isUseDrawerFilteredQuery(orgId)) {
+        boolean useDrawerFilteredQuery = backendConfig.isUseDrawerFilteredQuery(orgId);
+        boolean drawerEnabled = backendConfig.isDrawerEnabled(orgId);
+        if (useDrawerFilteredQuery) {
             String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
                 "LEFT JOIN FETCH a.endpoint e " +
                 "WHERE (b.orgId = :orgId OR b.orgId IS NULL) AND b.bundle.id = :bundleId " +
@@ -177,7 +179,7 @@ public class BehaviorGroupRepository {
                 .setParameter("bundleId", bundleId)
                 .getResultList();
 
-            if (!backendConfig.isDrawerEnabled(orgId)) {
+            if (!drawerEnabled) {
                 for (BehaviorGroup behaviorGroup : behaviorGroups) {
                     if (behaviorGroup.getActions() != null) {
                         behaviorGroup.setActions(

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -166,7 +166,7 @@ public class BehaviorGroupRepository {
         }
 
         List<BehaviorGroup> behaviorGroups;
-        if (backendConfig.isUseDrawerfilteredQuery(orgId)) {
+        if (backendConfig.isUseDrawerFilteredQuery(orgId)) {
             String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
                 "LEFT JOIN FETCH a.endpoint e " +
                 "WHERE (b.orgId = :orgId OR b.orgId IS NULL) AND b.bundle.id = :bundleId " +

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -177,7 +177,7 @@ public class BehaviorGroupRepository {
                 .setParameter("bundleId", bundleId)
                 .getResultList();
 
-            if (!backendConfig.isDrawerEnabled()) {
+            if (!backendConfig.isDrawerEnabled(orgId)) {
                 for (BehaviorGroup behaviorGroup : behaviorGroups) {
                     if (behaviorGroup.getActions() != null) {
                         behaviorGroup.setActions(

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.BehaviorGroupAction;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Endpoint;
+import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.models.EventTypeBehavior;
 import io.quarkus.logging.Log;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static jakarta.persistence.LockModeType.PESSIMISTIC_WRITE;
 
@@ -173,12 +175,28 @@ public class BehaviorGroupRepository {
          * When PostgreSQL sorts a BOOLEAN column in DESC order, true comes first. That's not true for all DBMS.
          */
         String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+                "LEFT JOIN FETCH a.endpoint e " +
                 "WHERE (b.orgId = :orgId OR b.orgId IS NULL) AND b.bundle.id = :bundleId " +
                 "ORDER BY b.created DESC, a.position ASC";
+
         List<BehaviorGroup> behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
                 .setParameter("orgId", orgId)
                 .setParameter("bundleId", bundleId)
                 .getResultList();
+
+        if (!backendConfig.isDrawerEnabled()) {
+            for (BehaviorGroup behaviorGroup : behaviorGroups) {
+                if (behaviorGroup.getActions() != null) {
+                    behaviorGroup.setActions(
+                            behaviorGroup.getActions().stream()
+                                    .filter(action -> action.getEndpoint() == null
+                                            || EndpointType.DRAWER != action.getEndpoint().getType())
+                                    .collect(Collectors.toList())
+                    );
+                }
+            }
+        }
+
         for (BehaviorGroup behaviorGroup : behaviorGroups) {
             behaviorGroup.filterOutBundle();
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -183,7 +183,7 @@ public class BehaviorGroupRepository {
                 .setParameter("bundleId", bundleId)
                 .getResultList();
 
-            if (!backendConfig.isDrawerEnabled()) {
+            if (!backendConfig.isDrawerEnabled(orgId)) {
                 for (BehaviorGroup behaviorGroup : behaviorGroups) {
                     if (behaviorGroup.getActions() != null) {
                         behaviorGroup.setActions(

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepository.java
@@ -171,30 +171,42 @@ public class BehaviorGroupRepository {
             throw new NotFoundException("Bundle not found");
         }
 
-        /*
-         * When PostgreSQL sorts a BOOLEAN column in DESC order, true comes first. That's not true for all DBMS.
-         */
-        String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+        List<BehaviorGroup> behaviorGroups;
+        if (backendConfig.isUseDrawerfilteredQuery(orgId)) {
+            String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
                 "LEFT JOIN FETCH a.endpoint e " +
                 "WHERE (b.orgId = :orgId OR b.orgId IS NULL) AND b.bundle.id = :bundleId " +
                 "ORDER BY b.created DESC, a.position ASC";
 
-        List<BehaviorGroup> behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
+            behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
                 .setParameter("orgId", orgId)
                 .setParameter("bundleId", bundleId)
                 .getResultList();
 
-        if (!backendConfig.isDrawerEnabled()) {
-            for (BehaviorGroup behaviorGroup : behaviorGroups) {
-                if (behaviorGroup.getActions() != null) {
-                    behaviorGroup.setActions(
+            if (!backendConfig.isDrawerEnabled()) {
+                for (BehaviorGroup behaviorGroup : behaviorGroups) {
+                    if (behaviorGroup.getActions() != null) {
+                        behaviorGroup.setActions(
                             behaviorGroup.getActions().stream()
-                                    .filter(action -> action.getEndpoint() == null
-                                            || EndpointType.DRAWER != action.getEndpoint().getType())
-                                    .collect(Collectors.toList())
-                    );
+                                .filter(action -> action.getEndpoint() == null
+                                    || EndpointType.DRAWER != action.getEndpoint().getType())
+                                .collect(Collectors.toList())
+                        );
+                    }
                 }
             }
+        } else {
+            /*
+             * When PostgreSQL sorts a BOOLEAN column in DESC order, true comes first. That's not true for all DBMS.
+             */
+            String query = "SELECT DISTINCT b FROM BehaviorGroup b LEFT JOIN FETCH b.actions a " +
+                "WHERE (b.orgId = :orgId OR b.orgId IS NULL) AND b.bundle.id = :bundleId " +
+                "ORDER BY b.created DESC, a.position ASC";
+
+            behaviorGroups = entityManager.createQuery(query, BehaviorGroup.class)
+                .setParameter("orgId", orgId)
+                .setParameter("bundleId", bundleId)
+                .getResultList();
         }
 
         for (BehaviorGroup behaviorGroup : behaviorGroups) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -157,20 +157,22 @@ public class EventResource {
             if (!includeActions) {
                 actions = Collections.emptyList();
             } else {
-                actions = event.getHistoryEntries().stream().map(historyEntry -> {
-                    EventLogEntryAction action = new EventLogEntryAction();
-                    action.setId(historyEntry.getId());
-                    action.setEndpointId(historyEntry.getEndpointId());
-                    action.setEndpointType(historyEntry.getEndpointType());
-                    action.setEndpointSubType(historyEntry.getEndpointSubType());
-                    action.setInvocationResult(historyEntry.isInvocationResult());
-                    action.setStatus(fromNotificationStatus(historyEntry.getStatus()));
-                    if (includeDetails) {
-                        action.setDetails(historyEntry.getDetails());
-                    }
-                    getRecipientsCount(historyEntry).ifPresent(action::setRecipientsCount);
-                    return action;
-                }).collect(Collectors.toList());
+                actions = event.getHistoryEntries().stream()
+                    .filter(notificationHistory -> EndpointType.DRAWER != notificationHistory.getEndpointType() || backendConfig.isDrawerEnabled())
+                    .map(historyEntry -> {
+                        EventLogEntryAction action = new EventLogEntryAction();
+                        action.setId(historyEntry.getId());
+                        action.setEndpointId(historyEntry.getEndpointId());
+                        action.setEndpointType(historyEntry.getEndpointType());
+                        action.setEndpointSubType(historyEntry.getEndpointSubType());
+                        action.setInvocationResult(historyEntry.isInvocationResult());
+                        action.setStatus(fromNotificationStatus(historyEntry.getStatus()));
+                        if (includeDetails) {
+                            action.setDetails(historyEntry.getDetails());
+                        }
+                        getRecipientsCount(historyEntry).ifPresent(action::setRecipientsCount);
+                        return action;
+                    }).collect(Collectors.toList());
             }
 
             EventLogEntry entry = new EventLogEntry();

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -158,7 +158,7 @@ public class EventResource {
                 actions = Collections.emptyList();
             } else {
                 actions = event.getHistoryEntries().stream()
-                    .filter(notificationHistory -> EndpointType.DRAWER != notificationHistory.getEndpointType() || backendConfig.isDrawerEnabled())
+                    .filter(notificationHistory -> EndpointType.DRAWER != notificationHistory.getEndpointType() || backendConfig.isDrawerEnabled(orgId))
                     .map(historyEntry -> {
                         EventLogEntryAction action = new EventLogEntryAction();
                         action.setId(historyEntry.getId());

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -157,8 +157,9 @@ public class EventResource {
             if (!includeActions) {
                 actions = Collections.emptyList();
             } else {
+                boolean drawerEnabled = backendConfig.isDrawerEnabled(orgId);
                 actions = event.getHistoryEntries().stream()
-                    .filter(notificationHistory -> EndpointType.DRAWER != notificationHistory.getEndpointType() || backendConfig.isDrawerEnabled(orgId))
+                    .filter(notificationHistory -> EndpointType.DRAWER != notificationHistory.getEndpointType() || drawerEnabled)
                     .map(historyEntry -> {
                         EventLogEntryAction action = new EventLogEntryAction();
                         action.setId(historyEntry.getId());

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -180,21 +180,21 @@ public class EventResource {
                     actions = Collections.emptyList();
                 } else {
                     actions = event.getHistoryEntries().stream()
-                        .filter(notificationHistory -> EndpointType.DRAWER != notificationHistory.getEndpointType() || backendConfig.isDrawerEnabled())
+                        .filter(notificationHistory -> EndpointType.DRAWER != notificationHistory.getEndpointType() || backendConfig.isDrawerEnabled(orgId))
                         .map(historyEntry -> {
-                        EventLogEntryAction action = new EventLogEntryAction();
-                        action.setId(historyEntry.getId());
-                        action.setEndpointId(historyEntry.getEndpointId());
-                        action.setEndpointType(historyEntry.getEndpointType());
-                        action.setEndpointSubType(historyEntry.getEndpointSubType());
-                        action.setInvocationResult(historyEntry.isInvocationResult());
-                        action.setStatus(fromNotificationStatus(historyEntry.getStatus()));
-                        if (includeDetails) {
-                            action.setDetails(historyEntry.getDetails());
-                        }
-                        getRecipientsCount(historyEntry).ifPresent(action::setRecipientsCount);
-                        return action;
-                    }).collect(Collectors.toList());
+                            EventLogEntryAction action = new EventLogEntryAction();
+                            action.setId(historyEntry.getId());
+                            action.setEndpointId(historyEntry.getEndpointId());
+                            action.setEndpointType(historyEntry.getEndpointType());
+                            action.setEndpointSubType(historyEntry.getEndpointSubType());
+                            action.setInvocationResult(historyEntry.isInvocationResult());
+                            action.setStatus(fromNotificationStatus(historyEntry.getStatus()));
+                            if (includeDetails) {
+                                action.setDetails(historyEntry.getDetails());
+                            }
+                            getRecipientsCount(historyEntry).ifPresent(action::setRecipientsCount);
+                            return action;
+                        }).collect(Collectors.toList());
                 }
 
                 EventLogEntry entry = new EventLogEntry();

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -179,7 +179,9 @@ public class EventResource {
                 if (!includeActions) {
                     actions = Collections.emptyList();
                 } else {
-                    actions = event.getHistoryEntries().stream().map(historyEntry -> {
+                    actions = event.getHistoryEntries().stream()
+                        .filter(notificationHistory -> EndpointType.DRAWER != notificationHistory.getEndpointType() || backendConfig.isDrawerEnabled())
+                        .map(historyEntry -> {
                         EventLogEntryAction action = new EventLogEntryAction();
                         action.setId(historyEntry.getId());
                         action.setEndpointId(historyEntry.getEndpointId());

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -42,9 +42,11 @@ import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPT
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
@@ -381,6 +383,11 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
         Endpoint endpoint1 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DRAWER);
         Endpoint endpoint2 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DRAWER);
         List<BehaviorGroupAction> bgActions = updateAndFetchBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
+        assertFalse(bgActions.isEmpty());
+        updateAndCheckBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
+
+        when(backendConfig.isUseDrawerfilteredQuery(eq(DEFAULT_ORG_ID))).thenReturn(true);
+        bgActions = updateAndFetchBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
         assertTrue(bgActions.isEmpty());
         when(backendConfig.isDrawerEnabled()).thenReturn(true);
         updateAndCheckBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
@@ -378,6 +380,9 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
         BehaviorGroup behaviorGroup = resourceHelpers.createBehaviorGroup(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, "displayName", bundle.getId());
         Endpoint endpoint1 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DRAWER);
         Endpoint endpoint2 = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DRAWER);
+        List<BehaviorGroupAction> bgActions = updateAndFetchBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
+        assertTrue(bgActions.isEmpty());
+        when(backendConfig.isDrawerEnabled()).thenReturn(true);
         updateAndCheckBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
     }
 
@@ -800,11 +805,15 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     @Transactional
-    void updateAndCheckBehaviorGroupActions(String orgId, UUID bundleId, UUID behaviorGroupId, UUID... endpointIds) {
+    List<BehaviorGroupAction> updateAndFetchBehaviorGroupActions(String orgId, UUID bundleId, UUID behaviorGroupId, UUID... endpointIds) {
         behaviorGroupRepository.updateBehaviorGroupActions(orgId, behaviorGroupId, Arrays.asList(endpointIds));
         entityManager.clear(); // We need to clear the session L1 cache before checking the update result.
         // If we expected a success, the behavior group actions should match exactly the given endpoint IDs.
-        List<BehaviorGroupAction> actions = findBehaviorGroupActions(orgId, bundleId, behaviorGroupId);
+        return findBehaviorGroupActions(orgId, bundleId, behaviorGroupId);
+    }
+
+    void updateAndCheckBehaviorGroupActions(String orgId, UUID bundleId, UUID behaviorGroupId, UUID... endpointIds) {
+        List<BehaviorGroupAction> actions = updateAndFetchBehaviorGroupActions(orgId, bundleId, behaviorGroupId, endpointIds);
         assertEquals(endpointIds.length, actions.size());
         for (int i = 0; i < endpointIds.length; i++) {
             assertEquals(endpointIds[i], actions.get(i).getEndpoint().getId());
@@ -812,9 +821,13 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
     }
 
     private List<BehaviorGroupAction> findBehaviorGroupActions(String orgId, UUID bundleId, UUID behaviorGroupId) {
-        return behaviorGroupRepository.findByBundleId(orgId, bundleId)
-                .stream().filter(behaviorGroup -> behaviorGroup.getId().equals(behaviorGroupId))
-                .findFirst().get().getActions();
+        final List<BehaviorGroup> behaviorGroups = behaviorGroupRepository.findByBundleId(orgId, bundleId)
+            .stream().filter(behaviorGroup -> behaviorGroup.getId().equals(behaviorGroupId)).toList();
+        if (behaviorGroups.isEmpty()) {
+            return new ArrayList<>();
+        } else {
+            return behaviorGroups.get(0).getActions();
+        }
     }
 
     private void findBehaviorGroupsByEndpointId(UUID endpointId, UUID... expectedBehaviorGroupIds) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -386,7 +386,7 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
         assertFalse(bgActions.isEmpty());
         updateAndCheckBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
 
-        when(backendConfig.isUseDrawerfilteredQuery(eq(DEFAULT_ORG_ID))).thenReturn(true);
+        when(backendConfig.isUseDrawerFilteredQuery(eq(DEFAULT_ORG_ID))).thenReturn(true);
         bgActions = updateAndFetchBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
         assertTrue(bgActions.isEmpty());
         when(backendConfig.isDrawerEnabled(eq(DEFAULT_ORG_ID))).thenReturn(true);

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -389,7 +389,7 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
         when(backendConfig.isUseDrawerfilteredQuery(eq(DEFAULT_ORG_ID))).thenReturn(true);
         bgActions = updateAndFetchBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
         assertTrue(bgActions.isEmpty());
-        when(backendConfig.isDrawerEnabled()).thenReturn(true);
+        when(backendConfig.isDrawerEnabled(eq(DEFAULT_ORG_ID))).thenReturn(true);
         updateAndCheckBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/BehaviorGroupRepositoryTest.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -389,7 +390,7 @@ public class BehaviorGroupRepositoryTest extends DbIsolatedTest {
         when(backendConfig.isUseDrawerfilteredQuery(eq(DEFAULT_ORG_ID))).thenReturn(true);
         bgActions = updateAndFetchBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
         assertTrue(bgActions.isEmpty());
-        when(backendConfig.isDrawerEnabled()).thenReturn(true);
+        when(backendConfig.isDrawerEnabled(anyString())).thenReturn(true);
         updateAndCheckBehaviorGroupActions(DEFAULT_ORG_ID, bundle.getId(), behaviorGroup.getId(), endpoint1.getId(), endpoint2.getId());
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -91,6 +91,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -252,7 +253,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
 
-        when(backendConfig.isDrawerEnabled()).thenReturn(true);
+        when(backendConfig.isDrawerEnabled(eq(DEFAULT_ORG_ID))).thenReturn(true);
         /*
          * Test #1.2
          * Account: DEFAULT_ACCOUNT_ID
@@ -1038,7 +1039,7 @@ public class EventResourceTest extends DbIsolatedTest {
     @Test
     void testEventsWithKesselCriterion() {
         when(backendConfig.isKesselChecksOnEventLogEnabled(anyString())).thenReturn(true);
-        when(backendConfig.isDrawerEnabled()).thenReturn(true);
+        when(backendConfig.isDrawerEnabled(eq(DEFAULT_ORG_ID))).thenReturn(true);
 
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -237,12 +237,30 @@ public class EventResourceTest extends DbIsolatedTest {
         assertNotNull(event3.getExternalId());
 
         /*
-         * Test #1
+         * Test #1.1
          * Account: DEFAULT_ACCOUNT_ID
          * Request: No filter
+         * Context: Drawer disabled
          * Expected response: All event log entries from DEFAULT_ACCOUNT_ID should be returned
          */
         Page<EventLogEntry> page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, null, null, null, null, null, null, false, true);
+        assertEquals(3, page.getMeta().getCount());
+        assertEquals(3, page.getData().size());
+        assertSameEvent(page.getData().get(0), event2, history3, history8);
+        assertSameEvent(page.getData().get(1), event3, history4, history5, history9);
+        assertSameEvent(page.getData().get(2), event1, history1, history2);
+        assertNull(page.getData().get(0).getPayload());
+        assertLinks(page.getLinks(), "first", "last");
+
+        when(backendConfig.isDrawerEnabled()).thenReturn(true);
+        /*
+         * Test #1.2
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: No filter
+         * Context: Drawer enabled
+         * Expected response: All event log entries from DEFAULT_ACCOUNT_ID should be returned
+         */
+        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, null, null, null, null, null, null, false, true);
         assertEquals(3, page.getMeta().getCount());
         assertEquals(3, page.getData().size());
         assertSameEvent(page.getData().get(0), event2, history3, history8);
@@ -1020,6 +1038,7 @@ public class EventResourceTest extends DbIsolatedTest {
     @Test
     void testEventsWithKesselCriterion() {
         when(backendConfig.isKesselChecksOnEventLogEnabled(anyString())).thenReturn(true);
+        when(backendConfig.isDrawerEnabled()).thenReturn(true);
 
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -260,7 +260,7 @@ public class EventResourceTest extends DbIsolatedTest {
         assertNull(page.getData().get(0).getPayload());
         assertLinks(page.getLinks(), "first", "last");
 
-        when(backendConfig.isDrawerEnabled()).thenReturn(true);
+        when(backendConfig.isDrawerEnabled(anyString())).thenReturn(true);
         /*
          * Test #1.2
          * Account: DEFAULT_ACCOUNT_ID
@@ -1062,7 +1062,7 @@ public class EventResourceTest extends DbIsolatedTest {
     void testEventsWithKesselCriterion(boolean useNormalizedQueries) {
         when(backendConfig.isKesselChecksOnEventLogEnabled(anyString())).thenReturn(true);
         when(backendConfig.isNormalizedQueriesEnabled(anyString())).thenReturn(useNormalizedQueries);
-        when(backendConfig.isDrawerEnabled()).thenReturn(true);
+        when(backendConfig.isDrawerEnabled(anyString())).thenReturn(true);
 
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -245,12 +245,30 @@ public class EventResourceTest extends DbIsolatedTest {
         assertNotNull(event3.getExternalId());
 
         /*
-         * Test #1
+         * Test #1.1
          * Account: DEFAULT_ACCOUNT_ID
          * Request: No filter
+         * Context: Drawer disabled
          * Expected response: All event log entries from DEFAULT_ACCOUNT_ID should be returned
          */
         Page<EventLogEntry> page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, null, null, null, null, null, null, false, true);
+        assertEquals(3, page.getMeta().getCount());
+        assertEquals(3, page.getData().size());
+        assertSameEvent(page.getData().get(0), event2, history3, history8);
+        assertSameEvent(page.getData().get(1), event3, history4, history5, history9);
+        assertSameEvent(page.getData().get(2), event1, history1, history2);
+        assertNull(page.getData().get(0).getPayload());
+        assertLinks(page.getLinks(), "first", "last");
+
+        when(backendConfig.isDrawerEnabled()).thenReturn(true);
+        /*
+         * Test #1.2
+         * Account: DEFAULT_ACCOUNT_ID
+         * Request: No filter
+         * Context: Drawer enabled
+         * Expected response: All event log entries from DEFAULT_ACCOUNT_ID should be returned
+         */
+        page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, null, null, null, null, null, null, false, true);
         assertEquals(3, page.getMeta().getCount());
         assertEquals(3, page.getData().size());
         assertSameEvent(page.getData().get(0), event2, history3, history8);
@@ -1044,6 +1062,7 @@ public class EventResourceTest extends DbIsolatedTest {
     void testEventsWithKesselCriterion(boolean useNormalizedQueries) {
         when(backendConfig.isKesselChecksOnEventLogEnabled(anyString())).thenReturn(true);
         when(backendConfig.isNormalizedQueriesEnabled(anyString())).thenReturn(useNormalizedQueries);
+        when(backendConfig.isDrawerEnabled()).thenReturn(true);
 
         Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
 


### PR DESCRIPTION
We want to controle Drawer endpoint visibility from backend event if some integrations/System behavior groups/ notifications history exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an org-level option to exclude a specific endpoint type from behavior groups and from event action history; changes affect which actions are shown in group listings and event details.

* **Tests**
  * Expanded tests to cover action-filtering behavior across different configuration states and query modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->