### PR TITLE
[RHCLOUD-46948] Update user preferences Instant label to monthly for Planning team

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/models/SettingsValueByEventTypeJsonForm.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/models/SettingsValueByEventTypeJsonForm.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.redhat.cloud.notifications.Severity;
-
+import com.redhat.cloud.notifications.qute.templates.InstantTemplateDetails;
+import com.redhat.cloud.notifications.qute.templates.mapping.InstantLabelMapping;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -138,9 +139,10 @@ public class SettingsValueByEventTypeJsonForm {
                         field.description =  "Daily summary of triggered application events in 24 hours span.";
                         break;
                     case INSTANT:
-                        field.label = "Instant notification";
-                        field.description = "Immediate email for each triggered application event.";
-                        field.checkedWarning = "Opting into this notification may result in a large number of emails";
+                        InstantTemplateDetails instantTemplateDetails = InstantLabelMapping.buildInstantNotificationDescription(bundleName, applicationName, eventTypeName);
+                        field.label = instantTemplateDetails.label();
+                        field.description = instantTemplateDetails.description();
+                        field.checkedWarning = instantTemplateDetails.checkedWarning();
                         break;
                     case DRAWER:
                         field.label = "Drawer notification";

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/InstantTemplateDetails.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/InstantTemplateDetails.java
@@ -1,0 +1,4 @@
+package com.redhat.cloud.notifications.qute.templates;
+
+public record InstantTemplateDetails(String label, String description, String checkedWarning) {
+}

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMapping.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMapping.java
@@ -17,14 +17,10 @@ public class InstantLabelMapping {
     public static InstantTemplateDetails buildInstantNotificationDescription(final String bundleName, final String applicationName, final String eventTypeName) {
         InstantTemplateDetails instantLabels = INSTANT_NOTIFICATION;
         if (Rhel.BUNDLE_NAME.equals(bundleName)) {
-            if (Rhel.LIFECYCLE_APP_NAME.equals(applicationName)) {
-                if (Rhel.RETIRING_LIFECYCLE.equals(eventTypeName)) {
-                    instantLabels = MONTHLY_NOTIFICATION;
-                }
-            } else if (Rhel.ROADMAP_APP_NAME.equals(applicationName)) {
-                if (Rhel.ROADMAP_MONTHLY_REPORT.equals(eventTypeName)) {
-                    instantLabels = MONTHLY_NOTIFICATION;
-                }
+            if (Rhel.LIFECYCLE_APP_NAME.equals(applicationName) && Rhel.RETIRING_LIFECYCLE.equals(eventTypeName)) {
+                instantLabels = MONTHLY_NOTIFICATION;
+            } else if (Rhel.ROADMAP_APP_NAME.equals(applicationName) && Rhel.ROADMAP_MONTHLY_REPORT.equals(eventTypeName)) {
+                instantLabels = MONTHLY_NOTIFICATION;
             }
         }
         return instantLabels;

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMapping.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMapping.java
@@ -21,6 +21,10 @@ public class InstantLabelMapping {
                 if (Rhel.RETIRING_LIFECYCLE.equals(eventTypeName)) {
                     instantLabels = MONTHLY_NOTIFICATION;
                 }
+            } else if (Rhel.ROADMAP_APP_NAME.equals(applicationName)) {
+                if (Rhel.ROADMAP_MONTHLY_REPORT.equals(eventTypeName)) {
+                    instantLabels = MONTHLY_NOTIFICATION;
+                }
             }
         }
         return instantLabels;

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMapping.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMapping.java
@@ -1,0 +1,29 @@
+package com.redhat.cloud.notifications.qute.templates.mapping;
+
+import com.redhat.cloud.notifications.qute.templates.InstantTemplateDetails;
+
+public class InstantLabelMapping {
+
+    static final InstantTemplateDetails MONTHLY_NOTIFICATION = new InstantTemplateDetails(
+        "Monthly notification",
+        "Monthly summary of triggered application events.",
+        null);
+
+    static final InstantTemplateDetails INSTANT_NOTIFICATION = new InstantTemplateDetails(
+        "Instant notification",
+        "Immediate email for each triggered application event.",
+        "Opting into this notification may result in a large number of emails");
+
+    public static InstantTemplateDetails buildInstantNotificationDescription(final String bundleName, final String applicationName, final String eventTypeName) {
+        InstantTemplateDetails instantLabels = INSTANT_NOTIFICATION;
+        if (Rhel.BUNDLE_NAME.equals(bundleName)) {
+            if (Rhel.LIFECYCLE_APP_NAME.equals(applicationName)) {
+                if (Rhel.RETIRING_LIFECYCLE.equals(eventTypeName)) {
+                    instantLabels = MONTHLY_NOTIFICATION;
+                }
+            }
+        }
+        return instantLabels;
+    }
+
+}

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
@@ -29,6 +29,9 @@ public class Rhel {
     public static final String LIFECYCLE_APP_NAME = "life-cycle";
     public static final String LIFECYCLE_FOLDER_NAME = "Lifecycle/";
 
+    public static final String ROADMAP_APP_NAME = "roadmap";
+    public static final String ROADMAP_FOLDER_NAME = "Roadmap/";
+
     public static final String POLICIES_APP_NAME = "policies";
     public static final String POLICY_FOLDER_NAME = "Policies/";
 
@@ -58,6 +61,9 @@ public class Rhel {
     public static final String PATCH_NEW_ADVISORY = "new-advisory";
 
     public static final String RETIRING_LIFECYCLE = "retiring-lifecycle";
+
+    public static final String ROADMAP_MONTHLY_REPORT = "roadmap-monthly-report";
+
     public static final String POLICIES_POLICY_TRIGGERED = "policy-triggered";
 
     public static final String TASK_EXECUTED_TASK_COMPLETED = "executed-task-completed";

--- a/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMappingTest.java
+++ b/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMappingTest.java
@@ -27,6 +27,24 @@ class InstantLabelMappingTest {
     }
 
     @Test
+    void roadmapMonthlyReportEventReturnsMonthlyNotification() {
+        InstantTemplateDetails details = InstantLabelMapping.buildInstantNotificationDescription("rhel", "roadmap", "roadmap-monthly-report");
+
+        assertEquals("Monthly notification", details.label());
+        assertEquals("Monthly summary of triggered application events.", details.description());
+        assertNull(details.checkedWarning());
+    }
+
+    @Test
+    void nonMonthlyReportRoadmapEventReturnsInstantNotification() {
+        InstantTemplateDetails details = InstantLabelMapping.buildInstantNotificationDescription("rhel", "roadmap", "other-event-type");
+
+        assertEquals("Instant notification", details.label());
+        assertEquals("Immediate email for each triggered application event.", details.description());
+        assertEquals("Opting into this notification may result in a large number of emails", details.checkedWarning());
+    }
+
+    @Test
     void nonLifecycleApplicationReturnsInstantNotification() {
         InstantTemplateDetails details = InstantLabelMapping.buildInstantNotificationDescription("rhel", "policies", "policy-triggered");
 

--- a/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMappingTest.java
+++ b/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMappingTest.java
@@ -1,0 +1,46 @@
+package com.redhat.cloud.notifications.qute.templates.mapping;
+
+import com.redhat.cloud.notifications.qute.templates.InstantTemplateDetails;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class InstantLabelMappingTest {
+
+    @Test
+    void retiringLifecycleEventReturnsMonthlyNotification() {
+        InstantTemplateDetails details = InstantLabelMapping.buildInstantNotificationDescription("rhel", "life-cycle", "retiring-lifecycle");
+
+        assertEquals("Monthly notification", details.label());
+        assertEquals("Monthly summary of triggered application events.", details.description());
+        assertNull(details.checkedWarning());
+    }
+
+    @Test
+    void nonRetiringLifecycleEventReturnsInstantNotification() {
+        InstantTemplateDetails details = InstantLabelMapping.buildInstantNotificationDescription("rhel", "life-cycle", "other-event-type");
+
+        assertEquals("Instant notification", details.label());
+        assertEquals("Immediate email for each triggered application event.", details.description());
+        assertEquals("Opting into this notification may result in a large number of emails", details.checkedWarning());
+    }
+
+    @Test
+    void nonLifecycleApplicationReturnsInstantNotification() {
+        InstantTemplateDetails details = InstantLabelMapping.buildInstantNotificationDescription("rhel", "policies", "policy-triggered");
+
+        assertEquals("Instant notification", details.label());
+        assertEquals("Immediate email for each triggered application event.", details.description());
+        assertEquals("Opting into this notification may result in a large number of emails", details.checkedWarning());
+    }
+
+    @Test
+    void nonRhelBundleReturnsInstantNotification() {
+        InstantTemplateDetails details = InstantLabelMapping.buildInstantNotificationDescription("openshift", "some-app", "some-event");
+
+        assertEquals("Instant notification", details.label());
+        assertEquals("Immediate email for each triggered application event.", details.description());
+        assertEquals("Opting into this notification may result in a large number of emails", details.checkedWarning());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription UI now shows dynamic labels, descriptions, and opt-in warnings tailored to each event type.
  * RHEL lifecycle retiring events and RHEL roadmap monthly reports display "Monthly notification" with appropriate frequency guidance; other events show "Instant notification" and an opt-in warning when applicable.

* **Tests**
  * Added tests validating mappings from event types to notification labels, descriptions, and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->