### PR TITLE
Add email template for Roadmap notification

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMapping.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMapping.java
@@ -17,9 +17,9 @@ public class InstantLabelMapping {
     public static InstantTemplateDetails buildInstantNotificationDescription(final String bundleName, final String applicationName, final String eventTypeName) {
         InstantTemplateDetails instantLabels = INSTANT_NOTIFICATION;
         if (Rhel.BUNDLE_NAME.equals(bundleName)) {
-            if (Rhel.LIFECYCLE_APP_NAME.equals(applicationName) && Rhel.RETIRING_LIFECYCLE.equals(eventTypeName)) {
+            if (Rhel.LIFECYCLE_APP_NAME.equals(applicationName) && Rhel.RETIRING_LIFECYCLE_REPORT.equals(eventTypeName)) {
                 instantLabels = MONTHLY_NOTIFICATION;
-            } else if (Rhel.ROADMAP_APP_NAME.equals(applicationName) && Rhel.ROADMAP_MONTHLY_REPORT.equals(eventTypeName)) {
+            } else if (Rhel.ROADMAP_APP_NAME.equals(applicationName) && Rhel.ROADMAP_REPORT.equals(eventTypeName)) {
                 instantLabels = MONTHLY_NOTIFICATION;
             }
         }

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
@@ -60,9 +60,9 @@ public class Rhel {
 
     public static final String PATCH_NEW_ADVISORY = "new-advisory";
 
-    public static final String RETIRING_LIFECYCLE = "retiring-lifecycle";
+    public static final String RETIRING_LIFECYCLE_REPORT = "retiring-lifecycle-monthly-report";
 
-    public static final String ROADMAP_MONTHLY_REPORT = "roadmap-monthly-report";
+    public static final String ROADMAP_REPORT = "roadmap-monthly-report";
 
     public static final String POLICIES_POLICY_TRIGGERED = "policy-triggered";
 
@@ -113,7 +113,7 @@ public class Rhel {
         entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), LIFECYCLE_FOLDER_NAME + "retiringLifecycleInstantEmailBody.html"),
 
         // Roadmap
-        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP), ROADMAP_FOLDER_NAME + "roadmapInstantEmailBody.html"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP_REPORT), ROADMAP_FOLDER_NAME + "roadmapInstantEmailBody.html"),
 
         // Policies
         entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, POLICIES_APP_NAME, POLICIES_POLICY_TRIGGERED), POLICY_FOLDER_NAME + "policyTriggeredBody.md"),

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
@@ -111,7 +111,7 @@ public class Rhel {
 
         // Lifecycle
         entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), LIFECYCLE_FOLDER_NAME + "retiringLifecycleInstantEmailBody.html"),
-        
+
         // Roadmap
         entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP), ROADMAP_FOLDER_NAME + "roadmapInstantEmailBody.html"),
 

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
@@ -110,7 +110,10 @@ public class Rhel {
         entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, PATCH_APP_NAME, null), PATCH_FOLDER_NAME + "dailyEmailBody.html"),
 
         // Lifecycle
-        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE), LIFECYCLE_FOLDER_NAME + "retiringLifecycleInstantEmailBody.html"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), LIFECYCLE_FOLDER_NAME + "retiringLifecycleInstantEmailBody.html"),
+        
+        // Roadmap
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP), ROADMAP_FOLDER_NAME + "roadmapInstantEmailBody.html"),
 
         // Policies
         entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, POLICIES_APP_NAME, POLICIES_POLICY_TRIGGERED), POLICY_FOLDER_NAME + "policyTriggeredBody.md"),

--- a/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
@@ -12,13 +12,13 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
     rhelSystemsCount = action.events[0].payload.rhel_retired.orEmpty.systems_count.or(0)
     rhel10RetiredCount = action.events[0].payload.appstream_retired.orEmpty.rhel10.orEmpty.count.or(0)
     rhel10ExpiringCount = action.events[0].payload.appstream_near_retirement.orEmpty.rhel10.orEmpty.count.or(0)
-    rhel10SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel10.orEmpty.systems_count.or(0) 
+    rhel10SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel10.orEmpty.systems_count.or(0)
     rhel9RetiredCount = action.events[0].payload.appstream_retired.orEmpty.rhel9.orEmpty.count.or(0)
     rhel9ExpiringCount = action.events[0].payload.appstream_near_retirement.orEmpty.rhel9.orEmpty.count.or(0)
-    rhel9SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel9.orEmpty.systems_count.or(0) 
+    rhel9SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel9.orEmpty.systems_count.or(0)
     rhel8RetiredCount = action.events[0].payload.appstream_retired.orEmpty.rhel8.orEmpty.count.or(0)
     rhel8ExpiringCount = action.events[0].payload.appstream_near_retirement.orEmpty.rhel8.orEmpty.count.or(0)
-    rhel8SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel8.orEmpty.systems_count.or(0) 
+    rhel8SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel8.orEmpty.systems_count.or(0)
 }
 <table style="width: 100%; border: 0">
 {! RHEL life cycle section !}

--- a/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
@@ -1,6 +1,6 @@
 {#include email/Common/insightsEmailBody}
 {#content-header-title}
-Red Hat Enterprise Linux - roadmap monthly report - {action.context.roadmap.report_date}
+Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.report_date}
 {/content-header-title}
 {#content-title}
     Roadmap
@@ -44,7 +44,7 @@ Red Hat Enterprise Linux - roadmap monthly report - {action.context.roadmap.repo
         sub-section-count = additionsCount
         sub-section-count-id = 'additionsCount'
         sub-section-description = 'Additions &amp; enhancements that could affect your systems'
-        sub-section-icon = 'img_incident.png'
+        sub-section-icon = 'img_info.png'
         sub-section-url = 'https://console.redhat.com/insights/planning/roadmap/?viewFilter=relevant&type=Addition&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 0
     }

--- a/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
@@ -19,7 +19,7 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
         sub-section-count-id = 'deprecationsCount'
         sub-section-description = 'Deprecations that could affect your systems'
         sub-section-icon = 'img_incident.png'
-        sub-section-url = 'https://console.redhat.com/insights/planning/roadmap/?viewFilter=relevant&type=Deprecations&addedToRoadmap=lastMonthToDate'
+        sub-section-url = '{environment.url}/insights/planning/roadmap/?viewFilter=relevant&type=Deprecations&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 1
     }
     {#insert content-roadmap-section}{/}
@@ -32,7 +32,7 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
         sub-section-count-id = 'changesCount'
         sub-section-description = 'Changes that could affect your systems'
         sub-section-icon = 'img_warning.png'
-        sub-section-url = 'https://console.redhat.com/insights/planning/roadmap/?viewFilter=relevant&type=Changes&addedToRoadmap=lastMonthToDate'
+        sub-section-url = '{environment.url}/insights/planning/roadmap/?viewFilter=relevant&type=Changes&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 1
     }
     {#insert content-roadmap-section}{/}
@@ -45,7 +45,7 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
         sub-section-count-id = 'additionsCount'
         sub-section-description = 'Additions &amp; enhancements that could affect your systems'
         sub-section-icon = 'img_info.png'
-        sub-section-url = 'https://console.redhat.com/insights/planning/roadmap/?viewFilter=relevant&type=Addition&addedToRoadmap=lastMonthToDate'
+        sub-section-url = '{environment.url}/insights/planning/roadmap/?viewFilter=relevant&type=Addition&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 0
     }
     {#insert content-roadmap-section}{/}
@@ -55,11 +55,13 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
 <p style="font-size: 14px; color: #151515; margin-top: 16px;">
     Your inventory remained fully supported. A value of 0 indicates that no roadmap changes affected your systems this month.
 </p>
-{#else}{#if deprecationsCount == 0 || changesCount == 0 || additionsCount == 0}
-<p style="font-size: 14px; color: #151515; margin-top: 16px;">
-    Certain roadmap changes affected your systems. A value of 0 in any category indicated that no additional changes affected your inventory.
-</p>
-{/if}{/if}
+{#else}
+    {#if deprecationsCount == 0 || changesCount == 0 || additionsCount == 0}
+    <p style="font-size: 14px; color: #151515; margin-top: 16px;">
+        Certain roadmap changes affected your systems. A value of 0 in any category indicated that no additional changes affected your inventory.
+    </p>
+    {/if}
+{/if}
 {/let}
 {/content-body}
 {#content-roadmap-section}

--- a/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
@@ -84,6 +84,6 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
 <tr><td style="line-height: 24px">&#xA0;</td></tr>
 {/if}
 {/content-roadmap-section}
-{#content-button-href}https://console.redhat.com/insights/planning/roadmap?{query_params}{/content-button-href}
+{#content-button-href}https://console.redhat.com/insights/planning/roadmap
 {#content-button-service-name}Roadmap - Planning{/content-button-service-name}
 {/include}

--- a/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
@@ -84,6 +84,6 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
 <tr><td style="line-height: 24px">&#xA0;</td></tr>
 {/if}
 {/content-roadmap-section}
-{#content-button-href}https://console.redhat.com/insights/planning/roadmap
+{#content-button-href}{environment.url}/insights/planning/roadmap?{query_params}{/content-button-href}
 {#content-button-service-name}Roadmap - Planning{/content-button-service-name}
 {/include}

--- a/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
@@ -1,0 +1,89 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+Red Hat Enterprise Linux - roadmap monthly report - {action.context.roadmap.report_date}
+{/content-header-title}
+{#content-title}
+    Roadmap
+{/content-title}
+{#content-body}
+{#let
+    deprecationsCount = action.events[0].payload.deprecations.orEmpty.count.or(0)
+    changesCount = action.events[0].payload.changes.orEmpty.count.or(0)
+    additionsCount = action.events[0].payload.additions.orEmpty.count.or(0)
+}
+<table style="width: 100%; border: 0">
+    {! Deprecations section !}
+    {#let
+        sub-section-title = 'Deprecations'
+        sub-section-count = deprecationsCount
+        sub-section-count-id = 'deprecationsCount'
+        sub-section-description = 'Deprecations that could affect your systems'
+        sub-section-icon = 'img_incident.png'
+        sub-section-url = 'https://console.redhat.com/insights/planning/roadmap/?viewFilter=relevant&type=Deprecations&addedToRoadmap=lastMonthToDate'
+        sub-section-not-the-last = 1
+    }
+    {#insert content-roadmap-section}{/}
+    {/let}
+
+    {! Changes section !}
+    {#let
+        sub-section-title = 'Changes'
+        sub-section-count = changesCount
+        sub-section-count-id = 'changesCount'
+        sub-section-description = 'Changes that could affect your systems'
+        sub-section-icon = 'img_warning.png'
+        sub-section-url = 'https://console.redhat.com/insights/planning/roadmap/?viewFilter=relevant&type=Changes&addedToRoadmap=lastMonthToDate'
+        sub-section-not-the-last = 1
+    }
+    {#insert content-roadmap-section}{/}
+    {/let}
+
+    {! Additions & enhancements section !}
+    {#let
+        sub-section-title = 'Additions &amp; enhancements'
+        sub-section-count = additionsCount
+        sub-section-count-id = 'additionsCount'
+        sub-section-description = 'Additions &amp; enhancements that could affect your systems'
+        sub-section-icon = 'img_incident.png'
+        sub-section-url = 'https://console.redhat.com/insights/planning/roadmap/?viewFilter=relevant&type=Addition&addedToRoadmap=lastMonthToDate'
+        sub-section-not-the-last = 0
+    }
+    {#insert content-roadmap-section}{/}
+    {/let}
+</table>
+{#if deprecationsCount == 0 && changesCount == 0 && additionsCount == 0}
+<p style="font-size: 14px; color: #151515; margin-top: 16px;">
+    Your inventory remained fully supported. A value of 0 indicates that no roadmap changes affected your systems this month.
+</p>
+{#else}{#if deprecationsCount == 0 || changesCount == 0 || additionsCount == 0}
+<p style="font-size: 14px; color: #151515; margin-top: 16px;">
+    Certain roadmap changes affected your systems. A value of 0 in any category indicated that no additional changes affected your inventory.
+</p>
+{/if}{/if}
+{/let}
+{/content-body}
+{#content-roadmap-section}
+<tr><td>
+    <table style="border: solid 1px #b8bbbe; border-radius: 16px; padding: 16px; width: 100%;">
+    <tr>
+        <td colspan="2" style="padding-bottom: 8px">
+            <strong style="font-size: 14px;">{sub-section-title}</strong>
+        </td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top;">
+            <div style="font-size: 32px; font-weight: 600; color: #1f1f1f;"><a style="{body-section-table-td-a-style}" href="{sub-section-url}" target="_blank" id="{sub-section-count-id}">{sub-section-count}</a></div>
+            <div style="font-size: 14px; color: #151515; margin-top: 4px;">
+                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/{sub-section-icon}" alt="" style="width:16px; height:16px; vertical-align:-2px; display: inline-block; margin-right: 4px;" border="0" width="16"/><!--[if mso]>&nbsp;&nbsp;<![endif]-->{sub-section-description}
+            </div>
+        </td>
+    </tr>
+    </table>
+</td></tr>
+{#if sub-section-not-the-last.or(0) > 0}
+<tr><td style="line-height: 24px">&#xA0;</td></tr>
+{/if}
+{/content-roadmap-section}
+{#content-button-href}https://console.redhat.com/insights/planning/roadmap?{query_params}{/content-button-href}
+{#content-button-service-name}Roadmap - Planning{/content-button-service-name}
+{/include}

--- a/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMappingTest.java
+++ b/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/mapping/InstantLabelMappingTest.java
@@ -10,7 +10,7 @@ class InstantLabelMappingTest {
 
     @Test
     void retiringLifecycleEventReturnsMonthlyNotification() {
-        InstantTemplateDetails details = InstantLabelMapping.buildInstantNotificationDescription("rhel", "life-cycle", "retiring-lifecycle");
+        InstantTemplateDetails details = InstantLabelMapping.buildInstantNotificationDescription("rhel", "life-cycle", "retiring-lifecycle-monthly-report");
 
         assertEquals("Monthly notification", details.label());
         assertEquals("Monthly summary of triggered application events.", details.description());

--- a/common-template/src/test/java/email/TestLifecycleTemplate.java
+++ b/common-template/src/test/java/email/TestLifecycleTemplate.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-import static com.redhat.cloud.notifications.qute.templates.mapping.Rhel.RETIRING_LIFECYCLE;
+import static com.redhat.cloud.notifications.qute.templates.mapping.Rhel.RETIRING_LIFECYCLE_REPORT;
 import static helpers.TestHelpers.DEFAULT_ORG_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -69,13 +69,13 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
     @Test
     public void testRetiringLifecycleEmailTitle() {
         eventTypeDisplayName = "life cycle monthly report";
-        String result = generateEmailSubject(RETIRING_LIFECYCLE, createLifecycleAction());
+        String result = generateEmailSubject(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
         assertEquals("Instant notification - life cycle monthly report - Life Cycle - Red Hat Enterprise Linux", result);
     }
 
     @Test
     public void testRetiringLifecycleEmailBody() {
-        String result = generateEmailBody(RETIRING_LIFECYCLE, createLifecycleAction());
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
         // Verify RHEL retired data is present
         assertTrue(result.contains("id=\"rhelRetiredCount\">6<"), "Body should contain rhel_versions_count for retired RHEL");
@@ -85,13 +85,13 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
 
     @Test
     public void testRetiringLifecycleEmailBodyContainsReportDate() {
-        String result = generateEmailBody(RETIRING_LIFECYCLE, createLifecycleAction());
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
         assertTrue(result.contains("15th Dec 2025"), "Body should contain the report date");
     }
 
     @Test
     public void testRetiringLifecycleEmailBodyContainsAppstreamData() {
-        String result = generateEmailBody(RETIRING_LIFECYCLE, createLifecycleAction());
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
         // Verify appstream retired data
         assertTrue(result.contains("id=\"rhel8RetiredCount\">2<"), "Body should contain appstream retired count for rhel8");
         assertTrue(result.contains("id=\"rhel9RetiredCount\">2<"), "Body should contain appstream retired count for rhel9");
@@ -121,7 +121,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(RETIRING_LIFECYCLE, action);
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
         assertTrue(result.contains("id=\"rhelRetiredCount\">3<"), "Body should contain retired rhel_versions_count");
         assertTrue(result.contains("id=\"rhelExpiringCount\">0<"), "Body should contain near retirement rhel_versions_count");
         assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain any appstreams section");
@@ -150,7 +150,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(RETIRING_LIFECYCLE, action);
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
         assertTrue(result.contains("id=\"rhelRetiredCount\">0<"), "Body should contain retired rhel_versions_count");
         assertTrue(result.contains("id=\"rhelExpiringCount\">2<"), "Body should contain near retirement rhel_versions_count");
         assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain any appstreams section");
@@ -179,7 +179,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(RETIRING_LIFECYCLE, action);
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
         assertFalse(result.contains("RHEL life cycle"), "Body shouldn't contain 'RHEL life cycle' section");
         assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain any appstreams section");
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
@@ -207,7 +207,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(RETIRING_LIFECYCLE, action);
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
         assertTrue(result.contains("id=\"rhel8RetiredCount\">3<"), "Body should contain appstream retired count for rhel8");
         assertTrue(result.contains("id=\"rhel8ExpiringCount\">0<"), "Body should contain near retirement count for rhel8");
         assertTrue(result.contains("id=\"rhel9RetiredCount\">0<"), "Body should contain appstream retired count for rhel9");
@@ -242,7 +242,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(RETIRING_LIFECYCLE, action);
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
         // Verify all RHEL versions are present
         assertTrue(result.contains("id=\"rhel8RetiredCount\">5<"), "Body should contain appstream retired count for rhel8");
         assertTrue(result.contains("id=\"rhel9RetiredCount\">3<"), "Body should contain appstream retired count for rhel9");
@@ -278,7 +278,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(RETIRING_LIFECYCLE, action);
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
         assertFalse(result.contains("RHEL life cycle"), "Body shouldn't contain 'RHEL life cycle' section when systems_count is 0");
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }

--- a/common-template/src/test/java/email/TestRoadmapTemplate.java
+++ b/common-template/src/test/java/email/TestRoadmapTemplate.java
@@ -1,0 +1,218 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.qute.templates.mapping.Rhel.ROADMAP;
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
+
+    public static Action createRoadmapAction() {
+        Action emailActionMessage = new Action();
+        emailActionMessage.setBundle(StringUtils.EMPTY);
+        emailActionMessage.setApplication(StringUtils.EMPTY);
+        emailActionMessage.setTimestamp(LocalDateTime.of(2026, 5, 1, 10, 30, 0, 0));
+        emailActionMessage.setEventType(StringUtils.EMPTY);
+        emailActionMessage.setRecipients(List.of());
+
+        emailActionMessage.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("roadmap", Map.of("report_date", "1st May 2026"))
+                .build()
+        );
+
+        emailActionMessage.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("deprecations", Map.of("count", 5))
+                        .withAdditionalProperty("changes", Map.of("count", 3))
+                        .withAdditionalProperty("additions", Map.of("count", 4))
+                        .build()
+                )
+                .build()
+        ));
+
+        emailActionMessage.setAccountId(StringUtils.EMPTY);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+
+        return emailActionMessage;
+    }
+
+    @Override
+    protected String getApp() {
+        return "life-cycle";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Life Cycle";
+    }
+
+    @Test
+    public void testRoadmapEmailTitle() {
+        eventTypeDisplayName = "roadmap monthly report";
+        String result = generateEmailSubject(ROADMAP, createRoadmapAction());
+        assertEquals("Instant notification - roadmap monthly report - Life Cycle - Red Hat Enterprise Linux", result);
+    }
+
+    @Test
+    public void testRoadmapEmailBody() {
+        String result = generateEmailBody(ROADMAP, createRoadmapAction());
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("id=\"deprecationsCount\">5<"), "Body should contain deprecations count");
+        assertTrue(result.contains("id=\"changesCount\">3<"), "Body should contain changes count");
+        assertTrue(result.contains("id=\"additionsCount\">4<"), "Body should contain additions count");
+    }
+
+    @Test
+    public void testRoadmapEmailBodyContainsReportDate() {
+        String result = generateEmailBody(ROADMAP, createRoadmapAction());
+        assertTrue(result.contains("1st May 2026"), "Body should contain the report date");
+    }
+
+    @Test
+    public void testRoadmapEmailBodyWithAllZeroCounts() {
+        Action action = createRoadmapAction();
+
+        action.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("deprecations", Map.of("count", 0))
+                        .withAdditionalProperty("changes", Map.of("count", 0))
+                        .withAdditionalProperty("additions", Map.of("count", 0))
+                        .build()
+                )
+                .build()
+        ));
+
+        String result = generateEmailBody(ROADMAP, action);
+        assertTrue(result.contains("Your inventory remained fully supported"), "Body should contain 'Your inventory remained fully supported' when all counts are 0");
+        assertTrue(result.contains("A value of 0 indicates that no roadmap changes affected your systems this month"), "Body should contain explanation for all zeros");
+        assertTrue(result.contains("id=\"deprecationsCount\">0<"), "Body should contain deprecations count 0");
+        assertTrue(result.contains("id=\"changesCount\">0<"), "Body should contain changes count 0");
+        assertTrue(result.contains("id=\"additionsCount\">0<"), "Body should contain additions count 0");
+    }
+
+    @Test
+    public void testRoadmapEmailBodyWithSomeZeroCounts() {
+        Action action = createRoadmapAction();
+
+        action.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("deprecations", Map.of("count", 5))
+                        .withAdditionalProperty("changes", Map.of("count", 0))
+                        .withAdditionalProperty("additions", Map.of("count", 2))
+                        .build()
+                )
+                .build()
+        ));
+
+        String result = generateEmailBody(ROADMAP, action);
+        assertTrue(result.contains("Certain roadmap changes affected your systems"), "Body should contain 'Certain roadmap changes affected your systems' when some counts are 0");
+        assertTrue(result.contains("A value of 0 in any category indicated that no additional changes affected your inventory"), "Body should contain explanation for some zeros");
+        assertTrue(result.contains("id=\"deprecationsCount\">5<"), "Body should contain deprecations count");
+        assertTrue(result.contains("id=\"changesCount\">0<"), "Body should contain changes count 0");
+        assertTrue(result.contains("id=\"additionsCount\">2<"), "Body should contain additions count");
+    }
+
+    @Test
+    public void testRoadmapEmailBodyWithOnlyDeprecations() {
+        Action action = createRoadmapAction();
+
+        action.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("deprecations", Map.of("count", 7))
+                        .withAdditionalProperty("changes", Map.of("count", 0))
+                        .withAdditionalProperty("additions", Map.of("count", 0))
+                        .build()
+                )
+                .build()
+        ));
+
+        String result = generateEmailBody(ROADMAP, action);
+        assertTrue(result.contains("id=\"deprecationsCount\">7<"), "Body should contain deprecations count");
+        assertTrue(result.contains("id=\"changesCount\">0<"), "Body should contain changes count 0");
+        assertTrue(result.contains("id=\"additionsCount\">0<"), "Body should contain additions count 0");
+        assertTrue(result.contains("Certain roadmap changes affected your systems"), "Body should contain partial zero message");
+    }
+
+    @Test
+    public void testRoadmapEmailBodyWithOnlyChanges() {
+        Action action = createRoadmapAction();
+
+        action.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("deprecations", Map.of("count", 0))
+                        .withAdditionalProperty("changes", Map.of("count", 8))
+                        .withAdditionalProperty("additions", Map.of("count", 0))
+                        .build()
+                )
+                .build()
+        ));
+
+        String result = generateEmailBody(ROADMAP, action);
+        assertTrue(result.contains("id=\"deprecationsCount\">0<"), "Body should contain deprecations count 0");
+        assertTrue(result.contains("id=\"changesCount\">8<"), "Body should contain changes count");
+        assertTrue(result.contains("id=\"additionsCount\">0<"), "Body should contain additions count 0");
+        assertTrue(result.contains("Certain roadmap changes affected your systems"), "Body should contain partial zero message");
+    }
+
+    @Test
+    public void testRoadmapEmailBodyWithOnlyAdditions() {
+        Action action = createRoadmapAction();
+
+        action.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(
+                    new Payload.PayloadBuilder()
+                        .withAdditionalProperty("deprecations", Map.of("count", 0))
+                        .withAdditionalProperty("changes", Map.of("count", 0))
+                        .withAdditionalProperty("additions", Map.of("count", 10))
+                        .build()
+                )
+                .build()
+        ));
+
+        String result = generateEmailBody(ROADMAP, action);
+        assertTrue(result.contains("id=\"deprecationsCount\">0<"), "Body should contain deprecations count 0");
+        assertTrue(result.contains("id=\"changesCount\">0<"), "Body should contain changes count 0");
+        assertTrue(result.contains("id=\"additionsCount\">10<"), "Body should contain additions count");
+        assertTrue(result.contains("Certain roadmap changes affected your systems"), "Body should contain partial zero message");
+    }
+
+    @Test
+    public void testRoadmapEmailBodyContainsAllSectionDescriptions() {
+        String result = generateEmailBody(ROADMAP, createRoadmapAction());
+        assertTrue(result.contains("Deprecations that could affect your systems"), "Body should contain deprecations description");
+        assertTrue(result.contains("Changes that could affect your systems"), "Body should contain changes description");
+        assertTrue(result.contains("Additions &amp; enhancements that could affect your systems"), "Body should contain additions description");
+    }
+}

--- a/common-template/src/test/java/email/TestRoadmapTemplate.java
+++ b/common-template/src/test/java/email/TestRoadmapTemplate.java
@@ -56,19 +56,19 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
 
     @Override
     protected String getApp() {
-        return "life-cycle";
+        return "roadmap";
     }
 
     @Override
     protected String getAppDisplayName() {
-        return "Life Cycle";
+        return "Roadmap";
     }
 
     @Test
     public void testRoadmapEmailTitle() {
         eventTypeDisplayName = "roadmap monthly report";
         String result = generateEmailSubject(ROADMAP_REPORT, createRoadmapAction());
-        assertEquals("Instant notification - roadmap monthly report - Life Cycle - Red Hat Enterprise Linux", result);
+        assertEquals("Instant notification - roadmap monthly report - Roadmap - Red Hat Enterprise Linux", result);
     }
 
     @Test

--- a/common-template/src/test/java/email/TestRoadmapTemplate.java
+++ b/common-template/src/test/java/email/TestRoadmapTemplate.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-import static com.redhat.cloud.notifications.qute.templates.mapping.Rhel.ROADMAP;
+import static com.redhat.cloud.notifications.qute.templates.mapping.Rhel.ROADMAP_REPORT;
 import static helpers.TestHelpers.DEFAULT_ORG_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -67,13 +67,13 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
     @Test
     public void testRoadmapEmailTitle() {
         eventTypeDisplayName = "roadmap monthly report";
-        String result = generateEmailSubject(ROADMAP, createRoadmapAction());
+        String result = generateEmailSubject(ROADMAP_REPORT, createRoadmapAction());
         assertEquals("Instant notification - roadmap monthly report - Life Cycle - Red Hat Enterprise Linux", result);
     }
 
     @Test
     public void testRoadmapEmailBody() {
-        String result = generateEmailBody(ROADMAP, createRoadmapAction());
+        String result = generateEmailBody(ROADMAP_REPORT, createRoadmapAction());
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
         assertTrue(result.contains("id=\"deprecationsCount\">5<"), "Body should contain deprecations count");
         assertTrue(result.contains("id=\"changesCount\">3<"), "Body should contain changes count");
@@ -82,7 +82,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
 
     @Test
     public void testRoadmapEmailBodyContainsReportDate() {
-        String result = generateEmailBody(ROADMAP, createRoadmapAction());
+        String result = generateEmailBody(ROADMAP_REPORT, createRoadmapAction());
         assertTrue(result.contains("1st May 2026"), "Body should contain the report date");
     }
 
@@ -103,7 +103,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(ROADMAP, action);
+        String result = generateEmailBody(ROADMAP_REPORT, action);
         assertTrue(result.contains("Your inventory remained fully supported"), "Body should contain 'Your inventory remained fully supported' when all counts are 0");
         assertTrue(result.contains("A value of 0 indicates that no roadmap changes affected your systems this month"), "Body should contain explanation for all zeros");
         assertTrue(result.contains("id=\"deprecationsCount\">0<"), "Body should contain deprecations count 0");
@@ -128,7 +128,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(ROADMAP, action);
+        String result = generateEmailBody(ROADMAP_REPORT, action);
         assertTrue(result.contains("Certain roadmap changes affected your systems"), "Body should contain 'Certain roadmap changes affected your systems' when some counts are 0");
         assertTrue(result.contains("A value of 0 in any category indicated that no additional changes affected your inventory"), "Body should contain explanation for some zeros");
         assertTrue(result.contains("id=\"deprecationsCount\">5<"), "Body should contain deprecations count");
@@ -153,7 +153,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(ROADMAP, action);
+        String result = generateEmailBody(ROADMAP_REPORT, action);
         assertTrue(result.contains("id=\"deprecationsCount\">7<"), "Body should contain deprecations count");
         assertTrue(result.contains("id=\"changesCount\">0<"), "Body should contain changes count 0");
         assertTrue(result.contains("id=\"additionsCount\">0<"), "Body should contain additions count 0");
@@ -177,7 +177,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(ROADMAP, action);
+        String result = generateEmailBody(ROADMAP_REPORT, action);
         assertTrue(result.contains("id=\"deprecationsCount\">0<"), "Body should contain deprecations count 0");
         assertTrue(result.contains("id=\"changesCount\">8<"), "Body should contain changes count");
         assertTrue(result.contains("id=\"additionsCount\">0<"), "Body should contain additions count 0");
@@ -201,7 +201,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
                 .build()
         ));
 
-        String result = generateEmailBody(ROADMAP, action);
+        String result = generateEmailBody(ROADMAP_REPORT, action);
         assertTrue(result.contains("id=\"deprecationsCount\">0<"), "Body should contain deprecations count 0");
         assertTrue(result.contains("id=\"changesCount\">0<"), "Body should contain changes count 0");
         assertTrue(result.contains("id=\"additionsCount\">10<"), "Body should contain additions count");
@@ -210,7 +210,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
 
     @Test
     public void testRoadmapEmailBodyContainsAllSectionDescriptions() {
-        String result = generateEmailBody(ROADMAP, createRoadmapAction());
+        String result = generateEmailBody(ROADMAP_REPORT, createRoadmapAction());
         assertTrue(result.contains("Deprecations that could affect your systems"), "Body should contain deprecations description");
         assertTrue(result.contains("Changes that could affect your systems"), "Body should contain changes description");
         assertTrue(result.contains("Additions &amp; enhancements that could affect your systems"), "Body should contain additions description");


### PR DESCRIPTION
This PR adds the email template and tests for the Roadmap notification. 
<img width="606" height="906" alt="image" src="https://github.com/user-attachments/assets/02202a65-b9dc-43a8-b84a-bee659dc5769" />
Payload used
{
 "version": "v1.0.0",
 "id": "63961201-49ba-45b0-9719-b847b7efc194",
 "bundle": "rhel",
 "application": "roadmap",
 "event_type": "roadmap-monthly-report",
 "timestamp": "2026-04-15T15:50:05Z",
 "org_id": "1234",
 "context": {
   "roadmap": {
     "report_date": "1st May 2026"
   }
 },
 "events": [
   {
     "metadata": {},
     "payload": {
       "deprecations": {
         "count": 5
       },
       "changes": {
         "count": 0
       },
       "additions": {
         "count": 4
       }
     }
   }
 ],
 "recipients": []
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Roadmap monthly report email template with dynamic report date, per-category counts, conditional messaging, and CTA/sections.

* **Updates**
  * Updated lifecycle monthly report handling and added roadmap report mapping for report-focused email rendering.
  * Minor template whitespace cleanup.

* **Tests**
  * Added tests for Roadmap email rendering and updated lifecycle email tests to use the new report identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

