### PR TITLE
Add missing '/' in lifecycle url

### DIFF
--- a/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
@@ -32,7 +32,7 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
         sub-section-expiring-months = 3
         sub-section-not-the-last = (rhel10SystemsCount + rhel9SystemsCount + rhel8SystemsCount)
         sub-section-retired-url = '{environment.url}/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
-        sub-section-expiring-url = '{environment.url}insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
+        sub-section-expiring-url = '{environment.url}/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
         }
     {#insert content-common-section}{/}
     {/let}


### PR DESCRIPTION
On line 35, there was a url with a missing '/'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL formatting issue in RHEL lifecycle retirement notification emails, ensuring the "Near retirement" link is properly constructed and functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->