### PR TITLE
Add templates for scheduler

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Console.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Console.java
@@ -21,6 +21,9 @@ public class Console {
     static final String SOURCES_APP_NAME = "sources";
     static final String SOURCES_FOLDER_NAME = "Sources/";
 
+    static final String SCHEDULER_APP_NAME = "scheduler";
+    static final String SCHEDULER_FOLDER_NAME = "Scheduler/";
+
     public static final String INTEGRATIONS_INTEGRATION_DISABLED = "integration-disabled";
     public static final String INTEGRATIONS_GENERAL_COMMUNICATION = "general-communication";
 
@@ -41,6 +44,10 @@ public class Console {
     public static final String RBAC_RH_NEW_TAM_REQUEST_CREATED = "rh-new-tam-request-created";
 
     public static final String SOURCES_AVAILABILITY_STATUS = "availability-status";
+
+    public static final String SCHEDULER_EXPORT_COMPLETE = "export-complete";
+    public static final String SCHEDULER_JOB_FAILED = "job-failed";
+    public static final String SCHEDULER_JOB_FAILED_PAUSED = "job-failed-paused";
 
     public static final Map<TemplateDefinition, String> templatesMap = Map.ofEntries(
         // Integration
@@ -83,6 +90,14 @@ public class Console {
 
         // Sources
         entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, SOURCES_APP_NAME, SOURCES_AVAILABILITY_STATUS), SOURCES_FOLDER_NAME + "availabilityStatusBody.md"),
-        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SOURCES_APP_NAME, SOURCES_AVAILABILITY_STATUS), SOURCES_FOLDER_NAME + "availabilityStatusEmailBody.html")
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SOURCES_APP_NAME, SOURCES_AVAILABILITY_STATUS), SOURCES_FOLDER_NAME + "availabilityStatusEmailBody.html"),
+
+        // Scheduler
+        entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, SCHEDULER_APP_NAME, SCHEDULER_EXPORT_COMPLETE), SCHEDULER_FOLDER_NAME + "exportCompleteBody.md"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SCHEDULER_APP_NAME, SCHEDULER_EXPORT_COMPLETE), SCHEDULER_FOLDER_NAME + "exportCompleteEmailBody.html"),
+        entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, SCHEDULER_APP_NAME, SCHEDULER_JOB_FAILED), SCHEDULER_FOLDER_NAME + "jobFailedBody.md"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SCHEDULER_APP_NAME, SCHEDULER_JOB_FAILED), SCHEDULER_FOLDER_NAME + "jobFailedEmailBody.html"),
+        entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, SCHEDULER_APP_NAME, SCHEDULER_JOB_FAILED_PAUSED), SCHEDULER_FOLDER_NAME + "jobFailedPausedBody.md"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SCHEDULER_APP_NAME, SCHEDULER_JOB_FAILED_PAUSED), SCHEDULER_FOLDER_NAME + "jobFailedPausedEmailBody.html")
     );
 }

--- a/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
@@ -1,1 +1,1 @@
-A scheduled export **[{data.context.job_name}]({environment.url}/api/exports/v1/exports/{data.context.export_id})** has completed.
+A scheduled export **[{data.context.job_name}]({environment.url()}/api/exports/v1/exports/{data.context.export_id})** has completed.

--- a/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
@@ -1,1 +1,1 @@
-A scheduled export ({action.context.job_name}) has completed
+A scheduled export ({data.context.job_name}) has completed.

--- a/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
@@ -1,1 +1,1 @@
-A scheduled export ({data.context.job_name}) has completed.
+A scheduled export **[{data.context.job_name}]({environment.url}/api/exports/v1/exports/{data.context.export_id})** has completed.

--- a/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
@@ -1,0 +1,1 @@
+A scheduled export ({action.context.job_name}) has completed

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
@@ -1,1 +1,1 @@
-A scheduled export ({data.context.job_name}) has failed.
+A scheduled export **[{data.context.job_name}]({environment.url()}/insights/jobs/{data.context.job_id})** has failed.

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
@@ -1,0 +1,1 @@
+A scheduled export ({action.context.job_name}) has failed

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
@@ -1,1 +1,1 @@
-A scheduled export ({action.context.job_name}) has failed
+A scheduled export ({data.context.job_name}) has failed.

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
@@ -1,1 +1,1 @@
-A scheduled export ({action.context.job_name}) has failed and been automatically paused.
+A scheduled export ({data.context.job_name}) has failed and been automatically paused.

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
@@ -1,0 +1,1 @@
+A scheduled export ({action.context.job_name}) has failed and been automatically paused.

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
@@ -1,1 +1,1 @@
-A scheduled export ({data.context.job_name}) has failed and been automatically paused.
+A scheduled export **[{data.context.job_name}]({environment.url()}/insights/jobs/{data.context.job_id})** has failed and been automatically paused.

--- a/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
@@ -11,4 +11,6 @@
         <a style="{body-section-underline-link-style}" href="{environment.url}/api/exports/v1/exports/{action.context.export_id}?{query_params}" target="_blank">Download exported data</a>.
     </p>
 {/content-body}
+{#content-button-href}{environment.url}/insights/jobs/{action.context.job_id}{/content-button-href}
+{#content-button-service-name}Scheduled jobs{/content-button-service-name}
 {/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
@@ -7,8 +7,8 @@
 {/content-title}
 {#content-body}
     <p style="{body-section-p-style}">
-        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}" target="_blank">{action.context.job_name}</a> scheduled export has completed successfully.
-        <a style="{body-section-underline-link-style}" href="{environment.url}/api/exports/v1/exports/{action.context.export_id}" target="_blank">Download exported data</a>.
+        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}?{query_params}" target="_blank">{action.context.job_name}</a> scheduled export has completed successfully.
+        <a style="{body-section-underline-link-style}" href="{environment.url}/api/exports/v1/exports/{action.context.export_id}?{query_params}" target="_blank">Download exported data</a>.
     </p>
 {/content-body}
 {/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
@@ -1,0 +1,14 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    Scheduler - Console
+{/content-header-title}
+{#content-title}
+    Scheduler export completed
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}" target="_blank">{action.context.job_name}</a> scheduled export has completed successfully.
+        <a style="{body-section-underline-link-style}" href="{environment.url}/api/exports/v1/exports/{action.context.export_id}" target="_blank">Download exported data</a>.
+    </p>
+{/content-body}
+{/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
@@ -7,7 +7,7 @@
 {/content-title}
 {#content-body}
     <p style="{body-section-p-style}">
-        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}" target="_blank">{action.context.job_name}</a> scheduled job has failed.
+        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}?{query_params}" target="_blank">{action.context.job_name}</a> scheduled job has failed.
     </p>
     {#if action.context.error_message}
     <p style="{body-section-p-style}">

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
@@ -15,4 +15,6 @@
     </p>
     {/if}
 {/content-body}
+{#content-button-href}{environment.url}/insights/jobs/{action.context.job_id}{/content-button-href}
+{#content-button-service-name}Scheduled jobs{/content-button-service-name}
 {/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
@@ -1,0 +1,18 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    Scheduler - Console
+{/content-header-title}
+{#content-title}
+    Scheduler job failed
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}" target="_blank">{action.context.job_name}</a> scheduled job has failed.
+    </p>
+    {#if action.context.error_message}
+    <p style="{body-section-p-style}">
+        <strong>Error:</strong> {action.context.error_message}
+    </p>
+    {/if}
+{/content-body}
+{/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
@@ -7,7 +7,7 @@
 {/content-title}
 {#content-body}
     <p style="{body-section-p-style}">
-        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}" target="_blank">{action.context.job_name}</a> scheduled job has failed and been automatically paused.
+        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}?{query_params}" target="_blank">{action.context.job_name}</a> scheduled job has failed and been automatically paused.
     </p>
     {#if action.context.error_message}
     <p style="{body-section-p-style}">

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
@@ -1,0 +1,21 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    Scheduler - Console
+{/content-header-title}
+{#content-title}
+    Scheduler job failed
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}" target="_blank">{action.context.job_name}</a> scheduled job has failed and been automatically paused.
+    </p>
+    {#if action.context.error_message}
+    <p style="{body-section-p-style}">
+        <strong>Error:</strong> {action.context.error_message}
+    </p>
+    {/if}
+    <p style="{body-section-p-style}">
+        The scheduled job has been paused to prevent further failures. Please review and resolve the issue before resuming the scheduled job.
+    </p>
+{/content-body}
+{/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
@@ -18,4 +18,6 @@
         The scheduled job has been paused to prevent further failures. Please review and resolve the issue before resuming the scheduled job.
     </p>
 {/content-body}
+{#content-button-href}{environment.url}/insights/jobs/{action.context.job_id}{/content-button-href}
+{#content-button-service-name}Scheduled jobs{/content-button-service-name}
 {/include}

--- a/common-template/src/test/java/drawer/TestSchedulerTemplate.java
+++ b/common-template/src/test/java/drawer/TestSchedulerTemplate.java
@@ -14,7 +14,6 @@ import static com.redhat.cloud.notifications.qute.templates.mapping.Console.SCHE
 import static helpers.SchedulerTestHelpers.createSchedulerExportCompleteAction;
 import static helpers.SchedulerTestHelpers.createSchedulerJobFailedAction;
 import static helpers.SchedulerTestHelpers.createSchedulerJobFailedPausedAction;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
@@ -27,21 +26,30 @@ class TestSchedulerTemplate {
     void testRenderedTemplateExportComplete() {
         Action action = createSchedulerExportCompleteAction();
         String result = renderTemplate(SCHEDULER_EXPORT_COMPLETE, action);
-        assertEquals("A scheduled export (Test Export Job) has completed.", result);
+        assertTrue(result.contains("A scheduled export"));
+        assertTrue(result.contains("**[Test Export Job]"));
+        assertTrue(result.contains("/api/exports/v1/exports/export-67890)**"));
+        assertTrue(result.contains("has completed"));
     }
 
     @Test
     void testRenderedTemplateJobFailed() {
         Action action = createSchedulerJobFailedAction();
         String result = renderTemplate(SCHEDULER_JOB_FAILED, action);
-        assertEquals("A scheduled export (Test Failed Job) has failed.", result);
+        assertTrue(result.contains("A scheduled export"));
+        assertTrue(result.contains("**[Test Failed Job]"));
+        assertTrue(result.contains("/insights/jobs/job-54321)**"));
+        assertTrue(result.contains("has failed"));
     }
 
     @Test
     void testRenderedTemplateJobFailedPaused() {
         Action action = createSchedulerJobFailedPausedAction();
         String result = renderTemplate(SCHEDULER_JOB_FAILED_PAUSED, action);
-        assertTrue(result.contains("A scheduled export (Test Paused Job) has failed and been automatically paused"));
+        assertTrue(result.contains("A scheduled export"));
+        assertTrue(result.contains("**[Test Paused Job]"));
+        assertTrue(result.contains("/insights/jobs/job-99999)**"));
+        assertTrue(result.contains("has failed and been automatically paused"));
     }
 
     String renderTemplate(final String eventType, final Action action) {

--- a/common-template/src/test/java/drawer/TestSchedulerTemplate.java
+++ b/common-template/src/test/java/drawer/TestSchedulerTemplate.java
@@ -1,0 +1,51 @@
+package drawer;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.qute.templates.IntegrationType;
+import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static com.redhat.cloud.notifications.qute.templates.mapping.Console.SCHEDULER_EXPORT_COMPLETE;
+import static com.redhat.cloud.notifications.qute.templates.mapping.Console.SCHEDULER_JOB_FAILED;
+import static com.redhat.cloud.notifications.qute.templates.mapping.Console.SCHEDULER_JOB_FAILED_PAUSED;
+import static helpers.SchedulerTestHelpers.createSchedulerExportCompleteAction;
+import static helpers.SchedulerTestHelpers.createSchedulerJobFailedAction;
+import static helpers.SchedulerTestHelpers.createSchedulerJobFailedPausedAction;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class TestSchedulerTemplate {
+
+    @Inject
+    TestHelpers testHelpers;
+
+    @Test
+    void testRenderedTemplateExportComplete() {
+        Action action = createSchedulerExportCompleteAction();
+        String result = renderTemplate(SCHEDULER_EXPORT_COMPLETE, action);
+        assertEquals("A scheduled export (Test Export Job) has completed.", result);
+    }
+
+    @Test
+    void testRenderedTemplateJobFailed() {
+        Action action = createSchedulerJobFailedAction();
+        String result = renderTemplate(SCHEDULER_JOB_FAILED, action);
+        assertEquals("A scheduled export (Test Failed Job) has failed.", result);
+    }
+
+    @Test
+    void testRenderedTemplateJobFailedPaused() {
+        Action action = createSchedulerJobFailedPausedAction();
+        String result = renderTemplate(SCHEDULER_JOB_FAILED_PAUSED, action);
+        assertTrue(result.contains("A scheduled export (Test Paused Job) has failed and been automatically paused"));
+    }
+
+    String renderTemplate(final String eventType, final Action action) {
+        TemplateDefinition templateConfig = new TemplateDefinition(IntegrationType.DRAWER, "console", "scheduler", eventType);
+        return testHelpers.renderTemplate(templateConfig, action);
+    }
+}

--- a/common-template/src/test/java/email/TestSchedulerTemplate.java
+++ b/common-template/src/test/java/email/TestSchedulerTemplate.java
@@ -1,0 +1,107 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static com.redhat.cloud.notifications.qute.templates.mapping.Console.SCHEDULER_EXPORT_COMPLETE;
+import static com.redhat.cloud.notifications.qute.templates.mapping.Console.SCHEDULER_JOB_FAILED;
+import static com.redhat.cloud.notifications.qute.templates.mapping.Console.SCHEDULER_JOB_FAILED_PAUSED;
+import static helpers.SchedulerTestHelpers.createSchedulerExportCompleteAction;
+import static helpers.SchedulerTestHelpers.createSchedulerJobFailedAction;
+import static helpers.SchedulerTestHelpers.createSchedulerJobFailedPausedAction;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestSchedulerTemplate extends EmailTemplatesRendererHelper {
+
+    @Override
+    protected String getBundle() {
+        return "console";
+    }
+
+    @Override
+    protected String getApp() {
+        return "scheduler";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "Console";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Scheduler";
+    }
+
+    @Test
+    public void testExportCompleteEmailBody() {
+        Action action = createSchedulerExportCompleteAction();
+        String result = generateEmailBody(SCHEDULER_EXPORT_COMPLETE, action);
+        assertTrue(result.contains("scheduled export has completed successfully"));
+        assertTrue(result.contains("Test Export Job"));
+        assertTrue(result.contains("/insights/jobs/"));
+        assertTrue(result.contains("Download exported data"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testExportCompleteEmailTitle() {
+        eventTypeDisplayName = "Scheduler export completed";
+        String result = generateEmailSubject(SCHEDULER_EXPORT_COMPLETE, createSchedulerExportCompleteAction());
+        assertEquals("Instant notification - Scheduler export completed - Scheduler - Console", result);
+    }
+
+    @Test
+    public void testJobFailedEmailBody() {
+        Action action = createSchedulerJobFailedAction();
+        String result = generateEmailBody(SCHEDULER_JOB_FAILED, action);
+        assertTrue(result.contains("scheduled job has failed"));
+        assertTrue(result.contains("Test Failed Job"));
+        assertTrue(result.contains("/insights/jobs/"));
+        assertTrue(result.contains("<strong>Error:</strong>"));
+        assertTrue(result.contains("Connection timeout"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testJobFailedEmailTitle() {
+        eventTypeDisplayName = "Scheduler job failed";
+        String result = generateEmailSubject(SCHEDULER_JOB_FAILED, createSchedulerJobFailedAction());
+        assertEquals("Instant notification - Scheduler job failed - Scheduler - Console", result);
+    }
+
+    @Test
+    public void testJobFailedPausedEmailBody() {
+        Action action = createSchedulerJobFailedPausedAction();
+        String result = generateEmailBody(SCHEDULER_JOB_FAILED_PAUSED, action);
+        assertTrue(result.contains("scheduled job has failed and been automatically paused"));
+        assertTrue(result.contains("Test Paused Job"));
+        assertTrue(result.contains("/insights/jobs/"));
+        assertTrue(result.contains("<strong>Error:</strong>"));
+        assertTrue(result.contains("Database connection failed"));
+        assertTrue(result.contains("The scheduled job has been paused to prevent further failures"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testJobFailedPausedEmailTitle() {
+        eventTypeDisplayName = "Scheduler job failed";
+        String result = generateEmailSubject(SCHEDULER_JOB_FAILED_PAUSED, createSchedulerJobFailedPausedAction());
+        assertEquals("Instant notification - Scheduler job failed - Scheduler - Console", result);
+    }
+
+    @Test
+    public void testJobFailedWithoutErrorMessage() {
+        Action action = createSchedulerJobFailedAction();
+        action.getContext().setAdditionalProperty("error_message", null);
+        String result = generateEmailBody(SCHEDULER_JOB_FAILED, action);
+        assertTrue(result.contains("scheduled job has failed"));
+        assertTrue(result.contains("Test Failed Job"));
+        // Should not contain error section if no error message
+        assertTrue(!result.contains("<strong>Error:</strong>") || result.contains("<strong>Error:</strong>  "));
+    }
+}

--- a/common-template/src/test/java/helpers/SchedulerTestHelpers.java
+++ b/common-template/src/test/java/helpers/SchedulerTestHelpers.java
@@ -1,0 +1,79 @@
+package helpers;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
+
+public class SchedulerTestHelpers {
+
+    public static Action createSchedulerExportCompleteAction() {
+        Action action = new Action();
+        action.setBundle(StringUtils.EMPTY);
+        action.setApplication(StringUtils.EMPTY);
+        action.setTimestamp(LocalDateTime.of(2026, 4, 9, 10, 30, 0, 0));
+        action.setEventType("export-complete");
+        action.setRecipients(List.of());
+
+        action.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("job_id", "job-12345")
+                .withAdditionalProperty("job_name", "Test Export Job")
+                .withAdditionalProperty("export_id", "export-67890")
+                .build()
+        );
+
+        action.setAccountId(StringUtils.EMPTY);
+        action.setOrgId(DEFAULT_ORG_ID);
+
+        return action;
+    }
+
+    public static Action createSchedulerJobFailedAction() {
+        Action action = new Action();
+        action.setBundle(StringUtils.EMPTY);
+        action.setApplication(StringUtils.EMPTY);
+        action.setTimestamp(LocalDateTime.of(2026, 4, 9, 10, 30, 0, 0));
+        action.setEventType("job-failed");
+        action.setRecipients(List.of());
+
+        action.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("job_id", "job-54321")
+                .withAdditionalProperty("job_name", "Test Failed Job")
+                .withAdditionalProperty("error_message", "Connection timeout")
+                .build()
+        );
+
+        action.setAccountId(StringUtils.EMPTY);
+        action.setOrgId(DEFAULT_ORG_ID);
+
+        return action;
+    }
+
+    public static Action createSchedulerJobFailedPausedAction() {
+        Action action = new Action();
+        action.setBundle(StringUtils.EMPTY);
+        action.setApplication(StringUtils.EMPTY);
+        action.setTimestamp(LocalDateTime.of(2026, 4, 9, 10, 30, 0, 0));
+        action.setEventType("job-failed-paused");
+        action.setRecipients(List.of());
+
+        action.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("job_id", "job-99999")
+                .withAdditionalProperty("job_name", "Test Paused Job")
+                .withAdditionalProperty("error_message", "Database connection failed")
+                .build()
+        );
+
+        action.setAccountId(StringUtils.EMPTY);
+        action.setOrgId(DEFAULT_ORG_ID);
+
+        return action;
+    }
+}


### PR DESCRIPTION
Adding templates for scheduler

Starting out pretty simple to test things out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduler notifications: in-app drawer markdown messages and HTML emails for export completed, job failed, and job failed+paused events. Notifications surface job name/ID, include links to job details and export downloads, conditionally show error details, and provide guidance when a job is auto-paused. Three new scheduler notification types are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->