### PR TITLE
[RHCLOUD-46700] Add Google chat connector Incoming cloud event format checks

### DIFF
--- a/connector-google-chat/src/main/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatMessageHandler.java
+++ b/connector-google-chat/src/main/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatMessageHandler.java
@@ -11,9 +11,14 @@ import io.smallrye.reactive.messaging.ce.IncomingCloudEventMetadata;
 import io.vertx.core.json.JsonObject;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import java.net.URLDecoder;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -35,10 +40,21 @@ public class GoogleChatMessageHandler extends MessageHandler {
     @RestClient
     GoogleChatRestClient webhookRestClient;
 
+    @Inject
+    Validator validator;
+
     @Override
     public HandledMessageDetails handle(final IncomingCloudEventMetadata<JsonObject> incomingCloudEvent) {
 
-        GoogleChatNotification notification =  incomingCloudEvent.getData().mapTo(GoogleChatNotification.class);
+        GoogleChatNotification notification = incomingCloudEvent.getData().mapTo(GoogleChatNotification.class);
+
+        Set<ConstraintViolation<GoogleChatNotification>> violations = validator.validate(notification);
+        if (!violations.isEmpty()) {
+            String errorMessage = violations.stream()
+                .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+                .collect(Collectors.joining(", "));
+            throw new ConstraintViolationException("Validation failed: " + errorMessage, violations);
+        }
 
         String bundle = null;
         String application = null;

--- a/connector-google-chat/src/main/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatNotification.java
+++ b/connector-google-chat/src/main/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatNotification.java
@@ -1,11 +1,16 @@
 package com.redhat.cloud.notifications.connector.google.chat;
 
 import com.redhat.cloud.notifications.connector.v2.models.NotificationToConnector;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
 public class GoogleChatNotification extends NotificationToConnector {
 
+    @NotNull
+    @NotBlank
     public String webhookUrl;
 
+    @NotNull
     public Map<String, Object> eventData;
 }

--- a/connector-google-chat/src/main/resources/application.properties
+++ b/connector-google-chat/src/main/resources/application.properties
@@ -1,6 +1,4 @@
-notifications.connector.kafka.incoming.group-id=notifications-connector-google-chat
-notifications.connector.kafka.incoming.topic=${mp.messaging.tocamel.topic}
-notifications.connector.kafka.outgoing.topic=${mp.messaging.fromcamel.topic}
+mp.messaging.incoming.incomingmessages.group.id=notifications-connector-google-chat
 notifications.connector.name=google_chat
 notifications.connector.supported-connector-headers=${notifications.connector.name}
 
@@ -17,9 +15,6 @@ quarkus.log.sentry.enabled=false
 quarkus.log.sentry.in-app-packages=com.redhat.cloud.notifications
 
 quarkus.kafka.devservices.port=9092
-
-mp.messaging.tocamel.topic=platform.notifications.tocamel
-mp.messaging.fromcamel.topic=platform.notifications.fromcamel
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/connector-google-chat/src/test/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatMessageHandlerTest.java
+++ b/connector-google-chat/src/test/java/com/redhat/cloud/notifications/connector/google/chat/GoogleChatMessageHandlerTest.java
@@ -8,6 +8,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
@@ -17,11 +18,14 @@ import java.util.Map;
 
 import static com.redhat.cloud.notifications.connector.v2.BaseConnectorIntegrationTest.buildIncomingCloudEvent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
@@ -144,6 +148,91 @@ class GoogleChatMessageHandlerTest {
 
         HandledHttpMessageDetails httpDetails = (HandledHttpMessageDetails) result;
         assertEquals(200, httpDetails.httpStatus);
+    }
+
+    @Test
+    void testNullWebhookUrl() {
+        JsonObject payload = new JsonObject();
+        payload.put("org_id", "12345");
+        payload.putNull("webhookUrl");
+        payload.put("eventData", new HashMap<>());
+
+        assertThrows(ConstraintViolationException.class, () ->
+            handler.handle(buildIncomingCloudEvent("test-id", "test-type", payload))
+        );
+    }
+
+    @Test
+    void testBlankWebhookUrl() {
+        JsonObject payload = buildPayload("", new HashMap<>());
+
+        assertThrows(ConstraintViolationException.class, () ->
+            handler.handle(buildIncomingCloudEvent("test-id", "test-type", payload))
+        );
+    }
+
+    @Test
+    void testNullEventData() {
+        JsonObject payload = new JsonObject();
+        payload.put("org_id", "12345");
+        payload.put("webhookUrl", "http://localhost/webhook");
+        payload.putNull("eventData");
+
+        assertThrows(ConstraintViolationException.class, () ->
+            handler.handle(buildIncomingCloudEvent("test-id", "test-type", payload))
+        );
+    }
+
+    @Test
+    void testHttpErrorStatus() {
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("bundle", "rhel");
+
+        when(connectorConfig.isUseBetaTemplatesEnabled(any(), any(), any(), any())).thenReturn(false);
+        when(templateService.renderTemplate(any(), anyMap())).thenReturn("{}");
+
+        Response mockResponse = mock(Response.class);
+        when(mockResponse.getStatus()).thenReturn(500);
+        when(webhookRestClient.post(anyString(), anyString())).thenReturn(mockResponse);
+
+        JsonObject payload = buildPayload("http://localhost/webhook", eventData);
+        HandledMessageDetails result = handler.handle(
+            buildIncomingCloudEvent("test-id", "test-type", payload)
+        );
+
+        HandledHttpMessageDetails httpDetails = (HandledHttpMessageDetails) result;
+        assertEquals(500, httpDetails.httpStatus);
+        assertEquals("http://localhost/webhook", httpDetails.targetUrl);
+    }
+
+    @Test
+    void testBetaTemplateEnabled() {
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("bundle", "rhel");
+        eventData.put("application", "advisor");
+        eventData.put("event_type", "new-recommendation");
+
+        when(connectorConfig.isUseBetaTemplatesEnabled(eq("12345"), eq("rhel"), eq("advisor"), eq("new-recommendation"))).thenReturn(true);
+        when(templateService.renderTemplate(
+            argThat(td -> "rhel".equals(td.bundle())
+                && "advisor".equals(td.application())
+                && "new-recommendation".equals(td.eventType())
+                && td.isBetaVersion()),
+            anyMap()
+        )).thenReturn("{\"text\": \"beta\"}");
+
+        Response mockResponse = mock(Response.class);
+        when(mockResponse.getStatus()).thenReturn(200);
+        when(webhookRestClient.post(anyString(), anyString())).thenReturn(mockResponse);
+
+        JsonObject payload = buildPayload("http://localhost/webhook", eventData);
+        HandledMessageDetails result = handler.handle(
+            buildIncomingCloudEvent("test-id", "test-type", payload)
+        );
+
+        HandledHttpMessageDetails httpDetails = (HandledHttpMessageDetails) result;
+        assertEquals(200, httpDetails.httpStatus);
+        verify(connectorConfig).isUseBetaTemplatesEnabled(eq("12345"), eq("rhel"), eq("advisor"), eq("new-recommendation"));
     }
 
     private static JsonObject buildPayload(String webhookUrl, Map<String, Object> eventData) {

--- a/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackMessageHandler.java
+++ b/connector-slack/src/main/java/com/redhat/cloud/notifications/connector/slack/SlackMessageHandler.java
@@ -44,10 +44,6 @@ public class SlackMessageHandler extends MessageHandler {
     @Override
     public HandledMessageDetails handle(final IncomingCloudEventMetadata<JsonObject> incomingCloudEvent) {
 
-        if (incomingCloudEvent.getData() == null) {
-            throw new IllegalStateException("CloudEvent data is null");
-        }
-
         SlackNotification notification = incomingCloudEvent.getData().mapTo(SlackNotification.class);
 
         Set<ConstraintViolation<SlackNotification>> violations = validator.validate(notification);

--- a/connector-webhook/src/main/resources/application.properties
+++ b/connector-webhook/src/main/resources/application.properties
@@ -1,6 +1,4 @@
-notifications.connector.kafka.incoming.group-id=notifications-connector-webhook
-notifications.connector.kafka.incoming.topic=${mp.messaging.tocamel.topic}
-notifications.connector.kafka.outgoing.topic=${mp.messaging.fromcamel.topic}
+mp.messaging.incoming.incomingmessages.group.id==notifications-connector-webhook
 notifications.connector.name=webhook
 notifications.connector.supported-connector-headers=ansible,webhook
 
@@ -14,9 +12,6 @@ quarkus.log.sentry.enabled=false
 quarkus.log.sentry.in-app-packages=com.redhat.cloud.notifications
 
 quarkus.kafka.devservices.port=9092
-
-mp.messaging.tocamel.topic=platform.notifications.tocamel
-mp.messaging.fromcamel.topic=platform.notifications.fromcamel
 
 %test.quarkus.log.category."com.redhat.cloud.notifications".level=DEBUG
 

--- a/connector-webhook/src/main/resources/application.properties
+++ b/connector-webhook/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-mp.messaging.incoming.incomingmessages.group.id==notifications-connector-webhook
+mp.messaging.incoming.incomingmessages.group.id=notifications-connector-webhook
 notifications.connector.name=webhook
 notifications.connector.supported-connector-headers=ansible,webhook
 

--- a/connector-webhook/src/main/resources/application.properties
+++ b/connector-webhook/src/main/resources/application.properties
@@ -4,6 +4,9 @@ notifications.connector.supported-connector-headers=ansible,webhook
 
 quarkus.http.port=9006
 
+# Configure the limit of how many messages the connector can process in parallel
+smallrye.messaging.worker.connector-thread-pool.max-concurrency=20
+
 quarkus.log.cloudwatch.enabled=false
 quarkus.log.cloudwatch.level=INFO
 quarkus.log.cloudwatch.log-stream-name=${HOST_NAME:notifications-connector-webhook}


### PR DESCRIPTION
[RHCLOUD-46700] Add Google chat connector Incoming cloud event format checks
Define google chat consumer group id
Define Slack consumer group id
Remove Slack cloud event null check (already done by common module)

[RHCLOUD-46700]: https://redhat.atlassian.net/browse/RHCLOUD-46700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added input validation for webhook URLs and event data to prevent invalid requests.

* **Bug Fixes**
  * Validation failures now return aggregated, specific constraint messages.
  * HTTP failures report detailed status and target URL info.
  * Connectors now rely on validation for missing event data instead of an early precondition.

* **Tests**
  * Added tests covering validation failures, HTTP error handling, and beta-template selection.

* **Chores**
  * Migrated messaging configuration to MicroProfile/SmallRye and added connector concurrency tuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->