### PR TITLE
SWATCH-4798: Create new event template for proactive usage notification.

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/UrlEncodingExtension.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/UrlEncodingExtension.java
@@ -1,0 +1,25 @@
+package com.redhat.cloud.notifications.qute.templates.extensions;
+
+import io.quarkus.qute.TemplateExtension;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Qute helper methods for URL-safe rendering in templates.
+ */
+public class UrlEncodingExtension {
+
+    /**
+     * Percent-encodes a URL path segment using UTF-8 and "%20" for spaces.
+     *
+     * @param value raw path segment value
+     * @return encoded value, or an empty string when input is {@code null}
+     */
+    @TemplateExtension
+    public static String urlEncode(String value) {
+        if (value == null) {
+            return "";
+        }
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+}

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/SubscriptionServices.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/SubscriptionServices.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.DRAWER;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_BODY;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_DAILY_DIGEST_BODY;
-import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_TITLE;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.GOOGLE_CHAT;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.MS_TEAMS;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.SLACK;
@@ -30,6 +29,7 @@ public class SubscriptionServices {
     public static final String ERRATA_NEW_SUBSCRIPTION_ENHANCEMENT_ERRATA = "new-subscription-enhancement-errata";
 
     public static final String SUBSCRIPTIONS_USAGE_EXCEEDED_UTILIZATION_THRESHOLD = "exceeded-utilization-threshold";
+    public static final String SUBSCRIPTIONS_USAGE_EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD = "exceeded-custom-utilization-threshold";
 
     public static final Map<TemplateDefinition, String> templatesMap = Map.ofEntries(
 
@@ -57,7 +57,7 @@ public class SubscriptionServices {
         entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, APPLICATION_SERVICES_APP_NAME, null), APPLICATION_SERVICES_FOLDER_NAME + "dailyEmailBody.html"),
 
         // Subscriptions Usage
-        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, SUBSCRIPTIONS_USAGE_APP_NAME, SUBSCRIPTIONS_USAGE_EXCEEDED_UTILIZATION_THRESHOLD), SUBSCRIPTIONS_USAGE_FOLDER_NAME + "usageThresholdExceededEmailTitle.txt"),
-        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SUBSCRIPTIONS_USAGE_APP_NAME, SUBSCRIPTIONS_USAGE_EXCEEDED_UTILIZATION_THRESHOLD), SUBSCRIPTIONS_USAGE_FOLDER_NAME + "usageThresholdExceededEmailBody.html")
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SUBSCRIPTIONS_USAGE_APP_NAME, SUBSCRIPTIONS_USAGE_EXCEEDED_UTILIZATION_THRESHOLD), SUBSCRIPTIONS_USAGE_FOLDER_NAME + "usageThresholdExceededEmailBody.html"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, SUBSCRIPTIONS_USAGE_APP_NAME, SUBSCRIPTIONS_USAGE_EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD), SUBSCRIPTIONS_USAGE_FOLDER_NAME + "customUtilizationThresholdExceededEmailBody.html")
     );
 }

--- a/common-template/src/main/resources/templates/email/SubscriptionsUsage/customUtilizationThresholdExceededEmailBody.html
+++ b/common-template/src/main/resources/templates/email/SubscriptionsUsage/customUtilizationThresholdExceededEmailBody.html
@@ -1,0 +1,53 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    Subscriptions Usage - Subscription Services
+{/content-header-title}
+{#content-title}
+    Proactive subscription usage notification: Usage at custom percentage limit reached
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        Product variant: <b>{action.context.product_id}</b>
+    </p>
+    {#if action.context.service_level??}
+    <p style="{body-section-p-style}">
+        SLA: <b>{action.context.service_level}</b>
+    </p>
+    {/if}
+    {#if action.context.usage??}
+    <p style="{body-section-p-style}">
+        Usage: <b>{action.context.usage}</b>
+    </p>
+    {/if}
+    <p style="{body-section-p-style}">
+        Organization: <b>{action.orgId}</b>
+    </p>
+
+    <p>
+        <strong>Proactive usage information</strong>
+    </p>
+
+    <p style="{body-section-p-style}">
+        Your subscription usage for this organization has exceeded your custom threshold. This notification helps you take action before reaching your subscription capacity limit. Your current subscription usage is shown as a utilization percentage below.
+    </p>
+
+    <table style="{body-section-table-style}">
+        <thead>
+            <tr>
+                <th style="{body-section-table-th-style} width: 30%">Usage metric</th>
+                <th style="{body-section-table-th-style} width: 60%">Subscription threshold utilization</th>
+            </tr>
+        </thead>
+        <tbody style="{body-section-table-tbody-style}">
+            <tr style="{body-section-table-tr-style}">
+                <td style="{body-section-table-td-style}">{action.context.metric_id}</td>
+                <td style="{body-section-table-td-style}">{action.events[0].payload.utilization_percentage}%</td>
+            </tr>
+        </tbody>
+    </table>
+    <br>
+    <p style="{body-section-p-style}">View your subscription usage data in the Subscriptions Usage service. To learn more about how subscription usage is calculated, see <a style="{body-section-underline-link-style}" href="https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/index" target="_blank" rel="noopener noreferrer">Getting Started with the Subscriptions Usage Service</a>. For additional help, contact your Red Hat account team.</p>
+{/content-body}
+{#content-button-href}{environment.url}/subscriptions/usage/{action.context.product_id.urlEncode}?{query_params}{/content-button-href}
+{#content-button-service-name}Subscription Usage{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/SubscriptionsUsage/usageThresholdExceededEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/SubscriptionsUsage/usageThresholdExceededEmailTitle.txt
@@ -1,1 +1,0 @@
-{action.severity.or('').severityAsEmailTitle}Instant notification - Subscription threshold exceeded - Subscriptions usage - Subscription services

--- a/common-template/src/test/java/email/TestSubscriptionsUsageTemplate.java
+++ b/common-template/src/test/java/email/TestSubscriptionsUsageTemplate.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.qute.templates.Severity;
 import helpers.SubscriptionsUsageTestHelpers;
 import helpers.TestHelpers;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestSubscriptionsUsageTemplate extends EmailTemplatesRendererHelper {
 
     static final String EXCEEDED_UTILIZATION_THRESHOLD = "exceeded-utilization-threshold";
+    static final String EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD = "exceeded-custom-utilization-threshold";
 
     private static final Action ACTION = SubscriptionsUsageTestHelpers.createSubscriptionsUsageAction();
 
@@ -40,17 +42,22 @@ public class TestSubscriptionsUsageTemplate extends EmailTemplatesRendererHelper
         return "Subscriptions Usage";
     }
 
+    @AfterEach
+    void cleanup() {
+        ACTION.setSeverity(null);
+        eventTypeDisplayName = null;
+    }
+
     @Test
     public void testUsageThresholdExceededEmailTitle() {
         eventTypeDisplayName = "Subscription threshold exceeded";
         String result = generateEmailSubject(EXCEEDED_UTILIZATION_THRESHOLD, ACTION);
-        assertEquals("Instant notification - Subscription threshold exceeded - Subscriptions usage - Subscription services", result);
+        assertEquals("Instant notification - Subscription threshold exceeded - Subscriptions Usage - Subscription Services", result);
 
         // Test with Low severity level
-        Action lowAction = ACTION;
-        lowAction.setSeverity(Severity.LOW.name());
-        String lowResult = generateEmailSubject(EXCEEDED_UTILIZATION_THRESHOLD, lowAction);
-        assertEquals("[LOW] Instant notification - Subscription threshold exceeded - Subscriptions usage - Subscription services", lowResult);
+        ACTION.setSeverity(Severity.LOW.name());
+        String lowResult = generateEmailSubject(EXCEEDED_UTILIZATION_THRESHOLD, ACTION);
+        assertEquals("[LOW] Instant notification - Subscription threshold exceeded - Subscriptions Usage - Subscription Services", lowResult);
     }
 
     @ParameterizedTest
@@ -98,6 +105,69 @@ public class TestSubscriptionsUsageTemplate extends EmailTemplatesRendererHelper
     public void testUsageThresholdExceededEmailBodyWithoutSlaAndUsage(boolean useBetaTemplate) {
         Action actionWithoutSlaAndUsage = SubscriptionsUsageTestHelpers.createSubscriptionsUsageActionWithoutSlaAndUsage();
         String result = generateEmailBody(EXCEEDED_UTILIZATION_THRESHOLD, actionWithoutSlaAndUsage, useBetaTemplate);
+        assertFalse(result.contains("SLA:"));
+        assertFalse(result.contains("Usage:"));
+    }
+
+    @Test
+    public void testExceededCustomUtilizationThresholdEmailTitle() {
+        eventTypeDisplayName = "Usage at custom percentage limit reached";
+        String result = generateEmailSubject(EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD, ACTION);
+        assertEquals("Instant notification - Usage at custom percentage limit reached - Subscriptions Usage - Subscription Services", result);
+
+        // Test with Low severity level
+        ACTION.setSeverity(Severity.LOW.name());
+        String lowResult = generateEmailSubject(EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD, ACTION);
+        assertEquals("[LOW] Instant notification - Usage at custom percentage limit reached - Subscriptions Usage - Subscription Services", lowResult);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testExceededCustomUtilizationThresholdEmailBody(boolean useBetaTemplate) {
+        String result = generateEmailBody(EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD, ACTION, useBetaTemplate);
+        assertTrue(result.contains("Subscriptions Usage - Subscription Services"));
+        assertTrue(result.contains("Proactive subscription usage notification: Usage at custom percentage limit reached"));
+        assertTrue(result.contains("Product variant: <b>RHEL for x86</b>"));
+        assertTrue(result.contains("SLA: <b>Premium</b>"));
+        assertTrue(result.contains("Usage: <b>Production</b>"));
+        assertTrue(result.contains("Organization: <b>" + TestHelpers.DEFAULT_ORG_ID + "</b>"));
+        // Proactive usage information section
+        assertTrue(result.contains("Proactive usage information"));
+        assertTrue(result.contains("Your subscription usage for this organization has exceeded your custom threshold."));
+        // Table headers
+        assertTrue(result.contains("Usage metric"));
+        assertTrue(result.contains("Subscription threshold utilization"));
+        // Table values
+        assertTrue(result.contains(">sockets<") || result.contains("sockets</td>"));
+        assertTrue(result.contains(">105%<") || result.contains("105%</td>"));
+        assertTrue(result.contains("Getting Started with the Subscriptions Usage Service"));
+        // Verify URL contains encoded product_id in path
+        assertTrue(result.contains("/subscriptions/usage/RHEL%20for%20x86?"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testExceededCustomUtilizationThresholdEmailBodyWithSlaOnly(boolean useBetaTemplate) {
+        Action actionWithSlaOnly = SubscriptionsUsageTestHelpers.createSubscriptionsUsageActionWithSlaOnly();
+        String result = generateEmailBody(EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD, actionWithSlaOnly, useBetaTemplate);
+        assertTrue(result.contains("SLA: <b>Premium</b>"));
+        assertFalse(result.contains("Usage:"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testExceededCustomUtilizationThresholdEmailBodyWithUsageOnly(boolean useBetaTemplate) {
+        Action actionWithUsageOnly = SubscriptionsUsageTestHelpers.createSubscriptionsUsageActionWithUsageOnly();
+        String result = generateEmailBody(EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD, actionWithUsageOnly, useBetaTemplate);
+        assertFalse(result.contains("SLA:"));
+        assertTrue(result.contains("Usage: <b>Production</b>"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testExceededCustomUtilizationThresholdEmailBodyWithoutSlaAndUsage(boolean useBetaTemplate) {
+        Action actionWithoutSlaAndUsage = SubscriptionsUsageTestHelpers.createSubscriptionsUsageActionWithoutSlaAndUsage();
+        String result = generateEmailBody(EXCEEDED_CUSTOM_UTILIZATION_THRESHOLD, actionWithoutSlaAndUsage, useBetaTemplate);
         assertFalse(result.contains("SLA:"));
         assertFalse(result.contains("Usage:"));
     }


### PR DESCRIPTION
Summary

This PR adds the new proactive email template as described in [SWATCH-4798](https://redhat.atlassian.net/browse/SWATCH-4798). 

I also added a cleanup logic in the template tests and added tests for the new template.

Naming conventions and wording has been discussed with Brandi (docs) 

[SWATCH-4798]: https://redhat.atlassian.net/browse/SWATCH-4798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom utilization threshold email notifications with dedicated email body and severity-aware titles; SLA and usage details conditionally shown and links include encoded product paths.

* **Bug Fixes**
  * Consolidated standard threshold email subject handling to avoid duplicate/ambiguous titles.

* **Tests**
  * Added tests covering custom threshold email subjects and body variants (with/without SLA or usage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->