### PR TITLE
[RHCLOUD-46659] Kickoff Application Services Releases daily digest

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/ApplicationServicesSortExtension.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/ApplicationServicesSortExtension.java
@@ -1,0 +1,26 @@
+package com.redhat.cloud.notifications.qute.templates.extensions;
+
+import io.quarkus.qute.TemplateExtension;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public class ApplicationServicesSortExtension {
+
+    /* Sort products map entries alphabetically by their "description" field */
+    @TemplateExtension
+    public static List<Map.Entry<String, Map<String, Object>>> sortByDescription(Map<String, Map<String, Object>> products) {
+        if (products == null) {
+            return List.of();
+        }
+        List<Map.Entry<String, Map<String, Object>>> entries = new ArrayList<>(products.entrySet());
+        entries.sort(Comparator.comparing(entry -> extractDescription(entry.getValue())));
+        return entries;
+    }
+
+    private static String extractDescription(Map<String, Object> value) {
+        Object desc = value.get("description");
+        return desc != null ? desc.toString() : "";
+    }
+}

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/ApplicationServicesSortExtension.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/ApplicationServicesSortExtension.java
@@ -8,19 +8,31 @@ import java.util.Map;
 
 public class ApplicationServicesSortExtension {
 
-    /* Sort products map entries alphabetically by their "description" field */
     @TemplateExtension
-    public static List<Map.Entry<String, Map<String, Object>>> sortByDescription(Map<String, Map<String, Object>> products) {
+    public static List<Map.Entry<String, Map<String, Object>>> sortByProductDescription(Map<String, Map<String, Object>> products) {
         if (products == null) {
             return List.of();
         }
         List<Map.Entry<String, Map<String, Object>>> entries = new ArrayList<>(products.entrySet());
-        entries.sort(Comparator.comparing(entry -> extractDescription(entry.getValue())));
+        entries.sort(Comparator.comparing(entry -> extractField(entry.getValue(), "description")));
         return entries;
     }
 
-    private static String extractDescription(Map<String, Object> value) {
-        Object desc = value.get("description");
-        return desc != null ? desc.toString() : "";
+    @TemplateExtension
+    public static List<Map<String, Object>> sortByEventTypeDisplayName(List<Map<String, Object>> eventTypes) {
+        if (eventTypes == null) {
+            return List.of();
+        }
+        List<Map<String, Object>> sorted = new ArrayList<>(eventTypes);
+        sorted.sort(Comparator.comparing(entry -> extractField(entry, "display_name")));
+        return sorted;
+    }
+
+    private static String extractField(Map<String, Object> value, String field) {
+        if (value == null) {
+            return "";
+        }
+        Object val = value.get(field);
+        return val != null ? val.toString() : "";
     }
 }

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/SubscriptionServices.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/SubscriptionServices.java
@@ -19,6 +19,9 @@ public class SubscriptionServices {
     public static final String ERRATA_APP_NAME = "errata-notifications";
     static final String ERRATA_FOLDER_NAME = "Errata/";
 
+    public static final String APPLICATION_SERVICES_APP_NAME = "application-services";
+    static final String APPLICATION_SERVICES_FOLDER_NAME = "ApplicationServices/";
+
     public static final String SUBSCRIPTIONS_USAGE_APP_NAME = "subscriptions";
     static final String SUBSCRIPTIONS_USAGE_FOLDER_NAME = "SubscriptionsUsage/";
 
@@ -49,6 +52,9 @@ public class SubscriptionServices {
         entry(new TemplateDefinition(SLACK, BUNDLE_NAME, ERRATA_APP_NAME, ERRATA_NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA), ERRATA_FOLDER_NAME + "newSubscriptionEnhancementErrata.json"),
 
         entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, ERRATA_APP_NAME, null), ERRATA_FOLDER_NAME + "dailyEmailBody.html"),
+
+        // Application Services Releases
+        entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, APPLICATION_SERVICES_APP_NAME, null), APPLICATION_SERVICES_FOLDER_NAME + "dailyEmailBody.html"),
 
         // Subscriptions Usage
         entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, SUBSCRIPTIONS_USAGE_APP_NAME, SUBSCRIPTIONS_USAGE_EXCEEDED_UTILIZATION_THRESHOLD), SUBSCRIPTIONS_USAGE_FOLDER_NAME + "usageThresholdExceededEmailTitle.txt"),

--- a/common-template/src/main/resources/templates/email/ApplicationServices/dailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/ApplicationServices/dailyEmailBody.html
@@ -4,7 +4,7 @@
 {@boolean renderButtonSection3=false}
 {@boolean renderCustomLinks=true}
 {@boolean renderTitleRightPart=true}
-{#let sortedProducts=action.context.application-services.products.sortByDescription}
+{#let sortedProducts=action.context.application-services.products.sortByProductDescription}
 {#include email/Common/insightsEmailBodyLight}
 {#content-render-custom-links-section}
     {#each sortedProducts}
@@ -53,7 +53,7 @@
             <tbody>
                 {#each sub-section-product-releases}
                 <tr style="font-size: 14px;">
-                    <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="{action.context.application-services.base_url}{it.id}" target="_blank">{it.description}</a></td>
+                    <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId={it.id}" target="_blank">{it.description}</a></td>
                     <td style="{body-section-table-td-style}">{it.version}</td>
                 </tr>
                 {/each}

--- a/common-template/src/main/resources/templates/email/ApplicationServices/dailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/ApplicationServices/dailyEmailBody.html
@@ -1,0 +1,71 @@
+{@boolean renderSection1=true}
+{@boolean renderSection2=false}
+{@boolean renderSection3=false}
+{@boolean renderButtonSection3=false}
+{@boolean renderCustomLinks=true}
+{@boolean renderTitleRightPart=true}
+{#let sortedProducts=action.context.application-services.products.sortByDescription}
+{#include email/Common/insightsEmailBodyLight}
+{#content-render-custom-links-section}
+    {#each sortedProducts}
+        {#if it.value.payloads.size() > 0}
+            <!-- next section -->
+            <a style="{body-section-table-td-a-style}" href="#application-services-section1-{it_count}">{it.value.description} ({it.value.payloads.size()})</a>
+        {/if}
+    {/each}
+{/content-render-custom-links-section}
+{#content-title-section1}
+    Application Services Releases
+{/content-title-section1}
+{#content-title-right-part}
+    {action.context.application-services.global_releases_number}
+{/content-title-right-part}
+{#content-body-section1}
+    {#each sortedProducts}
+        {#if it.value.payloads.size() > 0}
+            {#let
+                sub-section-product-id = it_count
+                sub-section-products-count = it.value.payloads.size()
+                sub-section-product-releases = it.value.payloads
+                sub-section-product-family = it.value.description
+                sub-section-not-the-last = it_hasNext
+                }
+                {#insert content-common-section}{/}
+            {/let}
+        {/if}
+    {/each}
+{/content-body-section1}
+{#content-common-section}
+    <a id="application-services-section1-{sub-section-product-id}" name="application-services-section1-{sub-section-product-id}"></a>
+    {#if sub-section-products-count == 1}
+        <p style="{body-section-p-style}">There is 1 {sub-section-product-family} release affecting your subscriptions.</p>
+    {#else}
+        <p style="{body-section-p-style}">There are {sub-section-products-count} {sub-section-product-family} releases affecting your subscriptions.</p>
+    {/if}
+    <table style="border: solid 1px #b8bbbe; border-radius: 16px; padding: 0 8px 0px 8px; width: 100%;"><tr><td>
+        <table style="{body-section-table-style}">
+            <thead>
+                <tr>
+                  <th style="{body-section-table-th-style}">Release</th>
+                  <th style="{body-section-table-th-style} width: 50px;">Version</th>
+                </tr>
+            </thead>
+            <tbody>
+                {#each sub-section-product-releases}
+                <tr style="font-size: 14px;">
+                    <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="{action.context.application-services.base_url}{it.id}" target="_blank">{it.description}</a></td>
+                    <td style="{body-section-table-td-style}">{it.version}</td>
+                </tr>
+                {/each}
+            </tbody>
+        </table>
+        </td></tr>
+    </table>
+    {#if sub-section-not-the-last.or(false)}
+    <div style="height: 24px">&#xA0;</div>
+    {/if}
+{/content-common-section}
+{#content-button-href}{environment.url}/subscriptions/inventory?{query_params}{/content-button-href}
+{#content-button-service-name}Subscriptions Inventory{/content-button-service-name}
+{/include}
+{/let}

--- a/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/extensions/ApplicationServicesSortExtensionTest.java
+++ b/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/extensions/ApplicationServicesSortExtensionTest.java
@@ -1,0 +1,85 @@
+package com.redhat.cloud.notifications.qute.templates.extensions;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApplicationServicesSortExtensionTest {
+
+    @Test
+    void testSortByDescriptionNullInput() {
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testSortByDescription() {
+        Map<String, Map<String, Object>> products = new LinkedHashMap<>();
+        products.put("keycloak-releases", Map.of("description", "Red Hat build of Keycloak", "payloads", List.of()));
+        products.put("eap-releases", Map.of("description", "Red Hat JBoss Enterprise Application Platform", "payloads", List.of()));
+        products.put("amq-releases", Map.of("description", "AMQ Broker", "payloads", List.of()));
+
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(products);
+
+        assertEquals(3, result.size());
+        assertEquals("amq-releases", result.get(0).getKey());
+        assertEquals("eap-releases", result.get(1).getKey());
+        assertEquals("keycloak-releases", result.get(2).getKey());
+    }
+
+    @Test
+    void testSortByDescriptionWithMissingDescription() {
+        Map<String, Map<String, Object>> products = new LinkedHashMap<>();
+        products.put("product-b", Map.of("description", "Bravo"));
+        products.put("product-a", Map.of("payloads", List.of()));
+        products.put("product-c", Map.of("description", "Alpha"));
+
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(products);
+
+        assertEquals(3, result.size());
+        // Missing description sorts as empty string, so it comes first
+        assertEquals("product-a", result.get(0).getKey());
+        assertEquals("product-c", result.get(1).getKey());
+        assertEquals("product-b", result.get(2).getKey());
+    }
+
+    @Test
+    void testSortByDescriptionSingleProduct() {
+        Map<String, Map<String, Object>> products = new LinkedHashMap<>();
+        products.put("only-product", Map.of("description", "Only Product"));
+
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(products);
+
+        assertEquals(1, result.size());
+        assertEquals("only-product", result.get(0).getKey());
+    }
+
+    @Test
+    void testSortByDescriptionEmptyMap() {
+        Map<String, Map<String, Object>> products = new LinkedHashMap<>();
+
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(products);
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void testSortByDescriptionDoesNotMutateOriginalMap() {
+        Map<String, Map<String, Object>> products = new LinkedHashMap<>();
+        products.put("keycloak-releases", Map.of("description", "Red Hat build of Keycloak"));
+        products.put("eap-releases", Map.of("description", "Red Hat JBoss Enterprise Application Platform"));
+        products.put("amq-releases", Map.of("description", "AMQ Broker"));
+
+        List<String> originalOrder = List.copyOf(products.keySet());
+
+        ApplicationServicesSortExtension.sortByDescription(products);
+
+        // Original map key order should be unchanged
+        assertEquals(originalOrder, List.copyOf(products.keySet()));
+    }
+}

--- a/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/extensions/ApplicationServicesSortExtensionTest.java
+++ b/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/extensions/ApplicationServicesSortExtensionTest.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.qute.templates.extensions;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,7 +14,7 @@ class ApplicationServicesSortExtensionTest {
 
     @Test
     void testSortByDescriptionNullInput() {
-        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(null);
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByProductDescription(null);
         assertTrue(result.isEmpty());
     }
 
@@ -24,7 +25,7 @@ class ApplicationServicesSortExtensionTest {
         products.put("eap-releases", Map.of("description", "Red Hat JBoss Enterprise Application Platform", "payloads", List.of()));
         products.put("amq-releases", Map.of("description", "AMQ Broker", "payloads", List.of()));
 
-        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(products);
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByProductDescription(products);
 
         assertEquals(3, result.size());
         assertEquals("amq-releases", result.get(0).getKey());
@@ -39,7 +40,7 @@ class ApplicationServicesSortExtensionTest {
         products.put("product-a", Map.of("payloads", List.of()));
         products.put("product-c", Map.of("description", "Alpha"));
 
-        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(products);
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByProductDescription(products);
 
         assertEquals(3, result.size());
         // Missing description sorts as empty string, so it comes first
@@ -53,7 +54,7 @@ class ApplicationServicesSortExtensionTest {
         Map<String, Map<String, Object>> products = new LinkedHashMap<>();
         products.put("only-product", Map.of("description", "Only Product"));
 
-        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(products);
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByProductDescription(products);
 
         assertEquals(1, result.size());
         assertEquals("only-product", result.get(0).getKey());
@@ -63,7 +64,7 @@ class ApplicationServicesSortExtensionTest {
     void testSortByDescriptionEmptyMap() {
         Map<String, Map<String, Object>> products = new LinkedHashMap<>();
 
-        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByDescription(products);
+        List<Map.Entry<String, Map<String, Object>>> result = ApplicationServicesSortExtension.sortByProductDescription(products);
 
         assertEquals(0, result.size());
     }
@@ -77,9 +78,81 @@ class ApplicationServicesSortExtensionTest {
 
         List<String> originalOrder = List.copyOf(products.keySet());
 
-        ApplicationServicesSortExtension.sortByDescription(products);
+        ApplicationServicesSortExtension.sortByProductDescription(products);
 
         // Original map key order should be unchanged
         assertEquals(originalOrder, List.copyOf(products.keySet()));
+    }
+
+    @Test
+    void testSortByDisplayNameNullInput() {
+        List<Map<String, Object>> result = ApplicationServicesSortExtension.sortByEventTypeDisplayName(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testSortByDisplayName() {
+        List<Map<String, Object>> eventTypes = new ArrayList<>();
+        eventTypes.add(Map.of("display_name", "Policies", "name", "policies"));
+        eventTypes.add(Map.of("display_name", "Advisor", "name", "advisor"));
+        eventTypes.add(Map.of("display_name", "Vulnerability", "name", "vulnerability"));
+
+        List<Map<String, Object>> result = ApplicationServicesSortExtension.sortByEventTypeDisplayName(eventTypes);
+
+        assertEquals(3, result.size());
+        assertEquals("Advisor", result.get(0).get("display_name"));
+        assertEquals("Policies", result.get(1).get("display_name"));
+        assertEquals("Vulnerability", result.get(2).get("display_name"));
+    }
+
+    @Test
+    void testSortByDisplayNameWithMissingDisplayName() {
+        List<Map<String, Object>> eventTypes = new ArrayList<>();
+        eventTypes.add(Map.of("display_name", "Drift", "name", "drift"));
+        eventTypes.add(Map.of("name", "no-display-name"));
+        eventTypes.add(Map.of("display_name", "Advisor", "name", "advisor"));
+
+        List<Map<String, Object>> result = ApplicationServicesSortExtension.sortByEventTypeDisplayName(eventTypes);
+
+        assertEquals(3, result.size());
+        assertEquals("no-display-name", result.get(0).get("name"));
+        assertEquals("Advisor", result.get(1).get("display_name"));
+        assertEquals("Drift", result.get(2).get("display_name"));
+    }
+
+    @Test
+    void testSortByDisplayNameSingleElement() {
+        List<Map<String, Object>> eventTypes = new ArrayList<>();
+        eventTypes.add(Map.of("display_name", "Only Event Type"));
+
+        List<Map<String, Object>> result = ApplicationServicesSortExtension.sortByEventTypeDisplayName(eventTypes);
+
+        assertEquals(1, result.size());
+        assertEquals("Only Event Type", result.get(0).get("display_name"));
+    }
+
+    @Test
+    void testSortByDisplayNameEmptyList() {
+        List<Map<String, Object>> result = ApplicationServicesSortExtension.sortByEventTypeDisplayName(new ArrayList<>());
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void testSortByDisplayNameDoesNotMutateOriginalList() {
+        List<Map<String, Object>> eventTypes = new ArrayList<>();
+        eventTypes.add(Map.of("display_name", "Policies"));
+        eventTypes.add(Map.of("display_name", "Advisor"));
+        eventTypes.add(Map.of("display_name", "Vulnerability"));
+
+        List<String> originalOrder = eventTypes.stream()
+            .map(e -> (String) e.get("display_name"))
+            .toList();
+
+        ApplicationServicesSortExtension.sortByEventTypeDisplayName(eventTypes);
+
+        List<String> orderAfterSort = eventTypes.stream()
+            .map(e -> (String) e.get("display_name"))
+            .toList();
+        assertEquals(originalOrder, orderAfterSort);
     }
 }

--- a/common-template/src/test/java/email/TestApplicationServicesTemplate.java
+++ b/common-template/src/test/java/email/TestApplicationServicesTemplate.java
@@ -1,0 +1,163 @@
+package email;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelper {
+
+    @Override
+    protected String getBundle() {
+        return "subscription-services";
+    }
+
+    @Override
+    protected String getApp() {
+        return "application-services";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "Subscription Services";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Application Services";
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testDailyDigestEmailBody(boolean useBetaTemplate) throws JsonProcessingException {
+        final String result = generateAggregatedEmailBody(JSON_APP_SERVICES_DEFAULT_AGGREGATION_CONTEXT, useBetaTemplate);
+
+        // Verify section links with descriptions and counts
+        assertTrue(result.contains("Red Hat build of Keycloak (2)"));
+        assertTrue(result.contains("Red Hat JBoss Enterprise Application Platform (3)"));
+
+        // Verify section anchors
+        assertTrue(result.contains("application-services-section1-1"));
+        assertTrue(result.contains("application-services-section1-2"));
+
+        // Verify release counts in section bodies
+        assertTrue(result.contains("2 "), "Keycloak section should show 2 releases");
+        assertTrue(result.contains("3 "), "EAP section should show 3 releases");
+        assertTrue(result.contains("releases affecting your subscriptions."));
+
+        // Verify base_url is used in payload links
+        assertEquals(5, StringUtils.countMatches(result, "https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId="));
+
+        // Verify payload data is rendered in the tables
+        assertTrue(result.contains("Red Hat build of Keycloak 26.2.13 Maven Repository"));
+        assertTrue(result.contains("Red Hat build of Keycloak 26.2.13 Server"));
+        assertTrue(result.contains("Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Installation Manager"));
+        assertTrue(result.contains("Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Source Code"));
+        assertTrue(result.contains("Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Maven Repository"));
+
+        // Verify product versions are rendered
+        assertTrue(result.contains("26.2.13"));
+        assertTrue(result.contains("8.1"));
+
+        // Verify HCC logo
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+    }
+
+    @Test
+    public void testDailyDigestSortsProductsByDescription() throws JsonProcessingException {
+        // Products are in reverse alphabetical order by description to verify sorting
+        String json = "{" +
+            "\"application-services\":{" +
+            "  \"base_url\":\"https://access.redhat.com/softwareDetail.html?softwareId=\"," +
+            "  \"global_releases_number\":2," +
+            "  \"products\":{" +
+            "    \"zzz-product\":{\"description\":\"Zebra Product\",\"payloads\":[{\"id\":\"1\",\"description\":\"Zebra Release\",\"version\":\"1.0\"}]}," +
+            "    \"aaa-product\":{\"description\":\"Alpha Product\",\"payloads\":[{\"id\":\"2\",\"description\":\"Alpha Release\",\"version\":\"2.0\"}]}" +
+            "  }" +
+            "}," +
+            "\"start_time\":null,\"end_time\":null" +
+            "}";
+
+        final String result = generateAggregatedEmailBody(json, false);
+
+        int alphaPos = result.indexOf("Alpha Product");
+        int zebraPos = result.indexOf("Zebra Product");
+        assertTrue(alphaPos > -1, "Alpha Product should appear in output");
+        assertTrue(zebraPos > -1, "Zebra Product should appear in output");
+        assertTrue(alphaPos < zebraPos, "Products should be sorted alphabetically by description");
+    }
+
+    @Test
+    public void testDailyDigestHidesProductsWithNoPayloads() throws JsonProcessingException {
+        String json = "{" +
+            "\"application-services\":{" +
+            "  \"base_url\":\"https://access.redhat.com/softwareDetail.html?softwareId=\"," +
+            "  \"global_releases_number\":1," +
+            "  \"products\":{" +
+            "    \"keycloak-releases\":{\"description\":\"Red Hat build of Keycloak\",\"payloads\":[]}," +
+            "    \"eap-releases\":{\"description\":\"Red Hat JBoss Enterprise Application Platform\",\"payloads\":[{\"id\":\"1\",\"description\":\"EAP Release\",\"version\":\"8.0\"}]}" +
+            "  }" +
+            "}," +
+            "\"start_time\":null,\"end_time\":null" +
+            "}";
+
+        final String result = generateAggregatedEmailBody(json, false);
+
+        assertFalse(result.contains("Red Hat build of Keycloak (0)"), "Products with empty payloads should not appear in links");
+        assertTrue(result.contains("Red Hat JBoss Enterprise Application Platform (1)"), "Products with payloads should appear");
+    }
+
+    public static final String JSON_APP_SERVICES_DEFAULT_AGGREGATION_CONTEXT = "{" +
+        "   \"application-services\":{" +
+        "      \"base_url\":\"https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=\"," +
+        "      \"global_releases_number\":5," +
+        "      \"products\":{" +
+        "         \"keycloak-releases\":{" +
+        "            \"description\":\"Red Hat build of Keycloak\"," +
+        "            \"payloads\":[" +
+        "               {" +
+        "                  \"id\":\"108766\"," +
+        "                  \"description\":\"Red Hat build of Keycloak 26.2.13 Maven Repository\"," +
+        "                  \"version\":\"26.2.13\"" +
+        "               }," +
+        "               {" +
+        "                  \"id\":\"108767\"," +
+        "                  \"description\":\"Red Hat build of Keycloak 26.2.13 Server\"," +
+        "                  \"version\":\"26.2.13\"" +
+        "               }" +
+        "            ]" +
+        "         }," +
+        "         \"eap-releases\":{" +
+        "            \"description\":\"Red Hat JBoss Enterprise Application Platform\"," +
+        "            \"payloads\":[" +
+        "               {" +
+        "                  \"id\":\"108920\"," +
+        "                  \"description\":\"Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Installation Manager\"," +
+        "                  \"version\":\"8.1\"" +
+        "               }," +
+        "               {" +
+        "                  \"id\":\"108917\"," +
+        "                  \"description\":\"Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Source Code\"," +
+        "                  \"version\":\"8.1\"" +
+        "               }," +
+        "               {" +
+        "                  \"id\":\"108918\"," +
+        "                  \"description\":\"Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Maven Repository\"," +
+        "                  \"version\":\"8.1\"" +
+        "               }" +
+        "            ]" +
+        "         }" +
+        "      }" +
+        "   }," +
+        "   \"start_time\":null," +
+        "   \"end_time\":null" +
+        "}";
+}

--- a/common-template/src/test/java/email/TestApplicationServicesTemplate.java
+++ b/common-template/src/test/java/email/TestApplicationServicesTemplate.java
@@ -72,11 +72,28 @@ public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelpe
     }
 
     @Test
+    public void testDailyDigestSingularRelease() throws JsonProcessingException {
+        String json = "{" +
+            "\"application-services\":{" +
+            "  \"global_releases_number\":1," +
+            "  \"products\":{" +
+            "    \"keycloak-releases\":{\"description\":\"Red Hat build of Keycloak\",\"payloads\":[{\"id\":\"108766\",\"description\":\"Red Hat build of Keycloak 26.2.13 Maven Repository\",\"version\":\"26.2.13\"}]}" +
+            "  }" +
+            "}," +
+            "\"start_time\":null,\"end_time\":null" +
+            "}";
+
+        final String result = generateAggregatedEmailBody(json, false);
+
+        assertTrue(result.contains("There is 1 Red Hat build of Keycloak release affecting your subscriptions."));
+        assertFalse(result.contains("There are 1"));
+    }
+
+    @Test
     public void testDailyDigestSortsProductsByDescription() throws JsonProcessingException {
         // Products are in reverse alphabetical order by description to verify sorting
         String json = "{" +
             "\"application-services\":{" +
-            "  \"base_url\":\"https://access.redhat.com/softwareDetail.html?softwareId=\"," +
             "  \"global_releases_number\":2," +
             "  \"products\":{" +
             "    \"zzz-product\":{\"description\":\"Zebra Product\",\"payloads\":[{\"id\":\"1\",\"description\":\"Zebra Release\",\"version\":\"1.0\"}]}," +
@@ -99,7 +116,6 @@ public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelpe
     public void testDailyDigestHidesProductsWithNoPayloads() throws JsonProcessingException {
         String json = "{" +
             "\"application-services\":{" +
-            "  \"base_url\":\"https://access.redhat.com/softwareDetail.html?softwareId=\"," +
             "  \"global_releases_number\":1," +
             "  \"products\":{" +
             "    \"keycloak-releases\":{\"description\":\"Red Hat build of Keycloak\",\"payloads\":[]}," +
@@ -115,9 +131,27 @@ public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelpe
         assertTrue(result.contains("Red Hat JBoss Enterprise Application Platform (1)"), "Products with payloads should appear");
     }
 
+    @Test
+    public void testDailyDigestWithAllProductsEmpty() throws JsonProcessingException {
+        String json = "{" +
+            "\"application-services\":{" +
+            "  \"global_releases_number\":0," +
+            "  \"products\":{" +
+            "    \"keycloak-releases\":{\"description\":\"Red Hat build of Keycloak\",\"payloads\":[]}," +
+            "    \"eap-releases\":{\"description\":\"Red Hat JBoss Enterprise Application Platform\",\"payloads\":[]}" +
+            "  }" +
+            "}," +
+            "\"start_time\":null,\"end_time\":null" +
+            "}";
+
+        final String result = generateAggregatedEmailBody(json, false);
+
+        assertFalse(result.contains("application-services-section1-1"), "No product sections should be rendered");
+        assertTrue(result.contains("Application Services Releases"), "Title should still be present");
+    }
+
     public static final String JSON_APP_SERVICES_DEFAULT_AGGREGATION_CONTEXT = "{" +
         "   \"application-services\":{" +
-        "      \"base_url\":\"https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=\"," +
         "      \"global_releases_number\":5," +
         "      \"products\":{" +
         "         \"keycloak-releases\":{" +

--- a/common-template/src/test/java/email/TestSubscriptionServicesDailyTemplate.java
+++ b/common-template/src/test/java/email/TestSubscriptionServicesDailyTemplate.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static email.TestApplicationServicesTemplate.JSON_APP_SERVICES_DEFAULT_AGGREGATION_CONTEXT;
 import static email.TestErrataTemplate.JSON_ERRATA_DEFAULT_AGGREGATION_CONTEXT;
 import static email.pojo.EmailPendo.GENERAL_PENDO_MESSAGE;
 import static email.pojo.EmailPendo.GENERAL_PENDO_TITLE;
@@ -43,6 +44,8 @@ class TestSubscriptionServicesDailyTemplate extends EmailTemplatesRendererHelper
         Map<String, DailyDigestSection> dataMap = new HashMap<>();
 
         generateAggregatedEmailBody(JSON_ERRATA_DEFAULT_AGGREGATION_CONTEXT, SubscriptionServices.ERRATA_APP_NAME, dataMap, useBetaVersion);
+
+        generateAggregatedEmailBody(JSON_APP_SERVICES_DEFAULT_AGGREGATION_CONTEXT, SubscriptionServices.APPLICATION_SERVICES_APP_NAME, dataMap, useBetaVersion);
 
         // sort application by name
         List<DailyDigestSection> result = dataMap.entrySet().stream()

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregator.java
@@ -14,8 +14,8 @@ public class ApplicationServicesEmailPayloadAggregator extends AbstractEmailPayl
     private static final String EVENTS_KEY = "events";
     private static final String CONTEXT_KEY = "context";
     private static final String PAYLOAD_KEY = "payload";
-    private static final String BASE_URL_KEY = "base_url";
-    private static final String FAMILY_KEY = "family";
+    private static final String SOURCE_KEY = "source";
+    private static final String DISPLAY_NAME_KEY = "display_name";
     private static final String DESCRIPTION_KEY = "description";
     private static final String PAYLOADS_KEY = "payloads";
     private static final String GLOBAL_RELEASES_NUMBER_KEY = "global_releases_number";
@@ -42,19 +42,18 @@ public class ApplicationServicesEmailPayloadAggregator extends AbstractEmailPayl
                 return;
             }
 
-            if (!applicationServices.containsKey(BASE_URL_KEY) && payloadContext.containsKey(BASE_URL_KEY)) {
-                applicationServices.put(BASE_URL_KEY, payloadContext.getString(BASE_URL_KEY));
-            }
-
             if (!products.containsKey(eventType)) {
-                String family = payloadContext.getString(FAMILY_KEY);
-                if (family == null) {
-                    Log.debugf("Skipping Application Services product initialization: missing family for eventType=%s, orgId=%s",
+                JsonObject source = notificationJson.getJsonObject(SOURCE_KEY);
+                String eventTypeDisplayName = source != null && source.getJsonObject(EVENT_TYPE) != null
+                    ? source.getJsonObject(EVENT_TYPE).getString(DISPLAY_NAME_KEY)
+                    : null;
+                if (eventTypeDisplayName == null) {
+                    Log.debugf("Skipping Application Services product initialization: missing event type display name for eventType=%s, orgId=%s",
                         eventType, getOrgId());
                     return;
                 }
                 JsonObject eventTypeObject = new JsonObject();
-                eventTypeObject.put(DESCRIPTION_KEY, family);
+                eventTypeObject.put(DESCRIPTION_KEY, eventTypeDisplayName);
                 eventTypeObject.put(PAYLOADS_KEY, new JsonArray());
                 products.put(eventType, eventTypeObject);
             }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregator.java
@@ -1,0 +1,87 @@
+package com.redhat.cloud.notifications.processors.email.aggregators;
+
+import com.redhat.cloud.notifications.models.EmailAggregation;
+import io.quarkus.logging.Log;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ApplicationServicesEmailPayloadAggregator extends AbstractEmailPayloadAggregator {
+
+    private static final String EVENT_TYPE = "event_type";
+
+    private static final String APPLICATION_SERVICES_KEY = "application-services";
+    private static final String PRODUCTS_KEY = "products";
+    private static final String EVENTS_KEY = "events";
+    private static final String CONTEXT_KEY = "context";
+    private static final String PAYLOAD_KEY = "payload";
+    private static final String BASE_URL_KEY = "base_url";
+    private static final String FAMILY_KEY = "family";
+    private static final String DESCRIPTION_KEY = "description";
+    private static final String PAYLOADS_KEY = "payloads";
+    private static final String GLOBAL_RELEASES_NUMBER_KEY = "global_releases_number";
+
+    public ApplicationServicesEmailPayloadAggregator() {
+        JsonObject applicationServices = new JsonObject();
+        applicationServices.put(PRODUCTS_KEY, new JsonObject());
+        applicationServices.put(GLOBAL_RELEASES_NUMBER_KEY, 0);
+        context.put(APPLICATION_SERVICES_KEY, applicationServices);
+    }
+
+    @Override
+    void processEmailAggregation(EmailAggregation notification) {
+        try {
+            JsonObject applicationServices = context.getJsonObject(APPLICATION_SERVICES_KEY);
+            JsonObject products = applicationServices.getJsonObject(PRODUCTS_KEY);
+            JsonObject notificationJson = notification.getPayload();
+            String eventType = notificationJson.getString(EVENT_TYPE);
+            JsonObject payloadContext = notificationJson.getJsonObject(CONTEXT_KEY);
+
+            if (eventType == null || payloadContext == null) {
+                Log.debugf("Skipping Application Services aggregation: eventType=%s, hasContext=%b, orgId=%s",
+                    eventType, payloadContext != null, getOrgId());
+                return;
+            }
+
+            if (!applicationServices.containsKey(BASE_URL_KEY) && payloadContext.containsKey(BASE_URL_KEY)) {
+                applicationServices.put(BASE_URL_KEY, payloadContext.getString(BASE_URL_KEY));
+            }
+
+            if (!products.containsKey(eventType)) {
+                String family = payloadContext.getString(FAMILY_KEY);
+                if (family == null) {
+                    Log.debugf("Skipping Application Services product initialization: missing family for eventType=%s, orgId=%s",
+                        eventType, getOrgId());
+                    return;
+                }
+                JsonObject eventTypeObject = new JsonObject();
+                eventTypeObject.put(DESCRIPTION_KEY, family);
+                eventTypeObject.put(PAYLOADS_KEY, new JsonArray());
+                products.put(eventType, eventTypeObject);
+            }
+
+            JsonArray events = notificationJson.getJsonArray(EVENTS_KEY);
+            if (events == null) {
+                Log.debugf("Skipping Application Services aggregation: no events array for eventType=%s, orgId=%s",
+                    eventType, getOrgId());
+                return;
+            }
+
+            int releasesCount = applicationServices.getInteger(GLOBAL_RELEASES_NUMBER_KEY, 0);
+            JsonArray targetPayloads = products.getJsonObject(eventType).getJsonArray(PAYLOADS_KEY);
+            for (int i = 0; i < events.size(); i++) {
+                JsonObject event = events.getJsonObject(i);
+                if (event == null) {
+                    continue;
+                }
+                JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
+                if (payload != null) {
+                    targetPayloads.add(payload);
+                    releasesCount++;
+                }
+            }
+            applicationServices.put(GLOBAL_RELEASES_NUMBER_KEY, releasesCount);
+        } catch (Exception e) {
+            Log.warnf(e, "Failed to process Application Services aggregation for orgId=%s", getOrgId());
+        }
+    }
+}

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
@@ -19,7 +19,6 @@ public class EmailPayloadAggregatorFactory {
     private static final String RESOURCE_OPTIMIZATION = "resource-optimization";
     private static final String ERRATA = "errata-notifications";
 
-
     private EmailPayloadAggregatorFactory() {
 
     }
@@ -51,6 +50,8 @@ public class EmailPayloadAggregatorFactory {
                 switch (application) {
                     case ERRATA:
                         return new ErrataEmailPayloadAggregator();
+                    case APPLICATION_SERVICES:
+                        return new ApplicationServicesEmailPayloadAggregator();
                     default:
                         // Do nothing.
                         break;

--- a/engine/src/test/java/com/redhat/cloud/notifications/ApplicationServicesTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ApplicationServicesTestHelpers.java
@@ -22,9 +22,7 @@ public class ApplicationServicesTestHelpers {
     public static final String BUNDLE = "subscription-services";
     public static final String APPLICATION = "application-services";
 
-    public static final String BASE_URL = "https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=";
-
-    public static Action createApplicationServicesAction(String eventType, String family, List<Event> events) {
+    public static Action createApplicationServicesAction(String eventType, List<Event> events) {
         Action action = new Action();
         action.setBundle(BUNDLE);
         action.setApplication(APPLICATION);
@@ -34,8 +32,6 @@ public class ApplicationServicesTestHelpers {
 
         action.setContext(
             new Context.ContextBuilder()
-                .withAdditionalProperty("base_url", BASE_URL)
-                .withAdditionalProperty("family", family)
                 .build()
         );
 
@@ -49,7 +45,6 @@ public class ApplicationServicesTestHelpers {
     public static Action createKeycloakReleasesAction() {
         return createApplicationServicesAction(
             "keycloak-releases",
-            "Red Hat build of Keycloak",
             List.of(
                 new Event.EventBuilder()
                     .withMetadata(new Metadata.MetadataBuilder().build())
@@ -78,7 +73,6 @@ public class ApplicationServicesTestHelpers {
     public static Action createEapReleasesAction() {
         return createApplicationServicesAction(
             "eap-releases",
-            "Red Hat JBoss Enterprise Application Platform",
             List.of(
                 new Event.EventBuilder()
                     .withMetadata(new Metadata.MetadataBuilder().build())
@@ -153,7 +147,6 @@ public class ApplicationServicesTestHelpers {
 
         action.setContext(
             new Context.ContextBuilder()
-                .withAdditionalProperty("base_url", BASE_URL)
                 .build()
         );
 
@@ -180,9 +173,10 @@ public class ApplicationServicesTestHelpers {
         // Build JSON directly because BaseTransformer cannot serialize null payloads
         JsonObject payload = new JsonObject();
         payload.put("event_type", "keycloak-releases");
-        payload.put("context", new JsonObject()
-            .put("base_url", BASE_URL)
-            .put("family", "Red Hat build of Keycloak"));
+        payload.put("context", new JsonObject());
+        payload.put("source", new JsonObject()
+            .put("event_type", new JsonObject()
+                .put("display_name", "Red Hat build of Keycloak")));
         payload.put("events", new JsonArray()
             .add(new JsonObject().put("payload", new JsonObject()
                 .put("id", "108766")
@@ -201,7 +195,6 @@ public class ApplicationServicesTestHelpers {
     public static Action createActionWithEmptyEvents() {
         return createApplicationServicesAction(
             "keycloak-releases",
-            "Red Hat build of Keycloak",
             List.of()
         );
     }
@@ -216,7 +209,6 @@ public class ApplicationServicesTestHelpers {
 
         action.setContext(
             new Context.ContextBuilder()
-                .withAdditionalProperty("base_url", BASE_URL)
                 .build()
         );
 
@@ -239,11 +231,15 @@ public class ApplicationServicesTestHelpers {
         return action;
     }
 
+    public static EmailAggregation createEmailAggregation(Action action, String eventTypeDisplayName) {
+        return TestHelpers.createEmailAggregationFromAction(action, eventTypeDisplayName);
+    }
+
     public static Map<String, Object> buildApplicationServicesAggregatedPayload() {
         ApplicationServicesEmailPayloadAggregator aggregator = new ApplicationServicesEmailPayloadAggregator();
 
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(createKeycloakReleasesAction()));
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(createEapReleasesAction()));
+        aggregator.aggregate(createEmailAggregation(createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(createEmailAggregation(createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
 
         return aggregator.getContext();
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/ApplicationServicesTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ApplicationServicesTestHelpers.java
@@ -6,14 +6,12 @@ import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.EmailAggregation;
-import com.redhat.cloud.notifications.processors.email.aggregators.ApplicationServicesEmailPayloadAggregator;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
@@ -229,18 +227,5 @@ public class ApplicationServicesTestHelpers {
         action.setOrgId(DEFAULT_ORG_ID);
 
         return action;
-    }
-
-    public static EmailAggregation createEmailAggregation(Action action, String eventTypeDisplayName) {
-        return TestHelpers.createEmailAggregationFromAction(action, eventTypeDisplayName);
-    }
-
-    public static Map<String, Object> buildApplicationServicesAggregatedPayload() {
-        ApplicationServicesEmailPayloadAggregator aggregator = new ApplicationServicesEmailPayloadAggregator();
-
-        aggregator.aggregate(createEmailAggregation(createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
-        aggregator.aggregate(createEmailAggregation(createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
-
-        return aggregator.getContext();
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/ApplicationServicesTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ApplicationServicesTestHelpers.java
@@ -1,0 +1,250 @@
+package com.redhat.cloud.notifications;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.models.EmailAggregation;
+import com.redhat.cloud.notifications.processors.email.aggregators.ApplicationServicesEmailPayloadAggregator;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+
+public class ApplicationServicesTestHelpers {
+
+    public static final String BUNDLE = "subscription-services";
+    public static final String APPLICATION = "application-services";
+
+    public static final String BASE_URL = "https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=";
+
+    public static Action createApplicationServicesAction(String eventType, String family, List<Event> events) {
+        Action action = new Action();
+        action.setBundle(BUNDLE);
+        action.setApplication(APPLICATION);
+        action.setTimestamp(LocalDateTime.of(2024, 10, 3, 15, 22, 13, 25));
+        action.setEventType(eventType);
+        action.setRecipients(List.of());
+
+        action.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("base_url", BASE_URL)
+                .withAdditionalProperty("family", family)
+                .build()
+        );
+
+        action.setEvents(events);
+        action.setAccountId(StringUtils.EMPTY);
+        action.setOrgId(DEFAULT_ORG_ID);
+
+        return action;
+    }
+
+    public static Action createKeycloakReleasesAction() {
+        return createApplicationServicesAction(
+            "keycloak-releases",
+            "Red Hat build of Keycloak",
+            List.of(
+                new Event.EventBuilder()
+                    .withMetadata(new Metadata.MetadataBuilder().build())
+                    .withPayload(
+                        new Payload.PayloadBuilder()
+                            .withAdditionalProperty("id", "108766")
+                            .withAdditionalProperty("description", "Red Hat build of Keycloak 26.2.13 Maven Repository")
+                            .withAdditionalProperty("version", "26.2.13")
+                            .build()
+                    )
+                    .build(),
+                new Event.EventBuilder()
+                    .withMetadata(new Metadata.MetadataBuilder().build())
+                    .withPayload(
+                        new Payload.PayloadBuilder()
+                            .withAdditionalProperty("id", "108767")
+                            .withAdditionalProperty("description", "Red Hat build of Keycloak 26.2.13 Server")
+                            .withAdditionalProperty("version", "26.2.13")
+                            .build()
+                    )
+                    .build()
+            )
+        );
+    }
+
+    public static Action createEapReleasesAction() {
+        return createApplicationServicesAction(
+            "eap-releases",
+            "Red Hat JBoss Enterprise Application Platform",
+            List.of(
+                new Event.EventBuilder()
+                    .withMetadata(new Metadata.MetadataBuilder().build())
+                    .withPayload(
+                        new Payload.PayloadBuilder()
+                            .withAdditionalProperty("id", "108920")
+                            .withAdditionalProperty("description", "Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Installation Manager")
+                            .withAdditionalProperty("version", "8.1")
+                            .build()
+                    )
+                    .build(),
+                new Event.EventBuilder()
+                    .withMetadata(new Metadata.MetadataBuilder().build())
+                    .withPayload(
+                        new Payload.PayloadBuilder()
+                            .withAdditionalProperty("id", "108917")
+                            .withAdditionalProperty("description", "Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Source Code")
+                            .withAdditionalProperty("version", "8.1")
+                            .build()
+                    )
+                    .build(),
+                new Event.EventBuilder()
+                    .withMetadata(new Metadata.MetadataBuilder().build())
+                    .withPayload(
+                        new Payload.PayloadBuilder()
+                            .withAdditionalProperty("id", "108918")
+                            .withAdditionalProperty("description", "Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Maven Repository")
+                            .withAdditionalProperty("version", "8.1")
+                            .build()
+                    )
+                    .build()
+            )
+        );
+    }
+
+    public static Action createActionWithNoContext() {
+        Action action = new Action();
+        action.setBundle(BUNDLE);
+        action.setApplication(APPLICATION);
+        action.setTimestamp(LocalDateTime.of(2024, 10, 3, 15, 22, 13, 25));
+        action.setEventType("keycloak-releases");
+        action.setRecipients(List.of());
+
+        action.setContext(null);
+
+        action.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("id", "999")
+                        .withAdditionalProperty("description", "Some release")
+                        .withAdditionalProperty("version", "1.0")
+                        .build()
+                )
+                .build()
+        ));
+
+        action.setAccountId(StringUtils.EMPTY);
+        action.setOrgId(DEFAULT_ORG_ID);
+
+        return action;
+    }
+
+    public static Action createActionWithNoFamily() {
+        Action action = new Action();
+        action.setBundle(BUNDLE);
+        action.setApplication(APPLICATION);
+        action.setTimestamp(LocalDateTime.of(2024, 10, 3, 15, 22, 13, 25));
+        action.setEventType("unknown-releases");
+        action.setRecipients(List.of());
+
+        action.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("base_url", BASE_URL)
+                .build()
+        );
+
+        action.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("id", "999")
+                        .withAdditionalProperty("description", "Some release")
+                        .withAdditionalProperty("version", "1.0")
+                        .build()
+                )
+                .build()
+        ));
+
+        action.setAccountId(StringUtils.EMPTY);
+        action.setOrgId(DEFAULT_ORG_ID);
+
+        return action;
+    }
+
+    public static EmailAggregation createAggregationWithNullPayloadEvent() {
+        // Build JSON directly because BaseTransformer cannot serialize null payloads
+        JsonObject payload = new JsonObject();
+        payload.put("event_type", "keycloak-releases");
+        payload.put("context", new JsonObject()
+            .put("base_url", BASE_URL)
+            .put("family", "Red Hat build of Keycloak"));
+        payload.put("events", new JsonArray()
+            .add(new JsonObject().put("payload", new JsonObject()
+                .put("id", "108766")
+                .put("description", "Red Hat build of Keycloak 26.2.13 Maven Repository")
+                .put("version", "26.2.13")))
+            .add(new JsonObject().putNull("payload")));
+
+        EmailAggregation aggregation = new EmailAggregation();
+        aggregation.setBundleName(BUNDLE);
+        aggregation.setApplicationName(APPLICATION);
+        aggregation.setOrgId(DEFAULT_ORG_ID);
+        aggregation.setPayload(payload);
+        return aggregation;
+    }
+
+    public static Action createActionWithEmptyEvents() {
+        return createApplicationServicesAction(
+            "keycloak-releases",
+            "Red Hat build of Keycloak",
+            List.of()
+        );
+    }
+
+    public static Action createActionWithNoEventType() {
+        Action action = new Action();
+        action.setBundle(BUNDLE);
+        action.setApplication(APPLICATION);
+        action.setTimestamp(LocalDateTime.of(2024, 10, 3, 15, 22, 13, 25));
+        action.setEventType(null);
+        action.setRecipients(List.of());
+
+        action.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("base_url", BASE_URL)
+                .build()
+        );
+
+        action.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("id", "999")
+                        .withAdditionalProperty("description", "Some release")
+                        .withAdditionalProperty("version", "1.0")
+                        .build()
+                )
+                .build()
+        ));
+
+        action.setAccountId(StringUtils.EMPTY);
+        action.setOrgId(DEFAULT_ORG_ID);
+
+        return action;
+    }
+
+    public static Map<String, Object> buildApplicationServicesAggregatedPayload() {
+        ApplicationServicesEmailPayloadAggregator aggregator = new ApplicationServicesEmailPayloadAggregator();
+
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(createKeycloakReleasesAction()));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(createEapReleasesAction()));
+
+        return aggregator.getContext();
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/TestHelpers.java
@@ -609,10 +609,25 @@ public class TestHelpers {
      * @return the {@link JsonObject} representation of the wrapped action.
      */
     public static JsonObject wrapActionToJsonObject(final Action action) {
+        return wrapActionToJsonObject(action, null);
+    }
+
+    public static JsonObject wrapActionToJsonObject(final Action action, final String eventTypeDisplayName) {
         com.redhat.cloud.notifications.models.Event event = new com.redhat.cloud.notifications.models.Event();
         event.setEventWrapper(new EventWrapperAction(action));
-
+        if (eventTypeDisplayName != null) {
+            event.setEventTypeDisplayName(eventTypeDisplayName);
+        }
         return new BaseTransformer().toJsonObject(event);
+    }
+
+    public static EmailAggregation createEmailAggregationFromAction(Action emailActionMessage, String eventTypeDisplayName) {
+        EmailAggregation aggregation = new EmailAggregation();
+        aggregation.setBundleName(emailActionMessage.getBundle());
+        aggregation.setApplicationName(emailActionMessage.getApplication());
+        aggregation.setOrgId(emailActionMessage.getOrgId());
+        aggregation.setPayload(TestHelpers.wrapActionToJsonObject(emailActionMessage, eventTypeDisplayName));
+        return aggregation;
     }
 
     public static NotificationsConsoleCloudEvent createConsoleCloudEvent() throws IOException {

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregatorTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static com.redhat.cloud.notifications.ApplicationServicesTestHelpers.createEmailAggregation;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,13 +28,13 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
     @Test
     void shouldSetOrgId() {
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
         assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
     }
 
     @Test
     void shouldAggregateKeycloakReleases() {
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
@@ -55,8 +54,8 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
     @Test
     void shouldAggregateMultipleProducts() {
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
@@ -71,8 +70,8 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
     @Test
     void shouldCalculateGlobalReleasesNumber() {
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
@@ -118,7 +117,7 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
     @Test
     void shouldHandleEmptyEvents() {
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createActionWithEmptyEvents(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createActionWithEmptyEvents(), "Red Hat build of Keycloak"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
@@ -131,8 +130,8 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
     @Test
     void shouldReturnConsistentContextOnMultipleCalls() {
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
 
         Map<String, Object> context1 = aggregator.getContext();
         Map<String, Object> context2 = aggregator.getContext();
@@ -162,8 +161,8 @@ class ApplicationServicesEmailPayloadAggregatorTest {
     @Test
     void shouldAccumulatePayloadsForSameEventType() {
         // Aggregate keycloak twice - payloads should accumulate
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
-        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregatorTest.java
@@ -1,0 +1,185 @@
+package com.redhat.cloud.notifications.processors.email.aggregators;
+
+import com.redhat.cloud.notifications.ApplicationServicesTestHelpers;
+import com.redhat.cloud.notifications.TestHelpers;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApplicationServicesEmailPayloadAggregatorTest {
+
+    ApplicationServicesEmailPayloadAggregator aggregator;
+
+    @BeforeEach
+    void setUp() {
+        aggregator = new ApplicationServicesEmailPayloadAggregator();
+    }
+
+    @Test
+    void emptyAggregatorHasNoOrgId() {
+        assertNull(aggregator.getOrgId(), "Empty aggregator has no orgId");
+    }
+
+    @Test
+    void shouldSetOrgId() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+        assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
+    }
+
+    @Test
+    void shouldAggregateKeycloakReleases() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+        JsonObject products = appServices.getJsonObject("products");
+
+        assertTrue(products.containsKey("keycloak-releases"));
+        JsonObject keycloak = products.getJsonObject("keycloak-releases");
+        assertEquals("Red Hat build of Keycloak", keycloak.getString("description"));
+
+        JsonArray payloads = keycloak.getJsonArray("payloads");
+        assertEquals(2, payloads.size());
+        assertEquals("108766", payloads.getJsonObject(0).getString("id"));
+        assertEquals("Red Hat build of Keycloak 26.2.13 Maven Repository", payloads.getJsonObject(0).getString("description"));
+        assertEquals("26.2.13", payloads.getJsonObject(0).getString("version"));
+        assertEquals("108767", payloads.getJsonObject(1).getString("id"));
+    }
+
+    @Test
+    void shouldAggregateMultipleProducts() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createEapReleasesAction()));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+        JsonObject products = appServices.getJsonObject("products");
+
+        assertTrue(products.containsKey("keycloak-releases"));
+        assertTrue(products.containsKey("eap-releases"));
+
+        assertEquals(2, products.getJsonObject("keycloak-releases").getJsonArray("payloads").size());
+        assertEquals(3, products.getJsonObject("eap-releases").getJsonArray("payloads").size());
+    }
+
+    @Test
+    void shouldCalculateGlobalReleasesNumber() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createEapReleasesAction()));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+
+        assertEquals(5, appServices.getInteger("global_releases_number"));
+    }
+
+    @Test
+    void shouldExtractBaseUrl() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+
+        assertEquals(ApplicationServicesTestHelpers.BASE_URL, appServices.getString("base_url"));
+    }
+
+    @Test
+    void shouldSkipNullEventType() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createActionWithNoEventType()));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+        JsonObject products = appServices.getJsonObject("products");
+
+        assertTrue(products.isEmpty());
+        assertEquals(0, appServices.getInteger("global_releases_number"));
+    }
+
+    @Test
+    void shouldSkipNullContext() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createActionWithNoContext()));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+        JsonObject products = appServices.getJsonObject("products");
+
+        assertTrue(products.isEmpty());
+        assertEquals(0, appServices.getInteger("global_releases_number"));
+    }
+
+    @Test
+    void shouldSkipNullFamily() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createActionWithNoFamily()));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+        JsonObject products = appServices.getJsonObject("products");
+
+        assertTrue(products.isEmpty());
+        assertEquals(0, appServices.getInteger("global_releases_number"));
+    }
+
+    @Test
+    void shouldHandleEmptyEvents() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createActionWithEmptyEvents()));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+        JsonObject products = appServices.getJsonObject("products");
+
+        assertTrue(products.containsKey("keycloak-releases"));
+        assertEquals(0, products.getJsonObject("keycloak-releases").getJsonArray("payloads").size());
+        assertEquals(0, appServices.getInteger("global_releases_number"));
+    }
+
+    @Test
+    void getContextShouldBeIdempotent() {
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createEapReleasesAction()));
+
+        Map<String, Object> context1 = aggregator.getContext();
+        Map<String, Object> context2 = aggregator.getContext();
+
+        JsonObject appServices1 = JsonObject.mapFrom(context1).getJsonObject("application-services");
+        JsonObject appServices2 = JsonObject.mapFrom(context2).getJsonObject("application-services");
+
+        assertEquals(appServices1.getInteger("global_releases_number"), appServices2.getInteger("global_releases_number"));
+        assertEquals(appServices1.getJsonObject("products").fieldNames(), appServices2.getJsonObject("products").fieldNames());
+    }
+
+    @Test
+    void shouldSkipNullPayloadEvents() {
+        aggregator.aggregate(ApplicationServicesTestHelpers.createAggregationWithNullPayloadEvent());
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+        JsonObject products = appServices.getJsonObject("products");
+
+        assertTrue(products.containsKey("keycloak-releases"));
+        JsonArray payloads = products.getJsonObject("keycloak-releases").getJsonArray("payloads");
+        assertEquals(1, payloads.size());
+        assertEquals("108766", payloads.getJsonObject(0).getString("id"));
+        assertEquals(1, appServices.getInteger("global_releases_number"));
+    }
+
+    @Test
+    void shouldAccumulatePayloadsForSameEventType() {
+        // Aggregate keycloak twice - payloads should accumulate
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+
+        Map<String, Object> context = aggregator.getContext();
+        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
+        JsonObject products = appServices.getJsonObject("products");
+
+        JsonArray payloads = products.getJsonObject("keycloak-releases").getJsonArray("payloads");
+        assertEquals(4, payloads.size());
+        assertEquals(4, appServices.getInteger("global_releases_number"));
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregatorTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static com.redhat.cloud.notifications.ApplicationServicesTestHelpers.createEmailAggregation;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,13 +29,13 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
     @Test
     void shouldSetOrgId() {
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
         assertEquals(DEFAULT_ORG_ID, aggregator.getOrgId());
     }
 
     @Test
     void shouldAggregateKeycloakReleases() {
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
@@ -54,8 +55,8 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
     @Test
     void shouldAggregateMultipleProducts() {
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createEapReleasesAction()));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
@@ -70,23 +71,13 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
     @Test
     void shouldCalculateGlobalReleasesNumber() {
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createEapReleasesAction()));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
 
         assertEquals(5, appServices.getInteger("global_releases_number"));
-    }
-
-    @Test
-    void shouldExtractBaseUrl() {
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
-
-        Map<String, Object> context = aggregator.getContext();
-        JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
-
-        assertEquals(ApplicationServicesTestHelpers.BASE_URL, appServices.getString("base_url"));
     }
 
     @Test
@@ -127,7 +118,7 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
     @Test
     void shouldHandleEmptyEvents() {
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createActionWithEmptyEvents()));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createActionWithEmptyEvents(), "Red Hat build of Keycloak"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");
@@ -139,9 +130,9 @@ class ApplicationServicesEmailPayloadAggregatorTest {
     }
 
     @Test
-    void getContextShouldBeIdempotent() {
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createEapReleasesAction()));
+    void shouldReturnConsistentContextOnMultipleCalls() {
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createEapReleasesAction(), "Red Hat JBoss Enterprise Application Platform"));
 
         Map<String, Object> context1 = aggregator.getContext();
         Map<String, Object> context2 = aggregator.getContext();
@@ -171,8 +162,8 @@ class ApplicationServicesEmailPayloadAggregatorTest {
     @Test
     void shouldAccumulatePayloadsForSameEventType() {
         // Aggregate keycloak twice - payloads should accumulate
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
-        aggregator.aggregate(TestHelpers.createEmailAggregationFromAction(ApplicationServicesTestHelpers.createKeycloakReleasesAction()));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
+        aggregator.aggregate(createEmailAggregation(ApplicationServicesTestHelpers.createKeycloakReleasesAction(), "Red Hat build of Keycloak"));
 
         Map<String, Object> context = aggregator.getContext();
         JsonObject appServices = JsonObject.mapFrom(context).getJsonObject("application-services");


### PR DESCRIPTION
[RHCLOUD-46659] Kickoff Application Services Releases daily digest, expected result looks like:
<img width="666" height="1272" alt="image" src="https://github.com/user-attachments/assets/7bb4fac4-9a57-4d0d-baf7-21c43ae67039" />


[RHCLOUD-46659]: https://redhat.atlassian.net/browse/RHCLOUD-46659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily Application Services digest email with per-product release sections, in-email navigation links, and a CTA to Subscriptions Inventory.
  * Aggregation now includes Application Services content and exposes a global releases counter.

* **Bug Fixes/Behavior**
  * Safer handling of missing/null fields during aggregation; products without releases are omitted and original ordering preserved.

* **Tests**
  * Added end-to-end and unit tests for aggregation, sorting, rendering, and multiple edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->