### PR TITLE
[RHCLOUD-47442] Fix environment propety serialization format

### DIFF
--- a/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/Environment.java
+++ b/connector-email/src/main/java/com/redhat/cloud/notifications/connector/email/model/aggregation/Environment.java
@@ -1,9 +1,7 @@
 package com.redhat.cloud.notifications.connector.email.model.aggregation;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record Environment(
-    @JsonProperty("url")        String url,
-    @JsonProperty("ocm_url")    String ocmUrl,
-    @JsonProperty("application_services_url")    String applicationServicesUrl
+    String url,
+    String ocmUrl,
+    String applicationServicesUrl
 ) { }

--- a/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/model/aggregation/EnvironmentTest.java
+++ b/connector-email/src/test/java/com/redhat/cloud/notifications/connector/email/model/aggregation/EnvironmentTest.java
@@ -1,0 +1,28 @@
+package com.redhat.cloud.notifications.connector.email.model.aggregation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EnvironmentTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void testDeserializationFromCamelCaseKeys() throws Exception {
+        String json = """
+            {
+                "url": "https://console.redhat.com",
+                "ocmUrl": "https://ocm.redhat.com",
+                "applicationServicesUrl": "https://app-services.redhat.com/"
+            }
+            """;
+
+        Environment env = objectMapper.readValue(json, Environment.class);
+
+        assertEquals("https://console.redhat.com", env.url());
+        assertEquals("https://ocm.redhat.com", env.ocmUrl());
+        assertEquals("https://app-services.redhat.com/", env.applicationServicesUrl());
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/templates/models/EnvironmentTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/templates/models/EnvironmentTest.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.templates.models;
 
 import com.redhat.cloud.notifications.models.Environment;
 import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -32,5 +33,18 @@ public class EnvironmentTest {
     @Test
     void testUrlDefaultValue() {
         Assertions.assertEquals(expectedTestEnvUrlValue, this.environment.url(), "unexpected default value for the environment's URL");
+    }
+
+    @Test
+    void testJsonSerializationUsesCamelCaseKeys() {
+        JsonObject json = JsonObject.mapFrom(environment);
+
+        Assertions.assertTrue(json.containsKey("url"), "expected key 'url'");
+        Assertions.assertTrue(json.containsKey("ocmUrl"), "expected camelCase key 'ocmUrl'");
+        Assertions.assertTrue(json.containsKey("applicationServicesUrl"), "expected camelCase key 'applicationServicesUrl'");
+
+        Assertions.assertEquals(expectedTestEnvUrlValue, json.getString("url"));
+        Assertions.assertEquals(expectedTestEnvUrlValue, json.getString("ocmUrl"));
+        Assertions.assertEquals("https://localhost/", json.getString("applicationServicesUrl"));
     }
 }


### PR DESCRIPTION
For daily digest email processing, engine module produce camel case serialization for Environment url properties, while email connector expects snake case.
We need to align those to camel case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched environment configuration JSON naming to camelCase (removed explicit custom property annotations).

* **Tests**
  * Added serialization and deserialization tests to validate camelCase JSON keys for environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->