### PR TITLE
fix(notifications-mcp): fix clowdapp.yaml to expose service port

### DIFF
--- a/.rhcicd/clowdapp-mcp.yaml
+++ b/.rhcicd/clowdapp-mcp.yaml
@@ -20,7 +20,8 @@ objects:
       minReplicas: ${{MIN_REPLICAS}}
       webServices:
         public:
-          enabled: false
+          enabled: true
+          apiPath: notifications-mcp
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         resources:


### PR DESCRIPTION
We are unable to communicate with the new notifications MCP service from our hcc-ai-assistant pod. This update should resolve the issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Enabled public web service access for the notifications service with configured API path routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->