### PR TITLE
[RHCLOUD-46778] Add Application services user preferences migration service

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationServicesMigrationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationServicesMigrationRepository.java
@@ -1,0 +1,57 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.models.EventType;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+
+import java.util.List;
+
+@ApplicationScoped
+public class ApplicationServicesMigrationRepository {
+
+    public static final String APPLICATION_SERVICES_BUNDLE_NAME = "subscription-services";
+    public static final String APPLICATION_SERVICES_APPLICATION_NAME = "application-services";
+
+    @Inject
+    EntityManager entityManager;
+
+    public List<EventType> findApplicationServicesEventTypes() {
+        final String query =
+            "FROM " +
+                "EventType AS et " +
+            "INNER JOIN " +
+                "et.application AS app " +
+            "INNER JOIN " +
+                "app.bundle AS bundle " +
+            "WHERE " +
+                "app.name = :applicationName " +
+            "AND " +
+                "bundle.name = :bundleName";
+
+        return entityManager
+            .createQuery(query, EventType.class)
+            .setParameter("applicationName", APPLICATION_SERVICES_APPLICATION_NAME)
+            .setParameter("bundleName", APPLICATION_SERVICES_BUNDLE_NAME)
+            .getResultList();
+    }
+
+    public void saveApplicationServicesSubscription(final String username, final String orgId, final EventType eventType) {
+        final String insertSql =
+            "INSERT INTO " +
+                "email_subscriptions(user_id, org_id, event_type_id, subscription_type, subscribed) " +
+            "VALUES " +
+                "(:userId, :orgId, :eventTypeId, 'DAILY', true) " +
+            "ON CONFLICT DO NOTHING";
+
+        entityManager
+            .createNativeQuery(insertSql)
+            .setParameter("userId", username)
+            .setParameter("orgId", orgId)
+            .setParameter("eventTypeId", eventType.getId())
+            .executeUpdate();
+
+        Log.infof("[org_id: %s][username: %s][event_type_id: %s][event_type_name: %s] Persisted application services subscription", orgId, username, eventType.getId(), eventType.getName());
+    }
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/userpreferencesmigration/ApplicationServicesSubscriptionInput.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/userpreferencesmigration/ApplicationServicesSubscriptionInput.java
@@ -1,0 +1,10 @@
+package com.redhat.cloud.notifications.routers.internal.userpreferencesmigration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ApplicationServicesSubscriptionInput(
+    String username,
+    @JsonProperty("org-id") String orgId,
+    @JsonProperty("notification_category") String eventType
+) {
+}

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/userpreferencesmigration/ApplicationServicesUserPreferencesMigrationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/userpreferencesmigration/ApplicationServicesUserPreferencesMigrationResource.java
@@ -1,0 +1,87 @@
+package com.redhat.cloud.notifications.routers.internal.userpreferencesmigration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.notifications.Constants;
+import com.redhat.cloud.notifications.auth.ConsoleIdentityProvider;
+import com.redhat.cloud.notifications.db.repositories.ApplicationServicesMigrationRepository;
+import com.redhat.cloud.notifications.models.EventType;
+import io.quarkus.logging.Log;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.RestForm;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Path(Constants.API_INTERNAL + "/application-services")
+@RolesAllowed(ConsoleIdentityProvider.RBAC_INTERNAL_ADMIN)
+public class ApplicationServicesUserPreferencesMigrationResource {
+
+    @Inject
+    ApplicationServicesMigrationRepository applicationServicesMigrationRepository;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Path("/migrate/json")
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    @Transactional
+    public void migrateApplicationServicesUserPreferencesJSON(@NotNull @RestForm("jsonFile") InputStream jsonFile) {
+        Log.info("Start migrateApplicationServicesUserPreferencesJSON");
+
+        final List<EventType> applicationServicesEventTypes = applicationServicesMigrationRepository.findApplicationServicesEventTypes();
+        final Map<String, EventType> mappedEventTypes = applicationServicesEventTypes
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    EventType::getName,
+                    Function.identity()
+                )
+            );
+
+        List<ApplicationServicesSubscriptionInput> inputs;
+        try {
+            inputs = objectMapper.readValue(
+                jsonFile.readAllBytes(),
+                objectMapper.getTypeFactory().constructCollectionType(List.class, ApplicationServicesSubscriptionInput.class)
+            );
+        } catch (final IOException e) {
+            Log.error("Failed to parse JSON migration file", e);
+            throw new BadRequestException("Invalid JSON format in migration file");
+        }
+
+        long totalInsertedElements = 0L;
+        Map<String, Long> skippedByEventType = new HashMap<>();
+        for (final ApplicationServicesSubscriptionInput input : inputs) {
+            final EventType eventType = mappedEventTypes.get(input.eventType());
+            if (eventType == null) {
+                Log.warnf("Unknown event type \"%s\" for user \"%s\" (org %s), skipping", input.eventType(), input.username(), input.orgId());
+                skippedByEventType.merge(input.eventType(), 1L, Long::sum);
+                continue;
+            }
+
+            applicationServicesMigrationRepository.saveApplicationServicesSubscription(input.username(), input.orgId(), eventType);
+            totalInsertedElements++;
+        }
+
+        if (!skippedByEventType.isEmpty()) {
+            Log.warnf("Skipped records by unknown event type: %s", skippedByEventType);
+        }
+        Log.infof("A total of %d Application Services subscriptions were persisted in the database, %d records skipped", totalInsertedElements, skippedByEventType.values().stream().mapToLong(Long::longValue).sum());
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/ApplicationServicesMigrationRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/ApplicationServicesMigrationRepositoryTest.java
@@ -1,0 +1,112 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.EventTypeEmailSubscription;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.redhat.cloud.notifications.db.repositories.ApplicationServicesMigrationRepository.APPLICATION_SERVICES_APPLICATION_NAME;
+import static com.redhat.cloud.notifications.db.repositories.ApplicationServicesMigrationRepository.APPLICATION_SERVICES_BUNDLE_NAME;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class ApplicationServicesMigrationRepositoryTest extends DbIsolatedTest {
+    @Inject
+    ApplicationServicesMigrationRepository applicationServicesMigrationRepository;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @Inject
+    SubscriptionRepository subscriptionRepository;
+
+    @Test
+    void testFindApplicationServicesEventTypes() {
+        final Bundle bundle = resourceHelpers.createBundle(APPLICATION_SERVICES_BUNDLE_NAME);
+        final Application application = resourceHelpers.createApplication(bundle.getId(), APPLICATION_SERVICES_APPLICATION_NAME);
+
+        final List<EventType> appServicesEventTypes = new ArrayList<>(5);
+        for (int i = 0; i < 5; i++) {
+            appServicesEventTypes.add(
+                resourceHelpers.createEventType(application.getId(), String.format("app-services-%s", UUID.randomUUID()))
+            );
+        }
+
+        final Application anotherApplication = resourceHelpers.createApplication(bundle.getId());
+        for (int i = 0; i < 10; i++) {
+            resourceHelpers.createEventType(anotherApplication.getId(), String.format("other-event-type-%s", UUID.randomUUID()));
+        }
+
+        final List<EventType> resultEventTypes = applicationServicesMigrationRepository.findApplicationServicesEventTypes();
+
+        Assertions.assertEquals(5, resultEventTypes.size(), "we only inserted 5 Application Services event types for the test, but a different number of them were found");
+
+        final List<UUID> expectedIds = appServicesEventTypes.stream().map(EventType::getId).toList();
+        for (final EventType eventType : resultEventTypes) {
+            Assertions.assertTrue(expectedIds.contains(eventType.getId()), "the function under test fetched an event type which is not of the Application Services type");
+        }
+    }
+
+    @Test
+    @Transactional
+    void testSaveApplicationServicesSubscriptions() {
+        final Bundle bundle = resourceHelpers.createBundle(APPLICATION_SERVICES_BUNDLE_NAME);
+        final Application application = resourceHelpers.createApplication(bundle.getId(), APPLICATION_SERVICES_APPLICATION_NAME);
+        final EventType eventTypeRhbk = resourceHelpers.createEventType(application.getId(), "rhbk");
+        final EventType eventTypeAppplatform = resourceHelpers.createEventType(application.getId(), "appplatform");
+        final EventType eventTypeDataGrid = resourceHelpers.createEventType(application.getId(), "data-grid");
+
+        applicationServicesMigrationRepository.saveApplicationServicesSubscription("username1", "orgId1", eventTypeRhbk);
+        applicationServicesMigrationRepository.saveApplicationServicesSubscription("username1", "orgId1", eventTypeAppplatform);
+        applicationServicesMigrationRepository.saveApplicationServicesSubscription("username2", "orgId2", eventTypeDataGrid);
+
+        final List<EventTypeEmailSubscription> user1Subscriptions = subscriptionRepository.getEmailSubscriptionsPerEventTypeForUser("orgId1", "username1");
+        Assertions.assertEquals(2, user1Subscriptions.size(), "unexpected number of subscriptions created for username1");
+
+        for (final EventTypeEmailSubscription emailSubscription : user1Subscriptions) {
+            Assertions.assertEquals("username1", emailSubscription.getUserId());
+            Assertions.assertEquals("orgId1", emailSubscription.getOrgId());
+            Assertions.assertTrue(
+                emailSubscription.getEventType().equals(eventTypeRhbk) || emailSubscription.getEventType().equals(eventTypeAppplatform),
+                "unexpected event type for username1"
+            );
+        }
+
+        final List<EventTypeEmailSubscription> user2Subscriptions = subscriptionRepository.getEmailSubscriptionsPerEventTypeForUser("orgId2", "username2");
+        Assertions.assertEquals(1, user2Subscriptions.size(), "unexpected number of subscriptions created for username2");
+        Assertions.assertEquals("username2", user2Subscriptions.get(0).getUserId());
+        Assertions.assertEquals("orgId2", user2Subscriptions.get(0).getOrgId());
+        Assertions.assertEquals(eventTypeDataGrid, user2Subscriptions.get(0).getEventType());
+    }
+
+    @Test
+    @Transactional
+    void testDuplicatedInsertionsDoNothing() {
+        final Bundle bundle = resourceHelpers.createBundle(APPLICATION_SERVICES_BUNDLE_NAME);
+        final Application application = resourceHelpers.createApplication(bundle.getId(), APPLICATION_SERVICES_APPLICATION_NAME);
+        final EventType eventType = resourceHelpers.createEventType(application.getId(), "rhbk");
+
+        final String username = "username";
+        final String orgId = "orgId";
+
+        for (int i = 0; i < 5; i++) {
+            applicationServicesMigrationRepository.saveApplicationServicesSubscription(username, orgId, eventType);
+        }
+
+        final List<EventTypeEmailSubscription> createdSubscriptions = subscriptionRepository.getEmailSubscriptionsPerEventTypeForUser(orgId, username);
+        Assertions.assertEquals(1, createdSubscriptions.size());
+    }
+}

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/applicationservices/ApplicationServicesUserPreferencesMigrationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/applicationservices/ApplicationServicesUserPreferencesMigrationResourceTest.java
@@ -1,0 +1,139 @@
+package com.redhat.cloud.notifications.routers.internal.applicationservices;
+
+import com.redhat.cloud.notifications.Constants;
+import com.redhat.cloud.notifications.TestHelpers;
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.DbIsolatedTest;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.repositories.ApplicationServicesMigrationRepository;
+import com.redhat.cloud.notifications.db.repositories.SubscriptionRepository;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.EventTypeEmailSubscription;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.http.HttpStatus;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+
+import static com.redhat.cloud.notifications.db.repositories.ApplicationServicesMigrationRepository.APPLICATION_SERVICES_BUNDLE_NAME;
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class ApplicationServicesUserPreferencesMigrationResourceTest extends DbIsolatedTest {
+
+    @InjectSpy
+    ApplicationServicesMigrationRepository applicationServicesMigrationRepository;
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @ConfigProperty(name = "internal.admin-role")
+    String adminRole;
+
+    @Inject
+    SubscriptionRepository subscriptionRepository;
+
+    @Test
+    void testUnsupportedEventTypesAreSkipped() throws URISyntaxException {
+        final EventType notAnAppServicesEventType = new EventType();
+        notAnAppServicesEventType.setName("not-an-app-services-event-type");
+
+        Mockito.when(applicationServicesMigrationRepository.findApplicationServicesEventTypes()).thenReturn(List.of(notAnAppServicesEventType));
+
+        final URL jsonResourceUrl = getClass().getResource("/application-services/subscriptions/application_services_subscriptions.json");
+        if (jsonResourceUrl == null) {
+            Assertions.fail("The path of the JSON test file is incorrect");
+        }
+
+        final File file = Paths.get(jsonResourceUrl.toURI()).toFile();
+
+        given()
+            .basePath(Constants.API_INTERNAL)
+            .header(TestHelpers.createTurnpikeIdentityHeader("user", adminRole))
+            .when()
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .multiPart("jsonFile", file)
+            .post("/application-services/migrate/json")
+            .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    void testJsonMigration() throws URISyntaxException {
+        final URL jsonResourceUrl = getClass().getResource("/application-services/subscriptions/application_services_subscriptions.json");
+        if (jsonResourceUrl == null) {
+            Assertions.fail("The path of the JSON test file is incorrect");
+        }
+
+        final File file = Paths.get(jsonResourceUrl.toURI()).toFile();
+
+        final Bundle bundle = resourceHelpers.createBundle(APPLICATION_SERVICES_BUNDLE_NAME);
+        final Application application = resourceHelpers.createApplication(bundle.getId(), ApplicationServicesMigrationRepository.APPLICATION_SERVICES_APPLICATION_NAME);
+        final EventType eventTypeRhbk = resourceHelpers.createEventType(application.getId(), "rhbk");
+        final EventType eventTypeAppplatform = resourceHelpers.createEventType(application.getId(), "appplatform");
+        final EventType eventTypeDataGrid = resourceHelpers.createEventType(application.getId(), "data-grid");
+        final EventType eventTypeRedhatQuarkus = resourceHelpers.createEventType(application.getId(), "redhat-quarkus");
+
+        given()
+            .basePath(Constants.API_INTERNAL)
+            .header(TestHelpers.createTurnpikeIdentityHeader("user", adminRole))
+            .when()
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .multiPart("jsonFile", file)
+            .post("/application-services/migrate/json")
+            .then()
+            .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        final List<EventTypeEmailSubscription> userASubscriptions = subscriptionRepository.getEmailSubscriptionsPerEventTypeForUser("12345", "a");
+        assertEmailSubscriptionDataIsCorrect(Set.of(eventTypeRhbk, eventTypeAppplatform), "a", userASubscriptions);
+
+        final List<EventTypeEmailSubscription> userBSubscriptions = subscriptionRepository.getEmailSubscriptionsPerEventTypeForUser("12345", "b");
+        assertEmailSubscriptionDataIsCorrect(Set.of(eventTypeRhbk), "b", userBSubscriptions);
+
+        final List<EventTypeEmailSubscription> userCSubscriptions = subscriptionRepository.getEmailSubscriptionsPerEventTypeForUser("12345", "c");
+        assertEmailSubscriptionDataIsCorrect(Set.of(eventTypeDataGrid), "c", userCSubscriptions);
+
+        final List<EventTypeEmailSubscription> userDSubscriptions = subscriptionRepository.getEmailSubscriptionsPerEventTypeForUser("12345", "d");
+        assertEmailSubscriptionDataIsCorrect(Set.of(eventTypeRedhatQuarkus), "d", userDSubscriptions);
+    }
+
+    private void assertEmailSubscriptionDataIsCorrect(final Set<EventType> expectedSubscribedEventTypes, final String expectedUsername, List<EventTypeEmailSubscription> createdEmailSubscriptions) {
+        Assertions.assertEquals(
+            expectedSubscribedEventTypes.size(),
+            createdEmailSubscriptions.size(),
+            String.format(
+                "unexpected number of created email subscriptions for user \"%s\". \"%s\" expected, got \"%s\": %s",
+                expectedUsername, expectedSubscribedEventTypes.size(), createdEmailSubscriptions.size(), createdEmailSubscriptions
+            ));
+
+        for (final EventTypeEmailSubscription emailSubscription : createdEmailSubscriptions) {
+            Assertions.assertEquals(expectedUsername, emailSubscription.getUserId(), "the fetched email subscription belongs to a different user than expected");
+            Assertions.assertEquals("12345", emailSubscription.getOrgId(), "the fetched email subscription has a different org ID than expected");
+
+            Assertions.assertTrue(
+                expectedSubscribedEventTypes.contains(emailSubscription.getEventType()),
+                String.format(
+                    "user \"%s\"'s email subscription contains an event type \"%s\" that is not from the expected list: %s",
+                    expectedUsername,
+                    emailSubscription.getEventType(),
+                    expectedSubscribedEventTypes
+                )
+            );
+        }
+    }
+}

--- a/backend/src/test/resources/application-services/subscriptions/application_services_subscriptions.json
+++ b/backend/src/test/resources/application-services/subscriptions/application_services_subscriptions.json
@@ -1,0 +1,27 @@
+[
+  {
+    "username": "a",
+    "org-id": "12345",
+    "notification_category": "rhbk"
+  },
+  {
+    "username": "a",
+    "org-id": "12345",
+    "notification_category": "appplatform"
+  },
+  {
+    "username": "b",
+    "org-id": "12345",
+    "notification_category": "rhbk"
+  },
+  {
+    "username": "c",
+    "org-id": "12345",
+    "notification_category": "data-grid"
+  },
+  {
+    "username": "d",
+    "org-id": "12345",
+    "notification_category": "redhat-quarkus"
+  }
+]


### PR DESCRIPTION
We need to migrate Application services user preferences from legacy tool to Notifications.
Application services (aka Jboss csp) will probide us an export file with about 500 users. We need to load, parse and create requested user preferences from it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal admin endpoint to import user subscription preferences from JSON files
  * Supports bulk import of notification subscriptions with automatic validation and conflict handling

* **Tests**
  * Added test coverage for import operations and subscription persistence
  * Includes tests for handling unsupported event types during import

<!-- end of auto-generated comment: release notes by coderabbit.ai -->