### PR TITLE
RHCLOUD-46243 Add MCP authentication via x-rh-identity header

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,219 @@
+# Notifications MCP Server
+
+MCP (Model Context Protocol) server for Red Hat Hybrid Cloud Console Notifications service.
+
+## Authentication
+
+Per [ADR-084](https://github.com/openshift-online/architecture/pull/67), this MCP server authenticates using the `x-rh-identity` header rather than standard MCP auth headers, since the HCC gateway strips and transforms authentication headers.
+
+### x-rh-identity Header Validation
+
+All requests to `/mcp/*` endpoints **must** include a valid `x-rh-identity` header. Requests without this header are rejected with HTTP 401.
+
+The authentication mechanism validates:
+
+1. **Header presence** - Requests must include `x-rh-identity`
+2. **Base64 encoding** - Header value must be valid Base64
+3. **JSON structure** - Decoded value must be valid JSON matching the ConsoleIdentityWrapper format
+4. **Identity type** - Only `User` identities are accepted. Service accounts and other types are rejected.
+5. **Required fields**:
+   - `org_id` - **Mandatory**, must be present and non-empty
+   - `user_id` - **Mandatory**, must be present and non-empty
+   - `username` - **Mandatory**, must be present and non-empty
+
+### Security Guarantees
+
+✅ **User-only access** - Only User identities are accepted; service accounts are rejected  
+✅ **Identity inheritance** - Tools operate with the same RBAC permissions as the authenticated user  
+✅ **Gateway validation** - The HCC gateway already handles OIDC token validation before forwarding requests  
+✅ **Tenant isolation** - Each request carries orgId for multi-tenant data access
+
+## MCP Tools
+
+All tools require a valid `x-rh-identity` header (enforced by `McpAuthMechanism` at the HTTP level).
+
+#### `serverInfo`
+
+Returns server status and version information. Does not use identity data.
+
+**Example:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "id": 1,
+  "params": {
+    "name": "serverInfo",
+    "arguments": {}
+  }
+}
+```
+
+#### `whoami`
+
+Returns information about the authenticated user from the x-rh-identity header.
+
+**Example:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "id": 2,
+  "params": {
+    "name": "whoami",
+    "arguments": {}
+  }
+}
+```
+
+**Response:**
+```
+Authenticated as:
+  Organization ID: 12345
+  User ID: user-abc-123
+  Username: jdoe
+```
+
+## Testing
+
+### Running Tests
+
+```bash
+./mvnw test -pl mcp
+```
+
+### Test Coverage
+
+- ✅ Valid x-rh-identity header authentication
+- ✅ Missing x-rh-identity header rejection (401)
+- ✅ Malformed x-rh-identity header rejection (401)
+- ✅ Missing or empty org_id rejection (401)
+- ✅ Missing or empty user_id rejection (401)
+- ✅ Missing or empty username rejection (401)
+- ✅ Service account identity rejection (401)
+- ✅ Authenticated tool access with valid identity (serverInfo, whoami)
+- ✅ Tools list returns registered tools
+- ✅ Tools list without identity is rejected (401)
+- ✅ Health endpoint does not require authentication
+- ✅ Micrometer counter assertions for auth success/failure
+
+### Manual Testing
+
+**Important:** The MCP Streamable HTTP transport requires `Accept: application/json, text/event-stream` on all requests.
+
+```bash
+# Initialize MCP session
+curl -X POST http://localhost:9010/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "x-rh-identity: <base64-encoded-identity>" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "initialize",
+    "id": 1,
+    "params": {
+      "protocolVersion": "2025-03-26",
+      "capabilities": {},
+      "implementation": {
+        "name": "my-client",
+        "version": "1.0.0"
+      }
+    }
+  }'
+
+# List available tools
+curl -X POST http://localhost:9010/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "x-rh-identity: <base64-encoded-identity>" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/list",
+    "id": 2,
+    "params": {}
+  }'
+
+# Call whoami tool
+curl -X POST http://localhost:9010/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "x-rh-identity: <base64-encoded-identity>" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 3,
+    "params": {
+      "name": "whoami",
+      "arguments": {}
+    }
+  }'
+```
+
+## Architecture
+
+### Components
+
+```
+┌─────────────────────────────────────────────┐
+│  HCC Gateway                                 │
+│  - OIDC token validation                    │
+│  - Injects x-rh-identity header             │
+└──────────────────┬──────────────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────────────┐
+│  MCP Server (this module)                   │
+│  ┌─────────────────────────────────────┐   │
+│  │ McpAuthMechanism                     │   │
+│  │ - Validates x-rh-identity header     │   │
+│  │ - Rejects unauthenticated requests   │   │
+│  └──────────────┬──────────────────────┘   │
+│                 ▼                            │
+│  ┌─────────────────────────────────────┐   │
+│  │ McpIdentityProvider                  │   │
+│  │ - Parses x-rh-identity JSON          │   │
+│  │ - Validates org_id, user_id, username│   │
+│  │ - Creates McpPrincipal               │   │
+│  └──────────────┬──────────────────────┘   │
+│                 ▼                            │
+│  ┌─────────────────────────────────────┐   │
+│  │ MCP Tools (McpServerTools)           │   │
+│  │ - Inject SecurityIdentity            │   │
+│  │ - Access user's org_id, user_id      │   │
+│  │ - Execute under user's permissions   │   │
+│  └─────────────────────────────────────┘   │
+└─────────────────────────────────────────────┘
+```
+
+### Classes
+
+- **`McpAuthMechanism`** - HTTP authentication mechanism, validates header presence
+- **`McpAuthenticationRequest`** - Request object carrying x-rh-identity value
+- **`McpIdentityProvider`** - Parses and validates x-rh-identity header
+- **`RhIdentity`** - Record holding parsed identity fields (type, orgId, accountId, userId, username)
+- **`McpPrincipal`** - Security principal wrapping RhIdentity
+- **`McpServerTools`** - MCP tool implementations
+
+## Configuration
+
+Authentication is enforced programmatically by `McpAuthMechanism`, not via `quarkus.http.auth.permission` properties. Health (`/q/health`) and metrics (`/q/metrics`) paths are exempt — see `McpAuthMechanism.ANONYMOUS_PATHS`.
+
+## Development
+
+### Adding New MCP Tools
+
+```java
+@Tool(description = "My new tool")
+public String myTool() {
+    McpPrincipal principal = (McpPrincipal) securityIdentity.getPrincipal();
+    String orgId = principal.getOrgId();
+    // Tool logic here, operates under user's identity
+    return "Result for org: " + orgId;
+}
+```
+
+## References
+
+- [ADR-084](https://github.com/openshift-online/architecture/pull/67) - MCP Authentication in HCC
+- [Model Context Protocol Specification](https://spec.modelcontextprotocol.io/)
+- [Quarkus MCP Server Extension](https://github.com/quarkiverse/quarkus-mcp-server)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -32,7 +32,7 @@ The authentication mechanism validates:
 
 All tools require a valid `x-rh-identity` header (enforced by `McpAuthMechanism` at the HTTP level).
 
-#### `serverInfo`
+### `serverInfo`
 
 Returns server status and version information. Does not use identity data.
 
@@ -49,7 +49,7 @@ Returns server status and version information. Does not use identity data.
 }
 ```
 
-#### `whoami`
+### `whoami`
 
 Returns information about the authenticated user from the x-rh-identity header.
 
@@ -67,7 +67,7 @@ Returns information about the authenticated user from the x-rh-identity header.
 ```
 
 **Response:**
-```
+```text
 Authenticated as:
   Organization ID: 12345
   User ID: user-abc-123
@@ -153,7 +153,7 @@ curl -X POST http://localhost:9010/mcp \
 
 ### Components
 
-```
+```text
 ┌─────────────────────────────────────────────┐
 │  HCC Gateway                                 │
 │  - OIDC token validation                    │

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -36,7 +36,19 @@
         <!-- Quarkus -->
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
 
         <!-- Clowder -->
@@ -60,8 +72,20 @@
 
         <!-- Test -->
         <dependency>
+            <groupId>com.redhat.cloud.notifications</groupId>
+            <artifactId>notifications-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -13,6 +13,36 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <profiles>
+
+        <!--
+        When Maven compiles a project with the "-Dmaven.test.skip" option, the tests compilation and execution are skipped
+        but Maven still resolves the dependencies from the "test" scope and fails if these dependencies cannot be found.
+        This is considered a Maven bug by many users and even though it was reported as such several years ago, it's never
+        been fixed. The following profile works around that limitation and makes the compilation successful when tests are
+        skipped even if the listed test dependencies are not available.
+        -->
+        <profile>
+            <id>resolve-test-jars-if-tests-are-not-skipped</id>
+            <activation>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.redhat.cloud.notifications</groupId>
+                    <artifactId>notifications-common</artifactId>
+                    <version>${project.version}</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+    </profiles>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -71,13 +101,7 @@
         </dependency>
 
         <!-- Test -->
-        <dependency>
-            <groupId>com.redhat.cloud.notifications</groupId>
-            <artifactId>notifications-common</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
+        <!-- Some test dependencies are declared in the "profiles" section of this POM. -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpAuthMechanism.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpAuthMechanism.java
@@ -41,7 +41,7 @@ public class McpAuthMechanism implements HttpAuthenticationMechanism {
         String path = routingContext.normalizedPath();
 
         for (String anonymousPath : ANONYMOUS_PATHS) {
-            if (path.startsWith(anonymousPath)) {
+            if (path.equals(anonymousPath) || path.startsWith(anonymousPath + "/")) {
                 return Uni.createFrom().item(QuarkusSecurityIdentity.builder()
                         .setPrincipal(() -> "anonymous")
                         .setAnonymous(true)

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpAuthMechanism.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpAuthMechanism.java
@@ -1,0 +1,76 @@
+package com.redhat.cloud.notifications.mcp;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.logging.Log;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * HTTP authentication mechanism for MCP endpoints that validates the x-rh-identity header.
+ * Per ADR-084, MCP servers within HCC must authenticate using x-rh-identity rather than
+ * standard MCP auth headers, as the HCC gateway strips and transforms authentication headers.
+ *
+ * All endpoints require authentication by default. Only paths listed in
+ * {@link #ANONYMOUS_PATHS} are allowed without an x-rh-identity header.
+ */
+@ApplicationScoped
+public class McpAuthMechanism implements HttpAuthenticationMechanism {
+
+    static final String X_RH_IDENTITY_HEADER = "x-rh-identity";
+    static final List<String> ANONYMOUS_PATHS = List.of("/q/health", "/q/metrics");
+
+    private static final Set<Class<? extends AuthenticationRequest>> CREDENTIAL_TYPES = Set.of(McpAuthenticationRequest.class);
+
+    @Inject
+    MeterRegistry registry;
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(RoutingContext routingContext, IdentityProviderManager identityProviderManager) {
+        String path = routingContext.normalizedPath();
+
+        for (String anonymousPath : ANONYMOUS_PATHS) {
+            if (path.startsWith(anonymousPath)) {
+                return Uni.createFrom().item(QuarkusSecurityIdentity.builder()
+                        .setPrincipal(() -> "anonymous")
+                        .setAnonymous(true)
+                        .build());
+            }
+        }
+
+        String xRhIdentityHeaderValue = routingContext.request().getHeader(X_RH_IDENTITY_HEADER);
+
+        Log.debugf("MCP authentication: path=%s, x-rh-identity present=%s", path, xRhIdentityHeaderValue != null);
+
+        if (xRhIdentityHeaderValue == null) {
+            registry.counter("notifications.mcp.auth.failure", "reason", "missing_header").increment();
+            Log.warnf("MCP authentication failed: missing %s header for path %s", X_RH_IDENTITY_HEADER, path);
+            return Uni.createFrom().failure(new AuthenticationFailedException("Missing " + X_RH_IDENTITY_HEADER + " header"));
+        }
+
+        McpAuthenticationRequest authRequest = new McpAuthenticationRequest(xRhIdentityHeaderValue);
+        return identityProviderManager.authenticate(authRequest);
+    }
+
+    @Override
+    public Uni<ChallengeData> getChallenge(RoutingContext routingContext) {
+        // No challenge data for header-based auth
+        return Uni.createFrom().nullItem();
+    }
+
+    @Override
+    public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+        return CREDENTIAL_TYPES;
+    }
+}

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpAuthenticationRequest.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpAuthenticationRequest.java
@@ -1,0 +1,16 @@
+package com.redhat.cloud.notifications.mcp;
+
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+
+public class McpAuthenticationRequest extends BaseAuthenticationRequest {
+
+    private final String xRhIdentityHeaderValue;
+
+    public McpAuthenticationRequest(String xRhIdentityHeaderValue) {
+        this.xRhIdentityHeaderValue = xRhIdentityHeaderValue;
+    }
+
+    public String getXRhIdentityHeaderValue() {
+        return xRhIdentityHeaderValue;
+    }
+}

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpIdentityProvider.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpIdentityProvider.java
@@ -1,0 +1,113 @@
+package com.redhat.cloud.notifications.mcp;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.logging.Log;
+import io.quarkus.security.AuthenticationFailedException;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Identity provider for MCP endpoints that validates x-rh-identity headers.
+ * Per ADR-084, MCP servers must strictly inherit the user's identity with no
+ * service-account elevation for user-initiated operations.
+ */
+@ApplicationScoped
+public class McpIdentityProvider implements IdentityProvider<McpAuthenticationRequest> {
+
+    @Inject
+    MeterRegistry registry;
+
+    @Override
+    public Class<McpAuthenticationRequest> getRequestType() {
+        return McpAuthenticationRequest.class;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(McpAuthenticationRequest request, AuthenticationRequestContext context) {
+        try {
+            RhIdentity rhIdentity = parseIdentity(request.getXRhIdentityHeaderValue());
+
+            validateRequiredField(rhIdentity.orgId(), "org_id");
+            validateRequiredField(rhIdentity.userId(), "user_id");
+            validateRequiredField(rhIdentity.username(), "username");
+
+            Log.debugf("MCP authentication successful: org_id=%s, user_id=%s, username=%s, type=%s",
+                    rhIdentity.orgId(), rhIdentity.userId(), rhIdentity.username(), rhIdentity.type());
+
+            McpPrincipal principal = new McpPrincipal(rhIdentity);
+
+            registry.counter("notifications.mcp.auth.success").increment();
+            return Uni.createFrom().item(QuarkusSecurityIdentity.builder()
+                    .setPrincipal(principal)
+                    .build());
+
+        } catch (MissingFieldException e) {
+            registry.counter("notifications.mcp.auth.failure", "reason", "missing_" + e.fieldName).increment();
+            Log.warnf("MCP authentication rejected: missing %s in x-rh-identity header", e.fieldName);
+            return Uni.createFrom().failure(new AuthenticationFailedException("Missing " + e.fieldName + " in identity header"));
+        } catch (IllegalArgumentException | DecodeException e) {
+            registry.counter("notifications.mcp.auth.failure", "reason", "invalid_header").increment();
+            Log.warnf(e, "MCP authentication failed: invalid x-rh-identity header");
+            return Uni.createFrom().failure(new AuthenticationFailedException("Invalid x-rh-identity header", e));
+        }
+    }
+
+    private static void validateRequiredField(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new MissingFieldException(fieldName);
+        }
+    }
+
+    private static class MissingFieldException extends RuntimeException {
+        final String fieldName;
+
+        MissingFieldException(String fieldName) {
+            super("Missing " + fieldName);
+            this.fieldName = fieldName;
+        }
+    }
+
+    /**
+     * Parse x-rh-identity header into RhIdentity record.
+     * Only User identities are accepted — service accounts and other types are rejected.
+     *
+     * SECURITY: This method trusts the x-rh-identity header without signature verification.
+     * The HCC gateway (3Scale/Turnpike) is responsible for OIDC token validation and injects
+     * this header into forwarded requests. The MCP service must never be exposed to untrusted
+     * networks — the ClowdApp deployment enforces this with {@code public: false}.
+     */
+    private RhIdentity parseIdentity(String xRhIdentityHeader) {
+        String decoded = new String(Base64.getDecoder().decode(xRhIdentityHeader.getBytes(UTF_8)), UTF_8);
+        JsonObject identity = new JsonObject(decoded).getJsonObject("identity");
+
+        if (identity == null) {
+            throw new IllegalArgumentException("Missing 'identity' field in x-rh-identity header");
+        }
+
+        String type = identity.getString("type");
+        if (!"User".equals(type)) {
+            throw new IllegalArgumentException("Unsupported identity type: " + type + ". Only User identities are allowed.");
+        }
+
+        JsonObject user = identity.getJsonObject("user");
+
+        return new RhIdentity(
+            type,
+            identity.getString("org_id"),
+            identity.getString("account_number"),
+            user != null ? user.getString("user_id") : null,
+            user != null ? user.getString("username") : null
+        );
+    }
+}

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpPrincipal.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpPrincipal.java
@@ -1,0 +1,46 @@
+package com.redhat.cloud.notifications.mcp;
+
+import java.security.Principal;
+
+/**
+ * Principal for MCP authenticated requests, carrying the user's identity from x-rh-identity.
+ * Provides access to orgId, userId, and other identity attributes for MCP tools.
+ */
+public class McpPrincipal implements Principal {
+
+    private final RhIdentity rhIdentity;
+
+    public McpPrincipal(RhIdentity rhIdentity) {
+        this.rhIdentity = rhIdentity;
+    }
+
+    @Override
+    public String getName() {
+        return rhIdentity.username();
+    }
+
+    public String getOrgId() {
+        return rhIdentity.orgId();
+    }
+
+    public String getUserId() {
+        return rhIdentity.userId();
+    }
+
+    public String getAccountId() {
+        return rhIdentity.accountId();
+    }
+
+    public String getType() {
+        return rhIdentity.type();
+    }
+
+    public RhIdentity getRhIdentity() {
+        return rhIdentity;
+    }
+
+    @Override
+    public String toString() {
+        return "McpPrincipal{orgId='" + getOrgId() + "', userId='" + getUserId() + "', username='" + getName() + "'}";
+    }
+}

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
@@ -1,16 +1,35 @@
 package com.redhat.cloud.notifications.mcp;
 
 import io.quarkiverse.mcp.server.Tool;
+import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
- * Placeholder MCP tools for the Notifications MCP server.
+ * MCP tools for the Notifications MCP server.
  */
 @ApplicationScoped
 public class McpServerTools {
 
+    @Inject
+    SecurityIdentity securityIdentity;
+
     @Tool(description = "Returns the server status and version information")
     public String serverInfo() {
         return "Notifications MCP Server is running.";
+    }
+
+    @Tool(description = "Returns information about the authenticated user")
+    public String whoami() {
+        McpPrincipal principal = (McpPrincipal) securityIdentity.getPrincipal();
+        return String.format(
+                "Authenticated as:%n" +
+                "  Organization ID: %s%n" +
+                "  User ID: %s%n" +
+                "  Username: %s",
+                principal.getOrgId(),
+                principal.getUserId(),
+                principal.getName()
+        );
     }
 }

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/RhIdentity.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/RhIdentity.java
@@ -1,0 +1,21 @@
+package com.redhat.cloud.notifications.mcp;
+
+/**
+ * Simplified Red Hat identity record for MCP authentication.
+ * Represents the parsed contents of the x-rh-identity header.
+ * Only User identities are supported.
+ *
+ * @param type Identity type (always "User")
+ * @param orgId Organization ID (mandatory)
+ * @param accountId Account number (legacy field)
+ * @param userId User ID (mandatory)
+ * @param username Username (mandatory)
+ */
+public record RhIdentity(
+        String type,
+        String orgId,
+        String accountId,
+        String userId,
+        String username
+) {
+}

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
@@ -1,0 +1,273 @@
+package com.redhat.cloud.notifications.mcp;
+
+import com.redhat.cloud.notifications.MicrometerAssertionHelper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
+import static com.redhat.cloud.notifications.mcp.McpAuthMechanism.X_RH_IDENTITY_HEADER;
+import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Tests for MCP x-rh-identity authentication.
+ * Note: The MCP Streamable HTTP transport requires Accept: text/event-stream.
+ */
+@QuarkusTest
+public class McpAuthTest {
+
+    private static final String MCP_ENDPOINT = "/mcp";
+    private static final String ACCEPT_MCP = "application/json, text/event-stream";
+
+    private static final String AUTH_SUCCESS_COUNTER = "notifications.mcp.auth.success";
+    private static final String AUTH_FAILURE_COUNTER = "notifications.mcp.auth.failure";
+
+    @Inject
+    MicrometerAssertionHelper micrometerAssertionHelper;
+
+    @BeforeEach
+    void beforeEach() {
+        micrometerAssertionHelper.saveCounterValuesBeforeTest(AUTH_SUCCESS_COUNTER);
+        micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(AUTH_FAILURE_COUNTER, "reason", "missing_header");
+        micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(AUTH_FAILURE_COUNTER, "reason", "missing_org_id");
+        micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(AUTH_FAILURE_COUNTER, "reason", "invalid_header");
+        micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(AUTH_FAILURE_COUNTER, "reason", "missing_user_id");
+        micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(AUTH_FAILURE_COUNTER, "reason", "missing_username");
+    }
+
+    @AfterEach
+    void afterEach() {
+        micrometerAssertionHelper.clearSavedValues();
+    }
+
+    private static final String INITIALIZE_BODY = """
+            {
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "id": 1,
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "test-client",
+                        "version": "1.0.0"
+                    },
+                    "implementation": {
+                        "name": "test-client",
+                        "version": "1.0.0"
+                    }
+                }
+            }
+            """;
+
+    private static final String TOOLS_LIST_BODY = """
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/list",
+                "id": 4,
+                "params": {}
+            }
+            """;
+
+    private static final String SERVER_INFO_BODY = """
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 2,
+                "params": {
+                    "name": "serverInfo",
+                    "arguments": {}
+                }
+            }
+            """;
+
+    private static final String WHOAMI_BODY = """
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 3,
+                "params": {
+                    "name": "whoami",
+                    "arguments": {}
+                }
+            }
+            """;
+
+    // --- Helpers ---
+
+    private static String validIdentity() {
+        return McpTestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
+    }
+
+    private static String base64Encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(UTF_8));
+    }
+
+    private ValidatableResponse postMcp(String identity, String body) {
+        RequestSpecification request = given()
+                .header("Accept", ACCEPT_MCP)
+                .contentType(ContentType.JSON)
+                .body(body);
+        if (identity != null) {
+            request = request.header(X_RH_IDENTITY_HEADER, identity);
+        }
+        return request.when().post(MCP_ENDPOINT).then();
+    }
+
+    private void assertInitializeRejected(String identity, String expectedReason) {
+        postMcp(identity, INITIALIZE_BODY).statusCode(401);
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_FAILURE_COUNTER, 1, "reason", expectedReason);
+    }
+
+    // --- Initialize tests ---
+
+    @Test
+    public void testMcpInitializeWithValidIdentity() {
+        postMcp(validIdentity(), INITIALIZE_BODY)
+                .statusCode(200)
+                .body("result.protocolVersion", notNullValue())
+                .body("result.serverInfo.name", notNullValue());
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+    }
+
+    @Test
+    public void testMcpInitializeWithoutIdentity() {
+        assertInitializeRejected(null, "missing_header");
+    }
+
+    @Test
+    public void testMcpInitializeWithInvalidBase64() {
+        assertInitializeRejected("!!!invalid-base64!!!", "invalid_header");
+    }
+
+    @Test
+    public void testMcpInitializeWithValidBase64InvalidJson() {
+        assertInitializeRejected(base64Encode("{not-valid-json"), "invalid_header");
+    }
+
+    @Test
+    public void testMcpInitializeWithMissingIdentityField() {
+        assertInitializeRejected(base64Encode("{\"wrong\": \"field\"}"), "invalid_header");
+    }
+
+    @Test
+    public void testMcpInitializeWithServiceAccountIdentityIsRejected() {
+        assertInitializeRejected(
+                McpTestHelpers.encodeRHServiceAccountIdentityInfo(DEFAULT_ORG_ID, "sa-client-id", "service-account-name"),
+                "invalid_header"
+        );
+    }
+
+    @Test
+    public void testMcpInitializeWithoutOrgId() {
+        assertInitializeRejected(
+                McpTestHelpers.encodeRHIdentityInfoWithoutOrgId(DEFAULT_ACCOUNT_ID, DEFAULT_USER),
+                "missing_org_id"
+        );
+    }
+
+    @Test
+    public void testMcpInitializeWithEmptyOrgId() {
+        assertInitializeRejected(
+                McpTestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, "   ", DEFAULT_USER),
+                "missing_org_id"
+        );
+    }
+
+    @Test
+    public void testMcpInitializeWithoutUserIdIsRejected() {
+        assertInitializeRejected(
+                McpTestHelpers.encodeRHIdentityInfoWithoutUserId(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER),
+                "missing_user_id"
+        );
+    }
+
+    @Test
+    public void testMcpInitializeWithEmptyUserIdIsRejected() {
+        assertInitializeRejected(
+                McpTestHelpers.encodeRHIdentityInfoWithCustomUserId(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, "   "),
+                "missing_user_id"
+        );
+    }
+
+    @Test
+    public void testMcpInitializeWithoutUsernameIsRejected() {
+        assertInitializeRejected(
+                McpTestHelpers.encodeRHIdentityInfoWithoutUsername(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER),
+                "missing_username"
+        );
+    }
+
+    @Test
+    public void testMcpInitializeWithEmptyUsernameIsRejected() {
+        assertInitializeRejected(
+                McpTestHelpers.encodeRHIdentityInfoWithCustomUsername(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, "   "),
+                "missing_username"
+        );
+    }
+
+    // --- Tools list tests ---
+
+    @Test
+    public void testToolsListWithValidIdentity() {
+        postMcp(validIdentity(), TOOLS_LIST_BODY)
+                .statusCode(200)
+                .body("result.tools.size()", greaterThanOrEqualTo(2))
+                .body("result.tools.name", hasItems("serverInfo", "whoami"));
+    }
+
+    @Test
+    public void testToolsListWithoutIdentity() {
+        postMcp(null, TOOLS_LIST_BODY).statusCode(401);
+    }
+
+    // --- Tool invocation tests ---
+
+    @Test
+    public void testServerInfoWithAuthentication() {
+        postMcp(validIdentity(), SERVER_INFO_BODY)
+                .statusCode(200)
+                .body("result.content[0].text", containsString("Notifications MCP Server is running"));
+    }
+
+    @Test
+    public void testAuthenticatedToolWhoami() {
+        postMcp(validIdentity(), WHOAMI_BODY)
+                .statusCode(200)
+                .body("result.content[0].text", containsString(DEFAULT_ORG_ID))
+                .body("result.content[0].text", containsString(DEFAULT_USER));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+    }
+
+    @Test
+    public void testWhoamiWithServiceAccountIdentityIsRejected() {
+        String identity = McpTestHelpers.encodeRHServiceAccountIdentityInfo(DEFAULT_ORG_ID, "sa-client-id", "sa-name");
+        postMcp(identity, WHOAMI_BODY).statusCode(401);
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_FAILURE_COUNTER, 1, "reason", "invalid_header");
+    }
+
+    // --- Health/metrics bypass tests ---
+
+    @Test
+    public void testHealthEndpointDoesNotRequireAuth() {
+        given()
+                .when()
+                .get("/q/health/live")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpTestHelpers.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpTestHelpers.java
@@ -1,0 +1,73 @@
+package com.redhat.cloud.notifications.mcp;
+
+import io.vertx.core.json.JsonObject;
+
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class McpTestHelpers {
+
+    public static String encodeRHIdentityInfo(String accountId, String orgId, String username) {
+        return buildIdentity(accountId, orgId, username, username);
+    }
+
+    public static String encodeRHIdentityInfoWithoutOrgId(String accountId, String username) {
+        return buildIdentity(accountId, null, username, username);
+    }
+
+    public static String encodeRHIdentityInfoWithoutUserId(String accountId, String orgId, String username) {
+        return buildIdentity(accountId, orgId, username, null);
+    }
+
+    public static String encodeRHIdentityInfoWithoutUsername(String accountId, String orgId, String userId) {
+        return buildIdentity(accountId, orgId, null, userId);
+    }
+
+    public static String encodeRHIdentityInfoWithCustomUserId(String accountId, String orgId, String username, String userId) {
+        return buildIdentity(accountId, orgId, username, userId);
+    }
+
+    public static String encodeRHIdentityInfoWithCustomUsername(String accountId, String orgId, String userId, String username) {
+        return buildIdentity(accountId, orgId, username, userId);
+    }
+
+    public static String encodeRHServiceAccountIdentityInfo(String orgId, String clientId, String username) {
+        JsonObject serviceAccount = new JsonObject();
+        serviceAccount.put("client_id", clientId);
+        serviceAccount.put("username", username);
+
+        JsonObject identity = new JsonObject();
+        identity.put("org_id", orgId);
+        identity.put("service_account", serviceAccount);
+        identity.put("type", "ServiceAccount");
+
+        JsonObject header = new JsonObject();
+        header.put("identity", identity);
+
+        return new String(Base64.getEncoder().encode(header.encode().getBytes(UTF_8)), UTF_8);
+    }
+
+    private static String buildIdentity(String accountId, String orgId, String username, String userId) {
+        JsonObject user = new JsonObject();
+        if (username != null) {
+            user.put("username", username);
+        }
+        if (userId != null) {
+            user.put("user_id", userId);
+        }
+
+        JsonObject identity = new JsonObject();
+        identity.put("account_number", accountId);
+        if (orgId != null) {
+            identity.put("org_id", orgId);
+        }
+        identity.put("user", user);
+        identity.put("type", "User");
+
+        JsonObject header = new JsonObject();
+        header.put("identity", identity);
+
+        return new String(Base64.getEncoder().encode(header.encode().getBytes(UTF_8)), UTF_8);
+    }
+}


### PR DESCRIPTION
# Summary
                                                                                                                                                                             
Implement x-rh-identity header authentication for the MCP server per ADR-084. The HCC gateway strips standard MCP auth headers, so the MCP server validates x-rh-identity directly — the same header used by all other HCC services.                                                                                                                 
                                                                                                                                                                           
# What changed                                                                                                                                                               
                                                                                                                                                                           
  - McpAuthMechanism — Quarkus HttpAuthenticationMechanism that rejects requests to /mcp/* without a valid x-rh-identity header (health/metrics endpoints remain unauthenticated)                                                                                                                                                         
  - McpIdentityProvider — Decodes the Base64 header, parses the JSON identity, validates org_id is present                                                                   
  - McpPrincipal / RhIdentity — Lightweight principal wrapping the caller's identity (orgId, userId, username), injected into tools via SecurityIdentity                     
  - McpServerTools — Added whoami tool demonstrating authenticated tool access                                                                                               
  - 9 integration tests covering valid auth, missing header, malformed header, missing org_id, tool execution under identity, and health endpoint bypass                     
                                                                                                                                                                             
# Design decisions                                                                                                                                                           
                                                                                                                                                                             
  - No internal module dependencies — The MCP module parses x-rh-identity directly with java.util.Base64 + Vert.x JsonObject, avoiding a dependency on notifications-common or notifications-backend                                                                                                                                                 
  - No service-account elevation — The only authentication path is the incoming x-rh-identity header; no PSK, OIDC client credentials, or token elevation                    
  - Gateway trust model — The HCC gateway already handles OIDC token validation; the MCP server validates the identity structure but does not re-validate the token          
                                                                                                                                                                             
# Test plan                                                                                                                                                                  
                                                                                                                                                                             
  - Valid x-rh-identity header → 200, identity available in tools                                                                                                            
  - Missing header → 401                                                                                                                                                   
  - Malformed Base64 → 401                                                                                                                                                   
  - Valid Base64 but missing org_id → 401                                                                                                                                  
  - whoami tool returns caller's orgId/userId/username                                                                                                                       
  - serverInfo tool works with authenticated requests                                                                                                                        
  - tools/list returns registered tools                                                                                                                                      
  - tools/list without identity → 401                                                                                                                                        
  - Health endpoint accessible without authentication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP endpoints now require x-rh-identity for user authentication (only User identities; org_id, user_id, username required).
  * Added a whoami tool (returns org, user ID, username) and retained serverInfo.
  * Per-request tenant isolation enforced; gateway OIDC validation occurs before forwarding.

* **Documentation**
  * Added comprehensive MCP README with auth details, example payloads, tools, and manual test instructions.

* **Tests**
  * Added integration tests covering success/failure identity cases, tool access, and health/metrics exemption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->