### PR TITLE
RHCLOUD-34917 Use CA certificate for IT service mTLS

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -205,6 +205,8 @@ objects:
           value: ${IT_SERVICES_TLS_KEY_PATH}
         - name: IT_SERVICES_TLS_CONFIG_NAME
           value: ${IT_SERVICES_TLS_CONFIG_NAME}
+        - name: IT_SERVICES_TLS_TRUST_STORE_CERTS
+          value: ${IT_SERVICES_TLS_TRUST_STORE_CERTS}
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
@@ -302,6 +304,9 @@ parameters:
   value: ""
 - name: IT_SERVICES_TLS_CONFIG_NAME
   description: Quarkus TLS configuration name for the IT s2s REST client. Set to "it-s2s" in stage/prod; empty elsewhere (disables PEM-based mTLS).
+  value: ""
+- name: IT_SERVICES_TLS_TRUST_STORE_CERTS
+  description: Path to the certificate trust store for IT service-to-service mTLS. Set to /etc/pki/tls/certs/ca-bundle.crt in stage/prod; (default UBI trust store path) empty elsewhere.
   value: ""
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=

--- a/recipients-resolver/src/main/resources/application.properties
+++ b/recipients-resolver/src/main/resources/application.properties
@@ -54,6 +54,7 @@ quarkus.rest-client.it-s2s.url=https://ci.cloud.redhat.com
 # %prod. guard prevents the Quarkus TLS registry from seeing empty-string paths in dev/test mode.
 %prod.quarkus.tls.it-s2s.key-store.pem[0].cert=${IT_SERVICES_TLS_CERT_PATH:}
 %prod.quarkus.tls.it-s2s.key-store.pem[0].key=${IT_SERVICES_TLS_KEY_PATH:}
+%prod.quarkus.tls.it-s2s.trust-store.pem.certs=${IT_SERVICES_TLS_TRUST_STORE_CERTS:}
 %prod.quarkus.rest-client.it-s2s.tls-configuration-name=${IT_SERVICES_TLS_CONFIG_NAME:}
 # Path to the PEM certificate used for startup expiry logging (empty = skip check).
 it.services.tls.cert-path=${IT_SERVICES_TLS_CERT_PATH:}


### PR DESCRIPTION
## Summary

Adds CA certificate trust store configuration for the IT service mTLS connection to enable proper certificate validation using the system CA bundle.

This change configures the Quarkus TLS registry to use the UBI image's system CA trust store (/etc/pki/tls/certs/ca-bundle.crt) for validating the IT service's certificate during mTLS connections. The system trust store already includes the Red Hat IT Root CA certificate after running update-ca-trust in the Dockerfile.

## Changes

- Add `IT_SERVICES_TLS_TRUST_STORE_CERTS` environment variable and parameter to `.rhcicd/clowdapp-recipients-resolver.yaml`
- Add `%prod.quarkus.tls.it-s2s.trust-store.pem.certs=${IT_SERVICES_TLS_TRUST_STORE_CERTS:}` to `recipients-resolver/src/main/resources/application.properties`

## Test plan

- [x] Tested with reproducer to verify the TLS configuration is created with CA certificate
- [ ] Verify in stage that the IT service connection works with proper certificate validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration to support TLS trust store certificate specification in production environments through environment variable configuration.
  * Enhanced deployment template to define and inject TLS trust store certificate configuration parameters with environment-specific defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->