### PR TITLE
chore(deps): migrate jandex-maven-plugin to io.smallrye

### DIFF
--- a/common-template/pom.xml
+++ b/common-template/pom.xml
@@ -61,9 +61,9 @@
         <plugins>
             <!-- The following plugin is required to inject beans from this module into other modules. -->
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/common-template/pom.xml
+++ b/common-template/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/common-unleash/pom.xml
+++ b/common-unleash/pom.xml
@@ -37,9 +37,9 @@
             </plugin>
             <!-- The following plugin is required to inject beans from this module into other modules -->
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/common-unleash/pom.xml
+++ b/common-unleash/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -111,9 +111,9 @@
             </plugin>
             <!-- The following plugin is required to inject beans from this module into other modules -->
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-authentication-v2/pom.xml
+++ b/connector-common-authentication-v2/pom.xml
@@ -68,7 +68,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-authentication-v2/pom.xml
+++ b/connector-common-authentication-v2/pom.xml
@@ -66,9 +66,9 @@
 
             <!-- The following plugin is required to inject beans from this module into other modules. -->
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-authentication/pom.xml
+++ b/connector-common-authentication/pom.xml
@@ -87,7 +87,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-authentication/pom.xml
+++ b/connector-common-authentication/pom.xml
@@ -85,9 +85,9 @@
 
             <!-- The following plugin is required to inject beans from this module into other modules. -->
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-http-v2/pom.xml
+++ b/connector-common-http-v2/pom.xml
@@ -98,9 +98,9 @@
 
             <!-- The following plugin is required to inject beans from this module into other modules. -->
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-http-v2/pom.xml
+++ b/connector-common-http-v2/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-http/pom.xml
+++ b/connector-common-http/pom.xml
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-http/pom.xml
+++ b/connector-common-http/pom.xml
@@ -100,7 +100,11 @@
                             <goal>jandex</goal>
                         </goals>
                     </execution>
-                    <!-- Index test classes so @Mock beans can be discovered from test-jar -->
+                    <!-- Index test classes so @Mock beans can be discovered from test-jar.
+                         indexDir must point to testOutputDirectory so the index lands in
+                         target/test-classes/META-INF/ (included by maven-jar-plugin test-jar).
+                         Without this, io.smallrye defaults to target/classes/META-INF/ and
+                         the test-jar ships without a Jandex index. -->
                     <execution>
                         <id>make-test-index</id>
                         <goals>
@@ -108,6 +112,7 @@
                         </goals>
                         <phase>process-test-classes</phase>
                         <configuration>
+                            <indexDir>${project.build.testOutputDirectory}/META-INF</indexDir>
                             <fileSets>
                                 <fileSet>
                                     <directory>${project.build.testOutputDirectory}</directory>

--- a/connector-common-http/pom.xml
+++ b/connector-common-http/pom.xml
@@ -90,9 +90,9 @@
 
             <!-- The following plugin is required to inject beans from this module into other modules. -->
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-v2/pom.xml
+++ b/connector-common-v2/pom.xml
@@ -130,9 +130,9 @@
 
             <!-- The following plugin is required to inject beans from this module into other modules. -->
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common-v2/pom.xml
+++ b/connector-common-v2/pom.xml
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common/pom.xml
+++ b/connector-common/pom.xml
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>${jandex-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/connector-common/pom.xml
+++ b/connector-common/pom.xml
@@ -157,9 +157,9 @@
 
             <!-- The following plugin is required to inject beans from this module into other modules. -->
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,8 @@
         <!-- Point the Sonar Qube Plugin always to the same JaCoCo report to aggregate sub-modules reports-->
         <sonar.coverage.jacoco.xmlReportPaths>target/jacoco-report/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
+        <jandex-maven-plugin.version>3.5.3</jandex-maven-plugin.version>
+
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary

- Migrates `jandex-maven-plugin` from deprecated `org.jboss.jandex` (v1.2.3, last released June 2022) to actively maintained `io.smallrye` (v3.5.3)
- Updates all 9 modules that use the plugin for CDI bean discovery indexing
- No functional changes — `io.smallrye` is the official successor with full backward compatibility

**Affected modules:** common, common-template, common-unleash, connector-common, connector-common-v2, connector-common-http, connector-common-http-v2, connector-common-authentication, connector-common-authentication-v2

RHCLOUD-46147

## Test plan

- [x] Maven compile succeeds for all affected modules
- [ ] CI pipeline passes
- [ ] Verify CDI bean injection still works across modules in integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized the build indexing plugin across modules and centralized its version to 3.5.3.
  * Switched to the maintained plugin coordinates and unified version management via a shared property.
  * Ensured generated test indexing is placed into test output so the index is included in test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->