### PR TITLE
Configure a test job for the MCP clowdapp

### DIFF
--- a/.rhcicd/stage-mcp-post-deployment-tests.yaml
+++ b/.rhcicd/stage-mcp-post-deployment-tests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: notifications-mcp-post-deployment-tests
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: notifications-connector-mcp-tests-${UID}
+  spec:
+    appName: notifications-connector-mcp
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        marker: 'notif_mcp and api'
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added post-deployment testing infrastructure for the notifications connector with automated test configuration and staging environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->