### PR TITLE
[RHCLOUD-48189] Lower log level

### DIFF
--- a/connector-common-v2/src/main/java/com/redhat/cloud/notifications/connector/v2/MessageConsumer.java
+++ b/connector-common-v2/src/main/java/com/redhat/cloud/notifications/connector/v2/MessageConsumer.java
@@ -103,7 +103,7 @@ public class MessageConsumer {
             outgoingMessageSender.sendSuccess(cloudEventMetadata, additionalConnectorDetails, startTime);
             success = true;
         } catch (Exception e) {
-            Log.errorf(e, "Error processing message: %s", e.getMessage());
+            Log.infof(e, "Error processing message: %s", e.getMessage());
             HandledExceptionDetails processedExceptionDetails = exceptionProcessor.processException(e, cloudEventMetadata);
 
             // Send failure response back to engine


### PR DESCRIPTION
When a connector fails to deliver a notification (e.g. DNS resolution failure, connection timeout, bad HTTP response), MessageConsumer.processMessage() catches the exception and unconditionally logs it at ERROR level with a full stack trace — before passing it to the ExceptionHandler.
  
  The problem is that these exceptions are already handled correctly: HttpExceptionHandler classifies them (e.g. UnknownHostException → UNKNOWN_HOST) and the failure is reported back to the engine. They represent expected delivery failures, often caused by user-misconfigured endpoints, not bugs in the connector itself.

  Logging them at ERROR causes noise in monitoring dashboards and can trigger false alerts. Lowering to INFO keeps the information visible in logs for debugging without polluting error-level observability signals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated exception logging behavior in message processing to accurately reflect error severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->