### PR TITLE
[RHCLOUD-44531] Remove legacy event deduplication table

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -223,8 +223,6 @@ objects:
       VACUUM ANALYZE notification_history;
       CALL cleanKafkaMessagesIds();
       VACUUM ANALYZE kafka_message;
-      CALL cleanEventDeduplication();
-      VACUUM ANALYZE event_deduplication;
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)

--- a/database/src/main/resources/db/migration/V1.132.0__RHCLOUD-44531_remove_event_deduplication.sql
+++ b/database/src/main/resources/db/migration/V1.132.0__RHCLOUD-44531_remove_event_deduplication.sql
@@ -1,0 +1,5 @@
+-- Event deduplication has been migrated from PostgreSQL to Valkey (in-memory).
+-- The event_deduplication table and its cleanup procedure are no longer needed.
+
+DROP PROCEDURE IF EXISTS cleanEventDeduplication();
+DROP TABLE IF EXISTS event_deduplication;

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/DefaultEventDeduplicationConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/DefaultEventDeduplicationConfig.java
@@ -19,10 +19,6 @@ public class DefaultEventDeduplicationConfig implements EventDeduplicationConfig
         if (event.getExternalId() != null) {
             return Optional.of(event.getExternalId().toString());
         }
-        // TODO remove check on id with RHCLOUD-44531
-        if (event.getId() != null) {
-            return Optional.of(event.getId().toString());
-        }
         return Optional.empty();
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicator.java
@@ -3,11 +3,8 @@ package com.redhat.cloud.notifications.events.deduplication;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.events.ValkeyService;
 import com.redhat.cloud.notifications.models.Event;
-import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -19,9 +16,6 @@ public class EventDeduplicator {
     private static final DefaultEventDeduplicationConfig DEFAULT_DEDUPLICATION_CONFIG = new DefaultEventDeduplicationConfig();
     private static final String SUBSCRIPTION_SERVICES_BUNDLE = "subscription-services";
     private static final String SUBSCRIPTIONS_APP = "subscriptions";
-
-    @Inject
-    EntityManager entityManager;
 
     @Inject
     SubscriptionsDeduplicationConfig subscriptionsDeduplicationConfig;
@@ -43,7 +37,6 @@ public class EventDeduplicator {
         };
     }
 
-    @Transactional
     public boolean isNew(Event event) {
 
         EventDeduplicationConfig eventDeduplicationConfig = getEventDeduplicationConfig(event);
@@ -54,37 +47,14 @@ public class EventDeduplicator {
             return true;
         }
 
+        // Events are always considered new if Valkey is not available.
+        if (!engineConfig.isInMemoryDbEnabled() || !engineConfig.isValkeyEventDeduplicatorEnabled()) {
+            return true;
+        }
+
         UUID eventTypeId = event.getEventType().getId();
         LocalDateTime deleteAfter = eventDeduplicationConfig.getDeleteAfter(event);
 
-        if (engineConfig.isInMemoryDbEnabled() && engineConfig.isValkeyEventDeduplicatorEnabled()) {
-            // RHCLOUD-35790: remove once Valkey deduplication is validated
-            boolean isNewEvent = postgresEventDeduplication(eventTypeId, deduplicationKey, deleteAfter);
-            boolean valkeyIsNewEvent = valkeyService.isNewEvent(eventTypeId, deduplicationKey.get(),
-                    deleteAfter);
-            if (valkeyIsNewEvent != isNewEvent) {
-                Log.warnf(
-                        "Valkey event deduplication (isNewEvent=%s) does not align with Postgres result (isNewEvent=%s) [event_type_id=%s, deduplication_key=%s]",
-                        valkeyIsNewEvent, isNewEvent, eventTypeId, deduplicationKey.get());
-            }
-
-            return isNewEvent;
-
-        } else {
-            return postgresEventDeduplication(eventTypeId, deduplicationKey, deleteAfter);
-        }
-    }
-
-    private boolean postgresEventDeduplication(UUID eventTypeId, Optional<String> deduplicationKey, LocalDateTime deleteAfter) {
-        String sql = "INSERT INTO event_deduplication(event_type_id, deduplication_key, delete_after) " +
-                "VALUES (:eventTypeId, :deduplicationKey, :deleteAfter) " +
-                "ON CONFLICT (event_type_id, deduplication_key) DO NOTHING";
-
-        int rowCount = entityManager.createNativeQuery(sql)
-                .setParameter("eventTypeId", eventTypeId)
-                .setParameter("deduplicationKey", deduplicationKey.get())
-                .setParameter("deleteAfter", deleteAfter)
-                .executeUpdate();
-        return rowCount > 0;
+        return valkeyService.isNewEvent(eventTypeId, deduplicationKey.get(), deleteAfter);
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfig.java
@@ -34,7 +34,7 @@ public class SubscriptionsDeduplicationConfig implements EventDeduplicationConfi
 
     @Override
     public LocalDateTime getDeleteAfter(Event event) {
-        // The event_deduplication entries will be purged from the DB on the first day of the next month, when the first purge cronjob runs after midnight UTC.
+        // Valkey deduplication entries will expire via TTL on the first day of the next month.
         return event.getTimestamp().plusMonths(1).withDayOfMonth(1).truncatedTo(DAYS);
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/EventConsumerTest.java
@@ -327,8 +327,17 @@ public class EventConsumerTest {
         micrometerAssertionHelper.awaitAndAssertTimerIncrement(CONSUMED_TIMER_NAME, 2);
         assertEquals(2L, getTimerCount(action.getBundle(), action.getApplication(), action.getEventType()));
         micrometerAssertionHelper.assertCounterIncrement(MESSAGE_ID_VALID_COUNTER_NAME, 2);
-        micrometerAssertionHelper.assertCounterIncrementWithTags(DUPLICATE_EVENT_COUNTER_NAME, 1,
-            TAG_KEY_BUNDLE, BUNDLE, TAG_KEY_APPLICATION, APP, TAG_KEY_EVENT_TYPE, EVENT_TYPE);
+
+        if (valkeyDedupEnabled) {
+            // With Valkey dedup enabled, the second event is detected as a duplicate.
+            micrometerAssertionHelper.assertCounterIncrementWithTags(DUPLICATE_EVENT_COUNTER_NAME, 1,
+                TAG_KEY_BUNDLE, BUNDLE, TAG_KEY_APPLICATION, APP, TAG_KEY_EVENT_TYPE, EVENT_TYPE);
+        } else {
+            // Without Valkey, there is no dedup mechanism — both events are processed.
+            micrometerAssertionHelper.assertCounterIncrementWithTags(DUPLICATE_EVENT_COUNTER_NAME, 0,
+                TAG_KEY_BUNDLE, BUNDLE, TAG_KEY_APPLICATION, APP, TAG_KEY_EVENT_TYPE, EVENT_TYPE);
+        }
+
         assertNoCounterIncrement(
                 REJECTED_COUNTER_NAME,
                 PROCESSING_ERROR_COUNTER_NAME,
@@ -338,7 +347,18 @@ public class EventConsumerTest {
         );
         micrometerAssertionHelper.assertCounterIncrementWithTags(PROCESSING_BLACKLISTED_COUNTER_NAME, 0,
             TAG_KEY_BUNDLE, BUNDLE, TAG_KEY_APPLICATION, APP, TAG_KEY_EVENT_TYPE, EVENT_TYPE, TAG_KEY_EVENT_TYPE_FQN, EVENT_TYPE_FQN);
-        verifyExactlyOneProcessing(eventType, payload, action, false);
+
+        int expectedProcessCount = valkeyDedupEnabled ? 1 : 2;
+        ArgumentCaptor<Event> argumentCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(endpointProcessor, times(expectedProcessCount)).process(argumentCaptor.capture());
+        // Verify the first processed event has expected fields.
+        Event firstEvent = argumentCaptor.getAllValues().get(0);
+        assertNull(firstEvent.getAccountId());
+        assertEquals(DEFAULT_ORG_ID, firstEvent.getOrgId());
+        assertEquals(eventType, firstEvent.getEventType());
+        assertEquals(payload, firstEvent.getPayload());
+        assertEquals(action, firstEvent.getEventWrapper().getEvent());
+
         verify(eventDeduplicator, times(2)).isNew(any(Event.class));
 
     }

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/DefaultEventDeduplicationConfigTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/DefaultEventDeduplicationConfigTest.java
@@ -15,18 +15,17 @@ class DefaultEventDeduplicationConfigTest {
     private final DefaultEventDeduplicationConfig deduplicationConfig = new DefaultEventDeduplicationConfig();
 
     @Test
-    void testGetDeduplicationKeyWithNullEventId() {
+    void testGetDeduplicationKeyWithNoExternalId() {
 
         Event event = new Event();
-        // Event ID is null by default.
 
         Optional<String> deduplicationKey = deduplicationConfig.getDeduplicationKey(event);
 
-        assertTrue(deduplicationKey.isEmpty(), "The default deduplication key should be empty when event ID is null");
+        assertTrue(deduplicationKey.isEmpty(), "The deduplication key should be empty when externalId is null");
     }
 
     @Test
-    void testGetDeduplicationKeyWithNonNullEventId() {
+    void testGetDeduplicationKeyWithEventIdOnlyReturnsEmpty() {
 
         UUID eventId = UUID.randomUUID();
         Event event = new Event();
@@ -34,22 +33,34 @@ class DefaultEventDeduplicationConfigTest {
 
         Optional<String> deduplicationKey = deduplicationConfig.getDeduplicationKey(event);
 
+        assertTrue(deduplicationKey.isEmpty(), "The deduplication key should be empty when only event ID is set (no externalId)");
+    }
+
+    @Test
+    void testGetDeduplicationKeyWithExternalId() {
+
+        UUID externalId = UUID.randomUUID();
+        Event event = new Event();
+        event.setExternalId(externalId);
+
+        Optional<String> deduplicationKey = deduplicationConfig.getDeduplicationKey(event);
+
         assertTrue(deduplicationKey.isPresent());
-        assertEquals(eventId.toString(), deduplicationKey.get());
+        assertEquals(externalId.toString(), deduplicationKey.get());
     }
 
     @Test
     void testGetDeduplicationKeyWithDifferentEvents() {
 
-        UUID eventId1 = UUID.randomUUID();
+        UUID externalId1 = UUID.randomUUID();
         Event event1 = new Event();
-        event1.setId(eventId1);
+        event1.setExternalId(externalId1);
 
         Optional<String> deduplicationKey1 = deduplicationConfig.getDeduplicationKey(event1);
 
-        UUID eventId2 = UUID.randomUUID();
+        UUID externalId2 = UUID.randomUUID();
         Event event2 = new Event();
-        event2.setId(eventId2);
+        event2.setExternalId(externalId2);
 
         Optional<String> deduplicationKey2 = deduplicationConfig.getDeduplicationKey(event2);
 
@@ -61,20 +72,20 @@ class DefaultEventDeduplicationConfigTest {
     @Test
     void testGetDeduplicationKeyWithSameData() {
 
-        UUID eventId = UUID.randomUUID();
+        UUID externalId = UUID.randomUUID();
 
         Event event1 = new Event();
-        event1.setId(eventId);
+        event1.setExternalId(externalId);
 
         Optional<String> deduplicationKey1 = deduplicationConfig.getDeduplicationKey(event1);
 
         Event event2 = new Event();
-        event2.setId(eventId);
+        event2.setExternalId(externalId);
 
         Optional<String> deduplicationKey2 = deduplicationConfig.getDeduplicationKey(event2);
 
         assertTrue(deduplicationKey1.isPresent());
         assertTrue(deduplicationKey2.isPresent());
-        assertEquals(deduplicationKey1.get(), deduplicationKey2.get(), "Events with the same data should have the same deduplication key");
+        assertEquals(deduplicationKey1.get(), deduplicationKey2.get(), "Events with the same externalId should have the same deduplication key");
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/EventDeduplicatorTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.events.deduplication;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.events.EventWrapperAction;
+import com.redhat.cloud.notifications.events.ValkeyService;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.Event;
@@ -15,9 +16,7 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -42,16 +41,11 @@ class EventDeduplicatorTest {
     @Inject
     EntityManager entityManager;
 
+    @Inject
+    ValkeyService valkeyService;
+
     @InjectSpy
     EngineConfig config;
-
-    @BeforeEach
-    @Transactional
-    void beforeEach() {
-        entityManager
-            .createNativeQuery("DELETE FROM event_deduplication")
-            .executeUpdate();
-    }
 
     @AfterEach
     @Transactional
@@ -63,44 +57,70 @@ class EventDeduplicatorTest {
                 .executeUpdate();
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testIsNewWithDefaultDeduplication(final boolean valkeyDedupEnabled) {
-        when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(valkeyDedupEnabled);
-        when(config.isInMemoryDbEnabled()).thenReturn(valkeyDedupEnabled);
+    @Test
+    void testIsNewWithDefaultDeduplication() {
+        when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(true);
+        when(config.isInMemoryDbEnabled()).thenReturn(true);
 
         EventType eventType = createEventType(TEST_BUNDLE_NAME, "test-app");
         LocalDateTime dateTime = LocalDateTime.now(UTC_ZONE);
 
-        UUID eventId1 = UUID.randomUUID();
+        UUID externalId1 = UUID.randomUUID();
         Event event1 = new Event();
-        event1.setId(eventId1);
+        event1.setExternalId(externalId1);
         event1.setEventType(eventType);
         event1.setEventWrapper(new EventWrapperAction(ActionBuilder.build(dateTime)));
 
         assertTrue(eventDeduplicator.isNew(event1), "New event should return true");
 
-        UUID eventId2 = UUID.randomUUID();
+        UUID externalId2 = UUID.randomUUID();
         Event event2 = new Event();
-        event2.setId(eventId2);
+        event2.setExternalId(externalId2);
         event2.setEventType(eventType);
         event2.setEventWrapper(new EventWrapperAction(ActionBuilder.build(dateTime)));
 
         assertTrue(eventDeduplicator.isNew(event2), "New event should return true");
 
         Event event3 = new Event();
-        event3.setId(eventId2);
+        event3.setExternalId(externalId2);
         event3.setEventType(eventType);
         event3.setEventWrapper(new EventWrapperAction(ActionBuilder.build(dateTime)));
 
         assertFalse(eventDeduplicator.isNew(event3), "Duplicate event should return false");
+
+        // Clean up Valkey entries.
+        valkeyService.removeEventFromDeduplication(eventType.getId(), externalId1.toString());
+        valkeyService.removeEventFromDeduplication(eventType.getId(), externalId2.toString());
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testIsNewWithSubscriptionsDeduplication(final boolean valkeyDedupEnabled) {
-        when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(valkeyDedupEnabled);
-        when(config.isInMemoryDbEnabled()).thenReturn(valkeyDedupEnabled);
+    @Test
+    void testIsNewWithoutValkeyReturnsAlwaysNew() {
+        when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(false);
+        when(config.isInMemoryDbEnabled()).thenReturn(false);
+
+        EventType eventType = createEventType(TEST_BUNDLE_NAME, "test-app");
+        LocalDateTime dateTime = LocalDateTime.now(UTC_ZONE);
+
+        UUID externalId = UUID.randomUUID();
+        Event event1 = new Event();
+        event1.setExternalId(externalId);
+        event1.setEventType(eventType);
+        event1.setEventWrapper(new EventWrapperAction(ActionBuilder.build(dateTime)));
+
+        assertTrue(eventDeduplicator.isNew(event1), "Event should be new when Valkey is disabled");
+
+        Event event2 = new Event();
+        event2.setExternalId(externalId);
+        event2.setEventType(eventType);
+        event2.setEventWrapper(new EventWrapperAction(ActionBuilder.build(dateTime)));
+
+        assertTrue(eventDeduplicator.isNew(event2), "Duplicate event should also be new when Valkey is disabled");
+    }
+
+    @Test
+    void testIsNewWithSubscriptionsDeduplication() {
+        when(config.isValkeyEventDeduplicatorEnabled()).thenReturn(true);
+        when(config.isInMemoryDbEnabled()).thenReturn(true);
 
         EventType eventType = createEventType(SUBSCRIPTION_SERVICES_BUNDLE_NAME, "subscriptions");
         LocalDateTime baseDateTime =


### PR DESCRIPTION
## Summary

- Remove the PostgreSQL `event_deduplication` table and its `cleanEventDeduplication()` stored procedure, completing the migration to Valkey (in-memory) as the sole event deduplication mechanism
- Simplify `EventDeduplicator` to use `ValkeyService` directly — no more dual-write or PostgreSQL fallback
- Remove the `event.getId()` fallback from `DefaultEventDeduplicationConfig`, keeping only `externalId`-based deduplication keys (per the existing TODO referencing this ticket)
- Remove the CronJob cleanup entries for the dropped table from `clowdapp-backend.yaml`
- Add Flyway migration `V1.132.0` to drop the table and procedure

## Changes

| File | Change |
|------|--------|
| `EventDeduplicator.java` | Remove PostgreSQL code, `EntityManager`, `@Transactional`. Valkey-only dedup. |
| `DefaultEventDeduplicationConfig.java` | Remove `event.getId()` fallback (TODO cleanup). |
| `SubscriptionsDeduplicationConfig.java` | Update comment to reflect Valkey TTL-based expiry. |
| `V1.132.0__RHCLOUD-44531_remove_event_deduplication.sql` | Drop table + stored procedure. |
| `.rhcicd/clowdapp-backend.yaml` | Remove cleanup CronJob entries for dropped table. |
| `EventDeduplicatorTest.java` | Rewrite for Valkey-only dedup + no-Valkey fallback test. |
| `DefaultEventDeduplicationConfigTest.java` | Update tests for externalId-only key generation. |

## Behavior

- **Valkey enabled**: Event deduplication works via Valkey `SET NX` with TTL expiry
- **Valkey disabled**: All events are treated as new (no deduplication) — acceptable since dedup was always optional
- Existing DB migration `V1.118.0` is preserved (never delete migrations)

## Test plan

- [ ] `EventDeduplicatorTest` — verifies Valkey dedup catches duplicates
- [ ] `EventDeduplicatorTest` — verifies no-Valkey mode treats all events as new
- [ ] `DefaultEventDeduplicationConfigTest` — verifies externalId-only key generation
- [ ] `DefaultEventDeduplicationConfigTest` — verifies event.getId() no longer produces a key
- [ ] Existing `ValkeyServiceTest` and `EventConsumerTest` unaffected
- [ ] CI pipeline passes

RHCLOUD-44531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switched event deduplication to a Valkey-backed mechanism.

* **Chores**
  * Removed legacy database deduplication table and cleanup procedures.
  * Updated deduplication to rely on events' external identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->