### PR TITLE
chore: set up togi

### DIFF
--- a/.claude/togi.md
+++ b/.claude/togi.md
@@ -6,6 +6,7 @@ To participate, run in Claude Code:
 
     /plugin marketplace add gwenneg/togi
     /plugin install togi@togi
+    /reload-plugins
     /togi:enable
 
 Disable togi any time with /togi:disable. This file is togi's adoption note: it records that this repo adopted togi, and its presence lets togi show a one-time opt-in notice to developers who already have the plugin installed — nothing in this repo installs or runs anything by itself.

--- a/.claude/togi.md
+++ b/.claude/togi.md
@@ -1,0 +1,11 @@
+# This repo uses togi (研ぎ)
+
+[Togi](https://github.com/gwenneg/togi) turns AI friction — corrections, clarifications, mistakes, denied tool calls — into context-doc pull requests. Capture is opt-in per developer and costs ~.05–.20 per session for those who opt in, billed at standard API rates from their separate Agent SDK credit (or API billing).
+
+To participate, run in Claude Code:
+
+    /plugin marketplace add gwenneg/togi
+    /plugin install togi@togi
+    /togi:enable
+
+Disable togi any time with /togi:disable. This file is togi's adoption note: it records that this repo adopted togi, and its presence lets togi show a one-time opt-in notice to developers who already have the plugin installed — nothing in this repo installs or runs anything by itself.

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ backend/src/main/resources/META-INF
 
 # python
 __pycache__
+
+# togi
+/.claude/friction/
+/.claude/settings.local.json
+/.claude/togi.log
+/.claude/togi-notice-shown

--- a/README.adoc
+++ b/README.adoc
@@ -221,3 +221,7 @@ For the requests as well as for the responses for querying the IT User Service w
 While the Grafana dashboard on stage gets updated automatically after merging a PR that changes the dashboard,
 prod still needs to be updated manually. If you want to update the dashboards on prod after you checked that your changes are working on stage,
 you need to update the reference in app-interface/data/services/insights/notifications/cicd/ci-int/saas-observability.yml
+
+## AI friction capture (togi)
+
+This repo uses [togi](https://github.com/gwenneg/togi) to turn AI friction into context-doc improvements. Participation is opt-in per developer — see [.claude/togi.md](.claude/togi.md) for the setup commands and cost model.


### PR DESCRIPTION
 ## Summary

  [Togi](https://github.com/gwenneg/togi) (研ぎ, to sharpen) captures AI friction — corrections, clarifications, mistakes, denied tool calls — and turns them into context-doc pull requests, so the same stumble
  doesn't happen twice.

  ## What changed

  | File | Purpose |
  |---|---|
  | `.claude/togi.md` | Adoption note — records that this repo uses togi and lists the opt-in commands |
  | `README.adoc` | Pointer to the adoption note |
  | `.gitignore` | Ignores per-developer togi files (friction events, local settings, logs) |

  No settings, no hooks, no code. Merging installs nothing and runs nothing on anyone's machine.

  ## How it works

  Developers who want to participate run three commands (listed in `.claude/togi.md`), then work normally. After each session, a headless sweep reviews the conversation for friction events and writes them to
  `.claude/friction/pending/`. Once enough accumulate, `/togi:update-context-docs` turns them into a doc PR.

  - **Opt-in per developer** — capture is off by default; enable with `/togi:enable`, disable with `/togi:disable`
  - **Private** — the sweep resumes your session under your own credentials, nothing is sent to any third party
  - **Cheap** — ~$0.05–0.20 per session, billed from your Agent SDK credit

  <details>
  <summary>Haven't opted in?</summary>

  You'll see a one-time notice suggesting you try it. Nothing else will ever run.
  </details>

  ---

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
