### PR TITLE
RHCLOUD-46754 Add 6 new vulnerability event types

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
@@ -70,6 +70,12 @@ public class Rhel {
     public static final String VULNERABILITY_NEW_CVE_SEVERITY = "new-cve-severity";
     public static final String VULNERABILITY_NEW_CVE_CVSS = "new-cve-cvss";
     public static final String VULNERABILITY_NEW_CVE_SECURITY_RULE = "new-cve-security-rule";
+    public static final String VULNERABILITY_NEW_CVE_ALL = "new-cve-all";
+    public static final String VULNERABILITY_SYSTEM_CVE_KNOWN_EXPLOIT = "system-cve-known-exploit";
+    public static final String VULNERABILITY_SYSTEM_CVE_SEVERITY = "system-cve-severity";
+    public static final String VULNERABILITY_SYSTEM_CVE_CVSS = "system-cve-cvss";
+    public static final String VULNERABILITY_SYSTEM_CVE_SECURITY_RULE = "system-cve-security-rule";
+    public static final String VULNERABILITY_SYSTEM_CVE_ALL = "system-cve-all";
 
     public static final Map<TemplateDefinition, String> templatesMap = Map.ofEntries(
         // Advisor
@@ -129,6 +135,18 @@ public class Rhel {
         entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_NEW_CVE_CVSS), VULNERABILITY_FOLDER_NAME + "newCveHighCvssEmailBody.html"),
         entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_NEW_CVE_SECURITY_RULE), VULNERABILITY_FOLDER_NAME + "newCveSecurityRuleBody.md"),
         entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_NEW_CVE_SECURITY_RULE), VULNERABILITY_FOLDER_NAME + "newCveSecurityRuleEmailBody.html"),
+        entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_NEW_CVE_ALL), VULNERABILITY_FOLDER_NAME + "newCveAllBody.md"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_NEW_CVE_ALL), VULNERABILITY_FOLDER_NAME + "newCveAllEmailBody.html"),
+        entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_KNOWN_EXPLOIT), VULNERABILITY_FOLDER_NAME + "systemCveKnownExploitBody.md"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_KNOWN_EXPLOIT), VULNERABILITY_FOLDER_NAME + "systemCveKnownExploitEmailBody.html"),
+        entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_SEVERITY), VULNERABILITY_FOLDER_NAME + "systemCveCritSeverityBody.md"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_SEVERITY), VULNERABILITY_FOLDER_NAME + "systemCveCritSeverityEmailBody.html"),
+        entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_CVSS), VULNERABILITY_FOLDER_NAME + "systemCveHighCvssBody.md"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_CVSS), VULNERABILITY_FOLDER_NAME + "systemCveHighCvssEmailBody.html"),
+        entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_SECURITY_RULE), VULNERABILITY_FOLDER_NAME + "systemCveSecurityRuleBody.md"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_SECURITY_RULE), VULNERABILITY_FOLDER_NAME + "systemCveSecurityRuleEmailBody.html"),
+        entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_ALL), VULNERABILITY_FOLDER_NAME + "systemCveAllBody.md"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, VULNERABILITY_APP_NAME, VULNERABILITY_SYSTEM_CVE_ALL), VULNERABILITY_FOLDER_NAME + "systemCveAllEmailBody.html"),
         entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, VULNERABILITY_APP_NAME, null), VULNERABILITY_FOLDER_NAME + "dailyEmailBody.html")
     );
 }

--- a/common-template/src/main/resources/templates/drawer/Vulnerability/newCveAllBody.md
+++ b/common-template/src/main/resources/templates/drawer/Vulnerability/newCveAllBody.md
@@ -1,0 +1,5 @@
+{#include drawer/Common/commonDrawerNotification.md}
+{#body}
+Red Hat Lightspeed identified a new vulnerability in your account. Review the details of **[{data.events[0].payload.reported_cve}]({environment.url}/insights/vulnerability/cves/{data.events[0].payload.reported_cve}?{query_params})** and affected systems to determine risk and exposure for your organization.
+{/body}
+{/include}

--- a/common-template/src/main/resources/templates/drawer/Vulnerability/newCveAllBody.md
+++ b/common-template/src/main/resources/templates/drawer/Vulnerability/newCveAllBody.md
@@ -1,5 +1,5 @@
 {#include drawer/Common/commonDrawerNotification.md}
 {#body}
-Red Hat Lightspeed identified a new vulnerability in your account. Review the details of **[{data.events[0].payload.reported_cve}]({environment.url}/insights/vulnerability/cves/{data.events[0].payload.reported_cve}?{query_params})** and affected systems to determine risk and exposure for your organization.
+{#if data.events.size() == 1}Red Hat Lightspeed identified a new vulnerability in your account. Review the details of **[{data.events[0].payload.reported_cve}]({environment.url}/insights/vulnerability/cves/{data.events[0].payload.reported_cve}?{query_params})** and affected systems to determine risk and exposure for your organization.{#else}Red Hat Lightspeed identified {data.events.size()} new vulnerabilities in your account. Review the details of [your CVEs]({environment.url}/insights/vulnerability/cves?{query_params}) and affected systems to determine risk and exposure for your organization.{/if}
 {/body}
 {/include}

--- a/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveAllBody.md
+++ b/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveAllBody.md
@@ -1,0 +1,5 @@
+{#include drawer/Common/commonDrawerNotification.md}
+{#body}
+Red Hat Lightspeed identified {data.events.size()} new {#if data.events.size() == 1}vulnerability{#else}vulnerabilities{/if} on **[{data.context.display_name}]({environment.url}/insights/inventory/{data.context.inventory_id}/vulnerabilities?{query_params})**. Review the details to determine risk and exposure for your organization.
+{/body}
+{/include}

--- a/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveCritSeverityBody.md
+++ b/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveCritSeverityBody.md
@@ -1,0 +1,5 @@
+{#include drawer/Common/commonDrawerNotification.md}
+{#body}
+Red Hat Lightspeed identified {data.events.size()} {#if data.events.size() == 1}vulnerability{#else}vulnerabilities{/if} with the **critical severity** status on **[{data.context.display_name}]({environment.url}/insights/inventory/{data.context.inventory_id}/vulnerabilities?{query_params})**. Review the details to determine risk and exposure for your organization.
+{/body}
+{/include}

--- a/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveHighCvssBody.md
+++ b/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveHighCvssBody.md
@@ -1,0 +1,5 @@
+{#include drawer/Common/commonDrawerNotification.md}
+{#body}
+Red Hat Lightspeed identified {data.events.size()} {#if data.events.size() == 1}vulnerability{#else}vulnerabilities{/if} with a CVSS score greater than or equal to 7.0 on **[{data.context.display_name}]({environment.url}/insights/inventory/{data.context.inventory_id}/vulnerabilities?{query_params})**. Review the details to determine risk and exposure for your organization.
+{/body}
+{/include}

--- a/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveKnownExploitBody.md
+++ b/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveKnownExploitBody.md
@@ -1,0 +1,5 @@
+{#include drawer/Common/commonDrawerNotification.md}
+{#body}
+Red Hat Lightspeed identified {data.events.size()} {#if data.events.size() == 1}vulnerability{#else}vulnerabilities{/if} with the known exploit label on **[{data.context.display_name}]({environment.url}/insights/inventory/{data.context.inventory_id}/vulnerabilities?{query_params})**. Review the details to determine risk and exposure for your organization. The "Known Exploit" label is added to any CVE that is determined to have been exploited publicly by Red Hat Product Security.
+{/body}
+{/include}

--- a/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveSecurityRuleBody.md
+++ b/common-template/src/main/resources/templates/drawer/Vulnerability/systemCveSecurityRuleBody.md
@@ -1,0 +1,5 @@
+{#include drawer/Common/commonDrawerNotification.md}
+{#body}
+Red Hat Lightspeed identified {data.events.size()} newly published {#if data.events.size() == 1}vulnerability{#else}vulnerabilities{/if} with the security rule label on **[{data.context.display_name}]({environment.url}/insights/inventory/{data.context.inventory_id}/vulnerabilities?{query_params})**. Review the details to determine risk and exposure for your organization.
+{/body}
+{/include}

--- a/common-template/src/main/resources/templates/email/Vulnerability/newCveAllEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Vulnerability/newCveAllEmailBody.html
@@ -1,0 +1,15 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    CVEs - Vulnerability - Red Hat Enterprise Linux
+{/content-header-title}
+{#content-title}
+    New vulnerability identified
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        Red Hat Lightspeed identified a new vulnerability in your account. Review the details of <a style="{body-section-underline-link-style}" href="{environment.url}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
+    </p>
+{/content-body}
+{#content-button-href}{environment.url}/insights/vulnerability/cves?{query_params}{/content-button-href}
+{#content-button-service-name}CVEs - Vulnerability{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/Vulnerability/newCveAllEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Vulnerability/newCveAllEmailBody.html
@@ -6,9 +6,15 @@
     New vulnerability identified
 {/content-title}
 {#content-body}
+    {#if action.events.size() == 1}
     <p style="{body-section-p-style}">
         Red Hat Lightspeed identified a new vulnerability in your account. Review the details of <a style="{body-section-underline-link-style}" href="{environment.url}/insights/vulnerability/cves/{action.events[0].payload.reported_cve}">{action.events[0].payload.reported_cve}</a> and affected systems to determine risk and exposure for your organization.
     </p>
+    {#else}
+    <p style="{body-section-p-style}">
+        Red Hat Lightspeed identified {action.events.size()} new vulnerabilities in your account. Review your <a style="{body-section-underline-link-style}" href="{environment.url}/insights/vulnerability/cves">CVEs</a> and affected systems to determine risk and exposure for your organization.
+    </p>
+    {/if}
 {/content-body}
 {#content-button-href}{environment.url}/insights/vulnerability/cves?{query_params}{/content-button-href}
 {#content-button-service-name}CVEs - Vulnerability{/content-button-service-name}

--- a/common-template/src/main/resources/templates/email/Vulnerability/systemCveAllEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Vulnerability/systemCveAllEmailBody.html
@@ -1,0 +1,28 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    CVEs - Vulnerability - Red Hat Enterprise Linux
+{/content-header-title}
+{#content-title}
+    System vulnerabilities identified
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        Red Hat Lightspeed identified {action.events.size()} new {#if action.events.size() == 1}vulnerability{#else}vulnerabilities{/if} on <a style="{body-section-underline-link-style}" href="{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities">{action.context.display_name}</a>. Review the details to determine risk and exposure for your organization.
+    </p>
+
+    {#if action.events.size() <= 25}
+    <p style="{body-section-p-style}">Identified CVEs:</p>
+    <ul>
+        {#for event in action.events}
+        <li><a style="{body-section-table-td-a-style}" href="{environment.url}/insights/vulnerability/cves/{event.payload.reported_cve}">{event.payload.reported_cve}</a></li>
+        {/for}
+    </ul>
+    {#else}
+    <p style="{body-section-p-style}">
+        {action.events.size()} CVEs were identified. View the complete list on the system's vulnerability page.
+    </p>
+    {/if}
+{/content-body}
+{#content-button-href}{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities?{query_params}{/content-button-href}
+{#content-button-service-name}System Vulnerabilities{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/Vulnerability/systemCveCritSeverityEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Vulnerability/systemCveCritSeverityEmailBody.html
@@ -1,0 +1,28 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    CVEs - Vulnerability - Red Hat Enterprise Linux
+{/content-header-title}
+{#content-title}
+    System vulnerabilities with critical severity
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        Red Hat Lightspeed identified {action.events.size()} {#if action.events.size() == 1}vulnerability{#else}vulnerabilities{/if} with the <strong>critical severity</strong> status on <a style="{body-section-underline-link-style}" href="{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities">{action.context.display_name}</a>. Review the details to determine risk and exposure for your organization.
+    </p>
+
+    {#if action.events.size() <= 25}
+    <p style="{body-section-p-style}">Identified CVEs:</p>
+    <ul>
+        {#for event in action.events}
+        <li><a style="{body-section-table-td-a-style}" href="{environment.url}/insights/vulnerability/cves/{event.payload.reported_cve}">{event.payload.reported_cve}</a></li>
+        {/for}
+    </ul>
+    {#else}
+    <p style="{body-section-p-style}">
+        {action.events.size()} CVEs were identified. View the complete list on the system's vulnerability page.
+    </p>
+    {/if}
+{/content-body}
+{#content-button-href}{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities?{query_params}{/content-button-href}
+{#content-button-service-name}System Vulnerabilities{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/Vulnerability/systemCveHighCvssEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Vulnerability/systemCveHighCvssEmailBody.html
@@ -1,0 +1,28 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    CVEs - Vulnerability - Red Hat Enterprise Linux
+{/content-header-title}
+{#content-title}
+    System vulnerabilities with CVSS >= 7.0
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        Red Hat Lightspeed identified {action.events.size()} {#if action.events.size() == 1}vulnerability{#else}vulnerabilities{/if} with a CVSS score greater than or equal to 7.0 on <a style="{body-section-underline-link-style}" href="{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities">{action.context.display_name}</a>. Review the details to determine risk and exposure for your organization.
+    </p>
+
+    {#if action.events.size() <= 25}
+    <p style="{body-section-p-style}">Identified CVEs:</p>
+    <ul>
+        {#for event in action.events}
+        <li><a style="{body-section-table-td-a-style}" href="{environment.url}/insights/vulnerability/cves/{event.payload.reported_cve}">{event.payload.reported_cve}</a></li>
+        {/for}
+    </ul>
+    {#else}
+    <p style="{body-section-p-style}">
+        {action.events.size()} CVEs were identified. View the complete list on the system's vulnerability page.
+    </p>
+    {/if}
+{/content-body}
+{#content-button-href}{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities?{query_params}{/content-button-href}
+{#content-button-service-name}System Vulnerabilities{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/Vulnerability/systemCveKnownExploitEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Vulnerability/systemCveKnownExploitEmailBody.html
@@ -1,0 +1,32 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    CVEs - Vulnerability - Red Hat Enterprise Linux
+{/content-header-title}
+{#content-title}
+    System vulnerabilities with known exploit identified
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        Red Hat Lightspeed identified {action.events.size()} {#if action.events.size() == 1}vulnerability{#else}vulnerabilities{/if} with the known exploit label on <a style="{body-section-underline-link-style}" href="{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities">{action.context.display_name}</a>. Review the details to determine risk and exposure for your organization.
+    </p>
+
+    <p style="{body-section-p-style}">
+         The <strong>known exploit</strong> label is added to any CVE that is determined to have been exploited publicly by Red Hat Product Security. This label does not reflect your environment.
+    </p>
+
+    {#if action.events.size() <= 25}
+    <p style="{body-section-p-style}">Identified CVEs:</p>
+    <ul>
+        {#for event in action.events}
+        <li><a style="{body-section-table-td-a-style}" href="{environment.url}/insights/vulnerability/cves/{event.payload.reported_cve}">{event.payload.reported_cve}</a></li>
+        {/for}
+    </ul>
+    {#else}
+    <p style="{body-section-p-style}">
+        {action.events.size()} CVEs were identified. View the complete list on the system's vulnerability page.
+    </p>
+    {/if}
+{/content-body}
+{#content-button-href}{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities?{query_params}{/content-button-href}
+{#content-button-service-name}System Vulnerabilities{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/Vulnerability/systemCveSecurityRuleEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Vulnerability/systemCveSecurityRuleEmailBody.html
@@ -1,0 +1,28 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    CVEs - Vulnerability - Red Hat Enterprise Linux
+{/content-header-title}
+{#content-title}
+    System vulnerabilities with security rule
+{/content-title}
+{#content-body}
+    <p style="{body-section-p-style}">
+        Red Hat Lightspeed identified {action.events.size()} newly published {#if action.events.size() == 1}vulnerability{#else}vulnerabilities{/if} with the security rule label on <a style="{body-section-underline-link-style}" href="{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities">{action.context.display_name}</a>. Review the details to determine risk and exposure for your organization.
+    </p>
+
+    {#if action.events.size() <= 25}
+    <p style="{body-section-p-style}">Identified CVEs:</p>
+    <ul>
+        {#for event in action.events}
+        <li><a style="{body-section-table-td-a-style}" href="{environment.url}/insights/vulnerability/cves/{event.payload.reported_cve}">{event.payload.reported_cve}</a></li>
+        {/for}
+    </ul>
+    {#else}
+    <p style="{body-section-p-style}">
+        {action.events.size()} CVEs were identified. View the complete list on the system's vulnerability page.
+    </p>
+    {/if}
+{/content-body}
+{#content-button-href}{environment.url}/insights/inventory/{action.context.inventory_id}/vulnerabilities?{query_params}{/content-button-href}
+{#content-button-service-name}System Vulnerabilities{/content-button-service-name}
+{/include}

--- a/common-template/src/test/java/drawer/TestVulnerabilityTemplate.java
+++ b/common-template/src/test/java/drawer/TestVulnerabilityTemplate.java
@@ -9,16 +9,24 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 class TestVulnerabilityTemplate {
 
     private static final Action ACTION = TestHelpers.createVulnerabilityAction();
+    private static final Action SYSTEM_ACTION = TestHelpers.createSystemVulnerabilityAction();
 
     static final String NEW_CVE_HIGH_CVSS_EVENT = "new-cve-cvss";
     static final String NEW_CVE_CRIT_SEVERITY_EVENT = "new-cve-severity";
     static final String NEW_CVE_SECURITY_RULE_EVENT = "new-cve-security-rule";
     static final String ANY_CVE_KNOWN_EXPLOIT_EVENT = "any-cve-known-exploit";
+    static final String NEW_CVE_ALL_EVENT = "new-cve-all";
+    static final String SYSTEM_CVE_KNOWN_EXPLOIT_EVENT = "system-cve-known-exploit";
+    static final String SYSTEM_CVE_SEVERITY_EVENT = "system-cve-severity";
+    static final String SYSTEM_CVE_CVSS_EVENT = "system-cve-cvss";
+    static final String SYSTEM_CVE_SECURITY_RULE_EVENT = "system-cve-security-rule";
+    static final String SYSTEM_CVE_ALL_EVENT = "system-cve-all";
 
     @Inject
     TestHelpers testHelpers;
@@ -45,6 +53,61 @@ class TestVulnerabilityTemplate {
     void testRenderedTemplateAnyKnownExploit() {
         String result = renderTemplate(ANY_CVE_KNOWN_EXPLOIT_EVENT, ACTION);
         assertEquals("Red Hat Lightspeed identified a CVE with the known exploit label. Review the details of the **[CVE-TEST](https://localhost/insights/vulnerability/cves/CVE-TEST?from=notifications&integration=drawer)** CVE and affected systems to determine risk and exposure for your organization. The \"Known Exploit\" label is added to any CVE that is determined to have been exploited publicly by Red Hat Product Security. This label does not reflect your environment.", result);
+    }
+
+    @Test
+    void testRenderedTemplateNewCveAll() {
+        String result = renderTemplate(NEW_CVE_ALL_EVENT, ACTION);
+        assertEquals("Red Hat Lightspeed identified a new vulnerability in your account. Review the details of **[CVE-TEST](https://localhost/insights/vulnerability/cves/CVE-TEST?from=notifications&integration=drawer)** and affected systems to determine risk and exposure for your organization.", result);
+    }
+
+    @Test
+    void testRenderedTemplateSystemCveKnownExploit() {
+        String result = renderTemplate(SYSTEM_CVE_KNOWN_EXPLOIT_EVENT, SYSTEM_ACTION);
+        assertTrue(result.contains("Red Hat Lightspeed identified 2"));
+        assertTrue(result.contains("vulnerabilities"));
+        assertTrue(result.contains("known exploit"));
+        assertTrue(result.contains("test-system"));
+        assertTrue(result.contains("b8125066-0db2-47df-b37a-09e71979269f/vulnerabilities"));
+    }
+
+    @Test
+    void testRenderedTemplateSystemCveCritSeverity() {
+        String result = renderTemplate(SYSTEM_CVE_SEVERITY_EVENT, SYSTEM_ACTION);
+        assertTrue(result.contains("Red Hat Lightspeed identified 2"));
+        assertTrue(result.contains("vulnerabilities"));
+        assertTrue(result.contains("critical severity"));
+        assertTrue(result.contains("test-system"));
+        assertTrue(result.contains("b8125066-0db2-47df-b37a-09e71979269f/vulnerabilities"));
+    }
+
+    @Test
+    void testRenderedTemplateSystemCveHighCvss() {
+        String result = renderTemplate(SYSTEM_CVE_CVSS_EVENT, SYSTEM_ACTION);
+        assertTrue(result.contains("Red Hat Lightspeed identified 2"));
+        assertTrue(result.contains("vulnerabilities"));
+        assertTrue(result.contains("7.0"));
+        assertTrue(result.contains("test-system"));
+        assertTrue(result.contains("b8125066-0db2-47df-b37a-09e71979269f/vulnerabilities"));
+    }
+
+    @Test
+    void testRenderedTemplateSystemCveSecurityRule() {
+        String result = renderTemplate(SYSTEM_CVE_SECURITY_RULE_EVENT, SYSTEM_ACTION);
+        assertTrue(result.contains("Red Hat Lightspeed identified 2"));
+        assertTrue(result.contains("vulnerabilit"));
+        assertTrue(result.contains("security rule"));
+        assertTrue(result.contains("test-system"));
+        assertTrue(result.contains("b8125066-0db2-47df-b37a-09e71979269f/vulnerabilities"));
+    }
+
+    @Test
+    void testRenderedTemplateSystemCveAll() {
+        String result = renderTemplate(SYSTEM_CVE_ALL_EVENT, SYSTEM_ACTION);
+        assertTrue(result.contains("Red Hat Lightspeed identified 2"));
+        assertTrue(result.contains("new vulnerabilit"));
+        assertTrue(result.contains("test-system"));
+        assertTrue(result.contains("b8125066-0db2-47df-b37a-09e71979269f/vulnerabilities"));
     }
 
     String renderTemplate(final String eventType, final Action action) {

--- a/common-template/src/test/java/email/TestVulnerabilityTemplate.java
+++ b/common-template/src/test/java/email/TestVulnerabilityTemplate.java
@@ -17,11 +17,18 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TestVulnerabilityTemplate extends EmailTemplatesRendererHelper {
 
     private static final Action ACTION = TestHelpers.createVulnerabilityAction();
+    private static final Action SYSTEM_ACTION = TestHelpers.createSystemVulnerabilityAction();
 
     static final String NEW_CVE_HIGH_CVSS_EVENT = "new-cve-cvss";
     static final String NEW_CVE_CRIT_SEVERITY_EVENT = "new-cve-severity";
     static final String NEW_CVE_SECURITY_RULE_EVENT = "new-cve-security-rule";
     static final String ANY_CVE_KNOWN_EXPLOIT_EVENT = "any-cve-known-exploit";
+    static final String NEW_CVE_ALL_EVENT = "new-cve-all";
+    static final String SYSTEM_CVE_KNOWN_EXPLOIT_EVENT = "system-cve-known-exploit";
+    static final String SYSTEM_CVE_SEVERITY_EVENT = "system-cve-severity";
+    static final String SYSTEM_CVE_CVSS_EVENT = "system-cve-cvss";
+    static final String SYSTEM_CVE_SECURITY_RULE_EVENT = "system-cve-security-rule";
+    static final String SYSTEM_CVE_ALL_EVENT = "system-cve-all";
 
     @Override
     protected String getApp() {
@@ -38,7 +45,18 @@ public class TestVulnerabilityTemplate extends EmailTemplatesRendererHelper {
             Arguments.of(ANY_CVE_KNOWN_EXPLOIT_EVENT, "Any vulnerability with known exploit"),
             Arguments.of(NEW_CVE_CRIT_SEVERITY_EVENT, "New vulnerability with Critical Severity"),
             Arguments.of(NEW_CVE_HIGH_CVSS_EVENT, "New vulnerability with CVSS >= 7.0"),
-            Arguments.of(NEW_CVE_SECURITY_RULE_EVENT, "New vulnerability containing Security rule")
+            Arguments.of(NEW_CVE_SECURITY_RULE_EVENT, "New vulnerability containing Security rule"),
+            Arguments.of(NEW_CVE_ALL_EVENT, "New vulnerability")
+        );
+    }
+
+    static Stream<Arguments> getSystemEventTypeNames() {
+        return Stream.of(
+            Arguments.of(SYSTEM_CVE_KNOWN_EXPLOIT_EVENT, "System vulnerability with known exploit"),
+            Arguments.of(SYSTEM_CVE_SEVERITY_EVENT, "System vulnerability with critical severity"),
+            Arguments.of(SYSTEM_CVE_CVSS_EVENT, "System vulnerability with CVSS >= 7.0"),
+            Arguments.of(SYSTEM_CVE_SECURITY_RULE_EVENT, "System vulnerability containing security rule"),
+            Arguments.of(SYSTEM_CVE_ALL_EVENT, "System vulnerability")
         );
     }
 
@@ -59,6 +77,14 @@ public class TestVulnerabilityTemplate extends EmailTemplatesRendererHelper {
         testTitle(eventType, result);
     }
 
+    @MethodSource("getSystemEventTypeNames")
+    @ParameterizedTest
+    public void testSystemInstantEmailTitle(String eventType, String eventTypeDispName) {
+        eventTypeDisplayName = eventTypeDispName;
+        String result = generateEmailSubject(eventType, SYSTEM_ACTION);
+        testTitle(eventType, result);
+    }
+
     private void testTitle(String eventType, String result) {
         switch (eventType) {
             case ANY_CVE_KNOWN_EXPLOIT_EVENT:
@@ -73,22 +99,49 @@ public class TestVulnerabilityTemplate extends EmailTemplatesRendererHelper {
             case NEW_CVE_SECURITY_RULE_EVENT:
                 assertEquals("Instant notification - New vulnerability containing Security rule - Vulnerability - Red Hat Enterprise Linux", result);
                 break;
+            case NEW_CVE_ALL_EVENT:
+                assertEquals("Instant notification - New vulnerability - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
+            case SYSTEM_CVE_KNOWN_EXPLOIT_EVENT:
+                assertEquals("Instant notification - System vulnerability with known exploit - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
+            case SYSTEM_CVE_SEVERITY_EVENT:
+                assertEquals("Instant notification - System vulnerability with critical severity - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
+            case SYSTEM_CVE_CVSS_EVENT:
+                assertEquals("Instant notification - System vulnerability with CVSS >= 7.0 - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
+            case SYSTEM_CVE_SECURITY_RULE_EVENT:
+                assertEquals("Instant notification - System vulnerability containing security rule - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
+            case SYSTEM_CVE_ALL_EVENT:
+                assertEquals("Instant notification - System vulnerability - Vulnerability - Red Hat Enterprise Linux", result);
+                break;
             default:
                 fail();
                 break;
         }
     }
 
-    @ValueSource(strings = { ANY_CVE_KNOWN_EXPLOIT_EVENT, NEW_CVE_CRIT_SEVERITY_EVENT, NEW_CVE_HIGH_CVSS_EVENT, NEW_CVE_SECURITY_RULE_EVENT })
+    @ValueSource(strings = { ANY_CVE_KNOWN_EXPLOIT_EVENT, NEW_CVE_CRIT_SEVERITY_EVENT, NEW_CVE_HIGH_CVSS_EVENT, NEW_CVE_SECURITY_RULE_EVENT, NEW_CVE_ALL_EVENT })
     @ParameterizedTest
     public void testInstantEmailBody(String eventType) {
         String result = generateEmailBody(eventType, ACTION);
-        testBody(eventType, result, false);
+        testBody(eventType, result);
         result = generateEmailBody(eventType, ACTION, true);
-        testBody(eventType, result, true);
+        testBody(eventType, result);
     }
 
-    private void testBody(String eventType, String result, boolean useBetaTemplate) {
+    @ValueSource(strings = { SYSTEM_CVE_KNOWN_EXPLOIT_EVENT, SYSTEM_CVE_SEVERITY_EVENT, SYSTEM_CVE_CVSS_EVENT, SYSTEM_CVE_SECURITY_RULE_EVENT, SYSTEM_CVE_ALL_EVENT })
+    @ParameterizedTest
+    public void testSystemInstantEmailBody(String eventType) {
+        String result = generateEmailBody(eventType, SYSTEM_ACTION);
+        testSystemBody(eventType, result);
+        result = generateEmailBody(eventType, SYSTEM_ACTION, true);
+        testSystemBody(eventType, result);
+    }
+
+    private void testBody(String eventType, String result) {
         assertTrue(result.contains(ACTION.getEvents().get(0).getPayload().getAdditionalProperties().get("reported_cve").toString()));
         switch (eventType) {
             case ANY_CVE_KNOWN_EXPLOIT_EVENT:
@@ -106,6 +159,38 @@ public class TestVulnerabilityTemplate extends EmailTemplatesRendererHelper {
             case NEW_CVE_SECURITY_RULE_EVENT:
                 assertTrue(result.contains("Red Hat Lightspeed identified a newly published CVE with the security rule label"));
                 assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            case NEW_CVE_ALL_EVENT:
+                assertTrue(result.contains("Red Hat Lightspeed identified a new vulnerability in your account"));
+                assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+                break;
+            default:
+                fail();
+                break;
+        }
+    }
+
+    private void testSystemBody(String eventType, String result) {
+        assertTrue(result.contains("test-system"));
+        assertTrue(result.contains("b8125066-0db2-47df-b37a-09e71979269f/vulnerabilities"));
+        assertTrue(result.contains("CVE-TEST-1"));
+        assertTrue(result.contains("CVE-TEST-2"));
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        switch (eventType) {
+            case SYSTEM_CVE_KNOWN_EXPLOIT_EVENT:
+                assertTrue(result.contains("known exploit"));
+                break;
+            case SYSTEM_CVE_SEVERITY_EVENT:
+                assertTrue(result.contains("critical severity"));
+                break;
+            case SYSTEM_CVE_CVSS_EVENT:
+                assertTrue(result.contains("7.0"));
+                break;
+            case SYSTEM_CVE_SECURITY_RULE_EVENT:
+                assertTrue(result.contains("security rule"));
+                break;
+            case SYSTEM_CVE_ALL_EVENT:
+                assertTrue(result.contains("new vulnerabilit"));
                 break;
             default:
                 fail();

--- a/common-template/src/test/java/helpers/TestHelpers.java
+++ b/common-template/src/test/java/helpers/TestHelpers.java
@@ -321,6 +321,43 @@ public class TestHelpers {
         return emailActionMessage;
     }
 
+    public static Action createSystemVulnerabilityAction() {
+        Action emailActionMessage = new Action();
+        emailActionMessage.setBundle(StringUtils.EMPTY);
+        emailActionMessage.setApplication(StringUtils.EMPTY);
+        emailActionMessage.setTimestamp(LocalDateTime.of(2020, 10, 3, 15, 22, 13, 25));
+        emailActionMessage.setEventType(EVENT_TYPE);
+        emailActionMessage.setRecipients(List.of());
+
+        emailActionMessage.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("display_name", "test-system")
+                .withAdditionalProperty("inventory_id", "b8125066-0db2-47df-b37a-09e71979269f")
+                .withAdditionalProperty("vulnerability", Map.of("reported_cves", List.of("CVE1", "CVE2", "CVE3")))
+                .build()
+        );
+
+        emailActionMessage.setEvents(List.of(
+            new Event.EventBuilder().withMetadata(new Metadata.MetadataBuilder()
+                    .build())
+                .withPayload(new Payload.PayloadBuilder()
+                    .withAdditionalProperty("reported_cve", "CVE-TEST-1")
+                    .build())
+                .build(),
+            new Event.EventBuilder().withMetadata(new Metadata.MetadataBuilder()
+                    .build())
+                .withPayload(new Payload.PayloadBuilder()
+                    .withAdditionalProperty("reported_cve", "CVE-TEST-2")
+                    .build())
+                .build()
+        ));
+
+        emailActionMessage.setAccountId(StringUtils.EMPTY);
+        emailActionMessage.setOrgId(DEFAULT_ORG_ID);
+
+        return emailActionMessage;
+    }
+
     public static Action createSourcesAction() {
         Action emailActionMessage = new Action();
         emailActionMessage.setBundle(StringUtils.EMPTY);

--- a/database/src/main/resources/db/migration/V1.134.0__RHCLOUD-46754_add_vulnerability_event_types.sql
+++ b/database/src/main/resources/db/migration/V1.134.0__RHCLOUD-46754_add_vulnerability_event_types.sql
@@ -1,0 +1,43 @@
+-- RHCLOUD-46754: Add 6 new vulnerability event types
+
+-- new-cve-all: Per-account catch-all for CVEs not in other categories
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'new-cve-all', 'New vulnerability', 'A new vulnerability was detected in the account', 'CRITICAL', json_build_array('CRITICAL'), TRUE
+FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
+WHERE a.name = 'vulnerability' AND b.name = 'rhel'
+ON CONFLICT DO NOTHING;
+
+-- system-cve-known-exploit: Per-system, vulnerabilities with known exploit
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-known-exploit', 'System vulnerability with known exploit', 'A new vulnerability with known exploit was detected on the system', 'CRITICAL', json_build_array('CRITICAL'), TRUE
+FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
+WHERE a.name = 'vulnerability' AND b.name = 'rhel'
+ON CONFLICT DO NOTHING;
+
+-- system-cve-severity: Per-system, vulnerabilities with critical severity
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-severity', 'System vulnerability with critical severity', 'A new vulnerability with critical severity was detected on the system', 'CRITICAL', json_build_array('CRITICAL'), TRUE
+FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
+WHERE a.name = 'vulnerability' AND b.name = 'rhel'
+ON CONFLICT DO NOTHING;
+
+-- system-cve-cvss: Per-system, vulnerabilities with CVSS >= 7.0
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-cvss', 'System vulnerability with CVSS >= 7.0', 'A new vulnerability with CVSS >= 7.0 was detected on the system', 'IMPORTANT', json_build_array('IMPORTANT'), TRUE
+FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
+WHERE a.name = 'vulnerability' AND b.name = 'rhel'
+ON CONFLICT DO NOTHING;
+
+-- system-cve-security-rule: Per-system, vulnerabilities containing security rule
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-security-rule', 'System vulnerability containing security rule', 'A new vulnerability containing security rule was detected on the system', 'IMPORTANT', json_build_array('IMPORTANT'), TRUE
+FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
+WHERE a.name = 'vulnerability' AND b.name = 'rhel'
+ON CONFLICT DO NOTHING;
+
+-- system-cve-all: Per-system catch-all
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-all', 'System vulnerability', 'A new vulnerability was detected on the system', 'IMPORTANT', json_build_array('IMPORTANT'), TRUE
+FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
+WHERE a.name = 'vulnerability' AND b.name = 'rhel'
+ON CONFLICT DO NOTHING;

--- a/database/src/main/resources/db/migration/V1.134.0__RHCLOUD-46754_add_vulnerability_event_types.sql
+++ b/database/src/main/resources/db/migration/V1.134.0__RHCLOUD-46754_add_vulnerability_event_types.sql
@@ -1,43 +1,44 @@
 -- RHCLOUD-46754: Add 6 new vulnerability event types
+-- visible=false and included_in_drawer=false until Vulnerability service is ready to go live and onboarded with Kessel
 
 -- new-cve-all: Per-account catch-all for CVEs not in other categories
-INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
-SELECT gen_random_uuid(), a.id, 'new-cve-all', 'New vulnerability', 'A new vulnerability was detected in the account', 'CRITICAL', json_build_array('CRITICAL'), TRUE
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, visible, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'new-cve-all', 'New vulnerability', 'A new vulnerability was detected in the account', 'CRITICAL', json_build_array('CRITICAL'), FALSE, FALSE
 FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
 WHERE a.name = 'vulnerability' AND b.name = 'rhel'
 ON CONFLICT DO NOTHING;
 
 -- system-cve-known-exploit: Per-system, vulnerabilities with known exploit
-INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
-SELECT gen_random_uuid(), a.id, 'system-cve-known-exploit', 'System vulnerability with known exploit', 'A new vulnerability with known exploit was detected on the system', 'CRITICAL', json_build_array('CRITICAL'), TRUE
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, visible, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-known-exploit', 'System vulnerability with known exploit', 'A new vulnerability with known exploit was detected on the system', 'CRITICAL', json_build_array('CRITICAL'), FALSE, FALSE
 FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
 WHERE a.name = 'vulnerability' AND b.name = 'rhel'
 ON CONFLICT DO NOTHING;
 
 -- system-cve-severity: Per-system, vulnerabilities with critical severity
-INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
-SELECT gen_random_uuid(), a.id, 'system-cve-severity', 'System vulnerability with critical severity', 'A new vulnerability with critical severity was detected on the system', 'CRITICAL', json_build_array('CRITICAL'), TRUE
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, visible, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-severity', 'System vulnerability with critical severity', 'A new vulnerability with critical severity was detected on the system', 'CRITICAL', json_build_array('CRITICAL'), FALSE, FALSE
 FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
 WHERE a.name = 'vulnerability' AND b.name = 'rhel'
 ON CONFLICT DO NOTHING;
 
 -- system-cve-cvss: Per-system, vulnerabilities with CVSS >= 7.0
-INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
-SELECT gen_random_uuid(), a.id, 'system-cve-cvss', 'System vulnerability with CVSS >= 7.0', 'A new vulnerability with CVSS >= 7.0 was detected on the system', 'IMPORTANT', json_build_array('IMPORTANT'), TRUE
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, visible, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-cvss', 'System vulnerability with CVSS >= 7.0', 'A new vulnerability with CVSS >= 7.0 was detected on the system', 'IMPORTANT', json_build_array('IMPORTANT'), FALSE, FALSE
 FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
 WHERE a.name = 'vulnerability' AND b.name = 'rhel'
 ON CONFLICT DO NOTHING;
 
 -- system-cve-security-rule: Per-system, vulnerabilities containing security rule
-INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
-SELECT gen_random_uuid(), a.id, 'system-cve-security-rule', 'System vulnerability containing security rule', 'A new vulnerability containing security rule was detected on the system', 'IMPORTANT', json_build_array('IMPORTANT'), TRUE
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, visible, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-security-rule', 'System vulnerability containing security rule', 'A new vulnerability containing security rule was detected on the system', 'IMPORTANT', json_build_array('IMPORTANT'), FALSE, FALSE
 FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
 WHERE a.name = 'vulnerability' AND b.name = 'rhel'
 ON CONFLICT DO NOTHING;
 
 -- system-cve-all: Per-system catch-all
-INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, included_in_drawer)
-SELECT gen_random_uuid(), a.id, 'system-cve-all', 'System vulnerability', 'A new vulnerability was detected on the system', 'IMPORTANT', json_build_array('IMPORTANT'), TRUE
+INSERT INTO event_type (id, application_id, name, display_name, description, default_severity, available_severities, visible, included_in_drawer)
+SELECT gen_random_uuid(), a.id, 'system-cve-all', 'System vulnerability', 'A new vulnerability was detected on the system', 'IMPORTANT', json_build_array('IMPORTANT'), FALSE, FALSE
 FROM applications a INNER JOIN bundles b ON a.bundle_id = b.id
 WHERE a.name = 'vulnerability' AND b.name = 'rhel'
 ON CONFLICT DO NOTHING;

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregator.java
@@ -26,8 +26,17 @@ public class VulnerabilityEmailPayloadAggregator extends AbstractEmailPayloadAgg
     private static final String SEVERITY_EVENT = "new-cve-severity";
     private static final String RULE_EVENT = "new-cve-security-rule";
     private static final String EXPLOITS_EVENT = "any-cve-known-exploit";
+    private static final String NEW_CVE_ALL_EVENT = "new-cve-all";
+    private static final String SYSTEM_CVE_KNOWN_EXPLOIT_EVENT = "system-cve-known-exploit";
+    private static final String SYSTEM_CVE_SEVERITY_EVENT = "system-cve-severity";
+    private static final String SYSTEM_CVE_CVSS_EVENT = "system-cve-cvss";
+    private static final String SYSTEM_CVE_SECURITY_RULE_EVENT = "system-cve-security-rule";
+    private static final String SYSTEM_CVE_ALL_EVENT = "system-cve-all";
     private static final Set<String> EVENT_TYPES = new HashSet<>(
-            Arrays.asList(CVSS_EVENT, SEVERITY_EVENT, RULE_EVENT, EXPLOITS_EVENT));
+            Arrays.asList(CVSS_EVENT, SEVERITY_EVENT, RULE_EVENT, EXPLOITS_EVENT,
+                    NEW_CVE_ALL_EVENT, SYSTEM_CVE_KNOWN_EXPLOIT_EVENT,
+                    SYSTEM_CVE_SEVERITY_EVENT, SYSTEM_CVE_CVSS_EVENT,
+                    SYSTEM_CVE_SECURITY_RULE_EVENT, SYSTEM_CVE_ALL_EVENT));
 
     // Vulnerability final payload helpers
     private final Set<String> uniqueCves = new HashSet<>();

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregatorTest.java
@@ -17,6 +17,12 @@ public class VulnerabilityEmailPayloadAggregatorTest {
     private static final String SEVERITY_EVENT = "new-cve-severity";
     private static final String RULE_EVENT = "new-cve-security-rule";
     private static final String EXPLOITS_EVENT = "any-cve-known-exploit";
+    private static final String NEW_CVE_ALL_EVENT = "new-cve-all";
+    private static final String SYSTEM_CVE_KNOWN_EXPLOIT_EVENT = "system-cve-known-exploit";
+    private static final String SYSTEM_CVE_SEVERITY_EVENT = "system-cve-severity";
+    private static final String SYSTEM_CVE_CVSS_EVENT = "system-cve-cvss";
+    private static final String SYSTEM_CVE_SECURITY_RULE_EVENT = "system-cve-security-rule";
+    private static final String SYSTEM_CVE_ALL_EVENT = "system-cve-all";
 
     private final String bundle = "rhel";
     private final String application = "vulnerability";
@@ -55,5 +61,31 @@ public class VulnerabilityEmailPayloadAggregatorTest {
         testCves.forEach(cve -> {
             Assertions.assertTrue(uniqueCves.contains(cve));
         });
+    }
+
+    @Test
+    void validatePayloadWithNewEventTypes() {
+        List<String> testCves = List.of("CVE-2023-0001", "CVE-2023-0002", "CVE-2023-0003", "CVE-2023-0004");
+
+        aggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, NEW_CVE_ALL_EVENT, testCves.get(0)));
+        aggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, SYSTEM_CVE_KNOWN_EXPLOIT_EVENT, testCves.get(1)));
+        aggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, SYSTEM_CVE_SEVERITY_EVENT, testCves.get(1)));
+        aggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, SYSTEM_CVE_CVSS_EVENT, testCves.get(2)));
+        aggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, SYSTEM_CVE_SECURITY_RULE_EVENT, testCves.get(3)));
+        aggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, SYSTEM_CVE_ALL_EVENT, testCves.get(3)));
+
+        List<String> uniqueCves = VulnerabilityTestHelpers.getReportedCves(aggregator);
+        Assertions.assertEquals(testCves.size(), uniqueCves.size());
+        testCves.forEach(cve -> {
+            Assertions.assertTrue(uniqueCves.contains(cve));
+        });
+    }
+
+    @Test
+    void shouldFilterUnknownEventTypes() {
+        aggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, "unknown-event-type", "CVE-2023-9999"));
+
+        List<String> uniqueCves = VulnerabilityTestHelpers.getReportedCves(aggregator);
+        Assertions.assertNull(uniqueCves);
     }
 }


### PR DESCRIPTION
## Summary
- Add 6 new vulnerability event types: `new-cve-all` (per-account) and 5 `system-cve-*` types (per-system) with drawer and email templates
- SQL migration inserts event types with appropriate severity levels (CRITICAL/IMPORTANT)
- System email templates list up to 25 CVEs with links, showing a count message when exceeded
- Aggregator updated to process new event types in daily digest

## Test plan
- [x] Template rendering tests pass (32 tests — email subjects, bodies, drawer output)
- [x] Aggregator tests pass (5 tests — payload validation, unknown type filtering)
- [ ] Deploy to ephemeral env and verify event types in DB
- [ ] E2E tests tracked separately in RHCLOUD-47947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new RHEL vulnerability event types (account-level and multiple system-level categories) for finer alerting.
  * New email and drawer notification templates to surface single- and multi-CVE messaging, counts, and contextual deep-links.

* **Tests**
  * Expanded test coverage for all new vulnerability event scenarios to ensure correct notification rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->