### PR TITLE
SWATCH-4796: Include preferences_hash in deduplication logic for custom threshold events

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfig.java
@@ -57,6 +57,7 @@ public class SubscriptionsDeduplicationConfig implements EventDeduplicationConfi
         Optional.ofNullable(context.getString("service_level")).ifPresent(sla -> deduplicationKey.put("service_level", sla));
         Optional.ofNullable(context.getString("usage")).ifPresent(usage -> deduplicationKey.put("usage", usage));
         deduplicationKey.put("month", event.getTimestamp().format(MONTH_FORMATTER));
+        Optional.ofNullable(context.getString("preferences_hash")).ifPresent(hash -> deduplicationKey.put("preferences_hash", hash));
         if (engineConfig.isSubscriptionsDeduplicationWillBeNotifiedEnabled(event.getOrgId())) {
             deduplicationKey.put("will_be_notified", willBeNotified(event.getOrgId(), event.getEventType().getId()));
         }

--- a/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfigTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/events/deduplication/SubscriptionsDeduplicationConfigTest.java
@@ -247,11 +247,84 @@ class SubscriptionsDeduplicationConfigTest {
                 "Same service_level and usage should produce identical deduplication keys");
     }
 
+    @Test
+    void testGetDeduplicationKeyWithPreferencesHash() {
+        String orgId = "test-org";
+        String productId = "product-123";
+        String metricId = "metric-456";
+        String billingAccountId = "billing-789";
+        String preferencesHash = "abc123def456";
+
+        Event event = givenSubscriptionEventWithPreferencesHash(orgId, productId, metricId, billingAccountId, preferencesHash);
+        Optional<String> deduplicationKey = deduplicationConfig.getDeduplicationKey(event);
+
+        assertTrue(deduplicationKey.isPresent());
+        JsonObject keyJson = new JsonObject(deduplicationKey.get());
+        assertEquals(preferencesHash, keyJson.getString("preferences_hash"));
+    }
+
+    @Test
+    void testGetDeduplicationKeyDifferentPreferencesHashProducesDifferentKey() {
+        String orgId = "test-org";
+        String productId = "product-123";
+        String metricId = "metric-456";
+        String billingAccountId = "billing-789";
+
+        Event event1 = givenSubscriptionEventWithPreferencesHash(orgId, productId, metricId, billingAccountId, "hash1");
+        Optional<String> deduplicationKey1 = deduplicationConfig.getDeduplicationKey(event1);
+
+        Event event2 = givenSubscriptionEventWithPreferencesHash(orgId, productId, metricId, billingAccountId, "hash2");
+        Optional<String> deduplicationKey2 = deduplicationConfig.getDeduplicationKey(event2);
+
+        assertTrue(deduplicationKey1.isPresent());
+        assertTrue(deduplicationKey2.isPresent());
+        assertNotEquals(deduplicationKey1.get(), deduplicationKey2.get(),
+                "Different preferences_hash should produce different deduplication keys");
+    }
+
+    @Test
+    void testGetDeduplicationKeySamePreferencesHashProducesSameKey() {
+        String orgId = "test-org";
+        String productId = "product-123";
+        String metricId = "metric-456";
+        String billingAccountId = "billing-789";
+        String preferencesHash = "same-hash-123";
+
+        Event event1 = givenSubscriptionEventWithPreferencesHash(orgId, productId, metricId, billingAccountId, preferencesHash);
+        Optional<String> deduplicationKey1 = deduplicationConfig.getDeduplicationKey(event1);
+
+        Event event2 = givenSubscriptionEventWithPreferencesHash(orgId, productId, metricId, billingAccountId, preferencesHash);
+        Optional<String> deduplicationKey2 = deduplicationConfig.getDeduplicationKey(event2);
+
+        assertTrue(deduplicationKey1.isPresent());
+        assertTrue(deduplicationKey2.isPresent());
+        assertEquals(deduplicationKey1.get(), deduplicationKey2.get(),
+                "Same preferences_hash should produce identical deduplication keys");
+    }
+
+    @Test
+    void testGetDeduplicationKeyWithoutPreferencesHash() {
+        Event event = givenSubscriptionEvent("org", "product", "metric", "billing");
+        Optional<String> deduplicationKey = deduplicationConfig.getDeduplicationKey(event);
+
+        assertTrue(deduplicationKey.isPresent());
+        JsonObject keyJson = new JsonObject(deduplicationKey.get());
+        assertFalse(keyJson.containsKey("preferences_hash"));
+    }
+
     private Event givenSubscriptionEvent(String orgId, String productId, String metricId, String billingAccountId) {
         return givenSubscriptionEvent(orgId, productId, metricId, billingAccountId, null, null);
     }
 
     private Event givenSubscriptionEvent(String orgId, String productId, String metricId, String billingAccountId, String serviceLevel, String usage) {
+        return givenSubscriptionEvent(orgId, productId, metricId, billingAccountId, serviceLevel, usage, null);
+    }
+
+    private Event givenSubscriptionEventWithPreferencesHash(String orgId, String productId, String metricId, String billingAccountId, String preferencesHash) {
+        return givenSubscriptionEvent(orgId, productId, metricId, billingAccountId, null, null, preferencesHash);
+    }
+
+    private Event givenSubscriptionEvent(String orgId, String productId, String metricId, String billingAccountId, String serviceLevel, String usage, String preferencesHash) {
         JsonObject context = new JsonObject();
         context.put("product_id", productId);
         context.put("metric_id", metricId);
@@ -261,6 +334,9 @@ class SubscriptionsDeduplicationConfigTest {
         }
         if (usage != null) {
             context.put("usage", usage);
+        }
+        if (preferencesHash != null) {
+            context.put("preferences_hash", preferencesHash);
         }
 
         EventType eventType = new EventType();


### PR DESCRIPTION
[SWATCH-4796](https://redhat.atlassian.net/browse/SWATCH-4796)

### Summary

  Updates the subscriptions deduplication logic to include a `preferences_hash` field in the deduplication key. This allows custom threshold preference changes to reset deduplication, ensuring users receive notifications after updating
  their custom utilization thresholds.

### Changes

  - **SubscriptionsDeduplicationConfig.java**: Added `preferences_hash` to deduplication key (line 60)
  - **SubscriptionsDeduplicationConfigTest.java**: Added 4 test cases to verify preferences_hash handling:
    - Hash inclusion in deduplication key
    - Different hashes produce different keys
    - Same hash produces same key
    - Backward compatibility without hash

[SWATCH-4796]: https://redhat.atlassian.net/browse/SWATCH-4796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Deduplication keys now optionally incorporate a preferences hash from event context, improving deduplication granularity when present.

* **Tests**
  * Added tests verifying deduplication behavior with and without preferences hash, ensuring different hashes produce distinct keys and identical hashes produce identical keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->