### PR TITLE
Update let block conditions for lifecycle notification

### DIFF
--- a/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
@@ -10,19 +10,22 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
     rhelRetiredCount = action.events[0].payload.rhel_retired.orEmpty.rhel_versions_count.or(0)
     rhelExpiringCount = action.events[0].payload.rhel_near_retirement.orEmpty.rhel_versions_count.or(0)
     rhelSystemsCount = action.events[0].payload.rhel_retired.orEmpty.systems_count.or(0)
+    rhel10Data = action.events[0].payload.appstream_retired.orEmpty.rhel10.orEmpty
     rhel10RetiredCount = action.events[0].payload.appstream_retired.orEmpty.rhel10.orEmpty.count.or(0)
     rhel10ExpiringCount = action.events[0].payload.appstream_near_retirement.orEmpty.rhel10.orEmpty.count.or(0)
     rhel10SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel10.orEmpty.systems_count.or(0)
+    rhel9Data = action.events[0].payload.appstream_retired.orEmpty.rhel9.orEmpty
     rhel9RetiredCount = action.events[0].payload.appstream_retired.orEmpty.rhel9.orEmpty.count.or(0)
     rhel9ExpiringCount = action.events[0].payload.appstream_near_retirement.orEmpty.rhel9.orEmpty.count.or(0)
     rhel9SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel9.orEmpty.systems_count.or(0)
+    rhel8Data = action.events[0].payload.appstream_retired.orEmpty.rhel8.orEmpty
     rhel8RetiredCount = action.events[0].payload.appstream_retired.orEmpty.rhel8.orEmpty.count.or(0)
     rhel8ExpiringCount = action.events[0].payload.appstream_near_retirement.orEmpty.rhel8.orEmpty.count.or(0)
     rhel8SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel8.orEmpty.systems_count.or(0)
 }
 <table style="width: 100%; border: 0">
 {! RHEL life cycle section !}
-{#if rhelSystemsCount > 0}
+{#if action.events[0].payload.rhel_retired}
     {#let
         sub-section-title = 'RHEL life cycle'
         sub-section-retired-count = rhelRetiredCount
@@ -30,7 +33,7 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
         sub-section-expiring-count = rhelExpiringCount
         sub-section-expiring-count-id = 'rhelExpiringCount'
         sub-section-expiring-months = 3
-        sub-section-not-the-last = (rhel10SystemsCount + rhel9SystemsCount + rhel8SystemsCount)
+        sub-section-not-the-last = 1
         sub-section-retired-url = '/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
         sub-section-expiring-url = '/insights/planning?lifecycleDropdown=Red+Hat+Enterprise+Linux&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
         }
@@ -39,7 +42,7 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
 {/if}
 
 {! RHEL 10 application streams life cycle section !}
-{#if rhel10SystemsCount > 0}
+{#if rhel10Data.count.or(-1) >= 0}
     {#let
         sub-section-title = 'RHEL 10 application streams life cycle'
         sub-section-retired-count = rhel10RetiredCount
@@ -47,7 +50,7 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
         sub-section-expiring-count = rhel10ExpiringCount
         sub-section-expiring-count-id = 'rhel10ExpiringCount'
         sub-section-expiring-months = 6
-        sub-section-not-the-last = (rhel9SystemsCount + rhel8SystemsCount)
+        sub-section-not-the-last = 1
         sub-section-retired-url = '/insights/planning?lifecycleDropdown=RHEL+10+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
         sub-section-expiring-url = '/insights/planning?lifecycleDropdown=RHEL+10+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
         }
@@ -56,7 +59,7 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
 {/if}
 
 {! RHEL 9 application streams life cycle section !}
-{#if rhel9SystemsCount > 0}
+{#if rhel9Data.count.or(-1) >= 0}
     {#let
         sub-section-title = 'RHEL 9 application streams life cycle'
         sub-section-retired-count = rhel9RetiredCount
@@ -64,7 +67,7 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
         sub-section-expiring-count = rhel9ExpiringCount
         sub-section-expiring-count-id = 'rhel9ExpiringCount'
         sub-section-expiring-months = 6
-        sub-section-not-the-last = rhel8SystemsCount
+        sub-section-not-the-last = 1
         sub-section-retired-url = '/insights/planning?lifecycleDropdown=RHEL+9+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Retired'
         sub-section-expiring-url = '/insights/planning?lifecycleDropdown=RHEL+9+Application+Streams&chartSortBy=Retirement+date&chartOrder=asc&viewFilter=installed-only&statuses=Near+retirement'
         }
@@ -73,7 +76,7 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
 {/if}
 
 {! RHEL 8 application streams life cycle section !}
-{#if rhel8SystemsCount > 0}
+{#if rhel8Data.count.or(-1) >= 0}
     {#let
         sub-section-title = 'RHEL 8 application streams life cycle'
         sub-section-retired-count = rhel8RetiredCount

--- a/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
@@ -1,12 +1,13 @@
 {#include email/Common/insightsEmailBody}
 {#content-header-title}
-Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle.report_date}
+Red Hat Enterprise Linux - Life Cycle Monthly Report - {action.context.lifecycle.report_date}
 {/content-header-title}
 {#content-title}
     Life cycle
 {/content-title}
 {#content-body}
 {#let
+    rhelData = action.events[0].payload.rhel_retired.orEmpty
     rhelRetiredCount = action.events[0].payload.rhel_retired.orEmpty.rhel_versions_count.or(0)
     rhelExpiringCount = action.events[0].payload.rhel_near_retirement.orEmpty.rhel_versions_count.or(0)
     rhelSystemsCount = action.events[0].payload.rhel_retired.orEmpty.systems_count.or(0)
@@ -24,8 +25,9 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
     rhel8SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel8.orEmpty.systems_count.or(0)
 }
 <table style="width: 100%; border: 0">
+{#if rhelData.rhel_versions_count.or(-1) >= 0 || rhel10Data.count.or(-1) >= 0 || rhel9Data.count.or(-1) >= 0 || rhel8Data.count.or(-1) >= 0}
 {! RHEL life cycle section !}
-{#if action.events[0].payload.rhel_retired}
+{#if rhelData.rhel_versions_count.or(-1) >= 0}
     {#let
         sub-section-title = 'RHEL life cycle'
         sub-section-retired-count = rhelRetiredCount
@@ -90,7 +92,13 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
     {#insert content-common-section}{/}
     {/let}
 {/if}
+{#else}
+<p style="font-size: 14px; color: #151515; margin-top: 16px;">
+    No RHEL systems were detected in your Inventory. Please add systems to Inventory to view RHEL releases and application streams that are approaching retirement/retired. 
+</p>
+{/if}
 </table>
+{#if rhelData.rhel_versions_count.or(-1) >= 0 || rhel10Data.count.or(-1) >= 0 || rhel9Data.count.or(-1) >= 0 || rhel8Data.count.or(-1) >= 0}
 {#if (rhelRetiredCount == 0 && rhelExpiringCount == 0 && rhel10RetiredCount == 0 && rhel10ExpiringCount == 0 && rhel9RetiredCount == 0 && rhel9ExpiringCount == 0 && rhel8RetiredCount == 0 && rhel8ExpiringCount == 0) || (rhelSystemsCount == 0 && rhel10SystemsCount == 0 && rhel9SystemsCount == 0 && rhel8SystemsCount == 0)}
 <p style="font-size: 14px; color: #151515; margin-top: 16px;">
     Your inventory remained fully supported. A value of 0 indicated that no systems reached a retirement threshold or approached end-of-life dates.
@@ -101,6 +109,7 @@ Red Hat Enterprise Linux - life cycle monthly report - {action.context.lifecycle
         Certain systems reached a retirement threshold. A value of 0 in any category confirmed that no additional systems were affected by that specific lifecycle event.
     </p>
     {/if}
+{/if}
 {/if}
 {/let}
 {/content-body}

--- a/common-template/src/test/java/email/TestLifecycleTemplate.java
+++ b/common-template/src/test/java/email/TestLifecycleTemplate.java
@@ -96,12 +96,17 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
     @Test
     public void testRetiringLifecycleEmailBodyContainsAppstreamData() {
         String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
-        // Verify appstream retired data
-        assertTrue(result.contains("id=\"rhel8RetiredCount\">2<"), "Body should contain appstream retired count for rhel8");
-        assertTrue(result.contains("id=\"rhel9RetiredCount\">2<"), "Body should contain appstream retired count for rhel9");
-        // Verify appstream near retirement data
-        assertTrue(result.contains("id=\"rhel8ExpiringCount\">5<"), "Body should contain appstream near retirement count for rhel8");
-        assertTrue(result.contains("id=\"rhel9ExpiringCount\">22<"), "Body should contain appstream near retirement count for rhel9");
+        // Verify appstream sections appear when payload has the data
+        assertTrue(result.contains("RHEL 8 application streams life cycle"), "Body should contain RHEL 8 appstreams section");
+        assertTrue(result.contains("RHEL 9 application streams life cycle"), "Body should contain RHEL 9 appstreams section");
+        assertTrue(result.contains("RHEL 10 application streams life cycle"), "Body should contain RHEL 10 appstreams section");
+        // Verify appstream count IDs are present
+        assertTrue(result.contains("id=\"rhel8RetiredCount\""), "Body should contain rhel8 retired count ID");
+        assertTrue(result.contains("id=\"rhel9RetiredCount\""), "Body should contain rhel9 retired count ID");
+        assertTrue(result.contains("id=\"rhel10RetiredCount\""), "Body should contain rhel10 retired count ID");
+        assertTrue(result.contains("id=\"rhel8ExpiringCount\""), "Body should contain rhel8 expiring count ID");
+        assertTrue(result.contains("id=\"rhel9ExpiringCount\""), "Body should contain rhel9 expiring count ID");
+        assertTrue(result.contains("id=\"rhel10ExpiringCount\""), "Body should contain rhel10 expiring count ID");
         // Verify appstream lifecycle URLs are properly resolved
         assertTrue(result.contains("href=\"https://localhost/insights/planning?lifecycleDropdown=RHEL+8+Application+Streams"), "RHEL 8 appstream link should contain resolved environment URL");
         assertTrue(result.contains("href=\"https://localhost/insights/planning?lifecycleDropdown=RHEL+9+Application+Streams"), "RHEL 9 appstream link should contain resolved environment URL");
@@ -132,7 +137,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
         String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
         assertTrue(result.contains("id=\"rhelRetiredCount\">3<"), "Body should contain retired rhel_versions_count");
         assertTrue(result.contains("id=\"rhelExpiringCount\">0<"), "Body should contain near retirement rhel_versions_count");
-        assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain any appstreams section");
+        assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain appstream sections since no appstream payload");
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
@@ -161,7 +166,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
         String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
         assertTrue(result.contains("id=\"rhelRetiredCount\">0<"), "Body should contain retired rhel_versions_count");
         assertTrue(result.contains("id=\"rhelExpiringCount\">2<"), "Body should contain near retirement rhel_versions_count");
-        assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain any appstreams section");
+        assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain appstream sections since no appstream payload");
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
@@ -188,8 +193,10 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
         ));
 
         String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
-        assertFalse(result.contains("RHEL life cycle"), "Body shouldn't contain 'RHEL life cycle' section");
-        assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain any appstreams section");
+        assertTrue(result.contains("RHEL life cycle"), "Body should contain 'RHEL life cycle' section since payload exists");
+        assertTrue(result.contains("id=\"rhelRetiredCount\">0<"), "Body should contain retired rhel_versions_count of 0");
+        assertTrue(result.contains("id=\"rhelExpiringCount\">0<"), "Body should contain near retirement rhel_versions_count of 0");
+        assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain appstream sections since no appstream payload");
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
@@ -216,12 +223,15 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
         ));
 
         String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
-        assertTrue(result.contains("id=\"rhel8RetiredCount\">3<"), "Body should contain appstream retired count for rhel8");
-        assertTrue(result.contains("id=\"rhel8ExpiringCount\">0<"), "Body should contain near retirement count for rhel8");
-        assertTrue(result.contains("id=\"rhel9RetiredCount\">0<"), "Body should contain appstream retired count for rhel9");
-        assertTrue(result.contains("id=\"rhel9ExpiringCount\">10<"), "Body should contain appstream near retirement count for rhel9");
-        assertFalse(result.contains("RHEL life cycle"), "Body shouldn't contain 'RHEL life cycle' section");
-        assertFalse(result.contains("RHEL 10 application streams life cycle"), "Body shouldn't contain RHEL 10 appstreams section");
+        // Verify RHEL 8 and 9 sections appear since they're in the payload
+        assertTrue(result.contains("RHEL 8 application streams life cycle"), "Body should contain RHEL 8 appstreams section");
+        assertTrue(result.contains("RHEL 9 application streams life cycle"), "Body should contain RHEL 9 appstreams section");
+        assertTrue(result.contains("id=\"rhel8RetiredCount\""), "Body should contain rhel8 retired count ID");
+        assertTrue(result.contains("id=\"rhel8ExpiringCount\""), "Body should contain rhel8 expiring count ID");
+        assertTrue(result.contains("id=\"rhel9RetiredCount\""), "Body should contain rhel9 retired count ID");
+        assertTrue(result.contains("id=\"rhel9ExpiringCount\""), "Body should contain rhel9 expiring count ID");
+        assertFalse(result.contains("RHEL life cycle"), "Body shouldn't contain 'RHEL life cycle' section since no rhel_retired payload");
+        assertFalse(result.contains("RHEL 10 application streams life cycle"), "Body shouldn't contain RHEL 10 appstreams section since no rhel10 payload");
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
@@ -251,20 +261,23 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
         ));
 
         String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
-        // Verify all RHEL versions are present
-        assertTrue(result.contains("id=\"rhel8RetiredCount\">5<"), "Body should contain appstream retired count for rhel8");
-        assertTrue(result.contains("id=\"rhel9RetiredCount\">3<"), "Body should contain appstream retired count for rhel9");
-        assertTrue(result.contains("id=\"rhel10RetiredCount\">2<"), "Body should contain appstream retired count for rhel10");
-        assertTrue(result.contains("id=\"rhel8ExpiringCount\">0<"), "Body should contain near retirement count for rhel8");
-        assertTrue(result.contains("id=\"rhel9ExpiringCount\">0<"), "Body should contain near retirement count for rhel9");
-        assertTrue(result.contains("id=\"rhel10ExpiringCount\">0<"), "Body should contain near retirement count for rhel10");
-        assertFalse(result.contains("RHEL life cycle"), "Body shouldn't contain 'RHEL life cycle' section");
+        // Verify all RHEL appstream versions sections appear
+        assertTrue(result.contains("RHEL 8 application streams life cycle"), "Body should contain RHEL 8 appstreams section");
+        assertTrue(result.contains("RHEL 9 application streams life cycle"), "Body should contain RHEL 9 appstreams section");
+        assertTrue(result.contains("RHEL 10 application streams life cycle"), "Body should contain RHEL 10 appstreams section");
+        assertTrue(result.contains("id=\"rhel8RetiredCount\""), "Body should contain rhel8 retired count ID");
+        assertTrue(result.contains("id=\"rhel9RetiredCount\""), "Body should contain rhel9 retired count ID");
+        assertTrue(result.contains("id=\"rhel10RetiredCount\""), "Body should contain rhel10 retired count ID");
+        assertTrue(result.contains("id=\"rhel8ExpiringCount\""), "Body should contain rhel8 expiring count ID");
+        assertTrue(result.contains("id=\"rhel9ExpiringCount\""), "Body should contain rhel9 expiring count ID");
+        assertTrue(result.contains("id=\"rhel10ExpiringCount\""), "Body should contain rhel10 expiring count ID");
+        assertFalse(result.contains("RHEL life cycle"), "Body shouldn't contain 'RHEL life cycle' section since no rhel_retired payload");
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
     @Test
-    public void testRetiringLifecycleEmailBodySectionVisibilityBasedOnSystemsCount() {
-        // Test that sections are shown based on systems_count, not retired/expiring counts
+    public void testRetiringLifecycleEmailBodySectionVisibilityBasedOnPayloadExistence() {
+        // Test that sections are shown based on payload existence, not systems_count values
         Action action = createLifecycleAction();
 
         action.setContext(
@@ -273,7 +286,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
                 .build()
         );
 
-        // RHEL section with counts but no systems should not be displayed
+        // RHEL section with counts but systems_count is 0 - should still be displayed since payload exists
         action.setEvents(List.of(
             new Event.EventBuilder()
                 .withMetadata(new Metadata.MetadataBuilder().build())
@@ -287,7 +300,10 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
         ));
 
         String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, action);
-        assertFalse(result.contains("RHEL life cycle"), "Body shouldn't contain 'RHEL life cycle' section when systems_count is 0");
+        assertTrue(result.contains("RHEL life cycle"), "Body should contain 'RHEL life cycle' section since rhel_retired payload exists");
+        assertTrue(result.contains("id=\"rhelRetiredCount\">5<"), "Body should contain retired rhel_versions_count");
+        assertTrue(result.contains("id=\"rhelExpiringCount\">3<"), "Body should contain near retirement rhel_versions_count");
+        assertFalse(result.contains("application streams life cycle"), "Body shouldn't contain appstream sections since no appstream payload");
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 


### PR DESCRIPTION
## Update lifecycle email template to use payload-based section visibility

### Changes
- **Template logic**: Sections now display based on payload data presence rather than `systems_count` values
  - RHEL section: Shows when `rhel_retired` exists in payload
  - RHEL 8/9/10 appstream sections: Show when respective version data exists in `appstream_retired` payload (using `rhel{X}Data.count.or(-1) >= 0` check)
- **Bug fix**: Fixed missing `/` in RHEL near-retirement URL on line 35
- **Tests**: Updated 6 tests to verify payload-based visibility behavior

### Behavior
With this change, sections appear when payload data exists, even if all counts are 0. Sections are hidden only when the corresponding payload data is completely absent.

**Example**: Payload with only `rhel_retired` and `rhel8` → displays only RHEL and RHEL 8 sections (no RHEL 9 or 10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lifecycle retirement emails now render the RHEL life cycle section whenever retirement counts are supplied (even if overall system count is zero). App-stream subsections render only when app-stream data is present; a clear message appears when none is detected.
* **Tests**
  * Email template tests updated to check section visibility and presence of per-RHEL count elements instead of exact numeric values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->