### PR TITLE
[RHCLOUD-46150] Add metrics to track current event log response time versus normalized approach

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -1,7 +1,6 @@
 package com.redhat.cloud.notifications.db.repositories;
 
 import com.redhat.cloud.notifications.Severity;
-import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.Query;
 import com.redhat.cloud.notifications.db.Sort;
 import com.redhat.cloud.notifications.models.CompositeEndpointType;
@@ -35,14 +34,10 @@ public class EventRepository {
     @Inject
     RecipientsAuthorizationCriterionExtractor recipientsAuthorizationCriterionExtractor;
 
-    @Inject
-    BackendConfig backendConfig;
-
-    public List<EventAuthorizationCriterion> getEventsWithCriterion(String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
+    public List<EventAuthorizationCriterion> getEventsWithCriterion(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                                                     LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                                                     Set<Boolean> invocationResults, Set<NotificationStatus> status) {
 
-        boolean useNormalized = backendConfig.isNormalizedQueriesEnabled(orgId);
         boolean bundlesNotEmpty = bundleIds != null && !bundleIds.isEmpty();
         boolean applicationsNotEmpty = appIds != null && !appIds.isEmpty();
         boolean eventTypeNameNotEmpty = eventTypeDisplayName != null;
@@ -81,12 +76,11 @@ public class EventRepository {
         return eventAuthorizationCriterion;
     }
 
-    public List<Event> getEvents(String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
+    public List<Event> getEvents(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                       Set<Boolean> invocationResults, boolean fetchNotificationHistory, Set<NotificationStatus> status, Set<Severity> severities, Query query,
                                       Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion) {
 
-        boolean useNormalized = backendConfig.isNormalizedQueriesEnabled(orgId);
         Optional<Sort> sort = Sort.getSort(query, "created:DESC", Event.getSortFields(useNormalized));
 
         List<UUID> eventIds = getEventIds(orgId, useNormalized, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, severities, query, uuidToExclude, includeEventsWithAuthCriterion);
@@ -141,11 +135,10 @@ public class EventRepository {
         return events;
     }
 
-    public Long count(String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
+    public Long count(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes,
                       Set<CompositeEndpointType> compositeEndpointTypes, Set<Boolean> invocationResults,
                       Set<NotificationStatus> status, Set<Severity> severities, Optional<List<UUID>> uuidToExclude, Boolean includeEventsWithAuthCriterion) {
-        boolean useNormalized = backendConfig.isNormalizedQueriesEnabled(orgId);
 
         // Calculate once for reuse
         boolean bundlesNotEmpty = bundleIds != null && !bundleIds.isEmpty();

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -21,6 +21,7 @@ import com.redhat.cloud.notifications.routers.models.PageLinksBuilder;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.quarkus.logging.Log;
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.BadRequestException;
@@ -79,6 +80,15 @@ public class EventResource {
     @Inject
     MeterRegistry meterRegistry;
 
+    private Timer normalizedTimer;
+    private Timer denormalizedTimer;
+
+    @PostConstruct
+    void initMetrics() {
+        normalizedTimer = meterRegistry.timer(GET_EVENTS_TIMER_NAME, NORMALIZED_QUERIES_TAG, "true");
+        denormalizedTimer = meterRegistry.timer(GET_EVENTS_TIMER_NAME, NORMALIZED_QUERIES_TAG, "false");
+    }
+
     @GET
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Retrieve the event log entries", description = "Retrieves the event log entries. Use this endpoint to review a full history of the events related to the tenant. You can sort by the bundle, application, event, and created fields. You can specify the sort order by appending :asc or :desc to the field, for example bundle:desc. Sorting defaults to desc for the created field and to asc for all other fields."
@@ -123,93 +133,96 @@ public class EventResource {
         boolean useNormalizedQueries = backendConfig.isNormalizedQueriesEnabled(orgId);
         Timer.Sample timerSample = Timer.start(meterRegistry);
 
-        List<Event> events;
-        Long count;
-        if (backendConfig.isKesselChecksOnEventLogEnabled(orgId)) {
-            Log.info("Check for events with authorization criterion");
-            List<EventAuthorizationCriterion> listEventsAuthCriterion = eventRepository.getEventsWithCriterion(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet);
-            List<UUID> uuidToExclude = new ArrayList<>();
-            Map<Integer, Boolean> criterionResultCache = new HashMap<>();
-            for (EventAuthorizationCriterion eventAuthorizationCriterion : listEventsAuthCriterion) {
-                int criterionHashCode = eventAuthorizationCriterion.authorizationCriterion().hashCode();
-                if (!criterionResultCache.containsKey(criterionHashCode)) {
-                    criterionResultCache.put(criterionHashCode, kesselInventoryAuthorization.hasPermissionOnResource(securityContext, eventAuthorizationCriterion.authorizationCriterion()));
+        try {
+            List<Event> events;
+            Long count;
+            if (backendConfig.isKesselChecksOnEventLogEnabled(orgId)) {
+                Log.info("Check for events with authorization criterion");
+                List<EventAuthorizationCriterion> listEventsAuthCriterion = eventRepository.getEventsWithCriterion(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet);
+                List<UUID> uuidToExclude = new ArrayList<>();
+                Map<Integer, Boolean> criterionResultCache = new HashMap<>();
+                for (EventAuthorizationCriterion eventAuthorizationCriterion : listEventsAuthCriterion) {
+                    int criterionHashCode = eventAuthorizationCriterion.authorizationCriterion().hashCode();
+                    if (!criterionResultCache.containsKey(criterionHashCode)) {
+                        criterionResultCache.put(criterionHashCode, kesselInventoryAuthorization.hasPermissionOnResource(securityContext, eventAuthorizationCriterion.authorizationCriterion()));
+                    }
+                    if (!criterionResultCache.get(criterionHashCode)) {
+                        Log.infof("%s is not visible for current user", eventAuthorizationCriterion.id());
+                        uuidToExclude.add(eventAuthorizationCriterion.id());
+                    }
                 }
-                if (!criterionResultCache.get(criterionHashCode)) {
-                    Log.infof("%s is not visible for current user", eventAuthorizationCriterion.id());
-                    uuidToExclude.add(eventAuthorizationCriterion.id());
+                if (uuidToExclude.isEmpty()) {
+                    uuidToExclude = null;
                 }
+                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.ofNullable(uuidToExclude), true);
+                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.ofNullable(uuidToExclude), true);
+            } else {
+                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.empty(), false);
+                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.empty(), false);
             }
-            if (uuidToExclude.isEmpty()) {
-                uuidToExclude = null;
-            }
-            events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.ofNullable(uuidToExclude), true);
-            count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.ofNullable(uuidToExclude), true);
-        } else {
-            events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.empty(), false);
-            count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.empty(), false);
-        }
 
-        timerSample.stop(meterRegistry.timer(GET_EVENTS_TIMER_NAME, NORMALIZED_QUERIES_TAG, String.valueOf(useNormalizedQueries)));
-        if (events.isEmpty()) {
+            if (events.isEmpty()) {
+                Meta meta = new Meta();
+                meta.setCount(0L);
+
+                Map<String, String> links = PageLinksBuilder.build(uriInfo, 0, query);
+
+                Page<EventLogEntry> page = new Page<>();
+                page.setData(new ArrayList<>());
+                page.setMeta(meta);
+                page.setLinks(links);
+                return page;
+            }
+
+            List<EventLogEntry> eventLogEntries = events.stream().map(event -> {
+                List<EventLogEntryAction> actions;
+                if (!includeActions) {
+                    actions = Collections.emptyList();
+                } else {
+                    actions = event.getHistoryEntries().stream().map(historyEntry -> {
+                        EventLogEntryAction action = new EventLogEntryAction();
+                        action.setId(historyEntry.getId());
+                        action.setEndpointId(historyEntry.getEndpointId());
+                        action.setEndpointType(historyEntry.getEndpointType());
+                        action.setEndpointSubType(historyEntry.getEndpointSubType());
+                        action.setInvocationResult(historyEntry.isInvocationResult());
+                        action.setStatus(fromNotificationStatus(historyEntry.getStatus()));
+                        if (includeDetails) {
+                            action.setDetails(historyEntry.getDetails());
+                        }
+                        getRecipientsCount(historyEntry).ifPresent(action::setRecipientsCount);
+                        return action;
+                    }).collect(Collectors.toList());
+                }
+
+                EventLogEntry entry = new EventLogEntry();
+                entry.setId(event.getId());
+                entry.setExternalId(event.getExternalId());
+                entry.setCreated(event.getCreated());
+                entry.setBundle(event.getBundleDisplayName());
+                entry.setApplication(event.getApplicationDisplayName());
+                entry.setEventType(event.getEventTypeDisplayName());
+                entry.setActions(actions);
+                entry.setSeverity(event.getSeverity());
+                if (includePayload) {
+                    entry.setPayload(event.getPayload());
+                }
+                return entry;
+            }).collect(Collectors.toList());
+
             Meta meta = new Meta();
-            meta.setCount(0L);
+            meta.setCount(count);
 
-            Map<String, String> links = PageLinksBuilder.build(uriInfo, 0, query);
+            Map<String, String> links = PageLinksBuilder.build(uriInfo, count, query);
 
             Page<EventLogEntry> page = new Page<>();
-            page.setData(new ArrayList<>());
+            page.setData(eventLogEntries);
             page.setMeta(meta);
             page.setLinks(links);
             return page;
+        } finally {
+            timerSample.stop(useNormalizedQueries ? normalizedTimer : denormalizedTimer);
         }
-
-        List<EventLogEntry> eventLogEntries = events.stream().map(event -> {
-            List<EventLogEntryAction> actions;
-            if (!includeActions) {
-                actions = Collections.emptyList();
-            } else {
-                actions = event.getHistoryEntries().stream().map(historyEntry -> {
-                    EventLogEntryAction action = new EventLogEntryAction();
-                    action.setId(historyEntry.getId());
-                    action.setEndpointId(historyEntry.getEndpointId());
-                    action.setEndpointType(historyEntry.getEndpointType());
-                    action.setEndpointSubType(historyEntry.getEndpointSubType());
-                    action.setInvocationResult(historyEntry.isInvocationResult());
-                    action.setStatus(fromNotificationStatus(historyEntry.getStatus()));
-                    if (includeDetails) {
-                        action.setDetails(historyEntry.getDetails());
-                    }
-                    getRecipientsCount(historyEntry).ifPresent(action::setRecipientsCount);
-                    return action;
-                }).collect(Collectors.toList());
-            }
-
-            EventLogEntry entry = new EventLogEntry();
-            entry.setId(event.getId());
-            entry.setExternalId(event.getExternalId());
-            entry.setCreated(event.getCreated());
-            entry.setBundle(event.getBundleDisplayName());
-            entry.setApplication(event.getApplicationDisplayName());
-            entry.setEventType(event.getEventTypeDisplayName());
-            entry.setActions(actions);
-            entry.setSeverity(event.getSeverity());
-            if (includePayload) {
-                entry.setPayload(event.getPayload());
-            }
-            return entry;
-        }).collect(Collectors.toList());
-
-        Meta meta = new Meta();
-        meta.setCount(count);
-
-        Map<String, String> links = PageLinksBuilder.build(uriInfo, count, query);
-
-        Page<EventLogEntry> page = new Page<>();
-        page.setData(eventLogEntries);
-        page.setMeta(meta);
-        page.setLinks(links);
-        return page;
     }
 
     static EventLogEntryActionStatus fromNotificationStatus(NotificationStatus status) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -18,6 +18,8 @@ import com.redhat.cloud.notifications.routers.models.EventLogEntryActionStatus;
 import com.redhat.cloud.notifications.routers.models.Meta;
 import com.redhat.cloud.notifications.routers.models.Page;
 import com.redhat.cloud.notifications.routers.models.PageLinksBuilder;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.quarkus.logging.Log;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
@@ -62,6 +64,8 @@ public class EventResource {
     }
 
     public static final String TOTAL_RECIPIENTS = "total_recipients";
+    static final String GET_EVENTS_TIMER_NAME = "notifications.event-log.get-events";
+    static final String NORMALIZED_QUERIES_TAG = "normalized_queries";
 
     @Inject
     BackendConfig backendConfig;
@@ -71,6 +75,9 @@ public class EventResource {
 
     @Inject
     KesselInventoryAuthorization kesselInventoryAuthorization;
+
+    @Inject
+    MeterRegistry meterRegistry;
 
     @GET
     @Produces(APPLICATION_JSON)
@@ -113,11 +120,14 @@ public class EventResource {
         }
 
         String orgId = getOrgId(securityContext);
+        boolean useNormalizedQueries = backendConfig.isNormalizedQueriesEnabled(orgId);
+        Timer.Sample timerSample = Timer.start(meterRegistry);
+
         List<Event> events;
         Long count;
         if (backendConfig.isKesselChecksOnEventLogEnabled(orgId)) {
             Log.info("Check for events with authorization criterion");
-            List<EventAuthorizationCriterion> listEventsAuthCriterion = eventRepository.getEventsWithCriterion(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet);
+            List<EventAuthorizationCriterion> listEventsAuthCriterion = eventRepository.getEventsWithCriterion(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet);
             List<UUID> uuidToExclude = new ArrayList<>();
             Map<Integer, Boolean> criterionResultCache = new HashMap<>();
             for (EventAuthorizationCriterion eventAuthorizationCriterion : listEventsAuthCriterion) {
@@ -133,12 +143,14 @@ public class EventResource {
             if (uuidToExclude.isEmpty()) {
                 uuidToExclude = null;
             }
-            events = eventRepository.getEvents(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.ofNullable(uuidToExclude), true);
-            count = eventRepository.count(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.ofNullable(uuidToExclude), true);
+            events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.ofNullable(uuidToExclude), true);
+            count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.ofNullable(uuidToExclude), true);
         } else {
-            events = eventRepository.getEvents(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.empty(), false);
-            count = eventRepository.count(orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.empty(), false);
+            events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.empty(), false);
+            count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.empty(), false);
         }
+
+        timerSample.stop(meterRegistry.timer(GET_EVENTS_TIMER_NAME, NORMALIZED_QUERIES_TAG, String.valueOf(useNormalizedQueries)));
         if (events.isEmpty()) {
             Meta meta = new Meta();
             meta.setCount(0L);

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.routers.handlers.event;
 
 import com.redhat.cloud.notifications.EventPayloadTestHelper;
+import com.redhat.cloud.notifications.MicrometerAssertionHelper;
 import com.redhat.cloud.notifications.MockServerConfig;
 import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.TestHelpers;
@@ -77,6 +78,8 @@ import static com.redhat.cloud.notifications.models.EndpointType.DRAWER;
 import static com.redhat.cloud.notifications.models.EndpointType.EMAIL_SUBSCRIPTION;
 import static com.redhat.cloud.notifications.models.EndpointType.PAGERDUTY;
 import static com.redhat.cloud.notifications.models.EndpointType.WEBHOOK;
+import static com.redhat.cloud.notifications.routers.handlers.event.EventResource.GET_EVENTS_TIMER_NAME;
+import static com.redhat.cloud.notifications.routers.handlers.event.EventResource.NORMALIZED_QUERIES_TAG;
 import static com.redhat.cloud.notifications.routers.handlers.event.EventResource.TOTAL_RECIPIENTS;
 import static com.redhat.cloud.notifications.routers.handlers.event.EventResource.toNotificationStatus;
 import static io.restassured.RestAssured.given;
@@ -127,6 +130,8 @@ public class EventResourceTest extends DbIsolatedTest {
     @Inject
     EntityManager entityManager;
 
+    @Inject
+    MicrometerAssertionHelper micrometerAssertionHelper;
 
     @Inject
     KesselTestHelper kesselTestHelper;
@@ -1305,5 +1310,25 @@ public class EventResourceTest extends DbIsolatedTest {
         // search with no matching severities
         page = getEventLogPage(defaultIdentityHeader, null, null, null, null, null, null, null, null, null, null, null, false, false, PATH, Set.of(Severity.MODERATE));
         assertEquals(0, page.getMeta().getCount());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testGetEventsTimerMetric(boolean useNormalizedQueries) {
+        when(backendConfig.isNormalizedQueriesEnabled(anyString())).thenReturn(useNormalizedQueries);
+
+        String tagValue = String.valueOf(useNormalizedQueries);
+        micrometerAssertionHelper.saveTimerCountFilteredByTagsBeforeTest(GET_EVENTS_TIMER_NAME, NORMALIZED_QUERIES_TAG, tagValue);
+
+        Header defaultIdentityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
+
+        // First request
+        getEventLogPage(defaultIdentityHeader, null, null, null, null, null, null, null, null, null, null, null, false, false);
+        micrometerAssertionHelper.awaitAndAssertTimerCountFilteredByTagsIncrement(GET_EVENTS_TIMER_NAME, NORMALIZED_QUERIES_TAG, tagValue, 1);
+
+        // Second request to verify increments
+        micrometerAssertionHelper.saveTimerCountFilteredByTagsBeforeTest(GET_EVENTS_TIMER_NAME, NORMALIZED_QUERIES_TAG, tagValue);
+        getEventLogPage(defaultIdentityHeader, null, null, null, null, null, null, null, null, null, null, null, false, false);
+        micrometerAssertionHelper.awaitAndAssertTimerCountFilteredByTagsIncrement(GET_EVENTS_TIMER_NAME, NORMALIZED_QUERIES_TAG, tagValue, 1);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -1314,7 +1314,7 @@ public class EventResourceTest extends DbIsolatedTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void testGetEventsTimerMetric(boolean useNormalizedQueries) {
+    void shouldIncrementTimerCountForEachGetEventsRequest(boolean useNormalizedQueries) {
         when(backendConfig.isNormalizedQueriesEnabled(anyString())).thenReturn(useNormalizedQueries);
 
         String tagValue = String.valueOf(useNormalizedQueries);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timing metrics for event log retrieval, tagged by query normalization status.

* **Refactor**
  * Switched to explicit propagation of the query-normalization flag through event query paths for clearer behavior and observability.

* **Tests**
  * Added tests to verify the timer increments per request for both normalization modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->