### PR TITLE
RHCLOUD-46244 Add getSeverities MCP tool with backend REST client

### DIFF
--- a/.rhcicd/clowdapp-mcp.yaml
+++ b/.rhcicd/clowdapp-mcp.yaml
@@ -13,6 +13,8 @@ objects:
   spec:
     envName: ${ENV_NAME}
     featureFlags: true
+    dependencies:
+    - notifications-backend
     deployments:
     - name: service
       minReplicas: ${{MIN_REPLICAS}}
@@ -67,7 +69,17 @@ objects:
           value: ${ENV_NAME}
         - name: QUARKUS_LOG_CLOUDWATCH_SERVICE_ENVIRONMENT
           value: ${ENV_NAME}
+        - name: QUARKUS_REST_CLIENT_NOTIFICATIONS_BACKEND_CONNECT_TIMEOUT
+          value: ${BACKEND_CONNECT_TIMEOUT}
+        - name: QUARKUS_REST_CLIENT_NOTIFICATIONS_BACKEND_READ_TIMEOUT
+          value: ${BACKEND_READ_TIMEOUT}
 parameters:
+- name: BACKEND_CONNECT_TIMEOUT
+  description: Delay in milliseconds before a backend connection attempt is interrupted
+  value: "2000"
+- name: BACKEND_READ_TIMEOUT
+  description: Delay in milliseconds before a backend request is interrupted
+  value: "2000"
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
   value: "false"

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -74,6 +74,30 @@ Authenticated as:
   Username: jdoe
 ```
 
+### `getSeverities`
+
+Returns the list of available notification severities. Calls the backend API via HTTP REST client, forwarding the caller's `x-rh-identity` header.
+
+Equivalent REST endpoint: `GET /api/notifications/v2.0/notifications/severities`
+
+**Example:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "id": 4,
+  "params": {
+    "name": "getSeverities",
+    "arguments": {}
+  }
+}
+```
+
+**Response:**
+```text
+["CRITICAL","IMPORTANT","MODERATE","LOW","NONE","UNDEFINED"]
+```
+
 ## Testing
 
 ### Running Tests

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -70,7 +70,15 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -110,6 +118,12 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/BackendRestClient.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/BackendRestClient.java
@@ -1,10 +1,10 @@
 package com.redhat.cloud.notifications.mcp;
 
+import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.ClientErrorException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/BackendRestClient.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/BackendRestClient.java
@@ -1,0 +1,23 @@
+package com.redhat.cloud.notifications.mcp;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.ClientErrorException;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import java.time.temporal.ChronoUnit;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@RegisterRestClient(configKey = "notifications-backend")
+@Retry(delay = 1, delayUnit = ChronoUnit.SECONDS, maxRetries = 2, abortOn = ClientErrorException.class) // 1 initial + 2 retries = 3 attempts
+public interface BackendRestClient {
+
+    @GET
+    @Path("/api/notifications/v2.0/notifications/severities")
+    @Produces(APPLICATION_JSON)
+    String getSeverities(@HeaderParam("x-rh-identity") String xRhIdentity);
+}

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpIdentityProvider.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpIdentityProvider.java
@@ -107,7 +107,8 @@ public class McpIdentityProvider implements IdentityProvider<McpAuthenticationRe
             identity.getString("org_id"),
             identity.getString("account_number"),
             user != null ? user.getString("user_id") : null,
-            user != null ? user.getString("username") : null
+            user != null ? user.getString("username") : null,
+            xRhIdentityHeader
         );
     }
 }

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpPrincipal.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpPrincipal.java
@@ -35,6 +35,10 @@ public class McpPrincipal implements Principal {
         return rhIdentity.type();
     }
 
+    public String getRawHeader() {
+        return rhIdentity.rawHeader();
+    }
+
     public RhIdentity getRhIdentity() {
         return rhIdentity;
     }

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
@@ -1,13 +1,17 @@
 package com.redhat.cloud.notifications.mcp;
 
-import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
-import io.quarkiverse.mcp.server.McpException;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolCallException;
 import io.quarkus.logging.Log;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.function.Supplier;
 
 /**
  * MCP tools for the Notifications MCP server.
@@ -21,6 +25,9 @@ public class McpServerTools {
     @Inject
     @RestClient
     BackendRestClient backendClient;
+
+    @Inject
+    MeterRegistry registry;
 
     @Tool(description = "Returns the server status and version information")
     public String serverInfo() {
@@ -44,11 +51,39 @@ public class McpServerTools {
     @Tool(description = "Returns the list of available notification severities")
     public String getSeverities() {
         McpPrincipal principal = (McpPrincipal) securityIdentity.getPrincipal();
+        return executeRestCall("getSeverities", principal,
+                () -> backendClient.getSeverities(principal.getRawHeader()));
+    }
+
+    /**
+     * Executes a REST client call, translating REST exceptions into MCP ToolCallExceptions.
+     * Unexpected exceptions are left unhandled so the framework's default handler logs and
+     * returns INTERNAL_ERROR automatically.
+     */
+    private <T> T executeRestCall(String toolName, McpPrincipal principal, Supplier<T> restCall) {
         try {
-            return backendClient.getSeverities(principal.getRawHeader());
-        } catch (Exception e) {
-            Log.errorf(e, "Failed to fetch severities from backend for org %s, user %s", principal.getOrgId(), principal.getUserId());
-            throw new McpException("Severities could not be fetched", JsonRpcErrorCodes.INTERNAL_ERROR);
+            return restCall.get();
+        } catch (WebApplicationException e) {
+            int status = e.getResponse().getStatus();
+            Log.warnf(e, "Tool '%s' failed (HTTP %d) for org %s, user %s",
+                    toolName, status, principal.getOrgId(), principal.getUserId());
+            registry.counter("notifications.mcp.tool.error", "tool", toolName, "type", "http_" + status).increment();
+            throw new ToolCallException(httpErrorMessage(status));
+        } catch (ProcessingException e) {
+            Log.errorf(e, "Tool '%s' connection error for org %s, user %s",
+                    toolName, principal.getOrgId(), principal.getUserId());
+            registry.counter("notifications.mcp.tool.error", "tool", toolName, "type", "connection").increment();
+            throw new ToolCallException("Backend service unavailable, try again later");
         }
+    }
+
+    private static String httpErrorMessage(int status) {
+        return switch (status) {
+            case 403 -> "Access denied";
+            case 404 -> "Resource not found";
+            default -> status >= 400 && status < 500
+                    ? "Invalid request (HTTP " + status + ")"
+                    : "Backend service error, try again later";
+        };
     }
 }

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.mcp;
 
+import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkus.logging.Log;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -46,7 +48,7 @@ public class McpServerTools {
             return backendClient.getSeverities(principal.getRawHeader());
         } catch (Exception e) {
             Log.errorf(e, "Failed to fetch severities from backend for org %s, user %s", principal.getOrgId(), principal.getUserId());
-            return "Severities could not be fetched.";
+            throw new McpException("Severities could not be fetched", JsonRpcErrorCodes.INTERNAL_ERROR);
         }
     }
 }

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
@@ -1,9 +1,11 @@
 package com.redhat.cloud.notifications.mcp;
 
 import io.quarkiverse.mcp.server.Tool;
+import io.quarkus.logging.Log;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 /**
  * MCP tools for the Notifications MCP server.
@@ -13,6 +15,10 @@ public class McpServerTools {
 
     @Inject
     SecurityIdentity securityIdentity;
+
+    @Inject
+    @RestClient
+    BackendRestClient backendClient;
 
     @Tool(description = "Returns the server status and version information")
     public String serverInfo() {
@@ -31,5 +37,16 @@ public class McpServerTools {
                 principal.getUserId(),
                 principal.getName()
         );
+    }
+
+    @Tool(description = "Returns the list of available notification severities")
+    public String getSeverities() {
+        McpPrincipal principal = (McpPrincipal) securityIdentity.getPrincipal();
+        try {
+            return backendClient.getSeverities(principal.getRawHeader());
+        } catch (Exception e) {
+            Log.errorf(e, "Failed to fetch severities from backend for org %s, user %s", principal.getOrgId(), principal.getUserId());
+            return "Severities could not be fetched.";
+        }
     }
 }

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/RhIdentity.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/RhIdentity.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.mcp;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * Simplified Red Hat identity record for MCP authentication.
  * Represents the parsed contents of the x-rh-identity header.
@@ -10,12 +12,23 @@ package com.redhat.cloud.notifications.mcp;
  * @param accountId Account number (legacy field)
  * @param userId User ID (mandatory)
  * @param username Username (mandatory)
+ * @param rawHeader The original Base64-encoded x-rh-identity header value, preserved for forwarding to backend calls
  */
 public record RhIdentity(
         String type,
         String orgId,
         String accountId,
         String userId,
-        String username
+        String username,
+        // Excluded from JSON serialization: this is effectively a bearer credential
+        // within the internal network and must not leak via Jackson auto-serialization
+        // of this record (e.g. in error responses or debug endpoints).
+        @JsonIgnore String rawHeader
 ) {
+    @Override
+    public String toString() {
+        return "RhIdentity[type=" + type + ", orgId=" + orgId
+                + ", accountId=" + accountId + ", userId=" + userId
+                + ", username=" + username + "]";
+    }
 }

--- a/mcp/src/main/resources/application.properties
+++ b/mcp/src/main/resources/application.properties
@@ -19,6 +19,11 @@ quarkus.http.access-log.pattern=combined
 quarkus.log.category."com.redhat.cloud.notifications".level=INFO
 %test.quarkus.log.category."com.redhat.cloud.notifications".level=DEBUG
 
+# Backend REST client
+quarkus.rest-client.notifications-backend.url=${clowder.endpoints.notifications-backend-service.url:http://localhost:8085}
+quarkus.rest-client.notifications-backend.connect-timeout=2000
+quarkus.rest-client.notifications-backend.read-timeout=2000
+
 # MCP Server - Streamable HTTP transport
 # The MCP endpoint is available at /mcp by default.
 # Enable stateless mode: each request gets its own ephemeral session,

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
@@ -28,6 +28,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 /**
@@ -324,7 +325,8 @@ public class McpAuthTest {
 
         postMcp(validIdentity(), GET_SEVERITIES_BODY)
                 .statusCode(200)
-                .body("result.content[0].text", containsString("Severities could not be fetched."));
+                .body("error.code", is(-32603))
+                .body("error.message", containsString("Severities could not be fetched"));
         micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
     }
 

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
@@ -1,6 +1,8 @@
 package com.redhat.cloud.notifications.mcp;
 
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
+import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
@@ -12,6 +14,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
@@ -28,6 +35,7 @@ import static org.hamcrest.Matchers.notNullValue;
  * Note: The MCP Streamable HTTP transport requires Accept: text/event-stream.
  */
 @QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
 public class McpAuthTest {
 
     private static final String MCP_ENDPOINT = "/mcp";
@@ -41,6 +49,7 @@ public class McpAuthTest {
 
     @BeforeEach
     void beforeEach() {
+        MockServerLifecycleManager.getClient().resetAll();
         micrometerAssertionHelper.saveCounterValuesBeforeTest(AUTH_SUCCESS_COUNTER);
         micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(AUTH_FAILURE_COUNTER, "reason", "missing_header");
         micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(AUTH_FAILURE_COUNTER, "reason", "missing_org_id");
@@ -102,6 +111,18 @@ public class McpAuthTest {
                 "id": 3,
                 "params": {
                     "name": "whoami",
+                    "arguments": {}
+                }
+            }
+            """;
+
+    private static final String GET_SEVERITIES_BODY = """
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 5,
+                "params": {
+                    "name": "getSeverities",
                     "arguments": {}
                 }
             }
@@ -226,8 +247,8 @@ public class McpAuthTest {
     public void testToolsListWithValidIdentity() {
         postMcp(validIdentity(), TOOLS_LIST_BODY)
                 .statusCode(200)
-                .body("result.tools.size()", greaterThanOrEqualTo(2))
-                .body("result.tools.name", hasItems("serverInfo", "whoami"));
+                .body("result.tools.size()", greaterThanOrEqualTo(3))
+                .body("result.tools.name", hasItems("serverInfo", "whoami", "getSeverities"));
     }
 
     @Test
@@ -258,6 +279,53 @@ public class McpAuthTest {
         String identity = McpTestHelpers.encodeRHServiceAccountIdentityInfo(DEFAULT_ORG_ID, "sa-client-id", "sa-name");
         postMcp(identity, WHOAMI_BODY).statusCode(401);
         micrometerAssertionHelper.assertCounterIncrement(AUTH_FAILURE_COUNTER, 1, "reason", "invalid_header");
+    }
+
+    // --- getSeverities tool tests ---
+
+    @Test
+    public void testGetSeveritiesWithValidIdentity() {
+        String severitiesJson = "[\"CRITICAL\",\"IMPORTANT\",\"MODERATE\",\"LOW\",\"NONE\",\"UNDEFINED\"]";
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v2.0/notifications/severities"))
+                        .withHeader("x-rh-identity", equalTo(validIdentity()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(severitiesJson))
+        );
+
+        postMcp(validIdentity(), GET_SEVERITIES_BODY)
+                .statusCode(200)
+                .body("result.content[0].text", containsString("CRITICAL"))
+                .body("result.content[0].text", containsString("IMPORTANT"))
+                .body("result.content[0].text", containsString("MODERATE"))
+                .body("result.content[0].text", containsString("LOW"))
+                .body("result.content[0].text", containsString("NONE"))
+                .body("result.content[0].text", containsString("UNDEFINED"));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+
+        MockServerLifecycleManager.getClient().verify(
+                getRequestedFor(urlPathEqualTo("/api/notifications/v2.0/notifications/severities"))
+                        .withHeader("x-rh-identity", equalTo(validIdentity()))
+        );
+    }
+
+    @Test
+    public void testGetSeveritiesWithoutIdentityIsRejected() {
+        postMcp(null, GET_SEVERITIES_BODY).statusCode(401);
+    }
+
+    @Test
+    public void testGetSeveritiesWhenBackendReturnsError() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v2.0/notifications/severities"))
+                        .willReturn(aResponse().withStatus(500))
+        );
+
+        postMcp(validIdentity(), GET_SEVERITIES_BODY)
+                .statusCode(200)
+                .body("result.content[0].text", containsString("Severities could not be fetched."));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
     }
 
     // --- Health/metrics bypass tests ---

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
@@ -317,7 +317,7 @@ public class McpAuthTest {
     }
 
     @Test
-    public void testGetSeveritiesWhenBackendReturnsError() {
+    public void testGetSeveritiesWhenBackendReturns500() {
         MockServerLifecycleManager.getClient().stubFor(
                 get(urlPathEqualTo("/api/notifications/v2.0/notifications/severities"))
                         .willReturn(aResponse().withStatus(500))
@@ -325,8 +325,36 @@ public class McpAuthTest {
 
         postMcp(validIdentity(), GET_SEVERITIES_BODY)
                 .statusCode(200)
-                .body("error.code", is(-32603))
-                .body("error.message", containsString("Severities could not be fetched"));
+                .body("result.isError", is(true))
+                .body("result.content[0].text", containsString("Backend service error, try again later"));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+    }
+
+    @Test
+    public void testGetSeveritiesWhenBackendReturns403() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v2.0/notifications/severities"))
+                        .willReturn(aResponse().withStatus(403))
+        );
+
+        postMcp(validIdentity(), GET_SEVERITIES_BODY)
+                .statusCode(200)
+                .body("result.isError", is(true))
+                .body("result.content[0].text", containsString("Access denied"));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+    }
+
+    @Test
+    public void testGetSeveritiesWhenBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v2.0/notifications/severities"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        postMcp(validIdentity(), GET_SEVERITIES_BODY)
+                .statusCode(200)
+                .body("result.isError", is(true))
+                .body("result.content[0].text", containsString("Resource not found"));
         micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
     }
 

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/TestLifecycleManager.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/TestLifecycleManager.java
@@ -1,0 +1,27 @@
+package com.redhat.cloud.notifications.mcp;
+
+import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.MockServerLifecycleManager.getMockServerUrl;
+
+public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager {
+
+    @Override
+    public Map<String, String> start() {
+        System.out.println("++++  MCP TestLifecycleManager start +++");
+        Map<String, String> properties = new HashMap<>();
+        MockServerLifecycleManager.start();
+        properties.put("quarkus.rest-client.notifications-backend.url", getMockServerUrl());
+        System.out.println(" -- Running with properties: " + properties);
+        return properties;
+    }
+
+    @Override
+    public void stop() {
+        MockServerLifecycleManager.stop();
+    }
+}


### PR DESCRIPTION
Expose the severities endpoint as the first MCP tool calling the notifications backend via REST client. Forwards the caller's x-rh-identity header for authentication, adds fault tolerance with retry, configurable timeouts, and WireMock-based tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added getSeverities tool to retrieve notification severity levels.
  * Integrated with notifications backend, including automatic retry and configurable connect/read timeouts (defaults: 2000ms).
* **Documentation**
  * Added getSeverities docs with JSON-RPC examples and sample response.
* **Tests**
  * Added tests for getSeverities: success, auth validation, and backend error mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->