### PR TITLE
[RHCLOUD-46249] Add McpAssured protocol-level tests for all MCP tools

### DIFF
--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -124,6 +124,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAssuredTestBase.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/McpAssuredTestBase.java
@@ -1,0 +1,42 @@
+package com.redhat.cloud.notifications.mcp;
+
+import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.vertx.core.MultiMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
+
+/**
+ * Base class for McpAssured-based tool tests.
+ * Uses the Quarkus MCP Server testing library instead of raw JSON-RPC payloads.
+ */
+public abstract class McpAssuredTestBase {
+
+    protected McpStreamableTestClient client;
+
+    @BeforeEach
+    void setUp() {
+        MockServerLifecycleManager.getClient().resetAll();
+        String identity = McpTestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
+        client = McpAssured.newStreamableClient()
+                .setAdditionalHeaders(msg -> {
+                    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+                    headers.add("x-rh-identity", identity);
+                    return headers;
+                })
+                .build()
+                .connect();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (client != null) {
+            client.disconnect();
+        }
+    }
+}

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredEventToolsTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredEventToolsTest.java
@@ -1,0 +1,65 @@
+package com.redhat.cloud.notifications.mcp.tools;
+
+import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import com.redhat.cloud.notifications.mcp.McpAssuredTestBase;
+import com.redhat.cloud.notifications.mcp.TestLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class McpAssuredEventToolsTest extends McpAssuredTestBase {
+
+    @Test
+    public void testListToolsContainsGetEvents() {
+        client.when()
+                .toolsList(page -> assertNotNull(page.findByName("getEvents")))
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetEvents() {
+        String eventsJson = "{\"data\":[{\"id\":\"11111111-1111-1111-1111-111111111111\",\"bundle\":\"rhel\",\"application\":\"patch\",\"event_type\":\"New advisory\",\"created\":\"2026-05-12T10:00:00\"}],\"meta\":{\"count\":1},\"links\":{}}";
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/events"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(eventsJson))
+        );
+
+        client.when()
+                .toolsCall("getEvents", Map.of(), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("rhel"));
+                    assertTrue(text.contains("patch"));
+                    assertTrue(text.contains("New advisory"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetEventsBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/events"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getEvents", Map.of(), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+}

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredIntegrationToolsTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredIntegrationToolsTest.java
@@ -1,0 +1,692 @@
+package com.redhat.cloud.notifications.mcp.tools;
+
+import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import com.redhat.cloud.notifications.mcp.McpAssuredTestBase;
+import com.redhat.cloud.notifications.mcp.TestLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class McpAssuredIntegrationToolsTest extends McpAssuredTestBase {
+
+    private static final String INTEGRATION_ID = "12345678-abcd-1234-abcd-1234567890ab";
+    private static final String HISTORY_ID = "abcd1234-abcd-1234-abcd-1234567890ab";
+    private static final String EVENT_TYPE_ID = "87654321-dcba-4321-dcba-ba0987654321";
+
+    @Test
+    public void testListToolsContainsIntegrationTools() {
+        client.when()
+                .toolsList(page -> {
+                    assertNotNull(page.findByName("getIntegrations"));
+                    assertNotNull(page.findByName("getIntegration"));
+                    assertNotNull(page.findByName("getIntegrationHistory"));
+                    assertNotNull(page.findByName("getIntegrationHistoryDetails"));
+                    assertNotNull(page.findByName("createIntegration"));
+                    assertNotNull(page.findByName("updateIntegration"));
+                    assertNotNull(page.findByName("deleteIntegration"));
+                    assertNotNull(page.findByName("enableIntegration"));
+                    assertNotNull(page.findByName("disableIntegration"));
+                    assertNotNull(page.findByName("testIntegration"));
+                    assertNotNull(page.findByName("addEventTypeToIntegration"));
+                    assertNotNull(page.findByName("deleteEventTypeFromIntegration"));
+                    assertNotNull(page.findByName("updateEventTypesLinkedToIntegration"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- getIntegrations ---
+
+    @Test
+    public void testGetIntegrations() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/integrations/v2.0/endpoints"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"data\":[{\"id\":\"" + INTEGRATION_ID + "\",\"name\":\"My Webhook\",\"type\":\"webhook\"}],\"meta\":{\"count\":1},\"links\":{}}"))
+        );
+
+        client.when()
+                .toolsCall("getIntegrations", Map.of(), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("My Webhook"));
+                    assertTrue(text.contains("webhook"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetIntegrationsBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/integrations/v2.0/endpoints"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getIntegrations", Map.of(), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- getIntegration ---
+
+    @Test
+    public void testGetIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/integrations/v2.0/endpoints/" + INTEGRATION_ID))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"id\":\"" + INTEGRATION_ID + "\",\"name\":\"My Webhook\",\"type\":\"webhook\",\"enabled\":true}"))
+        );
+
+        client.when()
+                .toolsCall("getIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("My Webhook"));
+                    assertTrue(text.contains(INTEGRATION_ID));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetIntegrationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/integrations/v2.0/endpoints/" + INTEGRATION_ID))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- getIntegrationHistory ---
+
+    @Test
+    public void testGetIntegrationHistory() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/integrations/v2.0/endpoints/" + INTEGRATION_ID + "/history"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"data\":[{\"id\":\"" + HISTORY_ID + "\",\"status\":\"SUCCESS\"}],\"meta\":{\"count\":1},\"links\":{}}"))
+        );
+
+        client.when()
+                .toolsCall("getIntegrationHistory", Map.of("id", INTEGRATION_ID), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("SUCCESS"));
+                    assertTrue(text.contains("abcd1234"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetIntegrationHistoryBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/integrations/v2.0/endpoints/" + INTEGRATION_ID + "/history"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getIntegrationHistory", Map.of("id", INTEGRATION_ID), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- getIntegrationHistoryDetails ---
+
+    @Test
+    public void testGetIntegrationHistoryDetails() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/history/" + HISTORY_ID + "/details"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"type\":\"com.redhat.console.notification.toCamel.webhook\",\"target\":\"https://example.com/hook\",\"outcome\":\"SUCCESS\"}"))
+        );
+
+        client.when()
+                .toolsCall("getIntegrationHistoryDetails",
+                        Map.of("integrationId", INTEGRATION_ID, "historyId", HISTORY_ID), response -> {
+                            assertFalse(response.isError());
+                            String text = response.firstContent().asText().text();
+                            assertTrue(text.contains("webhook"));
+                            assertTrue(text.contains("SUCCESS"));
+                        })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetIntegrationHistoryDetailsBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/history/" + HISTORY_ID + "/details"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getIntegrationHistoryDetails",
+                        Map.of("integrationId", INTEGRATION_ID, "historyId", HISTORY_ID), response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                        })
+                .thenAssertResults();
+    }
+
+    // --- enableIntegration ---
+
+    @Test
+    public void testEnableIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/enable"))
+                        .willReturn(aResponse().withStatus(200))
+        );
+
+        client.when()
+                .toolsCall("enableIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertFalse(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("enabled successfully"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testEnableIntegrationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/enable"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("enableIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testEnableIntegrationBackendReturns403() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/enable"))
+                        .willReturn(aResponse().withStatus(403))
+        );
+
+        client.when()
+                .toolsCall("enableIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Access denied"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- disableIntegration ---
+
+    @Test
+    public void testDisableIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                delete(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/enable"))
+                        .willReturn(aResponse().withStatus(204))
+        );
+
+        client.when()
+                .toolsCall("disableIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertFalse(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("disabled successfully"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testDisableIntegrationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                delete(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/enable"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("disableIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testDisableIntegrationBackendReturns403() {
+        MockServerLifecycleManager.getClient().stubFor(
+                delete(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/enable"))
+                        .willReturn(aResponse().withStatus(403))
+        );
+
+        client.when()
+                .toolsCall("disableIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Access denied"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- testIntegration ---
+
+    @Test
+    public void testTestIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                post(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/test"))
+                        .willReturn(aResponse().withStatus(204))
+        );
+
+        client.when()
+                .toolsCall("testIntegration", Map.of("uuid", INTEGRATION_ID), response -> {
+                    assertFalse(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Test notification sent successfully"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testTestIntegrationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                post(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/test"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("testIntegration", Map.of("uuid", INTEGRATION_ID), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testTestIntegrationWithCustomMessage() {
+        MockServerLifecycleManager.getClient().stubFor(
+                post(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/test"))
+                        .willReturn(aResponse().withStatus(204))
+        );
+
+        client.when()
+                .toolsCall("testIntegration",
+                        Map.of("uuid", INTEGRATION_ID,
+                                "requestBody", Map.of("message", "Custom test message")),
+                        response -> {
+                            assertFalse(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Test notification sent successfully"));
+                        })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                postRequestedFor(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/test"))
+                        .withRequestBody(matchingJsonPath("$.message", equalTo("Custom test message")))
+        );
+    }
+
+    @Test
+    public void testTestIntegrationWithBlankMessageReturnsValidationError() {
+        client.when()
+                .toolsCall("testIntegration",
+                        Map.of("uuid", INTEGRATION_ID,
+                                "requestBody", Map.of("message", "   ")),
+                        response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("must not be blank"));
+                        })
+                .thenAssertResults();
+    }
+
+    // --- deleteIntegration ---
+
+    @Test
+    public void testDeleteIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                delete(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID))
+                        .willReturn(aResponse().withStatus(204))
+        );
+
+        client.when()
+                .toolsCall("deleteIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertFalse(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("deleted successfully"));
+                })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                deleteRequestedFor(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID))
+        );
+    }
+
+    @Test
+    public void testDeleteIntegrationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                delete(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("deleteIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testDeleteIntegrationBackendReturns403() {
+        MockServerLifecycleManager.getClient().stubFor(
+                delete(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID))
+                        .willReturn(aResponse().withStatus(403))
+        );
+
+        client.when()
+                .toolsCall("deleteIntegration", Map.of("id", INTEGRATION_ID), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Access denied"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- createIntegration ---
+
+    @Test
+    public void testCreateWebhookIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                post(urlPathEqualTo("/api/integrations/v1.0/endpoints"))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"id\":\"" + INTEGRATION_ID + "\",\"name\":\"Test Webhook\",\"type\":\"webhook\"}"))
+        );
+
+        Map<String, Object> endpoint = Map.of(
+                "name", "Test Webhook",
+                "description", "Test webhook integration",
+                "type", "webhook",
+                "enabled", true,
+                "properties", Map.of(
+                        "url", "https://example.com/webhook",
+                        "method", "POST",
+                        "disable_ssl_verification", false
+                )
+        );
+
+        client.when()
+                .toolsCall("createIntegration", Map.of("endpoint", endpoint), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("Test Webhook"));
+                    assertTrue(text.contains("webhook"));
+                })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                postRequestedFor(urlPathEqualTo("/api/integrations/v1.0/endpoints"))
+                        .withRequestBody(matchingJsonPath("$.type", equalTo("webhook")))
+                        .withRequestBody(matchingJsonPath("$.properties.url", equalTo("https://example.com/webhook")))
+        );
+    }
+
+    @Test
+    public void testCreateIntegrationBackendReturns400() {
+        MockServerLifecycleManager.getClient().stubFor(
+                post(urlPathEqualTo("/api/integrations/v1.0/endpoints"))
+                        .willReturn(aResponse().withStatus(400))
+        );
+
+        Map<String, Object> endpoint = Map.of(
+                "name", "Test Webhook", "description", "Test webhook", "type", "webhook", "enabled", true,
+                "properties", Map.of("url", "https://example.com/webhook", "method", "POST", "disable_ssl_verification", false)
+        );
+
+        client.when()
+                .toolsCall("createIntegration", Map.of("endpoint", endpoint), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Invalid request"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testCreatePagerDutyIntegrationSerializesCorrectly() {
+        MockServerLifecycleManager.getClient().stubFor(
+                post(urlPathEqualTo("/api/integrations/v1.0/endpoints"))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withBody("{\"id\":\"pd-id\",\"name\":\"PagerDuty\",\"type\":\"pagerduty\"}"))
+        );
+
+        Map<String, Object> endpoint = Map.of(
+                "name", "PagerDuty Critical",
+                "description", "PagerDuty for critical incidents",
+                "type", "pagerduty",
+                "enabled", true,
+                "properties", Map.of("severity", "critical", "secret_token", "pd-key-123")
+        );
+
+        client.when()
+                .toolsCall("createIntegration", Map.of("endpoint", endpoint), response -> {
+                    assertFalse(response.isError());
+                })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                postRequestedFor(urlPathEqualTo("/api/integrations/v1.0/endpoints"))
+                        .withRequestBody(matchingJsonPath("$.type", equalTo("pagerduty")))
+                        .withRequestBody(matchingJsonPath("$.properties.severity", equalTo("critical")))
+                        .withRequestBody(matchingJsonPath("$.properties.secret_token", equalTo("pd-key-123")))
+        );
+    }
+
+    // --- updateIntegration ---
+
+    @Test
+    public void testUpdateIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID))
+                        .willReturn(aResponse().withStatus(200))
+        );
+
+        Map<String, Object> endpoint = Map.of(
+                "name", "Updated Webhook", "description", "Updated webhook integration",
+                "type", "webhook", "enabled", true,
+                "properties", Map.of("url", "https://example.com/updated", "method", "POST", "disable_ssl_verification", false)
+        );
+
+        client.when()
+                .toolsCall("updateIntegration",
+                        Map.of("id", INTEGRATION_ID, "endpoint", endpoint), response -> {
+                            assertFalse(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("updated successfully"));
+                        })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                putRequestedFor(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID))
+        );
+    }
+
+    @Test
+    public void testUpdateIntegrationBackendReturns400() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID))
+                        .willReturn(aResponse().withStatus(400))
+        );
+
+        Map<String, Object> endpoint = Map.of(
+                "name", "Updated", "description", "Updated webhook",
+                "type", "webhook", "enabled", true,
+                "properties", Map.of("url", "https://example.com", "method", "POST", "disable_ssl_verification", false)
+        );
+
+        client.when()
+                .toolsCall("updateIntegration",
+                        Map.of("id", INTEGRATION_ID, "endpoint", endpoint), response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Invalid request"));
+                        })
+                .thenAssertResults();
+    }
+
+    // --- addEventTypeToIntegration ---
+
+    @Test
+    public void testAddEventTypeToIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventType/" + EVENT_TYPE_ID))
+                        .willReturn(aResponse().withStatus(204))
+        );
+
+        client.when()
+                .toolsCall("addEventTypeToIntegration",
+                        Map.of("endpointId", INTEGRATION_ID, "eventTypeId", EVENT_TYPE_ID), response -> {
+                            assertFalse(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("linked to integration successfully"));
+                        })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                putRequestedFor(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventType/" + EVENT_TYPE_ID))
+        );
+    }
+
+    @Test
+    public void testAddEventTypeToIntegrationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventType/" + EVENT_TYPE_ID))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("addEventTypeToIntegration",
+                        Map.of("endpointId", INTEGRATION_ID, "eventTypeId", EVENT_TYPE_ID), response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                        })
+                .thenAssertResults();
+    }
+
+    // --- deleteEventTypeFromIntegration ---
+
+    @Test
+    public void testDeleteEventTypeFromIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                delete(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventType/" + EVENT_TYPE_ID))
+                        .willReturn(aResponse().withStatus(204))
+        );
+
+        client.when()
+                .toolsCall("deleteEventTypeFromIntegration",
+                        Map.of("endpointId", INTEGRATION_ID, "eventTypeId", EVENT_TYPE_ID), response -> {
+                            assertFalse(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("unlinked from integration successfully"));
+                        })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                deleteRequestedFor(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventType/" + EVENT_TYPE_ID))
+        );
+    }
+
+    @Test
+    public void testDeleteEventTypeFromIntegrationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                delete(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventType/" + EVENT_TYPE_ID))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("deleteEventTypeFromIntegration",
+                        Map.of("endpointId", INTEGRATION_ID, "eventTypeId", EVENT_TYPE_ID), response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                        })
+                .thenAssertResults();
+    }
+
+    // --- updateEventTypesLinkedToIntegration ---
+
+    @Test
+    public void testUpdateEventTypesLinkedToIntegration() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventTypes"))
+                        .willReturn(aResponse().withStatus(204))
+        );
+
+        client.when()
+                .toolsCall("updateEventTypesLinkedToIntegration",
+                        Map.of("endpointId", INTEGRATION_ID,
+                                "eventTypeIds", List.of(EVENT_TYPE_ID, "11111111-2222-3333-4444-555555555555")),
+                        response -> {
+                            assertFalse(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("associations updated successfully"));
+                        })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                putRequestedFor(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventTypes"))
+        );
+    }
+
+    @Test
+    public void testUpdateEventTypesLinkedToIntegrationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventTypes"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("updateEventTypesLinkedToIntegration",
+                        Map.of("endpointId", INTEGRATION_ID,
+                                "eventTypeIds", List.of(EVENT_TYPE_ID)),
+                        response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                        })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testUpdateEventTypesLinkedToIntegrationBackendReturns403() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/integrations/v1.0/endpoints/" + INTEGRATION_ID + "/eventTypes"))
+                        .willReturn(aResponse().withStatus(403))
+        );
+
+        client.when()
+                .toolsCall("updateEventTypesLinkedToIntegration",
+                        Map.of("endpointId", INTEGRATION_ID,
+                                "eventTypeIds", List.of(EVENT_TYPE_ID)),
+                        response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Access denied"));
+                        })
+                .thenAssertResults();
+    }
+}

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredNotificationToolsTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredNotificationToolsTest.java
@@ -1,0 +1,309 @@
+package com.redhat.cloud.notifications.mcp.tools;
+
+import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import com.redhat.cloud.notifications.mcp.McpAssuredTestBase;
+import com.redhat.cloud.notifications.mcp.TestLifecycleManager;
+import io.quarkus.cache.Cache;
+import io.quarkus.cache.CacheName;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class McpAssuredNotificationToolsTest extends McpAssuredTestBase {
+
+    @CacheName("mcp-get-severities")
+    Cache severitiesCache;
+
+    @CacheName("mcp-get-bundle")
+    Cache bundleCache;
+
+    @CacheName("mcp-get-application")
+    Cache applicationCache;
+
+    @CacheName("mcp-get-event-type")
+    Cache eventTypeCache;
+
+    @BeforeEach
+    void clearCaches() {
+        severitiesCache.invalidateAll().await().indefinitely();
+        bundleCache.invalidateAll().await().indefinitely();
+        applicationCache.invalidateAll().await().indefinitely();
+        eventTypeCache.invalidateAll().await().indefinitely();
+    }
+
+    @Test
+    public void testListToolsContainsNotificationTools() {
+        client.when()
+                .toolsList(page -> {
+                    assertNotNull(page.findByName("getSeverities"));
+                    assertNotNull(page.findByName("getBundle"));
+                    assertNotNull(page.findByName("getApplication"));
+                    assertNotNull(page.findByName("getEventType"));
+                    assertNotNull(page.findByName("getLinkedIntegrations"));
+                    assertNotNull(page.findByName("updateEventTypeIntegrations"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- getSeverities ---
+
+    @Test
+    public void testGetSeverities() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v2.0/notifications/severities"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("[\"CRITICAL\",\"IMPORTANT\",\"MODERATE\",\"LOW\",\"NONE\",\"UNDEFINED\"]"))
+        );
+
+        client.when()
+                .toolsCall("getSeverities", Map.of(), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("CRITICAL"));
+                    assertTrue(text.contains("IMPORTANT"));
+                    assertTrue(text.contains("MODERATE"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetSeveritiesBackendReturns500() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v2.0/notifications/severities"))
+                        .willReturn(aResponse().withStatus(500))
+        );
+
+        client.when()
+                .toolsCall("getSeverities", Map.of(), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Backend service error"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetSeveritiesBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v2.0/notifications/severities"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getSeverities", Map.of(), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- getBundle ---
+
+    @Test
+    public void testGetBundle() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"id\":\"1234\",\"name\":\"rhel\",\"display_name\":\"Red Hat Enterprise Linux\"}"))
+        );
+
+        client.when()
+                .toolsCall("getBundle", Map.of("bundleName", "rhel"), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("rhel"));
+                    assertTrue(text.contains("Red Hat Enterprise Linux"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetBundleBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getBundle", Map.of("bundleName", "rhel"), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- getApplication ---
+
+    @Test
+    public void testGetApplication() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"id\":\"5678\",\"name\":\"patch\",\"display_name\":\"Patch\",\"bundle_id\":\"1234\"}"))
+        );
+
+        client.when()
+                .toolsCall("getApplication", Map.of("bundleName", "rhel", "applicationName", "patch"), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("patch"));
+                    assertTrue(text.contains("Patch"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetApplicationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getApplication", Map.of("bundleName", "rhel", "applicationName", "patch"), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    // --- getEventType ---
+
+    @Test
+    public void testGetEventType() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch/eventTypes/new-advisory"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"id\":\"9012\",\"name\":\"new-advisory\",\"display_name\":\"New advisory\",\"application_id\":\"5678\"}"))
+        );
+
+        client.when()
+                .toolsCall("getEventType",
+                        Map.of("bundleName", "rhel", "applicationName", "patch", "eventTypeName", "new-advisory"),
+                        response -> {
+                            assertFalse(response.isError());
+                            String text = response.firstContent().asText().text();
+                            assertTrue(text.contains("new-advisory"));
+                            assertTrue(text.contains("New advisory"));
+                        })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetEventTypeBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/bundles/rhel/applications/patch/eventTypes/new-advisory"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getEventType",
+                        Map.of("bundleName", "rhel", "applicationName", "patch", "eventTypeName", "new-advisory"),
+                        response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                        })
+                .thenAssertResults();
+    }
+
+    // --- getLinkedIntegrations ---
+
+    @Test
+    public void testGetLinkedIntegrations() {
+        String endpointsJson = """
+                {"data":[{"id":"endpoint-1","name":"Webhook 1","type":"webhook"},{"id":"endpoint-2","name":"Slack Integration","type":"camel"}],"meta":{"count":2}}
+                """;
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(endpointsJson))
+        );
+
+        client.when()
+                .toolsCall("getLinkedIntegrations",
+                        Map.of("eventTypeId", "550e8400-e29b-41d4-a716-446655440000"), response -> {
+                            assertFalse(response.isError());
+                            String text = response.firstContent().asText().text();
+                            assertTrue(text.contains("endpoint-1"));
+                            assertTrue(text.contains("Webhook 1"));
+                        })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetLinkedIntegrationsBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getLinkedIntegrations",
+                        Map.of("eventTypeId", "550e8400-e29b-41d4-a716-446655440000"), response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                        })
+                .thenAssertResults();
+    }
+
+    // --- updateEventTypeIntegrations ---
+
+    @Test
+    public void testUpdateEventTypeIntegrations() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                        .willReturn(aResponse().withStatus(200))
+        );
+
+        client.when()
+                .toolsCall("updateEventTypeIntegrations",
+                        Map.of("eventTypeId", "550e8400-e29b-41d4-a716-446655440000",
+                                "endpointIds", List.of("660e8400-e29b-41d4-a716-446655440001")),
+                        response -> {
+                            assertFalse(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("updated successfully"));
+                        })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                putRequestedFor(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+        );
+    }
+
+    @Test
+    public void testUpdateEventTypeIntegrationsBackendReturns403() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                        .willReturn(aResponse().withStatus(403))
+        );
+
+        client.when()
+                .toolsCall("updateEventTypeIntegrations",
+                        Map.of("eventTypeId", "550e8400-e29b-41d4-a716-446655440000",
+                                "endpointIds", List.of("660e8400-e29b-41d4-a716-446655440001")),
+                        response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Access denied"));
+                        })
+                .thenAssertResults();
+    }
+}

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredOrgConfigToolsTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredOrgConfigToolsTest.java
@@ -1,0 +1,110 @@
+package com.redhat.cloud.notifications.mcp.tools;
+
+import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import com.redhat.cloud.notifications.mcp.McpAssuredTestBase;
+import com.redhat.cloud.notifications.mcp.TestLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class McpAssuredOrgConfigToolsTest extends McpAssuredTestBase {
+
+    @Test
+    public void testListToolsContainsOrgConfigTools() {
+        client.when()
+                .toolsList(page -> {
+                    assertNotNull(page.findByName("getDailyDigestTimePreference"));
+                    assertNotNull(page.findByName("setDailyDigestTimePreference"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetDailyDigestTimePreference() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/org-config/daily-digest/time-preference"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("\"09:00\""))
+        );
+
+        client.when()
+                .toolsCall("getDailyDigestTimePreference", Map.of(), response -> {
+                    assertFalse(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("09:00"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetDailyDigestTimePreferenceBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/org-config/daily-digest/time-preference"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getDailyDigestTimePreference", Map.of(), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testSetDailyDigestTimePreference() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/notifications/v1.0/org-config/daily-digest/time-preference"))
+                        .willReturn(aResponse().withStatus(204))
+        );
+
+        client.when()
+                .toolsCall("setDailyDigestTimePreference", Map.of("time", "14:30"), response -> {
+                    assertFalse(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Daily digest time preference set to 14:30 UTC"));
+                })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                putRequestedFor(urlPathEqualTo("/api/notifications/v1.0/org-config/daily-digest/time-preference"))
+        );
+    }
+
+    @Test
+    public void testSetDailyDigestTimePreferenceBackendReturns400() {
+        MockServerLifecycleManager.getClient().stubFor(
+                put(urlPathEqualTo("/api/notifications/v1.0/org-config/daily-digest/time-preference"))
+                        .willReturn(aResponse().withStatus(400))
+        );
+
+        client.when()
+                .toolsCall("setDailyDigestTimePreference", Map.of("time", "14:30"), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Invalid request"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testSetDailyDigestTimePreferenceWithInvalidMinute() {
+        client.when()
+                .toolsCall("setDailyDigestTimePreference", Map.of("time", "09:10"), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("must match"));
+                })
+                .thenAssertResults();
+    }
+}

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredServerToolsTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredServerToolsTest.java
@@ -1,0 +1,53 @@
+package com.redhat.cloud.notifications.mcp.tools;
+
+import com.redhat.cloud.notifications.mcp.McpAssuredTestBase;
+import com.redhat.cloud.notifications.mcp.TestLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
+import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class McpAssuredServerToolsTest extends McpAssuredTestBase {
+
+    @Test
+    public void testListToolsContainsServerTools() {
+        client.when()
+                .toolsList(page -> {
+                    assertNotNull(page.findByName("serverInfo"));
+                    assertNotNull(page.findByName("whoami"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testServerInfo() {
+        client.when()
+                .toolsCall("serverInfo", Map.of(), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("Notifications MCP Server is running"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testWhoami() {
+        client.when()
+                .toolsCall("whoami", Map.of(), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains(DEFAULT_ORG_ID));
+                    assertTrue(text.contains(DEFAULT_USER));
+                })
+                .thenAssertResults();
+    }
+}

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredUserConfigToolsTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredUserConfigToolsTest.java
@@ -1,0 +1,169 @@
+package com.redhat.cloud.notifications.mcp.tools;
+
+import com.redhat.cloud.notifications.MockServerLifecycleManager;
+import com.redhat.cloud.notifications.mcp.McpAssuredTestBase;
+import com.redhat.cloud.notifications.mcp.TestLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class McpAssuredUserConfigToolsTest extends McpAssuredTestBase {
+
+    @Test
+    public void testListToolsContainsUserConfigTools() {
+        client.when()
+                .toolsList(page -> {
+                    assertNotNull(page.findByName("getUserNotificationPreferences"));
+                    assertNotNull(page.findByName("getUserNotificationPreferencesByApplication"));
+                    assertNotNull(page.findByName("saveUserNotificationPreferences"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetUserNotificationPreferences() {
+        String prefsJson = "{\"bundles\":{\"rhel\":{\"display_name\":\"Red Hat Enterprise Linux\",\"applications\":{}}}}";
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/user-config/notification-event-type-preference"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(prefsJson))
+        );
+
+        client.when()
+                .toolsCall("getUserNotificationPreferences", Map.of(), response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("rhel"));
+                    assertTrue(text.contains("Red Hat Enterprise Linux"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetUserNotificationPreferencesBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/user-config/notification-event-type-preference"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getUserNotificationPreferences", Map.of(), response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetUserNotificationPreferencesByApplication() {
+        String appPrefsJson = "{\"display_name\":\"Patch\",\"event_types\":{\"new-advisory\":{\"display_name\":\"New advisory\"}}}";
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/user-config/notification-event-type-preference/rhel/patch"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(appPrefsJson))
+        );
+
+        client.when()
+                .toolsCall("getUserNotificationPreferencesByApplication",
+                        Map.of("bundleName", "rhel", "applicationName", "patch"), response -> {
+                            assertFalse(response.isError());
+                            String text = response.firstContent().asText().text();
+                            assertTrue(text.contains("Patch"));
+                            assertTrue(text.contains("New advisory"));
+                        })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testGetUserNotificationPreferencesByApplicationBackendReturns404() {
+        MockServerLifecycleManager.getClient().stubFor(
+                get(urlPathEqualTo("/api/notifications/v1.0/user-config/notification-event-type-preference/rhel/patch"))
+                        .willReturn(aResponse().withStatus(404))
+        );
+
+        client.when()
+                .toolsCall("getUserNotificationPreferencesByApplication",
+                        Map.of("bundleName", "rhel", "applicationName", "patch"), response -> {
+                            assertTrue(response.isError());
+                            assertTrue(response.firstContent().asText().text().contains("Resource not found"));
+                        })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testSaveUserNotificationPreferences() {
+        MockServerLifecycleManager.getClient().stubFor(
+                post(urlPathEqualTo("/api/notifications/v1.0/user-config/notification-event-type-preference"))
+                        .willReturn(aResponse().withStatus(200))
+        );
+
+        Map<String, Object> args = Map.of(
+                "bundleName", "rhel", "applicationName", "patch",
+                "eventTypeName", "new-advisory", "subscriptionType", "INSTANT",
+                "subscribe", true);
+
+        client.when()
+                .toolsCall("saveUserNotificationPreferences", args, response -> {
+                    assertFalse(response.isError());
+                    String text = response.firstContent().asText().text();
+                    assertTrue(text.contains("enabled successfully"));
+                    assertTrue(text.contains("rhel/patch/new-advisory"));
+                    assertTrue(text.contains("INSTANT"));
+                })
+                .thenAssertResults();
+
+        MockServerLifecycleManager.getClient().verify(
+                postRequestedFor(urlPathEqualTo("/api/notifications/v1.0/user-config/notification-event-type-preference"))
+        );
+    }
+
+    @Test
+    public void testSaveUserNotificationPreferencesBackendReturns500() {
+        MockServerLifecycleManager.getClient().stubFor(
+                post(urlPathEqualTo("/api/notifications/v1.0/user-config/notification-event-type-preference"))
+                        .willReturn(aResponse().withStatus(500))
+        );
+
+        Map<String, Object> args = Map.of(
+                "bundleName", "rhel", "applicationName", "patch",
+                "eventTypeName", "new-advisory", "subscriptionType", "INSTANT",
+                "subscribe", true);
+
+        client.when()
+                .toolsCall("saveUserNotificationPreferences", args, response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("Backend service error"));
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testSaveUserNotificationPreferencesInvalidSubscriptionType() {
+        Map<String, Object> args = Map.of(
+                "bundleName", "rhel", "applicationName", "patch",
+                "eventTypeName", "new-advisory", "subscriptionType", "WEEKLY",
+                "subscribe", true);
+
+        client.when()
+                .toolsCall("saveUserNotificationPreferences", args, response -> {
+                    assertTrue(response.isError());
+                    assertTrue(response.firstContent().asText().text().contains("subscriptionType must be one of"));
+                })
+                .thenAssertResults();
+    }
+}


### PR DESCRIPTION
## Summary

Adds McpAssured-based tests for all 27 MCP tools using the Quarkus MCP Server testing library (`quarkus-mcp-server-test`). These tests validate tools at the MCP protocol level via Streamable HTTP transport, complementing existing RestAssured tests that operate at the raw JSON-RPC layer.

- New `McpAssuredTestBase` base class handles client lifecycle with `x-rh-identity` header injection
- 6 new test classes covering all tool groups: server, notifications, integrations, events, org-config, user-config
- 60 new test cases covering happy paths, backend error responses (404/403/500), input validation, and tools listing verification

## Changes

| File | Description |
|------|-------------|
| `pom.xml` | Added `quarkus-mcp-server-test` test dependency (version managed by existing BOM) |
| `McpAssuredTestBase.java` | Base class: creates `McpStreamableTestClient` with RH identity headers |
| `McpAssuredServerToolsTest.java` | Tests `serverInfo`, `whoami`, tools listing |
| `McpAssuredNotificationToolsTest.java` | Tests `getSeverities`, `getBundle`, `getApplication`, `getEventType`, `getLinkedIntegrations`, `updateEventTypeIntegrations` |
| `McpAssuredIntegrationToolsTest.java` | Tests all 13 integration CRUD tools including polymorphic DTO serialization |
| `McpAssuredEventToolsTest.java` | Tests `getEvents` |
| `McpAssuredOrgConfigToolsTest.java` | Tests `getDailyDigestTimePreference`, `setDailyDigestTimePreference` |
| `McpAssuredUserConfigToolsTest.java` | Tests `getUserNotificationPreferences`, `getUserNotificationPreferencesByApplication`, `saveUserNotificationPreferences` |