### PR TITLE
RHCLOUD-46246 Add bundle, application and event type MCP tools

### DIFF
--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -62,8 +62,16 @@
             <groupId>io.quarkiverse.mcp</groupId>
             <artifactId>quarkus-mcp-server-http</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-hibernate-validator</artifactId>
+        </dependency>
 
         <!-- Quarkus -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-cache</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/BackendRestClient.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/BackendRestClient.java
@@ -2,11 +2,12 @@ package com.redhat.cloud.notifications.mcp;
 
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.reactive.RestHeader;
+import org.jboss.resteasy.reactive.RestPath;
 
 import java.time.temporal.ChronoUnit;
 
@@ -19,5 +20,20 @@ public interface BackendRestClient {
     @GET
     @Path("/api/notifications/v2.0/notifications/severities")
     @Produces(APPLICATION_JSON)
-    String getSeverities(@HeaderParam("x-rh-identity") String xRhIdentity);
+    String getSeverities(@RestHeader("x-rh-identity") String xRhIdentity);
+
+    @GET
+    @Path("/api/notifications/v1.0/notifications/bundles/{bundleName}")
+    @Produces(APPLICATION_JSON)
+    String getBundle(@RestHeader("x-rh-identity") String xRhIdentity, @RestPath String bundleName);
+
+    @GET
+    @Path("/api/notifications/v1.0/notifications/bundles/{bundleName}/applications/{applicationName}")
+    @Produces(APPLICATION_JSON)
+    String getApplication(@RestHeader("x-rh-identity") String xRhIdentity, @RestPath String bundleName, @RestPath String applicationName);
+
+    @GET
+    @Path("/api/notifications/v1.0/notifications/bundles/{bundleName}/applications/{applicationName}/eventTypes/{eventTypeName}")
+    @Produces(APPLICATION_JSON)
+    String getEventType(@RestHeader("x-rh-identity") String xRhIdentity, @RestPath String bundleName, @RestPath String applicationName, @RestPath String eventTypeName);
 }

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
@@ -51,6 +51,7 @@ public class McpServerTools {
         );
     }
 
+    // Cached here because severities are public, rarely updated, and require no ownership check.
     @CacheResult(cacheName = "mcp-get-severities")
     @Tool(description = "Returns the list of available notification severities")
     public String getSeverities() {
@@ -59,6 +60,7 @@ public class McpServerTools {
                 () -> backendClient.getSeverities(principal.getRawHeader()));
     }
 
+    // Cached here because bundles are public, rarely updated, and require no ownership check.
     @CacheResult(cacheName = "mcp-get-bundle")
     @Tool(description = "Retrieves a bundle by name")
     public String getBundle(
@@ -68,6 +70,7 @@ public class McpServerTools {
                 () -> backendClient.getBundle(principal.getRawHeader(), bundleName));
     }
 
+    // Cached here because applications are public, rarely updated, and require no ownership check.
     @CacheResult(cacheName = "mcp-get-application")
     @Tool(description = "Retrieves an application by bundle and application name")
     public String getApplication(
@@ -78,6 +81,7 @@ public class McpServerTools {
                 () -> backendClient.getApplication(principal.getRawHeader(), bundleName, applicationName));
     }
 
+    // Cached here because event types are public, rarely updated, and require no ownership check.
     @CacheResult(cacheName = "mcp-get-event-type")
     @Tool(description = "Retrieves an event type by bundle, application, and event type name")
     public String getEventType(

--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/McpServerTools.java
@@ -2,11 +2,14 @@ package com.redhat.cloud.notifications.mcp;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkus.cache.CacheResult;
 import io.quarkus.logging.Log;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.WebApplicationException;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -48,11 +51,42 @@ public class McpServerTools {
         );
     }
 
+    @CacheResult(cacheName = "mcp-get-severities")
     @Tool(description = "Returns the list of available notification severities")
     public String getSeverities() {
         McpPrincipal principal = (McpPrincipal) securityIdentity.getPrincipal();
         return executeRestCall("getSeverities", principal,
                 () -> backendClient.getSeverities(principal.getRawHeader()));
+    }
+
+    @CacheResult(cacheName = "mcp-get-bundle")
+    @Tool(description = "Retrieves a bundle by name")
+    public String getBundle(
+            @NotBlank @ToolArg(description = "The name of the bundle") String bundleName) {
+        McpPrincipal principal = (McpPrincipal) securityIdentity.getPrincipal();
+        return executeRestCall("getBundle", principal,
+                () -> backendClient.getBundle(principal.getRawHeader(), bundleName));
+    }
+
+    @CacheResult(cacheName = "mcp-get-application")
+    @Tool(description = "Retrieves an application by bundle and application name")
+    public String getApplication(
+            @NotBlank @ToolArg(description = "The name of the bundle") String bundleName,
+            @NotBlank @ToolArg(description = "The name of the application") String applicationName) {
+        McpPrincipal principal = (McpPrincipal) securityIdentity.getPrincipal();
+        return executeRestCall("getApplication", principal,
+                () -> backendClient.getApplication(principal.getRawHeader(), bundleName, applicationName));
+    }
+
+    @CacheResult(cacheName = "mcp-get-event-type")
+    @Tool(description = "Retrieves an event type by bundle, application, and event type name")
+    public String getEventType(
+            @NotBlank @ToolArg(description = "The name of the bundle") String bundleName,
+            @NotBlank @ToolArg(description = "The name of the application") String applicationName,
+            @NotBlank @ToolArg(description = "The name of the event type") String eventTypeName) {
+        McpPrincipal principal = (McpPrincipal) securityIdentity.getPrincipal();
+        return executeRestCall("getEventType", principal,
+                () -> backendClient.getEventType(principal.getRawHeader(), bundleName, applicationName, eventTypeName));
     }
 
     /**

--- a/mcp/src/main/resources/application.properties
+++ b/mcp/src/main/resources/application.properties
@@ -34,3 +34,8 @@ quarkus.mcp.server.http.streamable.dummy-init=true
 # MCP traffic logging (disabled by default, enable for debugging)
 quarkus.mcp.server.traffic-logging.enabled=false
 %dev.quarkus.mcp.server.traffic-logging.enabled=true
+
+quarkus.cache.caffeine.mcp-get-severities.expire-after-write=PT10M
+quarkus.cache.caffeine.mcp-get-bundle.expire-after-write=PT10M
+quarkus.cache.caffeine.mcp-get-application.expire-after-write=PT10M
+quarkus.cache.caffeine.mcp-get-event-type.expire-after-write=PT10M

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAuthTest.java
@@ -2,6 +2,8 @@ package com.redhat.cloud.notifications.mcp;
 
 import com.redhat.cloud.notifications.MicrometerAssertionHelper;
 import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import io.quarkus.cache.Cache;
+import io.quarkus.cache.CacheName;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
@@ -48,9 +50,25 @@ public class McpAuthTest {
     @Inject
     MicrometerAssertionHelper micrometerAssertionHelper;
 
+    @CacheName("mcp-get-severities")
+    Cache severitiesCache;
+
+    @CacheName("mcp-get-bundle")
+    Cache bundleCache;
+
+    @CacheName("mcp-get-application")
+    Cache applicationCache;
+
+    @CacheName("mcp-get-event-type")
+    Cache eventTypeCache;
+
     @BeforeEach
     void beforeEach() {
         MockServerLifecycleManager.getClient().resetAll();
+        severitiesCache.invalidateAll().await().indefinitely();
+        bundleCache.invalidateAll().await().indefinitely();
+        applicationCache.invalidateAll().await().indefinitely();
+        eventTypeCache.invalidateAll().await().indefinitely();
         micrometerAssertionHelper.saveCounterValuesBeforeTest(AUTH_SUCCESS_COUNTER);
         micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(AUTH_FAILURE_COUNTER, "reason", "missing_header");
         micrometerAssertionHelper.saveCounterValueWithTagsBeforeTest(AUTH_FAILURE_COUNTER, "reason", "missing_org_id");
@@ -125,6 +143,51 @@ public class McpAuthTest {
                 "params": {
                     "name": "getSeverities",
                     "arguments": {}
+                }
+            }
+            """;
+
+    private static final String GET_BUNDLE_BODY = """
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 6,
+                "params": {
+                    "name": "getBundle",
+                    "arguments": {
+                        "bundleName": "rhel"
+                    }
+                }
+            }
+            """;
+
+    private static final String GET_APPLICATION_BODY = """
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 7,
+                "params": {
+                    "name": "getApplication",
+                    "arguments": {
+                        "bundleName": "rhel",
+                        "applicationName": "patch"
+                    }
+                }
+            }
+            """;
+
+    private static final String GET_EVENT_TYPE_BODY = """
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 8,
+                "params": {
+                    "name": "getEventType",
+                    "arguments": {
+                        "bundleName": "rhel",
+                        "applicationName": "patch",
+                        "eventTypeName": "new-advisory"
+                    }
                 }
             }
             """;
@@ -248,8 +311,9 @@ public class McpAuthTest {
     public void testToolsListWithValidIdentity() {
         postMcp(validIdentity(), TOOLS_LIST_BODY)
                 .statusCode(200)
-                .body("result.tools.size()", greaterThanOrEqualTo(3))
-                .body("result.tools.name", hasItems("serverInfo", "whoami", "getSeverities"));
+                .body("result.tools.size()", greaterThanOrEqualTo(6))
+                .body("result.tools.name", hasItems("serverInfo", "whoami", "getSeverities",
+                        "getBundle", "getApplication", "getEventType"));
     }
 
     @Test
@@ -352,6 +416,138 @@ public class McpAuthTest {
         );
 
         postMcp(validIdentity(), GET_SEVERITIES_BODY)
+                .statusCode(200)
+                .body("result.isError", is(true))
+                .body("result.content[0].text", containsString("Resource not found"));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+    }
+
+    // --- getBundle tool tests ---
+
+    @Test
+    public void testGetBundleWithValidIdentity() {
+        String bundleJson = "{\"id\":\"1234\",\"name\":\"rhel\",\"display_name\":\"Red Hat Enterprise Linux\"}";
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel"))
+                        .withHeader("x-rh-identity", equalTo(validIdentity()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(bundleJson))
+        );
+
+        postMcp(validIdentity(), GET_BUNDLE_BODY)
+                .statusCode(200)
+                .body("result.content[0].text", containsString("rhel"))
+                .body("result.content[0].text", containsString("Red Hat Enterprise Linux"));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+
+        MockServerLifecycleManager.getClient().verify(
+                getRequestedFor(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel"))
+                        .withHeader("x-rh-identity", equalTo(validIdentity()))
+        );
+    }
+
+    @Test
+    public void testGetBundleWithoutIdentityIsRejected() {
+        postMcp(null, GET_BUNDLE_BODY).statusCode(401);
+    }
+
+    @Test
+    public void testGetBundleWhenBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        postMcp(validIdentity(), GET_BUNDLE_BODY)
+                .statusCode(200)
+                .body("result.isError", is(true))
+                .body("result.content[0].text", containsString("Resource not found"));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+    }
+
+    // --- getApplication tool tests ---
+
+    @Test
+    public void testGetApplicationWithValidIdentity() {
+        String applicationJson = "{\"id\":\"5678\",\"name\":\"patch\",\"display_name\":\"Patch\",\"bundle_id\":\"1234\"}";
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch"))
+                        .withHeader("x-rh-identity", equalTo(validIdentity()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(applicationJson))
+        );
+
+        postMcp(validIdentity(), GET_APPLICATION_BODY)
+                .statusCode(200)
+                .body("result.content[0].text", containsString("patch"))
+                .body("result.content[0].text", containsString("Patch"));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+
+        MockServerLifecycleManager.getClient().verify(
+                getRequestedFor(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch"))
+                        .withHeader("x-rh-identity", equalTo(validIdentity()))
+        );
+    }
+
+    @Test
+    public void testGetApplicationWithoutIdentityIsRejected() {
+        postMcp(null, GET_APPLICATION_BODY).statusCode(401);
+    }
+
+    @Test
+    public void testGetApplicationWhenBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        postMcp(validIdentity(), GET_APPLICATION_BODY)
+                .statusCode(200)
+                .body("result.isError", is(true))
+                .body("result.content[0].text", containsString("Resource not found"));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+    }
+
+    // --- getEventType tool tests ---
+
+    @Test
+    public void testGetEventTypeWithValidIdentity() {
+        String eventTypeJson = "{\"id\":\"9012\",\"name\":\"new-advisory\",\"display_name\":\"New advisory\",\"application_id\":\"5678\"}";
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch/eventTypes/new-advisory"))
+                        .withHeader("x-rh-identity", equalTo(validIdentity()))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(eventTypeJson))
+        );
+
+        postMcp(validIdentity(), GET_EVENT_TYPE_BODY)
+                .statusCode(200)
+                .body("result.content[0].text", containsString("new-advisory"))
+                .body("result.content[0].text", containsString("New advisory"));
+        micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
+
+        MockServerLifecycleManager.getClient().verify(
+                getRequestedFor(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch/eventTypes/new-advisory"))
+                        .withHeader("x-rh-identity", equalTo(validIdentity()))
+        );
+    }
+
+    @Test
+    public void testGetEventTypeWithoutIdentityIsRejected() {
+        postMcp(null, GET_EVENT_TYPE_BODY).statusCode(401);
+    }
+
+    @Test
+    public void testGetEventTypeWhenBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch/eventTypes/new-advisory"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        postMcp(validIdentity(), GET_EVENT_TYPE_BODY)
                 .statusCode(200)
                 .body("result.isError", is(true))
                 .body("result.content[0].text", containsString("Resource not found"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints to fetch bundle, application, and event-type details.
  * Enabled caching for severity, bundle, application, and event-type lookups with a 10-minute expiry and added input validation for those lookups.

* **Chores**
  * Expanded test coverage for the new endpoints, covering successful calls, missing-identity rejection, and error handling (including resource-not-found responses).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->