### PR TITLE
[RHCLOUD-46469] Customer notification of switching PagerDuty integrations to dynamic severity

### DIFF
--- a/common-template/src/main/resources/templates/email/Integrations/generalCommunicationBody.html
+++ b/common-template/src/main/resources/templates/email/Integrations/generalCommunicationBody.html
@@ -3,7 +3,7 @@
     Integrations - Console
 {/content-header-title}
 {#content-title}
-    Your PagerDuty integrations will filter notifications soon
+    Your PagerDuty integrations will soon filter notifications by severity level
 {/content-title}
 {#content-body}
     <p style="{body-section-p-style}">Dear Red Hat customer,</p>

--- a/common-template/src/main/resources/templates/email/Integrations/generalCommunicationBody.html
+++ b/common-template/src/main/resources/templates/email/Integrations/generalCommunicationBody.html
@@ -3,24 +3,25 @@
     Integrations - Console
 {/content-header-title}
 {#content-title}
-    Your Microsoft Teams integrations need attention
+    Your PagerDuty integrations will filter notifications soon
 {/content-title}
 {#content-body}
     <p style="{body-section-p-style}">Dear Red Hat customer,</p>
-    <p style="{body-section-p-style}">We are contacting you because you have the following Microsoft Teams integrations set up for your organization in the <a style="{body-section-underline-link-style}" target="_blank" href="https://console.redhat.com">Red Hat Hybrid Cloud Console</a>:</p>
+    <p style="{body-section-p-style}">We are contacting you because you have the following PagerDuty integrations set up for your organization in the <a style="{body-section-underline-link-style}" target="_blank" href="https://console.redhat.com">Red Hat Hybrid Cloud Console</a>:</p>
     <ul>
         {#for integrationName in action.events[0].payload.integration_names}
         <li>{integrationName}</li>
         {/for}
     </ul>
     <p style="{body-section-p-style}">
-        Microsoft is <a style="{body-section-underline-link-style}" target="_blank" href="https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/#why-are-we-retiring-office-365-connectors">retiring Office 365 connectors in favor of Power Automate workflows</a>,
-        and they are requesting that their customers transition from <i>Office 365 connectors</i> they have set up to <i>Workflows</i>.
-        Please review the Microsoft Teams integrations identified above and update them if needed, to avoid service interruption when Microsoft retires the old connectors.
-        <strong>If you have already updated your integrations to <i>Microsoft Workflows</i>, you can safely ignore this email</strong>.
+        On [[ SCHEDULED UPGRADE DATE ]], these integrations will begin mapping and filtering alert severity based on the notification type.
+        For example, errata notifications will be mapped according to their <a href="https://access.redhat.com/security/updates/classification">Red Hat severity rating</a>.
     </p>
-    <p style="{body-section-p-style}">You can update your Microsoft Teams integrations by following the steps in <a style="{body-section-underline-link-style}" target="_blank" href="https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/integrating_the_red_hat_hybrid_cloud_console_with_third-party_applications/index#assembly-configuring-integration-with-teams_integrating-communications">Integrating communications applications with the Hybrid Cloud Console</a> in the Red Hat documentation.</p>
-    <p style="{body-section-p-style}">Following the above steps will ensure that you will continue receiving the alerts and notifications in the Microsoft Teams channel that you have configured.</p>
+    <p style="{body-section-p-style}">
+        Please <a href="[[ LINK TO SET NOTIF SEVERITY ]]">review your notifications</a> and select the severity level of notifications that you would like to receive.
+        The <a href="https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/configuring_notifications_on_the_red_hat_hybrid_cloud_console/index#con-notif-severity_notif-config-intro">documentation on severity levels</a> explains what kind of notifications should be expected.
+        <strong>If you have previously selected severity levels (such as to filter email notifications), no further action is required.</strong>
+    </p>
     <p style="{body-section-p-style}">Thank you for your attention.</p>
     <p style="{body-section-p-style}">Kind regards,</p>
     <p style="{body-section-p-style}">Red Hat Hybrid Cloud Console</p>

--- a/common-template/src/main/resources/templates/email/Integrations/generalCommunicationBody.html
+++ b/common-template/src/main/resources/templates/email/Integrations/generalCommunicationBody.html
@@ -14,7 +14,7 @@
         {/for}
     </ul>
     <p style="{body-section-p-style}">
-        On <b>09-29-2026</b>, these integrations will begin mapping and filtering alert severity based on the notification type.
+        On <b>10-06-2026</b>, these integrations will begin mapping and filtering alert severity based on the notification type.
         For example, errata notifications will be mapped according to their <a href="https://access.redhat.com/security/updates/classification">Red Hat severity rating</a>.
     </p>
     <p style="{body-section-p-style}">

--- a/common-template/src/main/resources/templates/email/Integrations/generalCommunicationBody.html
+++ b/common-template/src/main/resources/templates/email/Integrations/generalCommunicationBody.html
@@ -14,11 +14,11 @@
         {/for}
     </ul>
     <p style="{body-section-p-style}">
-        On [[ SCHEDULED UPGRADE DATE ]], these integrations will begin mapping and filtering alert severity based on the notification type.
+        On <b>09-29-2026</b>, these integrations will begin mapping and filtering alert severity based on the notification type.
         For example, errata notifications will be mapped according to their <a href="https://access.redhat.com/security/updates/classification">Red Hat severity rating</a>.
     </p>
     <p style="{body-section-p-style}">
-        Please <a href="[[ LINK TO SET NOTIF SEVERITY ]]">review your notifications</a> and select the severity level of notifications that you would like to receive.
+        Please review your PagerDuty notifications settings and select the severity level of notifications that you would like to receive.
         The <a href="https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/configuring_notifications_on_the_red_hat_hybrid_cloud_console/index#con-notif-severity_notif-config-intro">documentation on severity levels</a> explains what kind of notifications should be expected.
         <strong>If you have previously selected severity levels (such as to filter email notifications), no further action is required.</strong>
     </p>

--- a/common-template/src/main/resources/templates/email/Integrations/generalCommunicationTitle.txt
+++ b/common-template/src/main/resources/templates/email/Integrations/generalCommunicationTitle.txt
@@ -1,1 +1,1 @@
-Your Microsoft Teams integrations need attention
+Your PagerDuty integrations will filter notifications soon

--- a/common-template/src/main/resources/templates/email/Integrations/generalCommunicationTitle.txt
+++ b/common-template/src/main/resources/templates/email/Integrations/generalCommunicationTitle.txt
@@ -1,1 +1,1 @@
-Your PagerDuty integrations will filter notifications soon
+Your PagerDuty integrations will soon filter notifications by severity level

--- a/common-template/src/test/java/email/TestIntegrationsTemplate.java
+++ b/common-template/src/test/java/email/TestIntegrationsTemplate.java
@@ -84,7 +84,7 @@ public class TestIntegrationsTemplate extends EmailTemplatesRendererHelper {
             "   \"events\":[" +
             "      {" +
             "         \"metadata\":{" +
-            "            \"communication-description\":\"General communication about customers' Microsoft Teams' URLs needing a review\"" +
+            "            \"communication-description\":\"General communication about customers' PagerDuty integrations switching to dynamic severity\"" +
             "         }," +
             "         \"payload\":{" +
             "            \"integration_names\":[%s]" +
@@ -115,13 +115,13 @@ public class TestIntegrationsTemplate extends EmailTemplatesRendererHelper {
                 integrationNames.stream().map(integrationName -> "\"" +  integrationName + "\"").collect(Collectors.joining(",")))
         );
         final String rendered = generateEmailBody(INTEGRATIONS_GENERAL_COMMUNICATION, action, useBetaTemplate);
-        assertTrue(rendered.contains("We are contacting you because you have the following Microsoft Teams integrations set up for your organization in the"));
+        assertTrue(rendered.contains("We are contacting you because you have the following PagerDuty integrations set up for your organization in the"));
         assertTrue(rendered.contains("Integration one"));
         assertTrue(rendered.contains("Another integration"));
         assertTrue(rendered.contains("Third integration"));
-        assertTrue(rendered.contains("retiring Office 365 connectors in favor of Power Automate workflows"));
-        assertTrue(rendered.contains("https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/#why-are-we-retiring-office-365-connectors"));
-        assertTrue(rendered.contains("https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/integrating_the_red_hat_hybrid_cloud_console_with_third-party_applications/index#assembly-configuring-integration-with-teams_integrating-communications"));
+        assertTrue(rendered.contains("begin mapping and filtering alert severity based on the notification type"));
+        assertTrue(rendered.contains("https://access.redhat.com/security/updates/classification"));
+        assertTrue(rendered.contains("https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/configuring_notifications_on_the_red_hat_hybrid_cloud_console/index#con-notif-severity_notif-config-intro"));
         assertTrue(rendered.contains("Red Hat Hybrid Cloud Console"));
     }
 

--- a/common-template/src/test/java/email/TestIntegrationsTemplate.java
+++ b/common-template/src/test/java/email/TestIntegrationsTemplate.java
@@ -79,7 +79,7 @@ public class TestIntegrationsTemplate extends EmailTemplatesRendererHelper {
             "   \"timestamp\":\"2025-07-11T09:01:36.220643799\"," +
             "   \"org_id\":\"%s\"," +
             "   \"context\":{" +
-            "      \"integration_category\":\"Communications\"" +
+            "      \"integration_category\":\"Reporting\"" +
             "   }," +
             "   \"events\":[" +
             "      {" +
@@ -123,6 +123,7 @@ public class TestIntegrationsTemplate extends EmailTemplatesRendererHelper {
         assertTrue(rendered.contains("https://access.redhat.com/security/updates/classification"));
         assertTrue(rendered.contains("https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html-single/configuring_notifications_on_the_red_hat_hybrid_cloud_console/index#con-notif-severity_notif-config-intro"));
         assertTrue(rendered.contains("Red Hat Hybrid Cloud Console"));
+        assertTrue(rendered.contains("/settings/integrations?category=Reporting"));
     }
 
     private Action buildIntegrationDisabledAction(final String errorType, final String errorDetails, final int errorCount, final int errorStatusCode) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -16,6 +16,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 import jakarta.transaction.Transactional;
 
 import java.time.Duration;
@@ -323,18 +324,32 @@ public class EndpointRepository {
      * integration names as the value.
      */
     public Map<String, List<String>> findIntegrationNamesByTypeGroupedByOrganizationId(final CompositeEndpointType integrationType) {
+        // The "subType" column can be null, and in SQL "column = NULL" never
+        // evaluates to true, so it needs to be compared with "IS NULL"
+        // instead of the equality operator.
+        final String subTypeCondition = integrationType.getSubType() == null
+            ? "e.compositeType.subType IS NULL"
+            : "e.compositeType.subType = :subType";
+
         final String findByTypeQuery =
             "SELECT " +
                 "e " +
             "FROM " +
                 "Endpoint AS e " +
             "WHERE " +
-                "e.compositeType = :type";
+                "e.compositeType.type = :type " +
+            "AND " +
+                subTypeCondition;
+
+        final TypedQuery<Endpoint> query = this.entityManager.createQuery(findByTypeQuery, Endpoint.class)
+            .setParameter("type", integrationType.getType());
+
+        if (integrationType.getSubType() != null) {
+            query.setParameter("subType", integrationType.getSubType());
+        }
 
         // Fetch the endpoints from the database.
-        final List<Endpoint> endpoints = this.entityManager.createQuery(findByTypeQuery, Endpoint.class)
-            .setParameter("type", integrationType)
-            .getResultList();
+        final List<Endpoint> endpoints = query.getResultList();
 
         // Group the endpoints by org ID.
         final Map<String, List<String>> result = new HashMap<>();

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifier.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifier.java
@@ -88,7 +88,7 @@ public class IntegrationDisabledNotifier {
      */
     public static String getFrontendCategory(Endpoint endpoint) {
         return switch (endpoint.getType()) {
-            case ANSIBLE -> "Reporting";
+            case ANSIBLE, PAGERDUTY -> "Reporting";
             case CAMEL -> {
                 yield switch (endpoint.getSubType()) {
                         case "google_chat", "slack", "teams" -> "Communications";

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifier.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/IntegrationDisabledNotifier.java
@@ -88,7 +88,7 @@ public class IntegrationDisabledNotifier {
      */
     public static String getFrontendCategory(Endpoint endpoint) {
         return switch (endpoint.getType()) {
-            case ANSIBLE -> "Reporting";
+            case ANSIBLE, PAGERDUTY -> "Reporting";
             case CAMEL -> {
                 yield switch (endpoint.getSubType()) {
                     case "google_chat", "slack", "teams" -> "Communications";

--- a/engine/src/main/java/com/redhat/cloud/notifications/routers/GeneralCommunicationsResource.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/routers/GeneralCommunicationsResource.java
@@ -46,7 +46,7 @@ public class GeneralCommunicationsResource {
     @Produces(MediaType.APPLICATION_JSON)
     public SendGeneralCommunicationResponse sendGeneralCommunication() {
         // Find all the integration names and group them by organization ID.
-        final CompositeEndpointType compositeEndpointType = new CompositeEndpointType(EndpointType.CAMEL, "teams");
+        final CompositeEndpointType compositeEndpointType = new CompositeEndpointType(EndpointType.PAGERDUTY);
         final Map<String, List<String>> endpointNamesPerOrg = this.endpointRepository.findIntegrationNamesByTypeGroupedByOrganizationId(compositeEndpointType);
 
         // Send a "no content" response when there is nothing to do. It is not

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/EndpointRepositoryTest.java
@@ -497,4 +497,29 @@ public class EndpointRepositoryTest {
             }
         }
     }
+
+    /**
+     * Tests that the function under test finds integration names for a
+     * type that has no subtype -- e.g. PagerDuty -- since the "subType"
+     * column being null requires an "IS NULL" comparison rather than an
+     * equality comparison.
+     */
+    @Test
+    @Transactional
+    void testFindIntegrationNamesByTypeGroupedByOrganizationIdWithNullSubType() {
+        final Endpoint pagerDutyEndpoint = this.resourceHelpers.createEndpoint(PAGERDUTY, null, true, 0);
+        pagerDutyEndpoint.setOrgId(DEFAULT_ORG_ID);
+        this.entityManager.persist(pagerDutyEndpoint);
+
+        // Create a "noise" endpoint of a different type to make sure it
+        // does not get incorrectly picked up.
+        final Endpoint camelEndpoint = this.resourceHelpers.createEndpoint(CAMEL, "teams", true, 0);
+        camelEndpoint.setOrgId(DEFAULT_ORG_ID);
+        this.entityManager.persist(camelEndpoint);
+
+        final Map<String, List<String>> result = this.endpointRepository.findIntegrationNamesByTypeGroupedByOrganizationId(new CompositeEndpointType(PAGERDUTY));
+
+        Assertions.assertTrue(result.containsKey(DEFAULT_ORG_ID), "the organization ID should be present in the result");
+        Assertions.assertEquals(List.of(pagerDutyEndpoint.getName()), result.get(DEFAULT_ORG_ID), "the PagerDuty endpoint should have been found");
+    }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/routers/GeneralCommunicationsResourceTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/routers/GeneralCommunicationsResourceTest.java
@@ -59,7 +59,7 @@ public class GeneralCommunicationsResourceTest {
         final String orgId = DEFAULT_ORG_ID + "test-send-gen-com";
         final List<Endpoint> createdEndpoints = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
-            final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(orgId, EndpointType.CAMEL, "teams", true, 0);
+            final Endpoint createdEndpoint = this.resourceHelpers.createEndpoint(orgId, EndpointType.PAGERDUTY, null, true, 0);
 
             createdEndpoints.add(createdEndpoint);
         }


### PR DESCRIPTION
## Jira work item

https://redhat.atlassian.net/browse/RHCLOUD-46469

## Description

This updates the Console Integrations template with a new message for customers, when PagerDuty integrations will be switch from static severity, to tenant-provided ("dynamic" ones)

> [!WARNING]
> This is a draft email, and not all links have been inserted into the email body.

## Compatibility

Only changes as described in the email, which do not take effect until `dynamic-pagerduty-severity` feature flag is enabled.

## Testing

Updated resource and general integrations test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added communications about upcoming PagerDuty notification filtering by severity on October 6, 2026.
  * Included severity-mapping guidance, notification settings instructions, and updated documentation links.
* **Updates**
  * PagerDuty integrations are now represented under Reporting settings.
  * Integration communications now reference PagerDuty rather than Microsoft Teams.
  * Improved matching for PagerDuty integrations without a subtype.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->