### PR TITLE
RHCLOUD-48159 - mitigation db cleaner update

### DIFF
--- a/.rhcicd/clowdapp-backend.yaml
+++ b/.rhcicd/clowdapp-backend.yaml
@@ -38,7 +38,7 @@ objects:
           limits:
             cpu: ${DB_CLEANER_CPU_LIMIT}
             memory: ${DB_CLEANER_MEMORY_LIMIT}
-        image: registry.redhat.io/rhel9/postgresql-16:9.7
+        image: registry.redhat.io/rhel9/postgresql-16:9.8
         imagePullPolicy: Always
         volumes:
           - name: notifications-db-cleaner-volume


### PR DESCRIPTION
Update db cleaner postgres  version from tag 9.7 to 9.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database cleaner container image to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->