### PR TITLE
feat(sources): add cross-cluster OIDC URL override

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -208,6 +208,8 @@ objects:
             secretKeyRef:
               name: oidc-authentication
               key: secret
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -332,6 +334,9 @@ parameters:
   value: "40"
 - name: LIVENESS_FAILURE_THRESHOLD
   value: "3"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: OIDC_CLIENT_ENABLED
   description: If true, the OIDC client will be enabled.
   value: "false"

--- a/.rhcicd/clowdapp-connector-pagerduty.yaml
+++ b/.rhcicd/clowdapp-connector-pagerduty.yaml
@@ -131,6 +131,8 @@ objects:
             secretKeyRef:
               name: oidc-authentication
               key: secret
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
         - name: QUARKUS_UNLEASH_ACTIVE
           value: ${NOTIFICATIONS_UNLEASH_ENABLED}
 parameters:
@@ -194,6 +196,9 @@ parameters:
   value: INFO
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: OIDC_CLIENT_ENABLED
   description: If true, the OIDC client will be enabled.
   value: "false"

--- a/.rhcicd/clowdapp-connector-servicenow.yaml
+++ b/.rhcicd/clowdapp-connector-servicenow.yaml
@@ -131,6 +131,8 @@ objects:
             secretKeyRef:
               name: oidc-authentication
               key: secret
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
         - name: QUARKUS_UNLEASH_ACTIVE
           value: ${NOTIFICATIONS_UNLEASH_ENABLED}
 parameters:
@@ -194,6 +196,9 @@ parameters:
   value: INFO
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: OIDC_CLIENT_ENABLED
   description: If true, the OIDC client will be enabled.
   value: "false"

--- a/.rhcicd/clowdapp-connector-splunk.yaml
+++ b/.rhcicd/clowdapp-connector-splunk.yaml
@@ -131,6 +131,8 @@ objects:
             secretKeyRef:
               name: oidc-authentication
               key: secret
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
         - name: QUARKUS_UNLEASH_ACTIVE
           value: ${NOTIFICATIONS_UNLEASH_ENABLED}
 parameters:
@@ -194,6 +196,9 @@ parameters:
   value: INFO
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: OIDC_CLIENT_ENABLED
   description: If true, the OIDC client will be enabled.
   value: "false"

--- a/.rhcicd/clowdapp-connector-webhook.yaml
+++ b/.rhcicd/clowdapp-connector-webhook.yaml
@@ -135,6 +135,8 @@ objects:
             secretKeyRef:
               name: oidc-authentication
               key: secret
+        - name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+          value: ${QUARKUS_REST_CLIENT_SOURCES_OIDC_URL}
         - name: QUARKUS_UNLEASH_ACTIVE
           value: ${NOTIFICATIONS_UNLEASH_ENABLED}
 parameters:
@@ -204,6 +206,9 @@ parameters:
   value: INFO
 - name: NOTIFICATIONS_UNLEASH_ENABLED
   value: "false"
+- name: QUARKUS_REST_CLIENT_SOURCES_OIDC_URL
+  description: Override URL for the OIDC-authenticated Sources REST client, used to point to the HCC cluster endpoint.
+  value: "http://localhost:8000"
 - name: OIDC_CLIENT_ENABLED
   description: If true, the OIDC client will be enabled.
   value: "false"

--- a/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/config/BackendConfig.java
@@ -48,7 +48,7 @@ public class BackendConfig {
     private String bypassBehaviorGroupMaxCreationLimitToggle;
     private String ignoreSourcesErrorOnEndpointDeleteToggle;
     private String useCommonTemplateModuleForUserPrefApisToggle;
-    private String sourcesOidcAuthToggle;
+    private String sourcesHccClusterToggle;
     private String toggleUseBetaTemplatesEnabled;
     private String showHiddenEventTypesToggle;
     private String normalizedQueriesToggle;
@@ -128,7 +128,7 @@ public class BackendConfig {
         bypassBehaviorGroupMaxCreationLimitToggle = toggleRegistry.register("bypass-behavior-group-max-creation-limit", true);
         ignoreSourcesErrorOnEndpointDeleteToggle = toggleRegistry.register("ignore-sources-error-on-endpoint-delete", true);
         useCommonTemplateModuleForUserPrefApisToggle = toggleRegistry.register("use-common-template-module-for-user-pref-apis", true);
-        sourcesOidcAuthToggle = toggleRegistry.register("sources-oidc-auth", true);
+        sourcesHccClusterToggle = toggleRegistry.register("sources-hcc-cluster", true);
         toggleUseBetaTemplatesEnabled = toggleRegistry.register("use-beta-templates", true);
         showHiddenEventTypesToggle = toggleRegistry.register("show-hidden-event-types", true);
         normalizedQueriesToggle = toggleRegistry.register("normalized-queries", true);
@@ -151,7 +151,7 @@ public class BackendConfig {
         config.put(RBAC_ENABLED, isRBACEnabled());
         config.put(SECURED_EMAIL_TEMPLATES, useSecuredEmailTemplates);
         config.put(UNLEASH, unleashEnabled);
-        config.put(sourcesOidcAuthToggle, isSourcesOidcAuthEnabled(null));
+        config.put(sourcesHccClusterToggle, isSourcesHccClusterEnabled(null));
         config.put(showHiddenEventTypesToggle, isShowHiddenEventTypes(null));
 
         Log.info("=== Startup configuration ===");
@@ -305,10 +305,10 @@ public class BackendConfig {
         }
     }
 
-    public boolean isSourcesOidcAuthEnabled(String orgId) {
+    public boolean isSourcesHccClusterEnabled(String orgId) {
         if (unleashEnabled) {
             UnleashContext unleashContext = buildUnleashContextWithOrgId(orgId);
-            return unleash.isEnabled(sourcesOidcAuthToggle, unleashContext, false);
+            return unleash.isEnabled(sourcesHccClusterToggle, unleashContext, false);
         } else {
             return false;
         }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/sources/SecretUtils.java
@@ -73,7 +73,7 @@ public class SecretUtils {
         final Timer.Sample getSecretTimer = Timer.start(this.meterRegistry);
 
         final Secret secret;
-        if (backendConfig.isSourcesOidcAuthEnabled(endpoint.getOrgId())) {
+        if (backendConfig.isSourcesHccClusterEnabled(endpoint.getOrgId())) {
             Log.debug("Using OIDC Sources client");
             secret = this.sourcesOidcService.getById(
                 endpoint.getOrgId(),
@@ -153,7 +153,7 @@ public class SecretUtils {
     private Long updateSecretToken(Endpoint endpoint, String password, Long secretId, String secretType, String logDisplaySecretType) {
         if (secretId != null) {
             if (password == null || password.isBlank()) {
-                if (backendConfig.isSourcesOidcAuthEnabled(endpoint.getOrgId())) {
+                if (backendConfig.isSourcesHccClusterEnabled(endpoint.getOrgId())) {
                     Log.debug("Using OIDC Sources client");
                     this.sourcesOidcService.delete(
                         endpoint.getOrgId(),
@@ -173,7 +173,7 @@ public class SecretUtils {
                 Secret secret = new Secret();
                 secret.password = password;
 
-                if (backendConfig.isSourcesOidcAuthEnabled(endpoint.getOrgId())) {
+                if (backendConfig.isSourcesHccClusterEnabled(endpoint.getOrgId())) {
                     Log.debug("Using OIDC Sources client");
                     this.sourcesOidcService.update(
                         endpoint.getOrgId(),
@@ -227,7 +227,7 @@ public class SecretUtils {
     }
 
     private void deleteSecret(Endpoint endpoint, Long secretId, String logMessageFormat) {
-        if (backendConfig.isSourcesOidcAuthEnabled(endpoint.getOrgId())) {
+        if (backendConfig.isSourcesHccClusterEnabled(endpoint.getOrgId())) {
             Log.debug("Using OIDC Sources client");
             this.sourcesOidcService.delete(
                 endpoint.getOrgId(),
@@ -261,7 +261,7 @@ public class SecretUtils {
 
     private Long createSecret(String orgId, Secret secret) {
         final Secret createdSecret;
-        if (backendConfig.isSourcesOidcAuthEnabled(orgId)) {
+        if (backendConfig.isSourcesHccClusterEnabled(orgId)) {
             Log.debug("Using OIDC Sources client");
             createdSecret = this.sourcesOidcService.create(
                 orgId,

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -108,9 +108,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 # Sources OIDC integration configuration for OIDC-based authentication
 quarkus.rest-client.sources-oidc.read-timeout=1000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OpenTelemetry -- see also jdbc driver above.
 quarkus.otel.exporter.otlp.traces.endpoint=http://localhost:4317

--- a/connector-common-authentication-v2/src/main/java/com/redhat/cloud/notifications/connector/authentication/v2/AuthenticationLoader.java
+++ b/connector-common-authentication-v2/src/main/java/com/redhat/cloud/notifications/connector/authentication/v2/AuthenticationLoader.java
@@ -53,7 +53,7 @@ public class AuthenticationLoader {
         Timer.Sample timer = Timer.start(meterRegistry);
         SourcesSecretResponse sourcesSecretResponse;
         try {
-            if (connectorConfig.isSourcesOidcAuthEnabled(orgId)) {
+            if (connectorConfig.isSourcesHccClusterEnabled(orgId)) {
                 Log.debug("Using OIDC Sources client");
                 sourcesSecretResponse = sourcesOidcClient.getById(orgId, secretRequest.secretId);
             } else {

--- a/connector-common-authentication-v2/src/test/java/com/redhat/cloud/notifications/connector/authentication/v2/AuthenticationLoaderTest.java
+++ b/connector-common-authentication-v2/src/test/java/com/redhat/cloud/notifications/connector/authentication/v2/AuthenticationLoaderTest.java
@@ -141,7 +141,7 @@ public class AuthenticationLoaderTest {
 
     @Test
     void testOidcAuthenticationFlow() {
-        when(connectorConfig.isSourcesOidcAuthEnabled(anyString())).thenReturn(true);
+        when(connectorConfig.isSourcesHccClusterEnabled(anyString())).thenReturn(true);
 
         SourcesSecretResponse sourcesSecret = new SourcesSecretResponse();
         sourcesSecret.username = "john_doe";

--- a/connector-common-authentication/src/main/java/com/redhat/cloud/notifications/connector/authentication/secrets/SecretsLoader.java
+++ b/connector-common-authentication/src/main/java/com/redhat/cloud/notifications/connector/authentication/secrets/SecretsLoader.java
@@ -49,7 +49,7 @@ public class SecretsLoader implements Processor {
 
             Timer.Sample timer = Timer.start(meterRegistry);
             SourcesSecret sourcesSecret;
-            if (connectorConfig.isSourcesOidcAuthEnabled(orgId)) {
+            if (connectorConfig.isSourcesHccClusterEnabled(orgId)) {
                 Log.debug("Using OIDC Sources client");
                 sourcesSecret = sourcesOidcClient.getById(orgId, secretId);
             } else {

--- a/connector-common-v2/src/main/java/com/redhat/cloud/notifications/connector/v2/ConnectorConfig.java
+++ b/connector-common-v2/src/main/java/com/redhat/cloud/notifications/connector/v2/ConnectorConfig.java
@@ -34,7 +34,7 @@ public class ConnectorConfig {
      */
 
     /*
-     * TODO: This sources-oidc-auth feature toggle is not ideally placed in the base ConnectorConfig class,
+     * TODO: This sources-hcc-cluster feature toggle is not ideally placed in the base ConnectorConfig class,
      * as it's only relevant for connectors that use Sources API authentication (PagerDuty, ServiceNow,
      * Splunk, and Webhook connectors). However, there's no better architectural solution currently available
      * that would allow sharing this toggle across multiple specific connector config classes without
@@ -43,7 +43,7 @@ public class ConnectorConfig {
      * This is a temporary situation - once PSK authentication is fully deprecated and removed from the
      * Sources API integration, this feature toggle can be removed entirely along with all PSK-related code.
      */
-    private String sourcesOidcAuthToggle;
+    private String sourcesHccClusterToggle;
 
     @ConfigProperty(name = UNLEASH, defaultValue = "false")
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
@@ -63,7 +63,7 @@ public class ConnectorConfig {
 
     @PostConstruct
     void postConstruct() {
-        sourcesOidcAuthToggle = toggleRegistry.register("sources-oidc-auth", true);
+        sourcesHccClusterToggle = toggleRegistry.register("sources-hcc-cluster", true);
     }
 
     public void log() {
@@ -78,7 +78,7 @@ public class ConnectorConfig {
         config.put(NAME, connectorName);
         config.put(SUPPORTED_CONNECTOR_HEADERS, supportedConnectorHeaders);
         config.put(UNLEASH, unleashEnabled);
-        config.put(sourcesOidcAuthToggle, isSourcesOidcAuthEnabled(null));
+        config.put(sourcesHccClusterToggle, isSourcesHccClusterEnabled(null));
         return config;
     }
 
@@ -90,10 +90,10 @@ public class ConnectorConfig {
         return supportedConnectorHeaders;
     }
 
-    public boolean isSourcesOidcAuthEnabled(String orgId) {
+    public boolean isSourcesHccClusterEnabled(String orgId) {
         if (unleashEnabled) {
             UnleashContext unleashContext = UnleashContextBuilder.buildUnleashContextWithOrgId(orgId);
-            return unleash.isEnabled(sourcesOidcAuthToggle, unleashContext, false);
+            return unleash.isEnabled(sourcesHccClusterToggle, unleashContext, false);
         } else {
             return false;
         }

--- a/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
+++ b/connector-common/src/main/java/com/redhat/cloud/notifications/connector/ConnectorConfig.java
@@ -47,7 +47,7 @@ public class ConnectorConfig {
      */
 
     /*
-     * TODO: This sources-oidc-auth feature toggle is not ideally placed in the base ConnectorConfig class,
+     * TODO: This sources-hcc-cluster feature toggle is not ideally placed in the base ConnectorConfig class,
      * as it's only relevant for connectors that use Sources API authentication (PagerDuty, ServiceNow,
      * Splunk, and Webhook connectors). However, there's no better architectural solution currently available
      * that would allow sharing this toggle across multiple specific connector config classes without
@@ -56,7 +56,7 @@ public class ConnectorConfig {
      * This is a temporary situation - once PSK authentication is fully deprecated and removed from the
      * Sources API integration, this feature toggle can be removed entirely along with all PSK-related code.
      */
-    private String sourcesOidcAuthToggle;
+    private String sourcesHccClusterToggle;
 
     @ConfigProperty(name = UNLEASH, defaultValue = "false")
     @Deprecated(forRemoval = true, since = "To be removed when we're done migrating to Unleash in all environments")
@@ -119,7 +119,7 @@ public class ConnectorConfig {
 
     @PostConstruct
     void postConstruct() {
-        sourcesOidcAuthToggle = toggleRegistry.register("sources-oidc-auth", true);
+        sourcesHccClusterToggle = toggleRegistry.register("sources-hcc-cluster", true);
     }
 
     public void log() {
@@ -147,7 +147,7 @@ public class ConnectorConfig {
         config.put(SEDA_QUEUE_SIZE, sedaQueueSize);
         config.put(SUPPORTED_CONNECTOR_HEADERS, supportedConnectorHeaders);
         config.put(UNLEASH, unleashEnabled);
-        config.put(sourcesOidcAuthToggle, isSourcesOidcAuthEnabled(null));
+        config.put(sourcesHccClusterToggle, isSourcesHccClusterEnabled(null));
         return config;
     }
 
@@ -211,10 +211,10 @@ public class ConnectorConfig {
         return supportedConnectorHeaders;
     }
 
-    public boolean isSourcesOidcAuthEnabled(String orgId) {
+    public boolean isSourcesHccClusterEnabled(String orgId) {
         if (unleashEnabled) {
             UnleashContext unleashContext = UnleashContextBuilder.buildUnleashContextWithOrgId(orgId);
-            return unleash.isEnabled(sourcesOidcAuthToggle, unleashContext, false);
+            return unleash.isEnabled(sourcesHccClusterToggle, unleashContext, false);
         } else {
             return false;
         }

--- a/connector-pagerduty/src/main/resources/application.properties
+++ b/connector-pagerduty/src/main/resources/application.properties
@@ -33,9 +33,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 
 quarkus.rest-client.sources-oidc.read-timeout=2000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR

--- a/connector-servicenow/src/main/resources/application.properties
+++ b/connector-servicenow/src/main/resources/application.properties
@@ -29,9 +29,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 
 quarkus.rest-client.sources-oidc.read-timeout=2000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR

--- a/connector-splunk/src/main/resources/application.properties
+++ b/connector-splunk/src/main/resources/application.properties
@@ -32,9 +32,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 
 quarkus.rest-client.sources-oidc.read-timeout=2000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR

--- a/connector-webhook/src/main/resources/application.properties
+++ b/connector-webhook/src/main/resources/application.properties
@@ -26,9 +26,6 @@ quarkus.rest-client.sources.trust-store-type=${clowder.endpoints.sources-api-svc
 
 quarkus.rest-client.sources-oidc.read-timeout=2000
 quarkus.rest-client.sources-oidc.url=${clowder.endpoints.sources-api-svc.url:http://localhost:8000}
-quarkus.rest-client.sources-oidc.trust-store=${clowder.endpoints.sources-api-svc.trust-store-path}
-quarkus.rest-client.sources-oidc.trust-store-password=${clowder.endpoints.sources-api-svc.trust-store-password}
-quarkus.rest-client.sources-oidc.trust-store-type=${clowder.endpoints.sources-api-svc.trust-store-type}
 
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -121,7 +121,7 @@ V2 connectors do not use Kafka reinjection. Exceptions thrown from `MessageHandl
 Connectors needing endpoint authentication use the `connector-common-authentication` (V1) or `connector-common-authentication-v2` module:
 
 1. `AuthenticationLoader.fetchAuthenticationData(orgId, authenticationJson)` calls Sources API to retrieve secrets.
-2. Sources API supports two auth mechanisms behind a feature toggle (`sources-oidc-auth`): OIDC client (via `SourcesOidcClient`) or PSK (via `SourcesPskClient`). PSK is deprecated.
+2. Sources API supports two auth mechanisms behind a feature toggle (`sources-hcc-cluster`): OIDC client (via `SourcesOidcClient`) or PSK (via `SourcesPskClient`). PSK is deprecated.
 3. Authentication types: `BEARER` (Authorization header) and `SECRET_TOKEN` (X-Insight-Token header).
 4. The `AuthenticationRequest` requires both `authenticationType` and `secretId` fields.
 

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -106,7 +106,7 @@ Every new repository method that accesses tenant data must follow this pattern.
 - `SecretUtils` handles the full lifecycle: create, read, update, delete secrets in Sources.
 
 ### 5.2 Dual Authentication to Sources
-- Sources supports two authentication methods, toggled per org via Unleash (`sources-oidc-auth`):
+- Sources supports two authentication methods, toggled per org via Unleash (`sources-hcc-cluster`):
   - **PSK**: Pre-shared key sent in `x-rh-sources-psk` header. Key is in `sources.psk` config property.
   - **OIDC**: OAuth2 client credentials flow via `@OidcClientFilter` annotation on the REST client.
 - PSK client uses internal Sources endpoints (`/internal/v2.0/secrets/{id}`).


### PR DESCRIPTION
## Summary

Replicates the cross-cluster communication pattern from PR #4262 (Export Service) for the Sources API integration, enabling Notifications to call Sources across HCC clusters via the east-west gateway.

**Changes:**
- Rename Unleash toggle `sources-oidc-auth` → `sources-hcc-cluster` across BackendConfig, ConnectorConfig (v1 + v2), and all callers
- Add `QUARKUS_REST_CLIENT_SOURCES_OIDC_URL` env var + parameter to 5 ClowdApp templates (backend, webhook, pagerduty, splunk, servicenow) for HCC cluster endpoint override
- Remove trust-store config from `sources-oidc` REST clients in 5 `application.properties` files (no longer needed for cross-cluster OIDC)
- Update docs (security-guidelines.md, integration-guidelines.md) to reference new toggle name

**Affected modules:** backend, connector-common, connector-common-v2, connector-common-authentication, connector-common-authentication-v2

RHCLOUD-46284

## Test plan
- [ ] Verify Unleash toggle `sources-hcc-cluster` correctly gates OIDC vs PSK client selection
- [ ] Verify `QUARKUS_REST_CLIENT_SOURCES_OIDC_URL` parameter overrides the Sources OIDC REST client URL in all ClowdApp components
- [ ] Confirm existing Sources PSK authentication still works when toggle is disabled
- [ ] Validate cross-cluster Sources API call from Notifications in hccs01ue1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added configurable Sources REST client URL parameter across deployment templates with a default value.
  * Simplified TLS configuration by removing trust-store settings from REST client configurations.

* **Documentation**
  * Updated security and integration guidelines to reflect authentication mechanism reference changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->