### PR TITLE
RHCLOUD-46284 Prepare cross-clusters communication test with Sources

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -327,8 +327,8 @@ parameters:
 - name: QUARKUS_HIBERNATE_ORM_LOG_SQL
   value: "false"
 - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
-  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
-  value: "http://localhost:8000"
+  description: Override URL for the OIDC-authenticated Sources Service REST client. Must be set to the HCC cluster Sources endpoint when enabling sources-hcc-cluster toggle. Leave empty to use the default Clowder-managed endpoint.
+  value: ""
 - name: READINESS_INITIAL_DELAY
   value: "40"
 - name: READINESS_FAILURE_THRESHOLD

--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -194,6 +194,8 @@ objects:
               name: sources-api-psk
               key: psk
               optional: true
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
         - name: QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL
           value: ${OIDC_ISSUER}
         - name: QUARKUS_OIDC_CLIENT_CLIENT_ENABLED
@@ -324,6 +326,9 @@ parameters:
   value: "false"
 - name: QUARKUS_HIBERNATE_ORM_LOG_SQL
   value: "false"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: READINESS_INITIAL_DELAY
   value: "40"
 - name: READINESS_FAILURE_THRESHOLD

--- a/.rhcicd/clowdapp-connector-pagerduty.yaml
+++ b/.rhcicd/clowdapp-connector-pagerduty.yaml
@@ -220,8 +220,8 @@ parameters:
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
 - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
-  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
-  value: "http://localhost:8000"
+  description: Override URL for the OIDC-authenticated Sources Service REST client. Must be set to the HCC cluster Sources endpoint when enabling sources-hcc-cluster toggle. Leave empty to use the default Clowder-managed endpoint.
+  value: ""
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/.rhcicd/clowdapp-connector-pagerduty.yaml
+++ b/.rhcicd/clowdapp-connector-pagerduty.yaml
@@ -69,6 +69,8 @@ objects:
             secretKeyRef:
               name: sources-api-psk
               key: psk
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
         - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
           value: ${NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_CONNECT_TIMEOUT_MS
@@ -217,6 +219,9 @@ parameters:
 - name: QUARKUS_LOG_CLOUDWATCH_MAX_QUEUE_SIZE
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/.rhcicd/clowdapp-connector-servicenow.yaml
+++ b/.rhcicd/clowdapp-connector-servicenow.yaml
@@ -220,8 +220,8 @@ parameters:
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
 - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
-  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
-  value: "http://localhost:8000"
+  description: Override URL for the OIDC-authenticated Sources Service REST client. Must be set to the HCC cluster Sources endpoint when enabling sources-hcc-cluster toggle. Leave empty to use the default Clowder-managed endpoint.
+  value: ""
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/.rhcicd/clowdapp-connector-servicenow.yaml
+++ b/.rhcicd/clowdapp-connector-servicenow.yaml
@@ -69,6 +69,8 @@ objects:
             secretKeyRef:
               name: sources-api-psk
               key: psk
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
         - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
           value: ${NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_CONNECT_TIMEOUT_MS
@@ -217,6 +219,9 @@ parameters:
 - name: QUARKUS_LOG_CLOUDWATCH_MAX_QUEUE_SIZE
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -220,8 +220,8 @@ parameters:
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
 - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
-  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
-  value: "http://localhost:8000"
+  description: Override URL for the OIDC-authenticated Sources Service REST client. Must be set to the HCC cluster Sources endpoint when enabling sources-hcc-cluster toggle. Leave empty to use the default Clowder-managed endpoint.
+  value: ""
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -69,6 +69,8 @@ objects:
             secretKeyRef:
               name: sources-api-psk
               key: psk
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
         - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
           value: ${NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_CONNECT_TIMEOUT_MS
@@ -217,6 +219,9 @@ parameters:
 - name: QUARKUS_LOG_CLOUDWATCH_MAX_QUEUE_SIZE
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/.rhcicd/clowdapp-connector-webhook.yaml
+++ b/.rhcicd/clowdapp-connector-webhook.yaml
@@ -69,6 +69,8 @@ objects:
             secretKeyRef:
               name: sources-api-psk
               key: psk
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
         - name: NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE
           value: ${NOTIFICATIONS_CONNECTOR_ENDPOINT_CACHE_MAX_SIZE}
         - name: NOTIFICATIONS_CONNECTOR_HTTP_CONNECT_TIMEOUT_MS
@@ -227,6 +229,9 @@ parameters:
 - name: QUARKUS_LOG_CLOUDWATCH_MAX_QUEUE_SIZE
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/.rhcicd/clowdapp-connector-webhook.yaml
+++ b/.rhcicd/clowdapp-connector-webhook.yaml
@@ -230,8 +230,8 @@ parameters:
   description: Optional maximum size of the log events queue. If this is not set, the queue will have a capacity of Integer#MAX_VALUE.
   value: "100000"
 - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
-  description: Override URL for the OIDC-authenticated Sources Service REST client, used to point to the HCC cluster endpoint.
-  value: "http://localhost:8000"
+  description: Override URL for the OIDC-authenticated Sources Service REST client. Must be set to the HCC cluster Sources endpoint when enabling sources-hcc-cluster toggle. Leave empty to use the default Clowder-managed endpoint.
+  value: ""
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -48,7 +48,7 @@ public class BackendConfig {
     private String bypassBehaviorGroupMaxCreationLimitToggle;
     private String ignoreSourcesErrorOnEndpointDeleteToggle;
     private String useCommonTemplateModuleForUserPrefApisToggle;
-    private String sourcesOidcAuthToggle;
+    private String sourcesHccClusterToggle;
     private String toggleUseBetaTemplatesEnabled;
     private String showHiddenEventTypesToggle;
     private String normalizedQueriesToggle;
@@ -128,7 +128,7 @@ public class BackendConfig {
         bypassBehaviorGroupMaxCreationLimitToggle = toggleRegistry.register("bypass-behavior-group-max-creation-limit", true);
         ignoreSourcesErrorOnEndpointDeleteToggle = toggleRegistry.register("ignore-sources-error-on-endpoint-delete", true);
         useCommonTemplateModuleForUserPrefApisToggle = toggleRegistry.register("use-common-template-module-for-user-pref-apis", true);
-        sourcesOidcAuthToggle = toggleRegistry.register("sources-oidc-auth", true);
+        sourcesHccClusterToggle = toggleRegistry.register("sources-hcc-cluster", true);
         toggleUseBetaTemplatesEnabled = toggleRegistry.register("use-beta-templates", true);
         showHiddenEventTypesToggle = toggleRegistry.register("show-hidden-event-types", true);
         normalizedQueriesToggle = toggleRegistry.register("normalized-queries", true);
@@ -151,7 +151,7 @@ public class BackendConfig {
         config.put(RBAC_ENABLED, isRBACEnabled());
         config.put(SECURED_EMAIL_TEMPLATES, useSecuredEmailTemplates);
         config.put(UNLEASH, unleashEnabled);
-        config.put(sourcesOidcAuthToggle, isSourcesOidcAuthEnabled(null));
+        config.put(sourcesHccClusterToggle, isSourcesHccClusterEnabled(null));
         config.put(showHiddenEventTypesToggle, isShowHiddenEventTypes(null));
 
         Log.info("=== Startup configuration ===");
@@ -305,10 +305,10 @@ public class BackendConfig {
         }
     }
 
-    public boolean isSourcesOidcAuthEnabled(String orgId) {
+    public boolean isSourcesHccClusterEnabled(String orgId) {
         if (unleashEnabled) {
             UnleashContext unleashContext = buildUnleashContextWithOrgId(orgId);
-            return unleash.isEnabled(sourcesOidcAuthToggle, unleashContext, false);
+            return unleash.isEnabled(sourcesHccClusterToggle, unleashContext, false);
         } else {
             return false;
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
@@ -73,7 +73,7 @@ public class SecretUtils {
         final Timer.Sample getSecretTimer = Timer.start(this.meterRegistry);
 
         final Secret secret;
-        if (backendConfig.isSourcesOidcAuthEnabled(endpoint.getOrgId())) {
+        if (backendConfig.isSourcesHccClusterEnabled(endpoint.getOrgId())) {
             Log.debug("Using OIDC Sources client");
             secret = this.sourcesOidcService.getById(
                 endpoint.getOrgId(),
@@ -153,7 +153,7 @@ public class SecretUtils {
     private Long updateSecretToken(Endpoint endpoint, String password, Long secretId, String secretType, String logDisplaySecretType) {
         if (secretId != null) {
             if (password == null || password.isBlank()) {
-                if (backendConfig.isSourcesOidcAuthEnabled(endpoint.getOrgId())) {
+                if (backendConfig.isSourcesHccClusterEnabled(endpoint.getOrgId())) {
                     Log.debug("Using OIDC Sources client");
                     this.sourcesOidcService.delete(
                         endpoint.getOrgId(),
@@ -173,7 +173,7 @@ public class SecretUtils {
                 Secret secret = new Secret();
                 secret.password = password;
 
-                if (backendConfig.isSourcesOidcAuthEnabled(endpoint.getOrgId())) {
+                if (backendConfig.isSourcesHccClusterEnabled(endpoint.getOrgId())) {
                     Log.debug("Using OIDC Sources client");
                     this.sourcesOidcService.update(
                         endpoint.getOrgId(),
@@ -227,7 +227,7 @@ public class SecretUtils {
     }
 
     private void deleteSecret(Endpoint endpoint, Long secretId, String logMessageFormat) {
-        if (backendConfig.isSourcesOidcAuthEnabled(endpoint.getOrgId())) {
+        if (backendConfig.isSourcesHccClusterEnabled(endpoint.getOrgId())) {
             Log.debug("Using OIDC Sources client");
             this.sourcesOidcService.delete(
                 endpoint.getOrgId(),
@@ -261,7 +261,7 @@ public class SecretUtils {
 
     private Long createSecret(String orgId, Secret secret) {
         final Secret createdSecret;
-        if (backendConfig.isSourcesOidcAuthEnabled(orgId)) {
+        if (backendConfig.isSourcesHccClusterEnabled(orgId)) {
             Log.debug("Using OIDC Sources client");
             createdSecret = this.sourcesOidcService.create(
                 orgId,

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -108,9 +108,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 # Sources OIDC integration configuration for OIDC-based authentication
 quarkus.rest-client.sources-oidc.read-timeout=1000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OpenTelemetry -- see also jdbc driver above.
 quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317

--- a/connector-common-authentication-v2/src/main/java/com/redhat/cloud/notifications/connector/authentication/v2/AuthenticationLoader.java
+++ b/connector-common-authentication-v2/src/main/java/com/redhat/cloud/notifications/connector/authentication/v2/AuthenticationLoader.java
@@ -53,7 +53,7 @@ public class AuthenticationLoader {
         Timer.Sample timer = Timer.start(meterRegistry);
         SourcesSecretResponse sourcesSecretResponse;
         try {
-            if (connectorConfig.isSourcesOidcAuthEnabled(orgId)) {
+            if (connectorConfig.isSourcesHccClusterEnabled(orgId)) {
                 Log.debug("Using OIDC Sources client");
                 sourcesSecretResponse = sourcesOidcClient.getById(orgId, secretRequest.secretId);
             } else {

--- a/connector-common-authentication-v2/src/test/java/com/redhat/cloud/notifications/connector/authentication/v2/AuthenticationLoaderTest.java
+++ b/connector-common-authentication-v2/src/test/java/com/redhat/cloud/notifications/connector/authentication/v2/AuthenticationLoaderTest.java
@@ -141,7 +141,7 @@ public class AuthenticationLoaderTest {
 
     @Test
     void testOidcAuthenticationFlow() {
-        when(connectorConfig.isSourcesOidcAuthEnabled(anyString())).thenReturn(true);
+        when(connectorConfig.isSourcesHccClusterEnabled(anyString())).thenReturn(true);
 
         SourcesSecretResponse sourcesSecret = new SourcesSecretResponse();
         sourcesSecret.username = "john_doe";

--- a/connector-common-authentication/src/main/java/com/redhat/cloud/notifications/connector/authentication/secrets/SecretsLoader.java
+++ b/connector-common-authentication/src/main/java/com/redhat/cloud/notifications/connector/authentication/secrets/SecretsLoader.java
@@ -49,7 +49,7 @@ public class SecretsLoader implements Processor {
 
             Timer.Sample timer = Timer.start(meterRegistry);
             SourcesSecret sourcesSecret;
-            if (connectorConfig.isSourcesOidcAuthEnabled(orgId)) {
+            if (connectorConfig.isSourcesHccClusterEnabled(orgId)) {
                 Log.debug("Using OIDC Sources client");
                 sourcesSecret = sourcesOidcClient.getById(orgId, secretId);
             } else {

--- a/connector-common-v2/src/main/java/com/redhat/cloud/notifications/connector/v2/ConnectorConfig.java
+++ b/connector-common-v2/src/main/java/com/redhat/cloud/notifications/connector/v2/ConnectorConfig.java
@@ -34,7 +34,7 @@ public class ConnectorConfig {
      */
 
     /*
-     * TODO: This sources-oidc-auth feature toggle is not ideally placed in the base ConnectorConfig class,
+     * TODO: This sources-hcc-cluster feature toggle is not ideally placed in the base ConnectorConfig class,
      * as it's only relevant for connectors that use Sources API authentication (PagerDuty, ServiceNow,
      * Splunk, and Webhook connectors). However, there's no better architectural solution currently available
      * that would allow sharing this toggle across multiple specific connector config classes without
@@ -43,7 +43,7 @@ public class ConnectorConfig {
      * This is a temporary situation - once PSK authentication is fully deprecated and removed from the
      * Sources API integration, this feature toggle can be removed entirely along with all PSK-related code.
      */
-    private String sourcesOidcAuthToggle;
+    private String sourcesHccClusterToggle;
 
     @ConfigProperty(name = UNLEASH, defaultValue = "false")
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
@@ -63,7 +63,7 @@ public class ConnectorConfig {
 
     @PostConstruct
     void postConstruct() {
-        sourcesOidcAuthToggle = toggleRegistry.register("sources-oidc-auth", true);
+        sourcesHccClusterToggle = toggleRegistry.register("sources-hcc-cluster", true);
     }
 
     public void log() {
@@ -78,7 +78,7 @@ public class ConnectorConfig {
         config.put(NAME, connectorName);
         config.put(SUPPORTED_CONNECTOR_HEADERS, supportedConnectorHeaders);
         config.put(UNLEASH, unleashEnabled);
-        config.put(sourcesOidcAuthToggle, isSourcesOidcAuthEnabled(null));
+        config.put(sourcesHccClusterToggle, isSourcesHccClusterEnabled(null));
         return config;
     }
 
@@ -90,10 +90,10 @@ public class ConnectorConfig {
         return supportedConnectorHeaders;
     }
 
-    public boolean isSourcesOidcAuthEnabled(String orgId) {
+    public boolean isSourcesHccClusterEnabled(String orgId) {
         if (unleashEnabled) {
             UnleashContext unleashContext = UnleashContextBuilder.buildUnleashContextWithOrgId(orgId);
-            return unleash.isEnabled(sourcesOidcAuthToggle, unleashContext, false);
+            return unleash.isEnabled(sourcesHccClusterToggle, unleashContext, false);
         } else {
             return false;
         }

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
@@ -47,7 +47,7 @@ public class ConnectorConfig {
      */
 
     /*
-     * TODO: This sources-oidc-auth feature toggle is not ideally placed in the base ConnectorConfig class,
+     * TODO: This sources-hcc-cluster feature toggle is not ideally placed in the base ConnectorConfig class,
      * as it's only relevant for connectors that use Sources API authentication (PagerDuty, ServiceNow,
      * Splunk, and Webhook connectors). However, there's no better architectural solution currently available
      * that would allow sharing this toggle across multiple specific connector config classes without
@@ -56,7 +56,7 @@ public class ConnectorConfig {
      * This is a temporary situation - once PSK authentication is fully deprecated and removed from the
      * Sources API integration, this feature toggle can be removed entirely along with all PSK-related code.
      */
-    private String sourcesOidcAuthToggle;
+    private String sourcesHccClusterToggle;
 
     @ConfigProperty(name = UNLEASH, defaultValue = "false")
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
@@ -119,7 +119,7 @@ public class ConnectorConfig {
 
     @PostConstruct
     void postConstruct() {
-        sourcesOidcAuthToggle = toggleRegistry.register("sources-oidc-auth", true);
+        sourcesHccClusterToggle = toggleRegistry.register("sources-hcc-cluster", true);
     }
 
     public void log() {
@@ -147,7 +147,7 @@ public class ConnectorConfig {
         config.put(SEDA_QUEUE_SIZE, sedaQueueSize);
         config.put(SUPPORTED_CONNECTOR_HEADERS, supportedConnectorHeaders);
         config.put(UNLEASH, unleashEnabled);
-        config.put(sourcesOidcAuthToggle, isSourcesOidcAuthEnabled(null));
+        config.put(sourcesHccClusterToggle, isSourcesHccClusterEnabled(null));
         return config;
     }
 
@@ -211,10 +211,10 @@ public class ConnectorConfig {
         return supportedConnectorHeaders;
     }
 
-    public boolean isSourcesOidcAuthEnabled(String orgId) {
+    public boolean isSourcesHccClusterEnabled(String orgId) {
         if (unleashEnabled) {
             UnleashContext unleashContext = UnleashContextBuilder.buildUnleashContextWithOrgId(orgId);
-            return unleash.isEnabled(sourcesOidcAuthToggle, unleashContext, false);
+            return unleash.isEnabled(sourcesHccClusterToggle, unleashContext, false);
         } else {
             return false;
         }

--- a/connector-pagerduty/src/main/resources/application.properties
+++ b/connector-pagerduty/src/main/resources/application.properties
@@ -33,9 +33,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 
 quarkus.rest-client.sources-oidc.read-timeout=2000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR

--- a/connector-servicenow/src/main/resources/application.properties
+++ b/connector-servicenow/src/main/resources/application.properties
@@ -29,9 +29,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 
 quarkus.rest-client.sources-oidc.read-timeout=2000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR

--- a/connector-splunk/src/main/resources/application.properties
+++ b/connector-splunk/src/main/resources/application.properties
@@ -32,9 +32,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 
 quarkus.rest-client.sources-oidc.read-timeout=2000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR

--- a/connector-webhook/src/main/resources/application.properties
+++ b/connector-webhook/src/main/resources/application.properties
@@ -26,9 +26,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 
 quarkus.rest-client.sources-oidc.read-timeout=2000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR


### PR DESCRIPTION
- Rename the sources-oidc-auth Unleash toggle to sources-hcc-cluster to better reflect its purpose: routing Sources Service calls to the HCC cluster endpoint
- Add a QUARKUS_REST_CLIENT_SOURCES_OIDC_URL environment variable to the ClowdApp deployments, allowing the OIDC-authenticated Sources Service REST client URL to be overridden (defaults to http://localhost:8000)
- Remove the trust-store configuration from the sources-oidc REST client, since cross-cluster communication won't rely on Clowder-managed private endpoint certificates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment templates to include new environment variable for configuring the OIDC Sources Service endpoint URL (defaults to `http://localhost:8000`), allowing runtime override across backend and connector services.
  * Replaced feature toggle mechanism for Sources integration from OIDC authentication to HCC cluster-based selection.
  * Simplified SSL/TLS configuration by removing trust-store settings from Sources OIDC client configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->