### PR TITLE
[RHCLOUD-47863] Fix broken email links: resolve {environment.url} in lifecycle and roadmap templates

### DIFF
--- a/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
@@ -31,8 +31,8 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
         sub-section-expiring-count-id = 'rhelExpiringCount'
         sub-section-expiring-months = 3
         sub-section-not-the-last = (rhel10SystemsCount + rhel9SystemsCount + rhel8SystemsCount)
-        sub-section-retired-url = '{environment.url}/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
-        sub-section-expiring-url = '{environment.url}/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
+        sub-section-retired-url = '/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
+        sub-section-expiring-url = '/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
         }
     {#insert content-common-section}{/}
     {/let}
@@ -48,8 +48,8 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
         sub-section-expiring-count-id = 'rhel10ExpiringCount'
         sub-section-expiring-months = 6
         sub-section-not-the-last = (rhel9SystemsCount + rhel8SystemsCount)
-        sub-section-retired-url = '{environment.url}/insights/planning?lifecycleDropdown=RHEL+10+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
-        sub-section-expiring-url = '{environment.url}/insights/planning?lifecycleDropdown=RHEL+10+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
+        sub-section-retired-url = '/insights/planning?lifecycleDropdown=RHEL+10+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
+        sub-section-expiring-url = '/insights/planning?lifecycleDropdown=RHEL+10+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
         }
     {#insert content-common-section}{/}
     {/let}
@@ -65,8 +65,8 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
         sub-section-expiring-count-id = 'rhel9ExpiringCount'
         sub-section-expiring-months = 6
         sub-section-not-the-last = rhel8SystemsCount
-        sub-section-retired-url = '{environment.url}/insights/planning?lifecycleDropdown=RHEL+9+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
-        sub-section-expiring-url = '{environment.url}/insights/planning?lifecycleDropdown=RHEL+9+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
+        sub-section-retired-url = '/insights/planning?lifecycleDropdown=RHEL+9+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
+        sub-section-expiring-url = '/insights/planning?lifecycleDropdown=RHEL+9+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
         }
     {#insert content-common-section}{/}
     {/let}
@@ -81,8 +81,8 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
         sub-section-expiring-count = rhel8ExpiringCount
         sub-section-expiring-count-id = 'rhel8ExpiringCount'
         sub-section-expiring-months = 6
-        sub-section-retired-url = '{environment.url}/insights/planning?lifecycleDropdown=RHEL+8+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
-        sub-section-expiring-url = '{environment.url}/insights/planning?lifecycleDropdown=RHEL+8+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
+        sub-section-retired-url = '/insights/planning?lifecycleDropdown=RHEL+8+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
+        sub-section-expiring-url = '/insights/planning?lifecycleDropdown=RHEL+8+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
         }
     {#insert content-common-section}{/}
     {/let}
@@ -111,13 +111,13 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
     </tr>
     <tr>
         <td style="width: 50%; padding-right: 8px; vertical-align: top;">
-            <div style="font-size: 32px; font-weight: 600; color: #1f1f1f;"><a style="{body-section-table-td-a-style}" href="{sub-section-retired-url}" target="_blank" id="{sub-section-retired-count-id}">{sub-section-retired-count}</a></div>
+            <div style="font-size: 32px; font-weight: 600; color: #1f1f1f;"><a style="{body-section-table-td-a-style}" href="{environment.url}{sub-section-retired-url}" target="_blank" id="{sub-section-retired-count-id}">{sub-section-retired-count}</a></div>
             <div style="font-size: 14px; color: #6a6e73; margin-top: 4px;">
                 <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_incident.png" alt="" style="width:16px; height:16px; vertical-align:-2px; display: inline-block; margin-right: 4px;" border="0" width="16"/><!--[if mso]>&nbsp;&nbsp;<![endif]-->Releases past retirement
             </div>
         </td>
         <td style="width: 50%; padding-left: 8px; vertical-align: top;">
-            <div style="font-size: 32px; font-weight: 600; color: #1f1f1f;"><a style="{body-section-table-td-a-style}" href="{sub-section-expiring-url}" target="_blank" id="{sub-section-expiring-count-id}">{sub-section-expiring-count}</a></div>
+            <div style="font-size: 32px; font-weight: 600; color: #1f1f1f;"><a style="{body-section-table-td-a-style}" href="{environment.url}{sub-section-expiring-url}" target="_blank" id="{sub-section-expiring-count-id}">{sub-section-expiring-count}</a></div>
             <div style="font-size: 14px; color: #6a6e73; margin-top: 4px;">
                 <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_warning.png" alt="" style="width:16px; height:16px; vertical-align:-2px; display: inline-block; margin-right: 4px;" border="0" width="16"/><!--[if mso]>&nbsp;&nbsp;<![endif]-->Releases retiring within {sub-section-expiring-months} months
             </div>

--- a/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
@@ -19,7 +19,7 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
         sub-section-count-id = 'deprecationsCount'
         sub-section-description = 'Deprecations that could affect your systems'
         sub-section-icon = 'img_incident.png'
-        sub-section-url = '{environment.url}/insights/planning/roadmap/?viewFilter=relevant&type=Deprecations&addedToRoadmap=lastMonthToDate'
+        sub-section-url = '/insights/planning/roadmap/?viewFilter=relevant&type=Deprecations&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 1
     }
     {#insert content-roadmap-section}{/}
@@ -32,7 +32,7 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
         sub-section-count-id = 'changesCount'
         sub-section-description = 'Changes that could affect your systems'
         sub-section-icon = 'img_warning.png'
-        sub-section-url = '{environment.url}/insights/planning/roadmap/?viewFilter=relevant&type=Changes&addedToRoadmap=lastMonthToDate'
+        sub-section-url = '/insights/planning/roadmap/?viewFilter=relevant&type=Changes&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 1
     }
     {#insert content-roadmap-section}{/}
@@ -45,7 +45,7 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
         sub-section-count-id = 'additionsCount'
         sub-section-description = 'Additions &amp; enhancements that could affect your systems'
         sub-section-icon = 'img_info.png'
-        sub-section-url = '{environment.url}/insights/planning/roadmap/?viewFilter=relevant&type=Addition&addedToRoadmap=lastMonthToDate'
+        sub-section-url = '/insights/planning/roadmap/?viewFilter=relevant&type=Addition&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 0
     }
     {#insert content-roadmap-section}{/}
@@ -74,7 +74,7 @@ Red Hat Enterprise Linux - Roadmap monthly report - {action.context.roadmap.repo
     </tr>
     <tr>
         <td style="vertical-align: top;">
-            <div style="font-size: 32px; font-weight: 600; color: #1f1f1f;"><a style="{body-section-table-td-a-style}" href="{sub-section-url}" target="_blank" id="{sub-section-count-id}">{sub-section-count}</a></div>
+            <div style="font-size: 32px; font-weight: 600; color: #1f1f1f;"><a style="{body-section-table-td-a-style}" href="{environment.url}{sub-section-url}" target="_blank" id="{sub-section-count-id}">{sub-section-count}</a></div>
             <div style="font-size: 14px; color: #151515; margin-top: 4px;">
                 <img src="https://console.redhat.com/apps/frontend-assets/email-assets/{sub-section-icon}" alt="" style="width:16px; height:16px; vertical-align:-2px; display: inline-block; margin-right: 4px;" border="0" width="16"/><!--[if mso]>&nbsp;&nbsp;<![endif]-->{sub-section-description}
             </div>

--- a/common-template/src/test/java/email/TestLifecycleTemplate.java
+++ b/common-template/src/test/java/email/TestLifecycleTemplate.java
@@ -81,6 +81,10 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains("id=\"rhelRetiredCount\">6<"), "Body should contain rhel_versions_count for retired RHEL");
         // Verify RHEL near retirement data is present
         assertTrue(result.contains("id=\"rhelExpiringCount\">1<"), "Body should contain rhel_versions_count for near retirement RHEL");
+        // Verify lifecycle URLs are properly resolved with the environment base URL
+        assertTrue(result.contains("href=\"https://localhost/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux"), "Retired RHEL link should contain resolved environment URL");
+        assertTrue(result.contains("href=\"https://localhost/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux"), "Expiring RHEL link should contain resolved environment URL");
+        assertFalse(result.contains("href=\"{environment.url}"), "Links should not contain unresolved template expression");
     }
 
     @Test
@@ -98,6 +102,10 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
         // Verify appstream near retirement data
         assertTrue(result.contains("id=\"rhel8ExpiringCount\">5<"), "Body should contain appstream near retirement count for rhel8");
         assertTrue(result.contains("id=\"rhel9ExpiringCount\">22<"), "Body should contain appstream near retirement count for rhel9");
+        // Verify appstream lifecycle URLs are properly resolved
+        assertTrue(result.contains("href=\"https://localhost/insights/planning?lifecycleDropdown=RHEL+8+Application+Streams"), "RHEL 8 appstream link should contain resolved environment URL");
+        assertTrue(result.contains("href=\"https://localhost/insights/planning?lifecycleDropdown=RHEL+9+Application+Streams"), "RHEL 9 appstream link should contain resolved environment URL");
+        assertTrue(result.contains("href=\"https://localhost/insights/planning?lifecycleDropdown=RHEL+10+Application+Streams"), "RHEL 10 appstream link should contain resolved environment URL");
     }
 
     @Test

--- a/common-template/src/test/java/email/TestRoadmapTemplate.java
+++ b/common-template/src/test/java/email/TestRoadmapTemplate.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import static com.redhat.cloud.notifications.qute.templates.mapping.Rhel.ROADMAP_REPORT;
 import static helpers.TestHelpers.DEFAULT_ORG_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
@@ -78,6 +79,11 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains("id=\"deprecationsCount\">5<"), "Body should contain deprecations count");
         assertTrue(result.contains("id=\"changesCount\">3<"), "Body should contain changes count");
         assertTrue(result.contains("id=\"additionsCount\">4<"), "Body should contain additions count");
+        // Verify roadmap URLs are properly resolved with the environment base URL
+        assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Deprecations"), "Deprecations link should contain resolved environment URL");
+        assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Changes"), "Changes link should contain resolved environment URL");
+        assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Addition"), "Additions link should contain resolved environment URL");
+        assertFalse(result.contains("href=\"{environment.url}"), "Links should not contain unresolved template expression");
     }
 
     @Test


### PR DESCRIPTION
## Summary
  - Fix broken links in lifecycle and roadmap email templates where Gmail strips the `href` attribute
  - Root cause: `{environment.url}` inside Qute `{#let}` string literals is treated as literal text, not evaluated — producing invalid URLs like `href="{environment.url}/insights/planning?..."`
  - Fix: moved `{environment.url}` out of string literals and prepended it as a Qute expression at the point of use (`href="{environment.url}{sub-section-url}"`)
  - Added test assertions to verify URLs are properly resolved and no unresolved template expressions remain

  ## Test plan
  - [x] All `TestLifecycleTemplate` tests pass (13 tests)
  - [x] All `TestRoadmapTemplate` tests pass (10 tests)
  - [x] Verified rendered HTML output contains `https://` URLs instead of `{environment.url}` literals
  - [ ] Send a test email and confirm links are clickable in Gmail

  🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed email link generation in lifecycle planning and roadmap emails to ensure proper URL resolution when users access links in notifications.
  * Improved handling of environment-specific URLs in email templates.

* **Tests**
  * Added additional test coverage for email links to verify correct resolution across different planning categories and lifecycle stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->