### PR TITLE
RHCLOUD-47525 Preserve all payload fields in Splunk HEC event body

### DIFF
--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkMessageHandler.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkMessageHandler.java
@@ -164,12 +164,13 @@ public class SplunkMessageHandler extends MessageHandler {
      */
     static String buildSplunkPayload(SplunkNotification notification) {
         JsonObject base = new JsonObject();
-        base.put("org_id", notification.getOrgId());
-        base.put("account_id", notification.accountId);
 
         for (Map.Entry<String, Object> entry : notification.getExtraFields().entrySet()) {
             base.put(entry.getKey(), entry.getValue());
         }
+
+        base.put("org_id", notification.getOrgId());
+        base.put("account_id", notification.accountId);
 
         JsonArray events = notification.events;
 

--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkMessageHandler.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkMessageHandler.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -165,6 +166,10 @@ public class SplunkMessageHandler extends MessageHandler {
         JsonObject base = new JsonObject();
         base.put("org_id", notification.getOrgId());
         base.put("account_id", notification.accountId);
+
+        for (Map.Entry<String, Object> entry : notification.getExtraFields().entrySet()) {
+            base.put(entry.getKey(), entry.getValue());
+        }
 
         JsonArray events = notification.events;
 

--- a/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkNotification.java
+++ b/connector-splunk/src/main/java/com/redhat/cloud/notifications/connector/splunk/SplunkNotification.java
@@ -1,11 +1,15 @@
 package com.redhat.cloud.notifications.connector.splunk;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.redhat.cloud.notifications.connector.v2.models.NotificationToConnector;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @RegisterForReflection
 public class SplunkNotification extends NotificationToConnector {
@@ -19,4 +23,15 @@ public class SplunkNotification extends NotificationToConnector {
 
     @NotNull
     public JsonArray events;
+
+    private final Map<String, Object> extraFields = new LinkedHashMap<>();
+
+    @JsonAnySetter
+    public void setExtraField(String key, Object value) {
+        extraFields.put(key, value);
+    }
+
+    public Map<String, Object> getExtraFields() {
+        return extraFields;
+    }
 }

--- a/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkConnectorIntegrationTest.java
+++ b/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkConnectorIntegrationTest.java
@@ -102,12 +102,12 @@ class SplunkConnectorIntegrationTest extends BaseHttpConnectorIntegrationTest {
             "source", "eventing",
             "sourcetype", "Insights event",
             "event", JsonObject.of(
-                "org_id", DEFAULT_ORG_ID,
-                "account_id", DEFAULT_ACCOUNT_ID,
                 "source", SplunkMessageHandlerTest.buildSourceField(),
                 "application", "my-app",
                 "bundle", "my-bundle",
                 "event_type", "my-event-type",
+                "org_id", DEFAULT_ORG_ID,
+                "account_id", DEFAULT_ACCOUNT_ID,
                 "events", JsonArray.of(
                     JsonObject.of(key, value)
                 )

--- a/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkConnectorIntegrationTest.java
+++ b/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkConnectorIntegrationTest.java
@@ -63,6 +63,10 @@ class SplunkConnectorIntegrationTest extends BaseHttpConnectorIntegrationTest {
             JsonObject.of("event-2-key", "event-2-value"),
             JsonObject.of("event-3-key", "event-3-value")
         ));
+        payload.put("source", SplunkMessageHandlerTest.buildSourceField());
+        payload.put("application", "my-app");
+        payload.put("bundle", "my-bundle");
+        payload.put("event_type", "my-event-type");
 
         // Mock the authentication loader to return a secret
         SourcesSecretResponse secretResponse = new SourcesSecretResponse();
@@ -100,6 +104,10 @@ class SplunkConnectorIntegrationTest extends BaseHttpConnectorIntegrationTest {
             "event", JsonObject.of(
                 "org_id", DEFAULT_ORG_ID,
                 "account_id", DEFAULT_ACCOUNT_ID,
+                "source", SplunkMessageHandlerTest.buildSourceField(),
+                "application", "my-app",
+                "bundle", "my-bundle",
+                "event_type", "my-event-type",
                 "events", JsonArray.of(
                     JsonObject.of(key, value)
                 )

--- a/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkMessageHandlerTest.java
+++ b/connector-splunk/src/test/java/com/redhat/cloud/notifications/connector/splunk/SplunkMessageHandlerTest.java
@@ -27,6 +27,7 @@ import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.connector.splunk.SplunkMessageHandler.SERVICES_COLLECTOR_EVENT;
 import static com.redhat.cloud.notifications.connector.v2.BaseConnectorIntegrationTest.buildIncomingCloudEvent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -536,11 +537,52 @@ class SplunkMessageHandlerTest {
         assertTrue(result.contains("\"org_id\":\"" + DEFAULT_ORG_ID + "\""));
     }
 
+    @Test
+    void testExtraFieldsPreservedInPayload() {
+        mockAuthentication();
+
+        Response mockResponse = mock(Response.class);
+        when(mockResponse.getStatus()).thenReturn(200);
+        when(splunkRestClient.post(anyString(), anyString(), anyString())).thenReturn(mockResponse);
+
+        JsonObject payload = buildPayload("https://splunk.example.com",
+            JsonArray.of(JsonObject.of("k", "v")));
+        handler.handle(buildIncomingCloudEvent("test-id", "test-type", payload));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(splunkRestClient).post(anyString(), anyString(), bodyCaptor.capture());
+
+        String sentBody = bodyCaptor.getValue();
+        JsonObject parsed = new JsonObject(sentBody);
+        JsonObject event = parsed.getJsonObject("event");
+
+        assertEquals(DEFAULT_ORG_ID, event.getString("org_id"));
+        assertEquals(DEFAULT_ACCOUNT_ID, event.getString("account_id"));
+        assertEquals("my-app", event.getString("application"));
+        assertEquals("my-bundle", event.getString("bundle"));
+        assertEquals("my-event-type", event.getString("event_type"));
+        assertEquals("2024-01-01T00:00:00Z", event.getString("timestamp"));
+
+        JsonObject source = event.getJsonObject("source");
+        assertNotNull(source);
+        assertEquals("My Bundle", source.getJsonObject("bundle").getString("display_name"));
+        assertEquals("My Application", source.getJsonObject("application").getString("display_name"));
+        assertEquals("My Event Type", source.getJsonObject("event_type").getString("display_name"));
+    }
+
     private void mockAuthentication() {
         SourcesSecretResponse secretResponse = new SourcesSecretResponse();
         secretResponse.password = "my-token";
         when(authenticationLoader.fetchAuthenticationData(anyString(), any(JsonObject.class)))
             .thenReturn(Optional.of(new AuthenticationResult(secretResponse, AuthenticationType.SECRET_TOKEN)));
+    }
+
+    static JsonObject buildSourceField() {
+        return JsonObject.of(
+            "bundle", JsonObject.of("display_name", "My Bundle"),
+            "application", JsonObject.of("display_name", "My Application"),
+            "event_type", JsonObject.of("display_name", "My Event Type")
+        );
     }
 
     private static JsonObject buildPayload(String targetUrl, JsonArray events) {
@@ -557,6 +599,11 @@ class SplunkMessageHandlerTest {
         payload.put("org_id", DEFAULT_ORG_ID);
         payload.put("account_id", DEFAULT_ACCOUNT_ID);
         payload.put("events", events);
+        payload.put("source", buildSourceField());
+        payload.put("application", "my-app");
+        payload.put("bundle", "my-bundle");
+        payload.put("event_type", "my-event-type");
+        payload.put("timestamp", "2024-01-01T00:00:00Z");
 
         return payload;
     }


### PR DESCRIPTION
                                                                                                                                                                             
  **Summary**                                                                                                                                                                    
                                                                                                                                                                             
  Fixes a regression introduced in #4310 (Camel removal from Splunk connector) where most payload fields were silently dropped from the Splunk HEC event body.               
                                                                                                                                                                             
  **Problem**                                                                                                                                                                    
                                                                                                                                                                             
  The engine builds a rich event payload via `BaseTransformer.toJsonObject()` containing fields like `source` (with bundle/application/event_type display names), `application`, `bundle`, `event_type`, `context`, `timestamp`, `severity`, etc.
                                                                                                                                                                             
  The old Camel-based `EventsSplitter` passed this entire payload through as the HEC "event" value. When #4310 refactored to Quarkus, `SplunkNotification` was introduced with only three explicitly mapped fields (`accountId`, `metadata`, `events`). Jackson deserialization silently discarded every unmapped field. Then `buildSplunkPayload()` reconstructed the event body from scratch using only `org_id`, `account_id`, and `events` — losing everything else.                                                                           
                                                                                                                                                                           
  This broke downstream Splunk integrations that rely on the `source` field (and other metadata) inside the HEC event body.                                                    
   
  **Fix**                                                                                                                                                                        
                                                            
  - Added `@JsonAnySetter` to SplunkNotification to capture all payload fields that don't map to explicit properties, preserving them in a `Map<String, Object>`.                
  - Updated `buildSplunkPayload()` to include the captured extra fields in the HEC event body, restoring the full payload structure.
  - Updated tests to include `source`, `application`, `bundle`, `event_type`, and `timestamp` in test payloads, with a dedicated test (`testExtraFieldsPreservedInPayload`) verifying the `source` JSON structure flows through end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now capture arbitrary extra top-level fields from incoming Splunk notifications and merge them into outgoing Splunk payloads so each event includes those custom fields.

* **Tests**
  * Expanded integration and unit tests to validate extra fields are preserved, correctly placed in the payload, and represented in the event/source structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->