### PR TITLE
[RHCLOUD-35790] Re-add remote cache event deduplication 

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -20,6 +20,7 @@ objects:
     - export-service
     database:
       sharedDbAppName: notifications-backend
+    inMemoryDb: ${{IN_MEMORY_DB_ENABLED}}
     featureFlags: true
     kafkaTopics:
     - topicName: platform.notifications.connector.email.high.volume
@@ -287,6 +288,9 @@ parameters:
   value: quay.io/cloudservices/notifications-engine
 - name: IMAGE_TAG
   value: latest
+- name: IN_MEMORY_DB_ENABLED
+  description: If inMemoryDb is set to true, Clowder will pass configuration of an In Memory Database to the pods in the ClowdApp. This single instance will be shared between all apps.
+  value: "false"
 - name: KAFKA_CONSUMED_TOTAL_CHECKER_ENABLED
   description: Is the Kafka records consumed total check included in the global health check?
   value: "false"

--- a/common/src/test/java/com/redhat/cloud/notifications/TestConstants.java
+++ b/common/src/test/java/com/redhat/cloud/notifications/TestConstants.java
@@ -16,4 +16,5 @@ public class TestConstants {
     public static final String DEFAULT_USER = "default-user";
 
     public static final String POSTGRES_MAJOR_VERSION = "16";
+    public static final String VALKEY_MAJOR_VERSION = "8";
 }

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -48,6 +48,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-redis-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-flyway</artifactId>
         </dependency>
         <dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -119,6 +119,12 @@
             <artifactId>flyway-database-postgresql</artifactId>
         </dependency>
 
+        <!-- Valkey connection management -->
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+        </dependency>
+
         <!-- events-schemas -->
         <dependency>
             <groupId>com.redhat.cloud.event</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -120,12 +120,6 @@
             <artifactId>flyway-database-postgresql</artifactId>
         </dependency>
 
-        <!-- Valkey connection management -->
-        <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
-        </dependency>
-
         <!-- events-schemas -->
         <dependency>
             <groupId>com.redhat.cloud.event</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <apache.commons.csv.version>1.14.1</apache.commons.csv.version>
+        <testcontainers-valkey.version>1.0.0</testcontainers-valkey.version>
     </properties>
 
     <dependencies>
@@ -192,6 +193,12 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-postgresql</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.ss-bhatt</groupId>
+            <artifactId>testcontainers-valkey</artifactId>
+            <version>${testcontainers-valkey.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -35,6 +35,7 @@ public class EngineConfig {
     private static final String UNLEASH = "notifications.unleash.enabled";
     private static final String PROCESSOR_CONNECTORS_MAX_SERVER_ERRORS = "processor.connectors.max-server-errors";
     private static final String PROCESSOR_CONNECTORS_MIN_DELAY_SINCE_FIRST_SERVER_ERROR = "processor.connectors.min-delay-since-first-server-error";
+    private static final String IN_MEMORY_DB_ENABLED = "in-memory-db.enabled";
 
     /**
      * Standard "Red Hat Hybrid Cloud Console" sender that the vast majority of the
@@ -155,6 +156,9 @@ public class EngineConfig {
     @ConfigProperty(name = NOTIFICATIONS_INGRESSREPLAY_END_TIME, defaultValue = "2025-12-15T09:30:00Z")
     String replayEndTime;
 
+    @ConfigProperty(name = IN_MEMORY_DB_ENABLED, defaultValue = "false")
+    boolean inMemoryDbEnabled;
+
     @Inject
     ToggleRegistry toggleRegistry;
 
@@ -206,6 +210,7 @@ public class EngineConfig {
         config.put(toggleIncludeSeverityToFilterRecipients, isIncludeSeverityToFilterRecipientsEnabled(""));
         config.put(toggleSkipProcessingMessagesOnReplayService, isSkipMessageProcessing());
         config.put(valkeyKafkaMessageDeduplicatorToggle, isValkeyKafkaMessageDeduplicatorEnabled());
+        config.put(IN_MEMORY_DB_ENABLED, isInMemoryDbEnabled());
 
         Log.info("=== Startup configuration ===");
         config.forEach((key, value) -> {
@@ -392,5 +397,9 @@ public class EngineConfig {
         } else {
             return false;
         }
+    }
+
+    public boolean isInMemoryDbEnabled() {
+        return inMemoryDbEnabled;
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -58,7 +58,7 @@ public class EngineConfig {
     private String drawerToggle;
     private String exportServiceHccClusterToggle;
     private String kafkaConsumedTotalCheckerToggle;
-    private String valkeyKafkaMessageDeduplicatorToggle;
+    private String valkeyEventDeduplicatorToggle;
     private String toggleBlacklistedEndpoints;
     private String toggleBlacklistedEventTypes;
     private String toggleKafkaOutgoingHighVolumeTopic;
@@ -172,7 +172,7 @@ public class EngineConfig {
         drawerToggle = toggleRegistry.register("drawer", true);
         exportServiceHccClusterToggle = toggleRegistry.register("export-service-hcc-cluster", true);
         kafkaConsumedTotalCheckerToggle = toggleRegistry.register("kafka-consumed-total-checker", true);
-        valkeyKafkaMessageDeduplicatorToggle = toggleRegistry.register("valkey-kafka-message-deduplicator", true);
+        valkeyEventDeduplicatorToggle = toggleRegistry.register("valkey-event-deduplicator", true);
         toggleKafkaOutgoingHighVolumeTopic = toggleRegistry.register("kafka-outgoing-high-volume-topic", true);
         toggleBlacklistedEndpoints = toggleRegistry.register("blacklisted-endpoints", true);
         toggleBlacklistedEventTypes = toggleRegistry.register("blacklisted-event-types", true);
@@ -209,7 +209,7 @@ public class EngineConfig {
         config.put(asyncEventProcessingToggle, isAsyncEventProcessing());
         config.put(toggleIncludeSeverityToFilterRecipients, isIncludeSeverityToFilterRecipientsEnabled(""));
         config.put(toggleSkipProcessingMessagesOnReplayService, isSkipMessageProcessing());
-        config.put(valkeyKafkaMessageDeduplicatorToggle, isValkeyKafkaMessageDeduplicatorEnabled());
+        config.put(valkeyEventDeduplicatorToggle, isValkeyEventDeduplicatorEnabled());
         config.put(IN_MEMORY_DB_ENABLED, isInMemoryDbEnabled());
 
         Log.info("=== Startup configuration ===");
@@ -391,9 +391,9 @@ public class EngineConfig {
         }
     }
 
-    public boolean isValkeyKafkaMessageDeduplicatorEnabled() {
+    public boolean isValkeyEventDeduplicatorEnabled() {
         if (unleashEnabled) {
-            return this.unleash.isEnabled(this.valkeyKafkaMessageDeduplicatorToggle, false);
+            return this.unleash.isEnabled(this.valkeyEventDeduplicatorToggle, false);
         } else {
             return false;
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -57,6 +57,7 @@ public class EngineConfig {
     private String drawerToggle;
     private String exportServiceHccClusterToggle;
     private String kafkaConsumedTotalCheckerToggle;
+    private String valkeyKafkaMessageDeduplicatorToggle;
     private String toggleBlacklistedEndpoints;
     private String toggleBlacklistedEventTypes;
     private String toggleKafkaOutgoingHighVolumeTopic;
@@ -167,6 +168,7 @@ public class EngineConfig {
         drawerToggle = toggleRegistry.register("drawer", true);
         exportServiceHccClusterToggle = toggleRegistry.register("export-service-hcc-cluster", true);
         kafkaConsumedTotalCheckerToggle = toggleRegistry.register("kafka-consumed-total-checker", true);
+        valkeyKafkaMessageDeduplicatorToggle = toggleRegistry.register("valkey-kafka-message-deduplicator", true);
         toggleKafkaOutgoingHighVolumeTopic = toggleRegistry.register("kafka-outgoing-high-volume-topic", true);
         toggleBlacklistedEndpoints = toggleRegistry.register("blacklisted-endpoints", true);
         toggleBlacklistedEventTypes = toggleRegistry.register("blacklisted-event-types", true);
@@ -203,6 +205,7 @@ public class EngineConfig {
         config.put(asyncEventProcessingToggle, isAsyncEventProcessing());
         config.put(toggleIncludeSeverityToFilterRecipients, isIncludeSeverityToFilterRecipientsEnabled(""));
         config.put(toggleSkipProcessingMessagesOnReplayService, isSkipMessageProcessing());
+        config.put(valkeyKafkaMessageDeduplicatorToggle, isValkeyKafkaMessageDeduplicatorEnabled());
 
         Log.info("=== Startup configuration ===");
         config.forEach((key, value) -> {
@@ -378,6 +381,14 @@ public class EngineConfig {
     public boolean isNormalizedQueriesEnabled(String orgId) {
         if (unleashEnabled) {
             return unleash.isEnabled(normalizedQueriesToggle, UnleashContextBuilder.buildUnleashContextWithOrgId(orgId), false);
+        } else {
+            return false;
+        }
+    }
+
+    public boolean isValkeyKafkaMessageDeduplicatorEnabled() {
+        if (unleashEnabled) {
+            return this.unleash.isEnabled(this.valkeyKafkaMessageDeduplicatorToggle, false);
         } else {
             return false;
         }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -101,6 +101,9 @@ public class EventConsumer {
     @Inject
     SeverityTransformer severityTransformer;
 
+    @Inject
+    ValkeyService valkeyService;
+
     ConsoleCloudEventParser cloudEventParser = new ConsoleCloudEventParser();
 
     private Counter rejectedCounter;
@@ -262,7 +265,21 @@ public class EventConsumer {
              * Before we persist the event into the DB and process it, we need to check whether the event is
              * a duplicate using the custom event deduplication logic tenants might have implemented.
              */
-            if (!eventDeduplicator.isNew(event)) {
+            boolean isNewEvent;
+
+            try {
+                isNewEvent = eventDeduplicator.isNew(event);
+            } catch (Exception e) {
+                // If Valkey deduplication is enabled, remove any keys that may have been created
+                if (engineConfig.isInMemoryDbEnabled() && engineConfig.isValkeyEventDeduplicatorEnabled()) {
+                    Optional<String> dedupKey = eventDeduplicator.getEventDeduplicationConfig(event).getDeduplicationKey(event);
+                    dedupKey.ifPresent(key -> valkeyService.removeEventFromDeduplication(key));
+                }
+
+                throw e;
+            }
+
+            if (!isNewEvent) {
                 // The event is already known and should therefore be ignored.
                 Log.debug("Duplicated event ignored");
                 registry.counter(DUPLICATE_EVENT_COUNTER_NAME,

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -273,7 +273,7 @@ public class EventConsumer {
                 // If Valkey deduplication is enabled, remove any keys that may have been created
                 if (engineConfig.isInMemoryDbEnabled() && engineConfig.isValkeyEventDeduplicatorEnabled()) {
                     Optional<String> dedupKey = eventDeduplicator.getEventDeduplicationConfig(event).getDeduplicationKey(event);
-                    dedupKey.ifPresent(key -> valkeyService.removeEventFromDeduplication(key));
+                    dedupKey.ifPresent(key -> valkeyService.removeEventFromDeduplication(event.getEventType().getId(), key));
                 }
 
                 throw e;

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/EventConsumer.java
@@ -173,6 +173,8 @@ public class EventConsumer {
         Timer.Sample consumedTimer = Timer.start(registry);
         String payload = message.getPayload();
         Map<String, String> tags = new HashMap<>();
+        Event event = null;
+
         // The two following variables have to be final or effectively final. That why their type is String[] instead of String.
         /*
          * Step 1
@@ -258,27 +260,14 @@ public class EventConsumer {
              * The EventType was found. It's time to create an Event from the current message.
              */
             Optional<String> sourceEnvironmentHeader = kafkaHeaders.get(SOURCE_ENVIRONMENT_HEADER);
-            Event event = new Event(eventType, payload, eventWrapperToProcess, sourceEnvironmentHeader, messageId);
+            event = new Event(eventType, payload, eventWrapperToProcess, sourceEnvironmentHeader, messageId);
 
             /*
              * Step 5
              * Before we persist the event into the DB and process it, we need to check whether the event is
              * a duplicate using the custom event deduplication logic tenants might have implemented.
              */
-            boolean isNewEvent;
-
-            try {
-                isNewEvent = eventDeduplicator.isNew(event);
-            } catch (Exception e) {
-                // If Valkey deduplication is enabled, remove any keys that may have been created
-                if (engineConfig.isInMemoryDbEnabled() && engineConfig.isValkeyEventDeduplicatorEnabled()) {
-                    Optional<String> dedupKey = eventDeduplicator.getEventDeduplicationConfig(event).getDeduplicationKey(event);
-                    dedupKey.ifPresent(key -> valkeyService.removeEventFromDeduplication(event.getEventType().getId(), key));
-                }
-
-                throw e;
-            }
-
+            boolean isNewEvent = eventDeduplicator.isNew(event);
             if (!isNewEvent) {
                 // The event is already known and should therefore be ignored.
                 Log.debug("Duplicated event ignored");
@@ -315,10 +304,16 @@ public class EventConsumer {
         } catch (Exception e) {
             /*
              * An exception was thrown at some point during the Kafka message processing,
-             * it is logged and added to the exception counter metric.
+             * it is logged and added to the exception counter metric. Any deduplication
+             * events added in Valkey will be rolled back.
              */
             processingExceptionCounter.increment();
             Log.infof(e, "Could not process the payload: %s", payload);
+            if (event != null && engineConfig.isInMemoryDbEnabled() && engineConfig.isValkeyEventDeduplicatorEnabled()) {
+                Event finalEvent = event;
+                Optional<String> dedupKey = eventDeduplicator.getEventDeduplicationConfig(event).getDeduplicationKey(event);
+                dedupKey.ifPresent(key -> valkeyService.removeEventFromDeduplication(finalEvent.getEventType().getId(), key));
+            }
         } finally {
             consumedTimer.stop(registry.timer(
                     CONSUMED_TIMER_NAME,

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -1,0 +1,44 @@
+package com.redhat.cloud.notifications.events;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.value.ValueCommands;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.time.Duration;
+import java.util.UUID;
+
+/** Stores and retrieves data from remote cache (i.e. Valkey). */
+@ApplicationScoped
+public class ValkeyService {
+
+    private static final String KAFKA_MESSAGE_KEY = "engine:kafka-message:";
+    private static final String NOT_USED = "";
+
+    @ConfigProperty(name = "valkey-service.ttl", defaultValue = "PT24H")
+    Duration ttl;
+
+    private final ValueCommands<String, String> kafkaMessageCommands;
+
+    public ValkeyService(RedisDataSource ds) {
+        kafkaMessageCommands = ds.value(String.class);
+    }
+
+    /**
+     * Verifies that another Kafka consumer didn't already process the given message and then failed to commit its
+     * offset. Such failure can happen when a consumer is kicked out of its consumer group because it didn't poll new
+     * messages fast enough. We experienced that already in production.
+     *
+     * @param messageId ID of an incoming message
+     * @return true if the message has not been processed yet
+     */
+    public boolean isNewMessageId(UUID messageId) {
+        String key = KAFKA_MESSAGE_KEY + messageId;
+        boolean isNew = kafkaMessageCommands.setnx(key, NOT_USED);
+        if (isNew) {
+            kafkaMessageCommands.setex(key, ttl.toSeconds(), NOT_USED);
+        }
+
+        return isNew;
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 @ApplicationScoped
 public class ValkeyService {
 
-    private static final String KAFKA_MESSAGE_KEY = "engine:kafka-message:";
+    private static final String EVENT_DEDUPLICATION_KEY = "engine:event-deduplication:";
     private static final String NOT_USED = "";
 
     @ConfigProperty(name = "valkey-service.ttl", defaultValue = "PT24H")
@@ -62,7 +62,7 @@ public class ValkeyService {
      * @return true if the message has not been processed yet
      */
     public boolean isNewMessageId(UUID messageId) {
-        String key = KAFKA_MESSAGE_KEY + messageId;
+        String key = EVENT_DEDUPLICATION_KEY + messageId;
 
         boolean isNew = valkey.setnxAndAwait(key, NOT_USED).toBoolean();
         if (isNew) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.events;
 
 import com.redhat.cloud.notifications.config.EngineConfig;
+import io.quarkus.logging.Log;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
@@ -11,6 +12,10 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.UUID;
 
 /** Stores and retrieves data from remote cache (i.e. Valkey). */
@@ -54,19 +59,28 @@ public class ValkeyService {
     }
 
     /**
-     * Verifies that another Kafka consumer didn't already process the given message and then failed to commit its
-     * offset. Such failure can happen when a consumer is kicked out of its consumer group because it didn't poll new
-     * messages fast enough. We experienced that already in production.
+     * Verifies that the event has not been previously processed. The format of saved keys is
+     * {@code engine:event-deduplication:<event_type>:<deduplication_key>}.
      *
-     * @param messageId ID of an incoming message
-     * @return true if the message has not been processed yet
+     * @param eventId only used for debugging
+     * @see com.redhat.cloud.notifications.events.deduplication.EventDeduplicator EventDeduplicator
      */
-    public boolean isNewMessageId(UUID messageId) {
-        String key = EVENT_DEDUPLICATION_KEY + messageId;
+    public boolean isNewEvent(UUID eventTypeId, String deduplicationKey, LocalDateTime deleteAfter, UUID eventId) {
+        String key = String.format("%s:%s:%s", EVENT_DEDUPLICATION_KEY, eventTypeId, deduplicationKey);
+        String deleteAfterIso = deleteAfter.format(DateTimeFormatter.ISO_DATE_TIME);
 
-        boolean isNew = valkey.setnxAndAwait(key, NOT_USED).toBoolean();
+        boolean isNew = valkey.setnxAndAwait(key, deleteAfterIso).toBoolean();
         if (isNew) {
-            valkey.setexAndForget(key, String.valueOf(ttl.toSeconds()), NOT_USED);
+            boolean expireSet = valkey.expireatAndAwait(List.of(
+                    key,
+                    String.valueOf(deleteAfter.toEpochSecond(ZoneOffset.UTC))
+            )).toBoolean();
+
+            if (!expireSet) {
+                // dedup key may include private information, so other fields are used
+                Log.warnf("unable to set expiry for Valkey event deduplication [event_type_id=%s, event_id=%s, delete_after=%s]",
+                        eventTypeId, eventId, deleteAfterIso);
+            }
         }
 
         return isNew;

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 @ApplicationScoped
 public class ValkeyService {
 
-    private static final String EVENT_DEDUPLICATION_KEY = "engine:event-deduplication:";
+    private static final String EVENT_DEDUPLICATION_KEY = "engine:event-deduplication";
     private static final String NOT_USED = "";
 
     @ConfigProperty(name = "valkey-service.ttl", defaultValue = "PT24H")

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -1,8 +1,13 @@
 package com.redhat.cloud.notifications.events;
 
-import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.value.ValueCommands;
+import com.redhat.cloud.notifications.config.EngineConfig;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.redis.client.Redis;
+import io.vertx.mutiny.redis.client.RedisAPI;
+import io.vertx.redis.client.RedisOptions;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.time.Duration;
@@ -18,10 +23,34 @@ public class ValkeyService {
     @ConfigProperty(name = "valkey-service.ttl", defaultValue = "PT24H")
     Duration ttl;
 
-    private final ValueCommands<String, String> kafkaMessageCommands;
+    @ConfigProperty(name = "quarkus.redis.hosts", defaultValue = "")
+    String valkeyHost;
 
-    public ValkeyService(RedisDataSource ds) {
-        kafkaMessageCommands = ds.value(String.class);
+    @ConfigProperty(name = "quarkus.redis.password", defaultValue = "")
+    String valkeyPassword;
+
+    @Inject
+    EngineConfig config;
+
+    @Inject
+    Vertx vertx;
+
+    /** The underlying client connecting to Valkey. */
+    private Redis valkeyClient;
+
+    /** Implementation of the Redis/Valkey API, using {@link #valkeyClient} */
+    private RedisAPI valkey;
+
+    @PostConstruct
+    void initialize() {
+        if (config.isInMemoryDbEnabled()) {
+            RedisOptions valkeyOptions = new RedisOptions().setConnectionString(valkeyHost);
+            if (valkeyPassword != null && valkeyPassword.isEmpty()) {
+                valkeyOptions.setPassword(valkeyPassword);
+            }
+            this.valkeyClient = Redis.createClient(vertx, valkeyOptions);
+            this.valkey = RedisAPI.api(this.valkeyClient);
+        }
     }
 
     /**
@@ -34,9 +63,10 @@ public class ValkeyService {
      */
     public boolean isNewMessageId(UUID messageId) {
         String key = KAFKA_MESSAGE_KEY + messageId;
-        boolean isNew = kafkaMessageCommands.setnx(key, NOT_USED);
+
+        boolean isNew = valkey.setnxAndAwait(key, NOT_USED).toBoolean();
         if (isNew) {
-            kafkaMessageCommands.setex(key, ttl.toSeconds(), NOT_USED);
+            valkey.setexAndForget(key, String.valueOf(ttl.toSeconds()), NOT_USED);
         }
 
         return isNew;

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 public class ValkeyService {
 
     private static final String EVENT_DEDUPLICATION_KEY = "engine:event-deduplication";
-    private static final String NOT_USED = "";
 
     @ConfigProperty(name = "valkey-service.ttl", defaultValue = "PT24H")
     Duration ttl;
@@ -51,7 +50,7 @@ public class ValkeyService {
     void initialize() {
         if (config.isInMemoryDbEnabled()) {
             if (valkeyHost.isEmpty() || valkeyHost.get().isEmpty()) {
-                Log.warn("In-memory DB enabled, but Valkey connection string was not provided");
+                throw new IllegalStateException("In-memory DB enabled, but Valkey connection string was not provided");
             } else {
                 RedisOptions valkeyOptions = new RedisOptions().setConnectionString(valkeyHost.get());
                 valkeyPassword.ifPresent(valkeyOptions::setPassword);

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /** Stores and retrieves data from remote cache (i.e. Valkey). */
@@ -29,10 +30,10 @@ public class ValkeyService {
     Duration ttl;
 
     @ConfigProperty(name = "quarkus.redis.hosts", defaultValue = "")
-    String valkeyHost;
+    Optional<String> valkeyHost;
 
     @ConfigProperty(name = "quarkus.redis.password", defaultValue = "")
-    String valkeyPassword;
+    Optional<String> valkeyPassword;
 
     @Inject
     EngineConfig config;
@@ -49,12 +50,15 @@ public class ValkeyService {
     @PostConstruct
     void initialize() {
         if (config.isInMemoryDbEnabled()) {
-            RedisOptions valkeyOptions = new RedisOptions().setConnectionString(valkeyHost);
-            if (valkeyPassword != null && valkeyPassword.isEmpty()) {
-                valkeyOptions.setPassword(valkeyPassword);
+            if (valkeyHost.isEmpty() || valkeyHost.get().isEmpty()) {
+                Log.warn("In-memory DB enabled, but Valkey connection string was not provided");
+            } else {
+                RedisOptions valkeyOptions = new RedisOptions().setConnectionString(valkeyHost.get());
+                valkeyPassword.ifPresent(valkeyOptions::setPassword);
+
+                this.valkeyClient = Redis.createClient(vertx, valkeyOptions);
+                this.valkey = RedisAPI.api(this.valkeyClient);
             }
-            this.valkeyClient = Redis.createClient(vertx, valkeyOptions);
-            this.valkey = RedisAPI.api(this.valkeyClient);
         }
     }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -78,10 +78,9 @@ public class ValkeyService {
      * Verifies that the event has not been previously processed. The format of saved keys is
      * {@code engine:event-deduplication:<event_type>:<deduplication_key>}.
      *
-     * @param eventId only used for debugging
      * @see com.redhat.cloud.notifications.events.deduplication.EventDeduplicator EventDeduplicator
      */
-    public boolean isNewEvent(UUID eventTypeId, String deduplicationKey, LocalDateTime deleteAfter, UUID eventId) {
+    public boolean isNewEvent(UUID eventTypeId, String deduplicationKey, LocalDateTime deleteAfter) {
         String key = formatDeduplicationKey(eventTypeId, deduplicationKey);
         String deleteAfterIso = deleteAfter.format(DateTimeFormatter.ISO_DATE_TIME);
         boolean isNew;
@@ -102,8 +101,8 @@ public class ValkeyService {
             } catch (Exception ignored) {
                 // Invalid response could not be mapped to string. Assume event is new
                 // dedup key may include private information, so other fields are used
-                Log.warnf("unable to check for duplicate event in Valkey [event_type_id=%s, event_id=%s, delete_after=%s]",
-                        eventTypeId, eventId, deleteAfterIso);
+                Log.warnf("unable to check for duplicate event in Valkey [event_type_id=%s, delete_after=%s, deduplication_key=%s]",
+                        eventTypeId, deleteAfterIso, deduplicationKey);
                 isNew = true;
             }
         }
@@ -111,12 +110,14 @@ public class ValkeyService {
         return isNew;
     }
 
-    /** This method should only be called to remove a key that may have been inserted by {@link #isNewEvent(UUID, String, LocalDateTime, UUID)} */
-    public boolean removeEventFromDeduplication(UUID eventTypeId, String key) {
+    /** This method should only be called to remove a key that may have been inserted by {@link #isNewEvent(UUID, String, LocalDateTime)} */
+    public boolean removeEventFromDeduplication(UUID eventTypeId, String deduplicationKey) {
         try {
-            return valkey.delAndAwait(List.of(formatDeduplicationKey(eventTypeId, key))).toBoolean();
+            return valkey.delAndAwait(List.of(formatDeduplicationKey(eventTypeId, deduplicationKey))).toBoolean();
         } catch (Exception ignored) {
-            Log.warnf("Failed to remove duplicate event from Valkey during rollback [event_type_id=%s]");
+            Log.warnf(
+                    "Failed to remove duplicate event from Valkey during rollback [event_type_id=%s, deduplication_key=%s]",
+                    eventTypeId, deduplicationKey);
             return false;
         }
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -5,6 +5,7 @@ import io.quarkus.logging.Log;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.redis.client.Redis;
 import io.vertx.mutiny.redis.client.RedisAPI;
+import io.vertx.mutiny.redis.client.Response;
 import io.vertx.redis.client.RedisOptions;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -52,13 +53,17 @@ public class ValkeyService {
             if (valkeyHost.isEmpty() || valkeyHost.get().isEmpty()) {
                 throw new IllegalStateException("In-memory DB enabled, but Valkey connection string was not provided");
             } else {
-                RedisOptions valkeyOptions = new RedisOptions().setConnectionString(valkeyHost.get());
+                RedisOptions valkeyOptions = new RedisOptions().setConnectionString(valkeyHost.get().replace("valkey://", "redis://"));
                 valkeyPassword.ifPresent(valkeyOptions::setPassword);
 
                 this.valkeyClient = Redis.createClient(vertx, valkeyOptions);
                 this.valkey = RedisAPI.api(this.valkeyClient);
             }
         }
+    }
+
+    public static String formatDeduplicationKey(UUID eventTypeId, String deduplicationKey) {
+        return String.format("%s:%s:%s", EVENT_DEDUPLICATION_KEY, eventTypeId, deduplicationKey);
     }
 
     /**
@@ -69,23 +74,33 @@ public class ValkeyService {
      * @see com.redhat.cloud.notifications.events.deduplication.EventDeduplicator EventDeduplicator
      */
     public boolean isNewEvent(UUID eventTypeId, String deduplicationKey, LocalDateTime deleteAfter, UUID eventId) {
-        String key = String.format("%s:%s:%s", EVENT_DEDUPLICATION_KEY, eventTypeId, deduplicationKey);
+        String key = formatDeduplicationKey(eventTypeId, deduplicationKey);
         String deleteAfterIso = deleteAfter.format(DateTimeFormatter.ISO_DATE_TIME);
+        boolean isNew;
 
-        boolean isNew = valkey.setnxAndAwait(key, deleteAfterIso).toBoolean();
-        if (isNew) {
-            boolean expireSet = valkey.expireatAndAwait(List.of(
-                    key,
-                    String.valueOf(deleteAfter.toEpochSecond(ZoneOffset.UTC))
-            )).toBoolean();
+        Response valkeyResp = valkey.setAndAwait(List.of(
+                key,
+                deleteAfterIso,
+                "NX",
+                "EXAT",
+                String.valueOf(deleteAfter.toEpochSecond(ZoneOffset.UTC))
+        ));
 
-            if (!expireSet) {
-                // dedup key may include private information, so other fields are used
-                Log.warnf("unable to set expiry for Valkey event deduplication [event_type_id=%s, event_id=%s, delete_after=%s]",
-                        eventTypeId, eventId, deleteAfterIso);
-            }
+        try {
+            isNew = valkeyResp.toString().equals("OK");
+        } catch (Exception ignored) {
+            // Invalid response could not be mapped to string. Assume event is new
+            // dedup key may include private information, so other fields are used
+            Log.warnf("unable to check for duplicate event in Valkey [event_type_id=%s, event_id=%s, delete_after=%s]",
+                    eventTypeId, eventId, deleteAfterIso);
+            isNew = true;
         }
 
         return isNew;
+    }
+
+    /** This method should only be called to remove a key that may have been inserted by {@link #isNewEvent(UUID, String, LocalDateTime, UUID)} */
+    public boolean removeEventFromDeduplication(String key) {
+        return valkey.delAndAwait(List.of(key)).toBoolean();
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -87,7 +87,11 @@ public class ValkeyService {
         ));
 
         try {
-            isNew = valkeyResp.toString().equals("OK");
+            if (valkeyResp == null) {
+                isNew = false;
+            } else {
+                isNew = valkeyResp.toString().equals("OK");
+            }
         } catch (Exception ignored) {
             // Invalid response could not be mapped to string. Assume event is new
             // dedup key may include private information, so other fields are used

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -66,6 +66,14 @@ public class ValkeyService {
         return String.format("%s:%s:%s", EVENT_DEDUPLICATION_KEY, eventTypeId, deduplicationKey);
     }
 
+    public String runHealthCheck() throws Exception {
+        if (config.isInMemoryDbEnabled()) {
+            return valkey.ping(List.of()).await().atMost(Duration.ofSeconds(10)).toString();
+        } else {
+            return "In-memory DB is disabled";
+        }
+    }
+
     /**
      * Verifies that the event has not been previously processed. The format of saved keys is
      * {@code engine:event-deduplication:<event_type>:<deduplication_key>}.
@@ -86,25 +94,30 @@ public class ValkeyService {
                 String.valueOf(deleteAfter.toEpochSecond(ZoneOffset.UTC))
         ));
 
-        try {
-            if (valkeyResp == null) {
-                isNew = false;
-            } else {
+        if (valkeyResp == null) {
+            isNew = false;
+        } else {
+            try {
                 isNew = valkeyResp.toString().equals("OK");
+            } catch (Exception ignored) {
+                // Invalid response could not be mapped to string. Assume event is new
+                // dedup key may include private information, so other fields are used
+                Log.warnf("unable to check for duplicate event in Valkey [event_type_id=%s, event_id=%s, delete_after=%s]",
+                        eventTypeId, eventId, deleteAfterIso);
+                isNew = true;
             }
-        } catch (Exception ignored) {
-            // Invalid response could not be mapped to string. Assume event is new
-            // dedup key may include private information, so other fields are used
-            Log.warnf("unable to check for duplicate event in Valkey [event_type_id=%s, event_id=%s, delete_after=%s]",
-                    eventTypeId, eventId, deleteAfterIso);
-            isNew = true;
         }
 
         return isNew;
     }
 
     /** This method should only be called to remove a key that may have been inserted by {@link #isNewEvent(UUID, String, LocalDateTime, UUID)} */
-    public boolean removeEventFromDeduplication(String key) {
-        return valkey.delAndAwait(List.of(key)).toBoolean();
+    public boolean removeEventFromDeduplication(UUID eventTypeId, String key) {
+        try {
+            return valkey.delAndAwait(List.of(formatDeduplicationKey(eventTypeId, key))).toBoolean();
+        } catch (Exception ignored) {
+            Log.warnf("Failed to remove duplicate event from Valkey during rollback [event_type_id=%s]");
+            return false;
+        }
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
@@ -58,6 +58,7 @@ public class EventDeduplicator {
         LocalDateTime deleteAfter = eventDeduplicationConfig.getDeleteAfter(event);
 
         if (engineConfig.isInMemoryDbEnabled() && engineConfig.isValkeyEventDeduplicatorEnabled()) {
+            // RHCLOUD-35790: remove once Valkey deduplication is validated
             boolean isNewEvent = postgresEventDeduplication(eventTypeId, deduplicationKey, deleteAfter);
             boolean valkeyIsNewEvent = valkeyService.isNewEvent(eventTypeId, deduplicationKey.get(),
                     deleteAfter, event.getId());

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
@@ -56,7 +56,7 @@ public class EventDeduplicator {
         UUID eventTypeId = event.getEventType().getId();
         LocalDateTime deleteAfter = eventDeduplicationConfig.getDeleteAfter(event);
 
-        if (engineConfig.isValkeyEventDeduplicatorEnabled()) {
+        if (engineConfig.isInMemoryDbEnabled() && engineConfig.isValkeyEventDeduplicatorEnabled()) {
             return valkeyService.isNewEvent(eventTypeId, deduplicationKey.get(), deleteAfter, event.getId());
         } else {
             String sql = "INSERT INTO event_deduplication(event_type_id, deduplication_key, delete_after) " +

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.events.deduplication;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.events.ValkeyService;
 import com.redhat.cloud.notifications.models.Event;
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -31,7 +32,7 @@ public class EventDeduplicator {
     @Inject
     ValkeyService valkeyService;
 
-    private EventDeduplicationConfig getEventDeduplicationConfig(Event event) {
+    public EventDeduplicationConfig getEventDeduplicationConfig(Event event) {
         return switch (event.getEventType().getApplication().getBundle().getName()) {
             case SUBSCRIPTION_SERVICES_BUNDLE ->
                 switch (event.getEventType().getApplication().getName()) {
@@ -57,18 +58,32 @@ public class EventDeduplicator {
         LocalDateTime deleteAfter = eventDeduplicationConfig.getDeleteAfter(event);
 
         if (engineConfig.isInMemoryDbEnabled() && engineConfig.isValkeyEventDeduplicatorEnabled()) {
-            return valkeyService.isNewEvent(eventTypeId, deduplicationKey.get(), deleteAfter, event.getId());
-        } else {
-            String sql = "INSERT INTO event_deduplication(event_type_id, deduplication_key, delete_after) " +
-                    "VALUES (:eventTypeId, :deduplicationKey, :deleteAfter) " +
-                    "ON CONFLICT (event_type_id, deduplication_key) DO NOTHING";
+            boolean isNewEvent = postgresEventDeduplication(eventTypeId, deduplicationKey, deleteAfter);
+            boolean valkeyIsNewEvent = valkeyService.isNewEvent(eventTypeId, deduplicationKey.get(),
+                    deleteAfter, event.getId());
+            if (valkeyIsNewEvent != isNewEvent) {
+                Log.warnf(
+                        "Valkey event deduplication (isNewEvent=%s) does not align with Postgres result (isNewEvent=%s) [event_type_id=%s, event_id=%s]",
+                        valkeyIsNewEvent, isNewEvent, eventTypeId, event.getId());
+            }
 
-            int rowCount = entityManager.createNativeQuery(sql)
-                    .setParameter("eventTypeId", eventTypeId)
-                    .setParameter("deduplicationKey", deduplicationKey.get())
-                    .setParameter("deleteAfter", deleteAfter)
-                    .executeUpdate();
-            return rowCount > 0;
+            return isNewEvent;
+
+        } else {
+            return postgresEventDeduplication(eventTypeId, deduplicationKey, deleteAfter);
         }
+    }
+
+    private boolean postgresEventDeduplication(UUID eventTypeId, Optional<String> deduplicationKey, LocalDateTime deleteAfter) {
+        String sql = "INSERT INTO event_deduplication(event_type_id, deduplication_key, delete_after) " +
+                "VALUES (:eventTypeId, :deduplicationKey, :deleteAfter) " +
+                "ON CONFLICT (event_type_id, deduplication_key) DO NOTHING";
+
+        int rowCount = entityManager.createNativeQuery(sql)
+                .setParameter("eventTypeId", eventTypeId)
+                .setParameter("deduplicationKey", deduplicationKey.get())
+                .setParameter("deleteAfter", deleteAfter)
+                .executeUpdate();
+        return rowCount > 0;
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
@@ -61,11 +61,11 @@ public class EventDeduplicator {
             // RHCLOUD-35790: remove once Valkey deduplication is validated
             boolean isNewEvent = postgresEventDeduplication(eventTypeId, deduplicationKey, deleteAfter);
             boolean valkeyIsNewEvent = valkeyService.isNewEvent(eventTypeId, deduplicationKey.get(),
-                    deleteAfter, event.getId());
+                    deleteAfter);
             if (valkeyIsNewEvent != isNewEvent) {
                 Log.warnf(
-                        "Valkey event deduplication (isNewEvent=%s) does not align with Postgres result (isNewEvent=%s) [event_type_id=%s, event_id=%s]",
-                        valkeyIsNewEvent, isNewEvent, eventTypeId, event.getId());
+                        "Valkey event deduplication (isNewEvent=%s) does not align with Postgres result (isNewEvent=%s) [event_type_id=%s, deduplication_key=%s]",
+                        valkeyIsNewEvent, isNewEvent, eventTypeId, deduplicationKey.get());
             }
 
             return isNewEvent;

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
@@ -1,12 +1,16 @@
 package com.redhat.cloud.notifications.events.deduplication;
 
+import com.redhat.cloud.notifications.config.EngineConfig;
+import com.redhat.cloud.notifications.events.ValkeyService;
 import com.redhat.cloud.notifications.models.Event;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.UUID;
 
 @ApplicationScoped
 public class EventDeduplicator {
@@ -20,6 +24,12 @@ public class EventDeduplicator {
 
     @Inject
     SubscriptionsDeduplicationConfig subscriptionsDeduplicationConfig;
+
+    @Inject
+    EngineConfig engineConfig;
+
+    @Inject
+    ValkeyService valkeyService;
 
     private EventDeduplicationConfig getEventDeduplicationConfig(Event event) {
         return switch (event.getEventType().getApplication().getBundle().getName()) {
@@ -43,15 +53,22 @@ public class EventDeduplicator {
             return true;
         }
 
-        String sql = "INSERT INTO event_deduplication(event_type_id, deduplication_key, delete_after) " +
-                "VALUES (:eventTypeId, :deduplicationKey, :deleteAfter) " +
-                "ON CONFLICT (event_type_id, deduplication_key) DO NOTHING";
+        UUID eventTypeId = event.getEventType().getId();
+        LocalDateTime deleteAfter = eventDeduplicationConfig.getDeleteAfter(event);
 
-        int rowCount = entityManager.createNativeQuery(sql)
-                .setParameter("eventTypeId", event.getEventType().getId())
-                .setParameter("deduplicationKey", deduplicationKey.get())
-                .setParameter("deleteAfter", eventDeduplicationConfig.getDeleteAfter(event))
-                .executeUpdate();
-        return rowCount > 0;
+        if (engineConfig.isValkeyEventDeduplicatorEnabled()) {
+            return valkeyService.isNewEvent(eventTypeId, deduplicationKey.get(), deleteAfter, event.getId());
+        } else {
+            String sql = "INSERT INTO event_deduplication(event_type_id, deduplication_key, delete_after) " +
+                    "VALUES (:eventTypeId, :deduplicationKey, :deleteAfter) " +
+                    "ON CONFLICT (event_type_id, deduplication_key) DO NOTHING";
+
+            int rowCount = entityManager.createNativeQuery(sql)
+                    .setParameter("eventTypeId", eventTypeId)
+                    .setParameter("deduplicationKey", deduplicationKey.get())
+                    .setParameter("deleteAfter", deleteAfter)
+                    .executeUpdate();
+            return rowCount > 0;
+        }
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/health/ValkeyHealthCheck.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/health/ValkeyHealthCheck.java
@@ -8,9 +8,11 @@ import jakarta.inject.Inject;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Liveness;
 import org.eclipse.microprofile.health.Readiness;
 
 @Readiness
+@Liveness
 @ApplicationScoped
 public class ValkeyHealthCheck implements HealthCheck {
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/health/ValkeyHealthCheck.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/health/ValkeyHealthCheck.java
@@ -1,0 +1,41 @@
+package com.redhat.cloud.notifications.health;
+
+import com.redhat.cloud.notifications.config.EngineConfig;
+import com.redhat.cloud.notifications.events.ValkeyService;
+import io.smallrye.mutiny.TimeoutException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+
+@Readiness
+@ApplicationScoped
+public class ValkeyHealthCheck implements HealthCheck {
+
+    @Inject
+    ValkeyService valkeyService;
+
+    @Inject
+    EngineConfig config;
+
+    @Override
+    public HealthCheckResponse call() {
+        String hostName = "Valkey in-memory DB";
+        HealthCheckResponseBuilder builder = HealthCheckResponse.named("Valkey connection health check");
+
+        try {
+            String healthCheckResp = valkeyService.runHealthCheck();
+            builder.up().withData(hostName, healthCheckResp);
+        } catch (TimeoutException te) {
+            builder.down().withData(hostName, "Unable to execute Valkey health check due to 10 second timeout");
+        } catch (Exception e) {
+            builder.down().withData(hostName, String.format("Unable to execute Valkey health check: %s", e));
+        }
+
+        return builder.build();
+    }
+
+
+}

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -10,6 +10,9 @@ quarkus.http.port=8087
 %test.quarkus.http.test-port=9087
 %test.quarkus.datasource.devservices.enabled=true
 
+# Configure Valkey devservices for test cases
+%test.quarkus.redis.devservices.enabled=true
+
 # Input queue
 mp.messaging.incoming.ingress.connector=smallrye-kafka
 mp.messaging.incoming.ingress.topic=platform.notifications.ingress

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -64,6 +64,9 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
         if (quarkusDatasourceDevServiceEnabled) {
             postgreSQLContainer.stop();
         }
+        if (quarkusValkeyDevServiceEnabled) {
+            valkeyContainer.stop();
+        }
         MockServerLifecycleManager.stop();
         InMemoryConnector.clear();
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestLifecycleManager.java
@@ -1,10 +1,12 @@
 package com.redhat.cloud.notifications;
 
+import io.github.ss_bhatt.testcontainers.valkey.ValkeyContainer;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import io.smallrye.reactive.messaging.memory.InMemoryConnector;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -15,26 +17,38 @@ import java.util.Optional;
 
 import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
 import static com.redhat.cloud.notifications.TestConstants.POSTGRES_MAJOR_VERSION;
+import static com.redhat.cloud.notifications.TestConstants.VALKEY_MAJOR_VERSION;
 
 public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
 
-    Boolean quarkusDevServiceEnabled = true;
+    Boolean quarkusDatasourceDevServiceEnabled = true;
+    Boolean quarkusValkeyDevServiceEnabled = true;
 
     PostgreSQLContainer<?> postgreSQLContainer;
+    ValkeyContainer valkeyContainer;
 
     @Override
     public Map<String, String> start() {
         System.out.println("++++  TestLifecycleManager start +++");
-        Optional<Boolean> quarkusDevServiceEnabledFlag = ConfigProvider.getConfig().getOptionalValue("quarkus.datasource.devservices.enabled", Boolean.class);
-        if (quarkusDevServiceEnabledFlag.isPresent()) {
-            quarkusDevServiceEnabled = quarkusDevServiceEnabledFlag.get();
-        }
-        System.out.println(" -- quarkusDatasourceDevServiceEnabled is " + quarkusDevServiceEnabled);
+        Optional<Boolean> quarkusDatasourceDevServiceEnabledFlag = ConfigProvider.getConfig().getOptionalValue("quarkus.datasource.devservices.enabled", Boolean.class);
+        quarkusDatasourceDevServiceEnabledFlag.ifPresent(flag -> quarkusDatasourceDevServiceEnabled = flag);
+        System.out.println(" -- quarkusDatasourceDevServiceEnabled is " + quarkusDatasourceDevServiceEnabled);
+
+        Optional<Boolean> quarkusValkeyDevServiceEnabledFlag = ConfigProvider.getConfig().getOptionalValue("quarkus.redis.devservices.enabled", Boolean.class);
+        quarkusValkeyDevServiceEnabledFlag.ifPresent(flag -> quarkusValkeyDevServiceEnabled = flag);
+        System.out.println(" -- quarkusValkeyDevServiceEnabled is " + quarkusValkeyDevServiceEnabled);
 
         Map<String, String> properties = new HashMap<>();
-        if (quarkusDevServiceEnabled) {
+        if (quarkusDatasourceDevServiceEnabled) {
             try {
                 setupPostgres(properties);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        if (quarkusValkeyDevServiceEnabled) {
+            try {
+                setupValkey(properties);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -47,7 +61,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
 
     @Override
     public void stop() {
-        if (quarkusDevServiceEnabled) {
+        if (quarkusDatasourceDevServiceEnabled) {
             postgreSQLContainer.stop();
         }
         MockServerLifecycleManager.stop();
@@ -74,6 +88,16 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
         statement.execute("CREATE EXTENSION pgcrypto;");
         statement.close();
         connection.close();
+    }
+
+    void setupValkey(Map<String, String> props) {
+        valkeyContainer = new ValkeyContainer(DockerImageName.parse("valkey/valkey:" + VALKEY_MAJOR_VERSION)
+                        .asCompatibleSubstituteFor("docker.io/valkey/valkey"));
+        valkeyContainer.start();
+        // Provide the connection credentials as a redis URI for compatibility
+        String valkeyHost = valkeyContainer.getConnectionString().replace("valkey://", "redis://");
+        props.put("quarkus.redis.hosts", valkeyHost);
+        props.put("in-memory-db.enabled", "true");
     }
 
     void setupMockEngine(Map<String, String> props) {

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -27,6 +27,8 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Set;
@@ -309,8 +311,11 @@ public class EventConsumerTest {
         verify(eventDeduplicator, times(1)).isNew(any(Event.class));
     }
 
-    @Test
-    void testDuplicatePayload() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testDuplicatePayload(final boolean valkeyDedupEnabled) {
+        when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(valkeyDedupEnabled);
+
         EventType eventType = mockGetEventTypeAndCreateEvent();
         Action action = buildValidAction(false);
         String payload = serializeAction(action);

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/ValkeyServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/ValkeyServiceTest.java
@@ -23,27 +23,26 @@ class ValkeyServiceTest {
     void testAddNewEntries() {
         UUID eventTypeId1 = UUID.randomUUID();
         String dedupKey1 = "dedup-key-new-" + UUID.randomUUID();
-        UUID eventId = UUID.randomUUID();
         LocalDateTime deleteAfter = LocalDateTime.now().plusDays(7);
 
         // Insert first event
-        assertTrue(valkeyService.isNewEvent(eventTypeId1, dedupKey1, deleteAfter, eventId));
+        assertTrue(valkeyService.isNewEvent(eventTypeId1, dedupKey1, deleteAfter));
 
         // Insert entry with different event type ID
         UUID eventTypeId2 = UUID.randomUUID();
-        assertTrue(valkeyService.isNewEvent(eventTypeId2, dedupKey1, deleteAfter, eventId));
+        assertTrue(valkeyService.isNewEvent(eventTypeId2, dedupKey1, deleteAfter));
 
         // Insert entry with different deduplication key
         String dedupKey2 = "dedup-key-new-" + UUID.randomUUID();
-        assertTrue(valkeyService.isNewEvent(eventTypeId1, dedupKey2, deleteAfter, eventId));
+        assertTrue(valkeyService.isNewEvent(eventTypeId1, dedupKey2, deleteAfter));
 
         // Deduplication required both event type and dedup key to match
-        assertTrue(valkeyService.isNewEvent(eventTypeId2, dedupKey2, deleteAfter, eventId));
+        assertTrue(valkeyService.isNewEvent(eventTypeId2, dedupKey2, deleteAfter));
 
         // Events which should have already expired will also return successfully
         LocalDateTime expiredDeleteAfter = LocalDateTime.of(2023, 5, 11, 15, 40, 21);
         String dedupKey3 = "dedup-key-new-" + UUID.randomUUID();
-        assertTrue(valkeyService.isNewEvent(eventTypeId1, dedupKey3, expiredDeleteAfter, eventId));
+        assertTrue(valkeyService.isNewEvent(eventTypeId1, dedupKey3, expiredDeleteAfter));
     }
 
     @Test
@@ -51,20 +50,15 @@ class ValkeyServiceTest {
         // Insert initial event
         UUID eventTypeId = UUID.randomUUID();
         String dedupKey = "dedup-key-duplicates-" + UUID.randomUUID();
-        UUID eventId = UUID.randomUUID();
         LocalDateTime deleteAfter = LocalDateTime.now().plusDays(7);
-        assertTrue(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter, eventId));
+        assertTrue(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter));
 
         // Attempt to reinsert the same event
-        assertFalse(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter, eventId));
+        assertFalse(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter));
 
         // Changing the expiry date does not affect duplicate detection
         LocalDateTime deleteAfter2 = deleteAfter.plusDays(10);
-        assertFalse(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter2, eventId));
-
-        // Event ID is not used to identify duplicates, and has no impact outside of debugging
-        UUID eventId2 = UUID.randomUUID();
-        assertFalse(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter, eventId2));
+        assertFalse(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter2));
     }
 
     @Test
@@ -75,10 +69,10 @@ class ValkeyServiceTest {
 
         // Key will expire in 7 seconds
         LocalDateTime deleteAfter = LocalDateTime.now().plusSeconds(7);
-        valkeyService.isNewEvent(eventTypeId, deduplicationKey, deleteAfter, eventId);
+        valkeyService.isNewEvent(eventTypeId, deduplicationKey, deleteAfter);
 
         // Wait 10 seconds and attempt to insert key that should have expired
         Thread.sleep(Duration.ofSeconds(10));
-        assertTrue(valkeyService.isNewEvent(eventTypeId, deduplicationKey, deleteAfter, eventId));
+        assertTrue(valkeyService.isNewEvent(eventTypeId, deduplicationKey, deleteAfter));
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/ValkeyServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/ValkeyServiceTest.java
@@ -1,0 +1,12 @@
+package com.redhat.cloud.notifications.events;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+class ValkeyServiceTest {
+    @Inject
+    ValkeyService valkeyService;
+
+    // TODO add client library-specific test cases
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/ValkeyServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/ValkeyServiceTest.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.events;
 
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -12,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
 class ValkeyServiceTest {
     @Inject
     ValkeyService valkeyService;

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/ValkeyServiceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/ValkeyServiceTest.java
@@ -2,11 +2,80 @@ package com.redhat.cloud.notifications.events;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 class ValkeyServiceTest {
     @Inject
     ValkeyService valkeyService;
 
-    // TODO add client library-specific test cases
+    @Test
+    void testAddNewEntries() {
+        UUID eventTypeId1 = UUID.randomUUID();
+        String dedupKey1 = "dedup-key-new-" + UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        LocalDateTime deleteAfter = LocalDateTime.now().plusDays(7);
+
+        // Insert first event
+        assertTrue(valkeyService.isNewEvent(eventTypeId1, dedupKey1, deleteAfter, eventId));
+
+        // Insert entry with different event type ID
+        UUID eventTypeId2 = UUID.randomUUID();
+        assertTrue(valkeyService.isNewEvent(eventTypeId2, dedupKey1, deleteAfter, eventId));
+
+        // Insert entry with different deduplication key
+        String dedupKey2 = "dedup-key-new-" + UUID.randomUUID();
+        assertTrue(valkeyService.isNewEvent(eventTypeId1, dedupKey2, deleteAfter, eventId));
+
+        // Deduplication required both event type and dedup key to match
+        assertTrue(valkeyService.isNewEvent(eventTypeId2, dedupKey2, deleteAfter, eventId));
+
+        // Events which should have already expired will also return successfully
+        LocalDateTime expiredDeleteAfter = LocalDateTime.of(2023, 5, 11, 15, 40, 21);
+        String dedupKey3 = "dedup-key-new-" + UUID.randomUUID();
+        assertTrue(valkeyService.isNewEvent(eventTypeId1, dedupKey3, expiredDeleteAfter, eventId));
+    }
+
+    @Test
+    void testAddDuplicateEntries() {
+        // Insert initial event
+        UUID eventTypeId = UUID.randomUUID();
+        String dedupKey = "dedup-key-duplicates-" + UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+        LocalDateTime deleteAfter = LocalDateTime.now().plusDays(7);
+        assertTrue(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter, eventId));
+
+        // Attempt to reinsert the same event
+        assertFalse(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter, eventId));
+
+        // Changing the expiry date does not affect duplicate detection
+        LocalDateTime deleteAfter2 = deleteAfter.plusDays(10);
+        assertFalse(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter2, eventId));
+
+        // Event ID is not used to identify duplicates, and has no impact outside of debugging
+        UUID eventId2 = UUID.randomUUID();
+        assertFalse(valkeyService.isNewEvent(eventTypeId, dedupKey, deleteAfter, eventId2));
+    }
+
+    @Test
+    void testEntryExpiry() throws InterruptedException {
+        UUID eventTypeId = UUID.randomUUID();
+        String deduplicationKey = "dedup-expiry-key-" + UUID.randomUUID();
+        UUID eventId = UUID.randomUUID();
+
+        // Key will expire in 7 seconds
+        LocalDateTime deleteAfter = LocalDateTime.now().plusSeconds(7);
+        valkeyService.isNewEvent(eventTypeId, deduplicationKey, deleteAfter, eventId);
+
+        // Wait 10 seconds and attempt to insert key that should have expired
+        Thread.sleep(Duration.ofSeconds(10));
+        assertTrue(valkeyService.isNewEvent(eventTypeId, deduplicationKey, deleteAfter, eventId));
+    }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
@@ -30,8 +30,6 @@ class EventDeduplicatorTest {
 
     public static final String TEST_BUNDLE_NAME = "test-bundle";
     public static final String SUBSCRIPTION_SERVICES_BUNDLE_NAME = "subscription-services";
-    public static final String TEST_APP_NAME = "test-app";
-    public static final String SUBSCRIPTIONS_APP_NAME = "subscriptions";
 
     static final ZoneId UTC_ZONE = ZoneId.of("UTC");
 
@@ -56,11 +54,6 @@ class EventDeduplicatorTest {
     @Transactional
     void afterEach() {
         entityManager
-                .createNativeQuery("DELETE FROM applications WHERE name = :testName OR name = :subName")
-                .setParameter("testName", TEST_APP_NAME)
-                .setParameter("subName", SUBSCRIPTIONS_APP_NAME)
-                .executeUpdate();
-        entityManager
                 .createNativeQuery("DELETE FROM bundles WHERE name = :testName OR name = :subName")
                 .setParameter("testName", TEST_BUNDLE_NAME)
                 .setParameter("subName", SUBSCRIPTION_SERVICES_BUNDLE_NAME)
@@ -73,7 +66,7 @@ class EventDeduplicatorTest {
         when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(valkeyDedupEnabled);
         when(config.isInMemoryDbEnabled()).thenReturn(valkeyDedupEnabled);
 
-        EventType eventType = createEventType(TEST_BUNDLE_NAME, TEST_APP_NAME);
+        EventType eventType = createEventType(TEST_BUNDLE_NAME, "test-app");
         LocalDateTime dateTime = LocalDateTime.now(UTC_ZONE);
 
         UUID eventId1 = UUID.randomUUID();
@@ -106,7 +99,7 @@ class EventDeduplicatorTest {
         when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(valkeyDedupEnabled);
         when(config.isInMemoryDbEnabled()).thenReturn(valkeyDedupEnabled);
 
-        EventType eventType = createEventType(SUBSCRIPTION_SERVICES_BUNDLE_NAME, SUBSCRIPTIONS_APP_NAME);
+        EventType eventType = createEventType(SUBSCRIPTION_SERVICES_BUNDLE_NAME, "subscriptions");
         LocalDateTime baseDateTime =
                 LocalDateTime.of(LocalDateTime.now(UTC_ZONE).plusYears(1).getYear(), 11, 14, 10, 52);
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
@@ -1,11 +1,13 @@
 package com.redhat.cloud.notifications.events.deduplication;
 
+import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.events.EventWrapperAction;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
 import io.vertx.core.json.JsonObject;
@@ -26,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
 class EventDeduplicatorTest {
 
     public static final String TEST_BUNDLE_NAME = "test-bundle";

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
@@ -1,32 +1,48 @@
 package com.redhat.cloud.notifications.events.deduplication;
 
+import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.events.EventWrapperAction;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
 import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 @QuarkusTest
 class EventDeduplicatorTest {
+
+    public static final String TEST_BUNDLE_NAME = "test-bundle";
+    public static final String SUBSCRIPTION_SERVICES_BUNDLE_NAME = "subscription-services";
+    public static final String TEST_APP_NAME = "test-app";
+    public static final String SUBSCRIPTIONS_APP_NAME = "subscriptions";
+
+    static final ZoneId UTC_ZONE = ZoneId.of("UTC");
 
     @Inject
     EventDeduplicator eventDeduplicator;
 
     @Inject
     EntityManager entityManager;
+
+    @InjectSpy
+    EngineConfig config;
 
     @BeforeEach
     @Transactional
@@ -36,16 +52,34 @@ class EventDeduplicatorTest {
             .executeUpdate();
     }
 
-    @Test
-    void testIsNewWithDefaultDeduplication() {
+    @AfterEach
+    @Transactional
+    void afterEach() {
+        entityManager
+                .createNativeQuery("DELETE FROM bundles WHERE name = :testName OR name = :subName")
+                .setParameter("testName", TEST_BUNDLE_NAME)
+                .setParameter("subName", SUBSCRIPTION_SERVICES_BUNDLE_NAME)
+                .executeUpdate();
+        entityManager
+                .createNativeQuery("DELETE FROM applications WHERE name = :testName OR name = :subName")
+                .setParameter("testName", TEST_APP_NAME)
+                .setParameter("subName", SUBSCRIPTIONS_APP_NAME)
+                .executeUpdate();
+    }
 
-        EventType eventType = createEventType("test-bundle", "test-app");
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testIsNewWithDefaultDeduplication(final boolean valkeyDedupEnabled) {
+        when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(valkeyDedupEnabled);
+
+        EventType eventType = createEventType(TEST_BUNDLE_NAME, TEST_APP_NAME);
+        LocalDateTime dateTime = LocalDateTime.now(UTC_ZONE);
 
         UUID eventId1 = UUID.randomUUID();
         Event event1 = new Event();
         event1.setId(eventId1);
         event1.setEventType(eventType);
-        event1.setEventWrapper(new EventWrapperAction(ActionBuilder.build(LocalDateTime.of(2025, 11, 14, 10, 52))));
+        event1.setEventWrapper(new EventWrapperAction(ActionBuilder.build(dateTime)));
 
         assertTrue(eventDeduplicator.isNew(event1), "New event should return true");
 
@@ -53,28 +87,32 @@ class EventDeduplicatorTest {
         Event event2 = new Event();
         event2.setId(eventId2);
         event2.setEventType(eventType);
-        event2.setEventWrapper(new EventWrapperAction(ActionBuilder.build(LocalDateTime.of(2025, 11, 14, 10, 52))));
+        event2.setEventWrapper(new EventWrapperAction(ActionBuilder.build(dateTime)));
 
         assertTrue(eventDeduplicator.isNew(event2), "New event should return true");
 
         Event event3 = new Event();
         event3.setId(eventId2);
         event3.setEventType(eventType);
-        event3.setEventWrapper(new EventWrapperAction(ActionBuilder.build(LocalDateTime.of(2025, 11, 14, 10, 52))));
+        event3.setEventWrapper(new EventWrapperAction(ActionBuilder.build(dateTime)));
 
         assertFalse(eventDeduplicator.isNew(event3), "Duplicate event should return false");
     }
 
-    @Test
-    void testIsNewWithSubscriptionsDeduplication() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testIsNewWithSubscriptionsDeduplication(final boolean valkeyDedupEnabled) {
+        when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(valkeyDedupEnabled);
 
-        EventType eventType = createEventType("subscription-services", "subscriptions");
+        EventType eventType = createEventType(SUBSCRIPTION_SERVICES_BUNDLE_NAME, SUBSCRIPTIONS_APP_NAME);
+        LocalDateTime baseDateTime =
+                LocalDateTime.of(LocalDateTime.now(UTC_ZONE).plusYears(1).getYear(), 11, 14, 10, 52);
 
         Event event1 = createSubscriptionsEvent(
             UUID.randomUUID(),
             "org123",
             eventType,
-            LocalDateTime.of(2025, 11, 14, 10, 52),
+            baseDateTime,
             "prod456",
             "metric789",
             "billing001");
@@ -85,7 +123,7 @@ class EventDeduplicatorTest {
             UUID.randomUUID(),
             "org123",
             eventType,
-            LocalDateTime.of(2025, 11, 15, 14, 30), // Different day, same month.
+            baseDateTime.withDayOfMonth(15).withHour(14).withMinute(30), // Different day, same month.
             "prod456",
             "metric789",
             "billing001");
@@ -96,7 +134,7 @@ class EventDeduplicatorTest {
             UUID.randomUUID(),
             "org999",
             eventType,
-            LocalDateTime.of(2025, 11, 16, 9, 15), // Different day, still same month.
+            baseDateTime.withDayOfMonth(16).withHour(9).withMinute(15), // Different day, still same month.
             "prod456",
             "metric789",
             "billing001");
@@ -107,7 +145,7 @@ class EventDeduplicatorTest {
             UUID.randomUUID(),
             "org123",
             eventType,
-            LocalDateTime.of(2025, 12, 1, 10, 0), // Different month.
+            baseDateTime.withMonth(12).withDayOfMonth(1).withHour(10).withMinute(0), // Different month.
             "prod456",
             "metric789",
             "billing001");
@@ -118,7 +156,7 @@ class EventDeduplicatorTest {
             UUID.randomUUID(),
             "org123",
             eventType,
-            LocalDateTime.of(2025, 11, 17, 11, 0),
+            baseDateTime.withDayOfMonth(17).withHour(11).withMinute(0),
             "prod999",
             "metric789",
             "billing001");
@@ -129,7 +167,7 @@ class EventDeduplicatorTest {
             UUID.randomUUID(),
             "org123",
             eventType,
-            LocalDateTime.of(2025, 11, 18, 11, 0),
+            baseDateTime.withDayOfMonth(18).withHour(11).withMinute(0),
             "prod999",
             "metric999",
             "billing001");
@@ -140,7 +178,7 @@ class EventDeduplicatorTest {
             UUID.randomUUID(),
             "org123",
             eventType,
-            LocalDateTime.of(2025, 11, 19, 11, 0),
+            baseDateTime.withDayOfMonth(19).withHour(11).withMinute(0),
             "prod999",
             "metric999",
             "billing999");

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
@@ -56,14 +56,14 @@ class EventDeduplicatorTest {
     @Transactional
     void afterEach() {
         entityManager
-                .createNativeQuery("DELETE FROM bundles WHERE name = :testName OR name = :subName")
-                .setParameter("testName", TEST_BUNDLE_NAME)
-                .setParameter("subName", SUBSCRIPTION_SERVICES_BUNDLE_NAME)
-                .executeUpdate();
-        entityManager
                 .createNativeQuery("DELETE FROM applications WHERE name = :testName OR name = :subName")
                 .setParameter("testName", TEST_APP_NAME)
                 .setParameter("subName", SUBSCRIPTIONS_APP_NAME)
+                .executeUpdate();
+        entityManager
+                .createNativeQuery("DELETE FROM bundles WHERE name = :testName OR name = :subName")
+                .setParameter("testName", TEST_BUNDLE_NAME)
+                .setParameter("subName", SUBSCRIPTION_SERVICES_BUNDLE_NAME)
                 .executeUpdate();
     }
 
@@ -71,6 +71,7 @@ class EventDeduplicatorTest {
     @ValueSource(booleans = {true, false})
     void testIsNewWithDefaultDeduplication(final boolean valkeyDedupEnabled) {
         when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(valkeyDedupEnabled);
+        when(config.isInMemoryDbEnabled()).thenReturn(valkeyDedupEnabled);
 
         EventType eventType = createEventType(TEST_BUNDLE_NAME, TEST_APP_NAME);
         LocalDateTime dateTime = LocalDateTime.now(UTC_ZONE);
@@ -103,6 +104,7 @@ class EventDeduplicatorTest {
     @ValueSource(booleans = {true, false})
     void testIsNewWithSubscriptionsDeduplication(final boolean valkeyDedupEnabled) {
         when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(valkeyDedupEnabled);
+        when(config.isInMemoryDbEnabled()).thenReturn(valkeyDedupEnabled);
 
         EventType eventType = createEventType(SUBSCRIPTION_SERVICES_BUNDLE_NAME, SUBSCRIPTIONS_APP_NAME);
         LocalDateTime baseDateTime =


### PR DESCRIPTION
## Jira work item

https://redhat.atlassian.net/browse/RHCLOUD-35790

## Description

This re-adds support for event deduplication via remote caches, implemented with Valkey. It works identically to the PostgreSQL database table, and depends on two parameters:
- `IN_MEMORY_DB_ENABLED`: instructs Clowder to create a Valkey instance to store the data in
- `notifications-engine.valkey-event-deduplicator.enabled`: Unleash toggle to switch to using Valkey for event dedup

Deduplication is done with keys in the format

```
engine:event-deduplication:<eventTypeId>:<dedupKey>
```

And additionally stores `deleteAfter` as a value so it is internally similar to Postgres. If the event has not been seen before, the key is set to expire at this time.

**Improvements since last time:**
- Reimplemented using the lower-level Vert.x Mutiny API, meaning that it will not try to connect to a Valkey instance on startup. This means it will work where Valkey isn't available.
- Implements the new deduplication logic
- The test configuration actually works locally

## Compatibilty

No impact unless _both_ of the above feature flags are enabled.

## Testing

- Added test cases to check that event deduplication works with either Valkey or Postgres enabled
- Added ValkeyServiceTest to validate that duplicates are identified correctly
- Modified TestLifecycleManager to configure Valkey pod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional in-memory DB mode for event deduplication with a configurable toggle and Redis/Valkey-backed deduplicator; cross-checking between native and Valkey deduplication with mismatch logging and safer cleanup on errors.
  * Test profile support to enable Redis/Valkey provisioning for test runs.

* **Tests**
  * New and expanded tests for deduplication, duplicate detection, and expiry; test lifecycle now supports independent Postgres and Valkey containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->