### PR TITLE
[RHCLOUD-48473] Add application name on Drawer payloads

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/DrawerNotificationRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/DrawerNotificationRepository.java
@@ -147,7 +147,7 @@ public class DrawerNotificationRepository {
         } else {
             return "SELECT e.id, " +
                 "drs.id IS NOT NULL, " +
-                "bundle.displayName, app.displayName, et.displayName, e.created, e.renderedDrawerNotification, bundle.name, e.severity " +
+                "bundle.displayName, app.displayName, et.displayName, e.created, e.renderedDrawerNotification, bundle.name, e.severity, app.name " +
                 "FROM Event e " +
                 "JOIN e.eventType et " +
                 "JOIN et.application app " +

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/DrawerNotificationRepositoryTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/repositories/DrawerNotificationRepositoryTest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -176,6 +177,20 @@ public class DrawerNotificationRepositoryTest extends DbIsolatedTest {
     }
 
     @Test
+    void testGetNotifications_ReturnsApplicationName() {
+        Event event = createDrawerEvent(orgId, "bundle1", "app1", "event-type-1");
+        Application app = entityManager.find(Application.class, event.getApplicationId());
+
+        List<DrawerEntryPayload> result = drawerNotificationRepository.getNotifications(
+            orgId, username, null, null, null, null, null, null, new Query(), null
+        );
+
+        assertEquals(1, result.size());
+        assertNotNull(result.get(0).getApplication(), "application field should not be null");
+        assertEquals(app.getName(), result.get(0).getApplication(), "Application name should match app.name from the database");
+    }
+
+    @Test
     void testGetNotifications_RespectsReadStatusFilter_Unread() {
         Event unreadEvent = createDrawerEvent(orgId, "bundle1", "app1", "event-type-1");
         Event readEvent = createDrawerEvent(orgId, "bundle1", "app1", "event-type-1");
@@ -298,6 +313,7 @@ public class DrawerNotificationRepositoryTest extends DbIsolatedTest {
         when(backendConfig.isNormalizedQueriesEnabled(anyString())).thenReturn(true);
 
         Event event = createDrawerEvent(orgId, "bundle1", "app1", "event-type-1");
+        Application app = entityManager.find(Application.class, event.getApplicationId());
 
         List<DrawerEntryPayload> result = drawerNotificationRepository.getNotifications(
             orgId, username, null, null, null, null, null, null, new Query(), null
@@ -305,6 +321,8 @@ public class DrawerNotificationRepositoryTest extends DbIsolatedTest {
 
         assertEquals(1, result.size(), "Normalized query path should return results");
         assertEquals(event.getId(), result.get(0).getEventId());
+        assertNotNull(result.get(0).getApplication(), "Normalized query should also return application name");
+        assertEquals(app.getName(), result.get(0).getApplication());
     }
 
     @Test

--- a/common/src/main/java/com/redhat/cloud/notifications/models/DrawerEntryPayload.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/models/DrawerEntryPayload.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.redhat.cloud.notifications.Severity;
 import jakarta.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -36,6 +37,9 @@ public class DrawerEntryPayload {
 
     private String bundle;
 
+    @Schema(description = "The technical name of the application (not the display name)")
+    private String application;
+
     private String severity;
 
     public DrawerEntryPayload() {
@@ -52,6 +56,9 @@ public class DrawerEntryPayload {
         bundle = (String) rawDrawerEntry[7];
         if (rawDrawerEntry[8] instanceof Severity) {
             severity = ((Severity) rawDrawerEntry[8]).name();
+        }
+        if (rawDrawerEntry.length > 9) {
+            application = (String) rawDrawerEntry[9];
         }
     }
 
@@ -117,5 +124,13 @@ public class DrawerEntryPayload {
 
     public void setSeverity(String severity) {
         this.severity = severity;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public void setApplication(String application) {
+        this.application = application;
     }
 }

--- a/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/models/DrawerEntryPayload.java
+++ b/connector-drawer/src/main/java/com/redhat/cloud/notifications/connector/drawer/models/DrawerEntryPayload.java
@@ -33,6 +33,8 @@ public class DrawerEntryPayload {
 
     private String bundle;
 
+    private String application;
+
     private String severity;
 
     public DrawerEntryPayload() {
@@ -100,5 +102,13 @@ public class DrawerEntryPayload {
 
     public void setSeverity(String severity) {
         this.severity = severity;
+    }
+
+    public String getApplication() {
+        return application;
+    }
+
+    public void setApplication(String application) {
+        this.application = application;
     }
 }

--- a/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorIntegrationTest.java
+++ b/connector-drawer/src/test/java/com/redhat/cloud/notifications/connector/drawer/DrawerConnectorIntegrationTest.java
@@ -79,6 +79,7 @@ class DrawerConnectorIntegrationTest extends BaseConnectorIntegrationTest {
         drawerEntryPayload.setTitle("the title");
         drawerEntryPayload.setBundle("My Bundle");
         drawerEntryPayload.setSeverity("IMPORTANT");
+        drawerEntryPayload.setApplication("my-application");
 
         RecipientSettings recipientSettings = new RecipientSettings();
         return new DrawerNotificationToConnector(orgId, drawerEntryPayload, Set.of(recipientSettings),
@@ -199,6 +200,7 @@ class DrawerConnectorIntegrationTest extends BaseConnectorIntegrationTest {
         assertEquals(testNotification.getDrawerEntryPayload().getSource(), secondPayloadLevel.getString("source"));
         assertEquals(testNotification.getDrawerEntryPayload().getTitle(), secondPayloadLevel.getString("title"));
         assertEquals(testNotification.getDrawerEntryPayload().getSeverity(), secondPayloadLevel.getString("severity"));
+        assertEquals(testNotification.getDrawerEntryPayload().getApplication(), secondPayloadLevel.getString("application"));
     }
 
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -28,7 +28,7 @@ public class ApplicationRepository {
         }
     }
 
-    @CacheResult(cacheName = "get-application-by-id")
+    @CacheResult(cacheName = "get-application-name-by-id")
     public String getApplicationName(UUID id) {
         try {
             return entityManager.createQuery(

--- a/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepository.java
@@ -7,6 +7,7 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import java.util.Optional;
+import java.util.UUID;
 
 @ApplicationScoped
 public class ApplicationRepository {
@@ -24,6 +25,18 @@ public class ApplicationRepository {
                 .getSingleResult());
         } catch (NoResultException e) {
             return Optional.empty();
+        }
+    }
+
+    @CacheResult(cacheName = "get-application-by-id")
+    public String getApplicationName(UUID id) {
+        try {
+            return entityManager.createQuery(
+                    "SELECT a.name FROM Application a WHERE a.id = :id", String.class)
+                .setParameter("id", id)
+                .getSingleResult();
+        } catch (NoResultException e) {
+            return null;
         }
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.config.EngineConfig;
+import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.db.repositories.BundleRepository;
 import com.redhat.cloud.notifications.db.repositories.EventRepository;
 import com.redhat.cloud.notifications.db.repositories.SubscriptionRepository;
@@ -54,6 +55,9 @@ public class DrawerProcessor extends SystemEndpointTypeProcessor {
 
     @Inject
     SubscriptionRepository subscriptionRepository;
+
+    @Inject
+    ApplicationRepository applicationRepository;
 
     @Inject
     BundleRepository bundleRepository;
@@ -130,6 +134,7 @@ public class DrawerProcessor extends SystemEndpointTypeProcessor {
         drawerEntryPayload.setCreated(event.getCreated());
         drawerEntryPayload.setSource(String.format("%s - %s", event.getApplicationDisplayName(), event.getBundleDisplayName()));
         drawerEntryPayload.setBundle(bundleRepository.getBundle(event.getBundleId()).getName());
+        drawerEntryPayload.setApplication(applicationRepository.getApplicationName(event.getApplicationId()));
         drawerEntryPayload.setEventId(event.getId());
         if (event.getSeverity() != null) {
             drawerEntryPayload.setSeverity(event.getSeverity().name());

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -193,7 +193,7 @@ quarkus.cache.caffeine.is-email-aggregation-supported.expire-after-write=PT5M
 quarkus.cache.caffeine.recipients-resolver-results.expire-after-write=PT1M
 quarkus.cache.caffeine.get-bundle-by-id.expire-after-write=PT15M
 quarkus.cache.caffeine.get-app-by-name.expire-after-write=PT15M
-quarkus.cache.caffeine.get-application-by-id.expire-after-write=PT15M
+quarkus.cache.caffeine.get-application-name-by-id.expire-after-write=PT15M
 quarkus.cache.caffeine.aggregation-target-email-subscription-endpoints.expire-after-write=PT5M
 
 quarkus.unleash.active=false

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -193,6 +193,7 @@ quarkus.cache.caffeine.is-email-aggregation-supported.expire-after-write=PT5M
 quarkus.cache.caffeine.recipients-resolver-results.expire-after-write=PT1M
 quarkus.cache.caffeine.get-bundle-by-id.expire-after-write=PT15M
 quarkus.cache.caffeine.get-app-by-name.expire-after-write=PT15M
+quarkus.cache.caffeine.get-application-by-id.expire-after-write=PT15M
 quarkus.cache.caffeine.aggregation-target-email-subscription-endpoints.expire-after-write=PT5M
 
 quarkus.unleash.active=false

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepositoryTest.java
@@ -29,7 +29,7 @@ public class ApplicationRepositoryTest {
     @Inject
     ApplicationRepository applicationRepository;
 
-    @CacheInvalidateAll(cacheName = "get-application-by-id")
+    @CacheInvalidateAll(cacheName = "get-application-name-by-id")
     void invalidateApplicationCache() {
     }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/ApplicationRepositoryTest.java
@@ -1,0 +1,59 @@
+package com.redhat.cloud.notifications.db.repositories;
+
+import com.redhat.cloud.notifications.TestLifecycleManager;
+import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.models.Application;
+import com.redhat.cloud.notifications.models.Bundle;
+import io.quarkus.cache.CacheInvalidateAll;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class ApplicationRepositoryTest {
+
+    private static final String BUNDLE_NAME = "app-repo-test-bundle";
+    private static final String APP_NAME = "app-repo-test-app";
+
+    @Inject
+    ResourceHelpers resourceHelpers;
+
+    @Inject
+    ApplicationRepository applicationRepository;
+
+    @CacheInvalidateAll(cacheName = "get-application-by-id")
+    void invalidateApplicationCache() {
+    }
+
+    @AfterEach
+    void afterEach() {
+        invalidateApplicationCache();
+        resourceHelpers.deleteApp(BUNDLE_NAME, APP_NAME);
+        resourceHelpers.deleteBundle(BUNDLE_NAME);
+    }
+
+    @Test
+    void testGetApplicationNameById_ReturnsCorrectName() {
+        Bundle bundle = resourceHelpers.createBundle(BUNDLE_NAME);
+        Application app = resourceHelpers.createApp(bundle.getId(), APP_NAME);
+
+        String result = applicationRepository.getApplicationName(app.getId());
+
+        assertEquals(APP_NAME, result);
+    }
+
+    @Test
+    void testGetApplicationNameById_UnknownId_ReturnsNull() {
+        String result = applicationRepository.getApplicationName(UUID.randomUUID());
+
+        assertNull(result, "Should return null for an unknown application ID");
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessorTest.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.processors.drawer;
 import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.db.repositories.NotificationHistoryRepository;
 import com.redhat.cloud.notifications.events.EventWrapperAction;
 import com.redhat.cloud.notifications.ingress.Action;
@@ -36,6 +37,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -47,10 +49,12 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,6 +74,9 @@ class DrawerProcessorTest {
 
     @Inject
     protected ResourceHelpers resourceHelpers;
+
+    @InjectSpy
+    ApplicationRepository applicationRepository;
 
     @InjectSpy
     NotificationHistoryRepository notificationHistoryRepository;
@@ -158,12 +165,53 @@ class DrawerProcessorTest {
         assertFalse(message.getPayload().isEmpty());
 
         assertNotNull(message.getPayload().getJsonObject("event_data"));
+        JsonObject drawerEntryPayload = message.getPayload().getJsonObject("drawer_entry_payload");
+        assertNotNull(drawerEntryPayload, "drawer_entry_payload should be present in the message");
+        assertEquals("test-drawer-engine-event-application", drawerEntryPayload.getString("application"),
+            "application field should contain the application name");
         CloudEventMetadata cloudEventMetadata = message.getMetadata(CloudEventMetadata.class).get();
         assertNotNull(cloudEventMetadata);
         assertFalse(cloudEventMetadata.getId().isEmpty());
         assertFalse(cloudEventMetadata.getType().isEmpty());
 
         deleteEvent(createdEvent);
+    }
+
+    @Test
+    void shouldHandleNullApplicationName() {
+        inMemoryToCamelSink.clear();
+
+        User user = new User();
+        user.setId("foo");
+        user.setUsername("foo");
+
+        when(externalRecipientsResolver.recipientUsers(any(), any(), any(), any(), eq(true), any(RecipientsAuthorizationCriterion.class)))
+                .thenReturn(Set.of(user));
+
+        Event createdEvent = createEvent(true);
+
+        doReturn(null).when(applicationRepository).getApplicationName(any());
+
+        try {
+            Endpoint endpoint = new Endpoint();
+            endpoint.setProperties(new SystemSubscriptionProperties());
+            endpoint.setType(EndpointType.DRAWER);
+
+            when(engineConfig.isDrawerEnabled(anyString())).thenReturn(true);
+            testee.process(createdEvent, List.of(endpoint));
+
+            await().until(() -> inMemoryToCamelSink.received().size() == 1);
+            Message<JsonObject> message = inMemoryToCamelSink.received().get(0);
+
+            JsonObject drawerEntryPayload = message.getPayload().getJsonObject("drawer_entry_payload");
+            assertNotNull(drawerEntryPayload, "drawer_entry_payload should be present in the message");
+            assertNull(drawerEntryPayload.getString("application"),
+                "application field should be null when repository returns null");
+        } finally {
+            Mockito.reset(applicationRepository);
+            inMemoryToCamelSink.clear();
+            deleteEvent(createdEvent);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## Summary

Adds the application technical name (e.g. `policies`, `advisor`) to drawer notification payloads, complementing the existing display name exposed via the `source` field.

### Changes

**Common module** (`DrawerEntryPayload`)
- New nullable `application` field with `@Schema` annotation for OpenAPI documentation
- Backward-compatible constructor: defensive `rawDrawerEntry.length > 9` check before reading index 9

**Engine module** (`DrawerProcessor` / `ApplicationRepository`)
- New `getApplicationName(UUID id)` method with `@CacheResult` (Caffeine, 15-min TTL) — matches the existing `get-bundle-by-id` cache pattern
- `DrawerProcessor.buildJsonPayloadFromEvent()` now sets `application` on the payload sent to the connector

**Backend module** (`DrawerNotificationRepository`)
- JPQL query updated to select `app.name` at position 9 (existing `app` join, no new joins)

**Connector-drawer module** (`DrawerEntryPayload`)
- Mirrored `application` field so the connector deserializes and forwards it correctly

### API impact

- **Non-breaking**: the new field is nullable and simply added to the existing `DrawerEntryPayload` response — existing clients ignore unknown fields
- No new endpoints, no versioning change required

### Tests

- `DrawerNotificationRepositoryTest`: verifies `application` is returned for both standard and normalized query paths
- `ApplicationRepositoryTest` (new): covers happy path and unknown-UUID-returns-null
- `DrawerProcessorTest`: asserts the field in the outgoing Kafka message; added null-application-name edge case
- `DrawerConnectorIntegrationTest`: verifies round-trip serialization of the new field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drawer notifications now include an `application` field (application name) in the emitted payload to provide clearer context for each notification.

* **Performance**
  * Application-name lookups are now cached for improved efficiency (15-minute expiration).

* **Tests**
  * Added and extended repository, processor, and connector integration tests to verify `application` population matches persisted data and correctly handles missing application names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->