### PR TITLE
[RHCLOUD-47442] Update application services template links

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -89,6 +89,8 @@ objects:
           value: ${ENV_NAME}
         - name: ENV_OCM_BASE_URL
           value: ${ENV_OCM_BASE_URL}
+        - name: ENV_APPLICATION_SERVICES_BASE_URL
+          value: ${ENV_APPLICATION_SERVICES_BASE_URL}
         - name: HOST_NAME
           value: ${HOSTNAME}
         - name: MP_MESSAGING_INCOMING_FROMCAMEL_ENABLED
@@ -280,6 +282,9 @@ parameters:
 - name: ENV_OCM_BASE_URL
   value: https://cloud.redhat.com
   description: The environment's base URL for OCM
+- name: ENV_APPLICATION_SERVICES_BASE_URL
+  value: https://access.redhat.com/downloads/content/application-services/
+  description: The environment's base URL for Application services
 - name: ENV_NAME
   description: ClowdEnvironment name (ephemeral, stage, prod)
   required: true

--- a/common-template/src/main/resources/templates/email/ApplicationServices/dailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/ApplicationServices/dailyEmailBody.html
@@ -53,7 +53,7 @@
             <tbody>
                 {#each sub-section-product-releases}
                 <tr style="font-size: 14px;">
-                    <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId={it.id}" target="_blank">{it.description}</a></td>
+                    <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="{environment.applicationServicesUrl}{it.download_path}" target="_blank">{it.description}</a></td>
                     <td style="{body-section-table-td-style}">{it.version}</td>
                 </tr>
                 {/each}

--- a/common-template/src/test/java/email/TestApplicationServicesTemplate.java
+++ b/common-template/src/test/java/email/TestApplicationServicesTemplate.java
@@ -53,8 +53,8 @@ public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelpe
         assertTrue(result.contains("3 "), "EAP section should show 3 releases");
         assertTrue(result.contains("releases affecting your subscriptions."));
 
-        // Verify base_url is used in payload links
-        assertEquals(5, StringUtils.countMatches(result, "https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId="));
+        // Verify environment URL + download_path is used in payload links
+        assertEquals(5, StringUtils.countMatches(result, "https://localhost/jbossnetwork/restricted/softwareDetail.html?softwareId="));
 
         // Verify payload data is rendered in the tables
         assertTrue(result.contains("Red Hat build of Keycloak 26.2.13 Maven Repository"));
@@ -77,7 +77,7 @@ public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelpe
             "\"application-services\":{" +
             "  \"global_releases_number\":1," +
             "  \"products\":{" +
-            "    \"keycloak-releases\":{\"description\":\"Red Hat build of Keycloak\",\"payloads\":[{\"id\":\"108766\",\"description\":\"Red Hat build of Keycloak 26.2.13 Maven Repository\",\"version\":\"26.2.13\"}]}" +
+            "    \"keycloak-releases\":{\"description\":\"Red Hat build of Keycloak\",\"payloads\":[{\"download_path\":\"jbossnetwork/restricted/softwareDetail.html?softwareId=108766\",\"description\":\"Red Hat build of Keycloak 26.2.13 Maven Repository\",\"version\":\"26.2.13\"}]}" +
             "  }" +
             "}," +
             "\"start_time\":null,\"end_time\":null" +
@@ -96,8 +96,8 @@ public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelpe
             "\"application-services\":{" +
             "  \"global_releases_number\":2," +
             "  \"products\":{" +
-            "    \"zzz-product\":{\"description\":\"Zebra Product\",\"payloads\":[{\"id\":\"1\",\"description\":\"Zebra Release\",\"version\":\"1.0\"}]}," +
-            "    \"aaa-product\":{\"description\":\"Alpha Product\",\"payloads\":[{\"id\":\"2\",\"description\":\"Alpha Release\",\"version\":\"2.0\"}]}" +
+            "    \"zzz-product\":{\"description\":\"Zebra Product\",\"payloads\":[{\"download_path\":\"downloads/1\",\"description\":\"Zebra Release\",\"version\":\"1.0\"}]}," +
+            "    \"aaa-product\":{\"description\":\"Alpha Product\",\"payloads\":[{\"download_path\":\"downloads/2\",\"description\":\"Alpha Release\",\"version\":\"2.0\"}]}" +
             "  }" +
             "}," +
             "\"start_time\":null,\"end_time\":null" +
@@ -119,7 +119,7 @@ public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelpe
             "  \"global_releases_number\":1," +
             "  \"products\":{" +
             "    \"keycloak-releases\":{\"description\":\"Red Hat build of Keycloak\",\"payloads\":[]}," +
-            "    \"eap-releases\":{\"description\":\"Red Hat JBoss Enterprise Application Platform\",\"payloads\":[{\"id\":\"1\",\"description\":\"EAP Release\",\"version\":\"8.0\"}]}" +
+            "    \"eap-releases\":{\"description\":\"Red Hat JBoss Enterprise Application Platform\",\"payloads\":[{\"download_path\":\"downloads/1\",\"description\":\"EAP Release\",\"version\":\"8.0\"}]}" +
             "  }" +
             "}," +
             "\"start_time\":null,\"end_time\":null" +
@@ -158,12 +158,12 @@ public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelpe
         "            \"description\":\"Red Hat build of Keycloak\"," +
         "            \"payloads\":[" +
         "               {" +
-        "                  \"id\":\"108766\"," +
+        "                  \"download_path\":\"jbossnetwork/restricted/softwareDetail.html?softwareId=108766\"," +
         "                  \"description\":\"Red Hat build of Keycloak 26.2.13 Maven Repository\"," +
         "                  \"version\":\"26.2.13\"" +
         "               }," +
         "               {" +
-        "                  \"id\":\"108767\"," +
+        "                  \"download_path\":\"jbossnetwork/restricted/softwareDetail.html?softwareId=108767\"," +
         "                  \"description\":\"Red Hat build of Keycloak 26.2.13 Server\"," +
         "                  \"version\":\"26.2.13\"" +
         "               }" +
@@ -173,17 +173,17 @@ public class TestApplicationServicesTemplate extends EmailTemplatesRendererHelpe
         "            \"description\":\"Red Hat JBoss Enterprise Application Platform\"," +
         "            \"payloads\":[" +
         "               {" +
-        "                  \"id\":\"108920\"," +
+        "                  \"download_path\":\"jbossnetwork/restricted/softwareDetail.html?softwareId=108920\"," +
         "                  \"description\":\"Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Installation Manager\"," +
         "                  \"version\":\"8.1\"" +
         "               }," +
         "               {" +
-        "                  \"id\":\"108917\"," +
+        "                  \"download_path\":\"jbossnetwork/restricted/softwareDetail.html?softwareId=108917\"," +
         "                  \"description\":\"Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Source Code\"," +
         "                  \"version\":\"8.1\"" +
         "               }," +
         "               {" +
-        "                  \"id\":\"108918\"," +
+        "                  \"download_path\":\"jbossnetwork/restricted/softwareDetail.html?softwareId=108918\"," +
         "                  \"description\":\"Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Maven Repository\"," +
         "                  \"version\":\"8.1\"" +
         "               }" +

--- a/common-template/src/test/java/email/pojo/Environment.java
+++ b/common-template/src/test/java/email/pojo/Environment.java
@@ -18,6 +18,9 @@ public class Environment {
     @ConfigProperty(name = "env.ocm.base.url", defaultValue = "https://localhost")
     String ocmUrl;
 
+    @ConfigProperty(name = "env.application-services.base.url", defaultValue = "https://localhost/")
+    String applicationServicesUrl;
+
     public String name() {
         return this.environment;
     }
@@ -28,6 +31,10 @@ public class Environment {
 
     public String ocmUrl() {
         return this.ocmUrl;
+    }
+
+    public String applicationServicesUrl() {
+        return this.applicationServicesUrl;
     }
 
     // add regular getters for jackson serialization

--- a/common/src/main/java/com/redhat/cloud/notifications/models/Environment.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/Environment.java
@@ -18,6 +18,9 @@ public class Environment {
     @ConfigProperty(name = "env.ocm.base.url", defaultValue = "https://localhost")
     String ocmUrl;
 
+    @ConfigProperty(name = "env.application-services.base.url", defaultValue = "https://localhost/")
+    String applicationServicesUrl;
+
     public String name() {
         return this.environment;
     }
@@ -30,6 +33,10 @@ public class Environment {
         return this.ocmUrl;
     }
 
+    public String applicationServicesUrl() {
+        return this.applicationServicesUrl;
+    }
+
     // add regular getters for jackson serialization
     public String getUrl() {
         return url;
@@ -37,6 +44,10 @@ public class Environment {
 
     public String getOcmUrl() {
         return ocmUrl;
+    }
+
+    public String getApplicationServicesUrl() {
+        return applicationServicesUrl;
     }
 
     /**

--- a/engine/src/test/java/com/redhat/cloud/notifications/ApplicationServicesTestHelpers.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/ApplicationServicesTestHelpers.java
@@ -48,7 +48,7 @@ public class ApplicationServicesTestHelpers {
                     .withMetadata(new Metadata.MetadataBuilder().build())
                     .withPayload(
                         new Payload.PayloadBuilder()
-                            .withAdditionalProperty("id", "108766")
+                            .withAdditionalProperty("download_path", "jbossnetwork/restricted/softwareDetail.html?softwareId=108766")
                             .withAdditionalProperty("description", "Red Hat build of Keycloak 26.2.13 Maven Repository")
                             .withAdditionalProperty("version", "26.2.13")
                             .build()
@@ -58,7 +58,7 @@ public class ApplicationServicesTestHelpers {
                     .withMetadata(new Metadata.MetadataBuilder().build())
                     .withPayload(
                         new Payload.PayloadBuilder()
-                            .withAdditionalProperty("id", "108767")
+                            .withAdditionalProperty("download_path", "jbossnetwork/restricted/softwareDetail.html?softwareId=108767")
                             .withAdditionalProperty("description", "Red Hat build of Keycloak 26.2.13 Server")
                             .withAdditionalProperty("version", "26.2.13")
                             .build()
@@ -76,7 +76,7 @@ public class ApplicationServicesTestHelpers {
                     .withMetadata(new Metadata.MetadataBuilder().build())
                     .withPayload(
                         new Payload.PayloadBuilder()
-                            .withAdditionalProperty("id", "108920")
+                            .withAdditionalProperty("download_path", "jbossnetwork/restricted/softwareDetail.html?softwareId=108920")
                             .withAdditionalProperty("description", "Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Installation Manager")
                             .withAdditionalProperty("version", "8.1")
                             .build()
@@ -86,7 +86,7 @@ public class ApplicationServicesTestHelpers {
                     .withMetadata(new Metadata.MetadataBuilder().build())
                     .withPayload(
                         new Payload.PayloadBuilder()
-                            .withAdditionalProperty("id", "108917")
+                            .withAdditionalProperty("download_path", "jbossnetwork/restricted/softwareDetail.html?softwareId=108917")
                             .withAdditionalProperty("description", "Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Source Code")
                             .withAdditionalProperty("version", "8.1")
                             .build()
@@ -96,7 +96,7 @@ public class ApplicationServicesTestHelpers {
                     .withMetadata(new Metadata.MetadataBuilder().build())
                     .withPayload(
                         new Payload.PayloadBuilder()
-                            .withAdditionalProperty("id", "108918")
+                            .withAdditionalProperty("download_path", "jbossnetwork/restricted/softwareDetail.html?softwareId=108918")
                             .withAdditionalProperty("description", "Red Hat JBoss Enterprise Application Platform 8.1 Update 05 Maven Repository")
                             .withAdditionalProperty("version", "8.1")
                             .build()
@@ -121,7 +121,7 @@ public class ApplicationServicesTestHelpers {
                 .withMetadata(new Metadata.MetadataBuilder().build())
                 .withPayload(
                     new Payload.PayloadBuilder()
-                        .withAdditionalProperty("id", "999")
+                        .withAdditionalProperty("download_path", "downloads/999")
                         .withAdditionalProperty("description", "Some release")
                         .withAdditionalProperty("version", "1.0")
                         .build()
@@ -153,7 +153,7 @@ public class ApplicationServicesTestHelpers {
                 .withMetadata(new Metadata.MetadataBuilder().build())
                 .withPayload(
                     new Payload.PayloadBuilder()
-                        .withAdditionalProperty("id", "999")
+                        .withAdditionalProperty("download_path", "downloads/999")
                         .withAdditionalProperty("description", "Some release")
                         .withAdditionalProperty("version", "1.0")
                         .build()
@@ -177,7 +177,7 @@ public class ApplicationServicesTestHelpers {
                 .put("display_name", "Red Hat build of Keycloak")));
         payload.put("events", new JsonArray()
             .add(new JsonObject().put("payload", new JsonObject()
-                .put("id", "108766")
+                .put("download_path", "jbossnetwork/restricted/softwareDetail.html?softwareId=108766")
                 .put("description", "Red Hat build of Keycloak 26.2.13 Maven Repository")
                 .put("version", "26.2.13")))
             .add(new JsonObject().putNull("payload")));
@@ -215,7 +215,7 @@ public class ApplicationServicesTestHelpers {
                 .withMetadata(new Metadata.MetadataBuilder().build())
                 .withPayload(
                     new Payload.PayloadBuilder()
-                        .withAdditionalProperty("id", "999")
+                        .withAdditionalProperty("download_path", "downloads/999")
                         .withAdditionalProperty("description", "Some release")
                         .withAdditionalProperty("version", "1.0")
                         .build()

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ApplicationServicesEmailPayloadAggregatorTest.java
@@ -46,10 +46,10 @@ class ApplicationServicesEmailPayloadAggregatorTest {
 
         JsonArray payloads = keycloak.getJsonArray("payloads");
         assertEquals(2, payloads.size());
-        assertEquals("108766", payloads.getJsonObject(0).getString("id"));
+        assertEquals("jbossnetwork/restricted/softwareDetail.html?softwareId=108766", payloads.getJsonObject(0).getString("download_path"));
         assertEquals("Red Hat build of Keycloak 26.2.13 Maven Repository", payloads.getJsonObject(0).getString("description"));
         assertEquals("26.2.13", payloads.getJsonObject(0).getString("version"));
-        assertEquals("108767", payloads.getJsonObject(1).getString("id"));
+        assertEquals("jbossnetwork/restricted/softwareDetail.html?softwareId=108767", payloads.getJsonObject(1).getString("download_path"));
     }
 
     @Test
@@ -154,7 +154,7 @@ class ApplicationServicesEmailPayloadAggregatorTest {
         assertTrue(products.containsKey("keycloak-releases"));
         JsonArray payloads = products.getJsonObject("keycloak-releases").getJsonArray("payloads");
         assertEquals(1, payloads.size());
-        assertEquals("108766", payloads.getJsonObject(0).getString("id"));
+        assertEquals("jbossnetwork/restricted/softwareDetail.html?softwareId=108766", payloads.getJsonObject(0).getString("download_path"));
         assertEquals(1, appServices.getInteger("global_releases_number"));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification emails now use a configurable Application Services base URL and the deployment exposes a corresponding environment variable so links can be customized at runtime.

* **Chores**
  * Updated email templates and content generation to build links from the configurable base URL.

* **Tests**
  * Adjusted tests and helpers to validate link generation using the new configurable base URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->