### PR TITLE
Add missing in memory flag in engine clowder config file

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -227,6 +227,8 @@ objects:
           value: ${PROCESSOR_CONNECTORS_MIN_DELAY_SINCE_FIRST_SERVER_ERROR}
         - name: NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES
           value: ${NOTIFICATIONS_USE_OCM_REFACTORED_TEMPLATES}
+        - name: IN_MEMORY_DB_ENABLED
+          value: ${IN_MEMORY_DB_ENABLED}
       autoScaler:
         minReplicaCount: ${{MIN_REPLICAS}}
         maxReplicaCount: 6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for in-memory database configuration in the notifications engine, enabling users to optionally enable this capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->