### PR TITLE
Fix export url in scheduler templates

### DIFF
--- a/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
@@ -1,1 +1,1 @@
-A scheduled export **[{data.context.job_name}]({environment.url()}/api/exports/v1/exports/{data.context.export_id})** has completed.
+A scheduled export **[{data.context.job_name}]({environment.url()}/api/export/v1/exports/{data.context.export_id})** has completed.

--- a/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
@@ -8,7 +8,7 @@
 {#content-body}
     <p style="{body-section-p-style}">
         The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}?{query_params}" target="_blank">{action.context.job_name}</a> scheduled export has completed successfully.
-        <a style="{body-section-underline-link-style}" href="{environment.url}/api/exports/v1/exports/{action.context.export_id}?{query_params}" target="_blank">Download exported data</a>.
+        <a style="{body-section-underline-link-style}" href="{environment.url}/api/export/v1/exports/{action.context.export_id}?{query_params}" target="_blank">Download exported data</a>.
     </p>
 {/content-body}
 {#content-button-href}{environment.url}/insights/jobs/{action.context.job_id}{/content-button-href}

--- a/common-template/src/test/java/drawer/TestSchedulerTemplate.java
+++ b/common-template/src/test/java/drawer/TestSchedulerTemplate.java
@@ -28,7 +28,7 @@ class TestSchedulerTemplate {
         String result = renderTemplate(SCHEDULER_EXPORT_COMPLETE, action);
         assertTrue(result.contains("A scheduled export"));
         assertTrue(result.contains("**[Test Export Job]"));
-        assertTrue(result.contains("/api/exports/v1/exports/export-67890)**"));
+        assertTrue(result.contains("/api/export/v1/exports/export-67890)**"));
         assertTrue(result.contains("has completed"));
     }
 


### PR DESCRIPTION
Fix export url in scheduler templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the API endpoint path for exported data downloads referenced in completion notifications and emails to ensure download links function correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->