### PR TITLE
Add tls support for valkey integration

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/events/ValkeyService.java
@@ -53,7 +53,13 @@ public class ValkeyService {
             if (valkeyHost.isEmpty() || valkeyHost.get().isEmpty()) {
                 throw new IllegalStateException("In-memory DB enabled, but Valkey connection string was not provided");
             } else {
-                RedisOptions valkeyOptions = new RedisOptions().setConnectionString(valkeyHost.get().replace("valkey://", "redis://"));
+                String connectionString = valkeyHost.get()
+                        .replace("valkey://", "redis://")
+                        .replace("valkeys://", "rediss://");
+                RedisOptions valkeyOptions = new RedisOptions().setConnectionString(connectionString);
+                if (connectionString.startsWith("rediss://")) {
+                    valkeyOptions.getNetClientOptions().setHostnameVerificationAlgorithm("HTTPS");
+                }
                 valkeyPassword.ifPresent(valkeyOptions::setPassword);
 
                 this.valkeyClient = Redis.createClient(vertx, valkeyOptions);


### PR DESCRIPTION
## Problem

In stage, Clowder provisions Valkey with TLS and sets `quarkus.redis.hosts` to a `valkeys://` URL. `ValkeyService` was building its `RedisOptions` with two bugs:

1. The scheme replacement only handled `valkey://` → `redis://`, leaving `valkeys://` untouched instead of mapping it to `rediss://`.
2. When the resulting connection string uses `rediss://` (TLS), Vert.x requires an explicit hostname verification algorithm on the net client options. Without it, the connection fails with:
   ```
   Missing hostname verification algorithm: you must set TCP client options host name verification algorithm
   ```

## Fix

- Added `valkeys://` → `rediss://` scheme mapping alongside the existing `valkey://` → `redis://` one.
- When the connection string starts with `rediss://`, set `hostnameVerificationAlgorithm("HTTPS")` on the `NetClientOptions`.