### PR TITLE
[RHCLOUD-47531] Switch maven central repo for Konflux builds

### DIFF
--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,10 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>google-maven-central</id>
+      <name>Google Maven Central Mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
+wrapperUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/docker/Dockerfile.notifications-aggregator.jvm
+++ b/docker/Dockerfile.notifications-aggregator.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests -pl :notifications-aggregator -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -DskipTests -pl :notifications-aggregator -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-backend.jvm
+++ b/docker/Dockerfile.notifications-backend.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests -pl :notifications-backend -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -DskipTests -pl :notifications-backend -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-connector-drawer.jvm
+++ b/docker/Dockerfile.notifications-connector-drawer.jvm
@@ -45,7 +45,7 @@ ENV PATH=${JAVA_HOME}/bin:${PATH}
 COPY . /home/jboss
 WORKDIR /home/jboss
 # '-Dquarkus.native.container-build=false' option disables containerized native image building, because the build is already running inside the Mandrel builder container
-RUN ./mvnw clean package \
+RUN ./mvnw -s .mvn/settings.xml clean package \
     -Dquarkus.package.type=native \
     -Dquarkus.native.container-build=false \
     -Dquarkus.kafka.snappy.enabled=true \

--- a/docker/Dockerfile.notifications-connector-email.jvm
+++ b/docker/Dockerfile.notifications-connector-email.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-email -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-email -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-connector-google-chat.jvm
+++ b/docker/Dockerfile.notifications-connector-google-chat.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-google-chat -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-google-chat -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
+++ b/docker/Dockerfile.notifications-connector-microsoft-teams.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-microsoft-teams -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-microsoft-teams -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-connector-pagerduty.jvm
+++ b/docker/Dockerfile.notifications-connector-pagerduty.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-pagerduty -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-pagerduty -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-connector-servicenow.jvm
+++ b/docker/Dockerfile.notifications-connector-servicenow.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-servicenow -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-servicenow -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-connector-slack.jvm
+++ b/docker/Dockerfile.notifications-connector-slack.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-slack -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-slack -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-connector-splunk.jvm
+++ b/docker/Dockerfile.notifications-connector-splunk.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-splunk -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-splunk -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-connector-webhook.jvm
+++ b/docker/Dockerfile.notifications-connector-webhook.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-webhook -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-connector-webhook -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-engine.jvm
+++ b/docker/Dockerfile.notifications-engine.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -DskipTests -pl :notifications-engine -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -DskipTests -pl :notifications-engine -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-mcp.jvm
+++ b/docker/Dockerfile.notifications-mcp.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-mcp -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-mcp -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest

--- a/docker/Dockerfile.notifications-recipients-resolver.jvm
+++ b/docker/Dockerfile.notifications-recipients-resolver.jvm
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
-RUN ./mvnw clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-recipients-resolver -am --no-transfer-progress
+RUN ./mvnw -s .mvn/settings.xml clean package -Dmaven.test.skip -Dcheckstyle.skip -pl :notifications-recipients-resolver -am --no-transfer-progress
 
 # Build the container
 FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Maven configuration to use a Google-hosted mirror for dependency downloads and updated the Maven wrapper to point to the same mirror, streamlining builds and improving dependency resolution across build environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->