### PR TITLE
SWATCH-4128: Include the product_id in the subscriptions usage link

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/UrlEncodingExtension.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/UrlEncodingExtension.java
@@ -1,0 +1,25 @@
+package com.redhat.cloud.notifications.qute.templates.extensions;
+
+import io.quarkus.qute.TemplateExtension;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Qute helper methods for URL-safe rendering in templates.
+ */
+public class UrlEncodingExtension {
+
+    /**
+     * Percent-encodes a URL path segment using UTF-8 and "%20" for spaces.
+     *
+     * @param value raw path segment value
+     * @return encoded value, or an empty string when input is {@code null}
+     */
+    @TemplateExtension
+    public static String urlEncode(String value) {
+        if (value == null) {
+            return "";
+        }
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+}

--- a/common-template/src/main/resources/templates/email/SubscriptionsUsage/usageThresholdExceededEmailBody.html
+++ b/common-template/src/main/resources/templates/email/SubscriptionsUsage/usageThresholdExceededEmailBody.html
@@ -48,6 +48,6 @@
     <br>
     <p style="{body-section-p-style}">View your subscription usage data in the Subscriptions Usage service. To learn more about how subscription usage is calculated, see <a style="{body-section-underline-link-style}" href="https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/index" target="_blank" rel="noopener noreferrer">Getting Started with the Subscriptions Usage Service</a>. For additional help, contact your Red Hat account team.</p>
 {/content-body}
-{#content-button-href}{environment.url}/subscriptions/usage?{query_params}{/content-button-href}
+{#content-button-href}{environment.url}/subscriptions/usage/{action.context.product_id.urlEncode}?{query_params}{/content-button-href}
 {#content-button-service-name}Subscription Usage{/content-button-service-name}
 {/include}

--- a/common-template/src/test/java/email/TestSubscriptionsUsageTemplate.java
+++ b/common-template/src/test/java/email/TestSubscriptionsUsageTemplate.java
@@ -57,6 +57,7 @@ public class TestSubscriptionsUsageTemplate extends EmailTemplatesRendererHelper
     @ValueSource(booleans = {true, false})
     public void testUsageThresholdExceededEmailBody(boolean useBetaTemplate) {
         String result = generateEmailBody(EXCEEDED_UTILIZATION_THRESHOLD, ACTION, useBetaTemplate);
+        assertTrue(result.contains("/subscriptions/usage/RHEL%20for%20x86?"));
         assertTrue(result.contains("Subscriptions Usage - Subscription Services"));
         assertTrue(result.contains("Subscription threshold exceeded"));
         assertTrue(result.contains("Product variant: <b>RHEL for x86</b>"));


### PR DESCRIPTION
After fixing the frontend product resolution logic (which is compatible spaces), we can now add the product_id into the subscriptions usage link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the subscription usage email notification link to include product-specific routing for more accurate navigation.

* **Tests**
  * Updated tests to verify the email notification link now correctly includes product-specific information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->