### PR TITLE
Fix recipients-resolver default trust store

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -306,8 +306,8 @@ parameters:
   description: Quarkus TLS configuration name for the IT s2s REST client. Set to "it-s2s" in stage/prod; empty elsewhere (disables PEM-based mTLS).
   value: ""
 - name: IT_SERVICES_TLS_TRUST_STORE_CERTS
-  description: Path to the certificate trust store for IT service-to-service mTLS. Set to /etc/pki/tls/certs/ca-bundle.crt in stage/prod; (default UBI trust store path) empty elsewhere.
-  value: ""
+  description: Path to the certificate trust store for IT service-to-service mTLS. Set to /etc/pki/tls/certs/ca-bundle.crt in stage/prod; (default UBI trust store path).
+  value: "/etc/pki/tls/certs/ca-bundle.crt"
 - name: SENTRY_DSN
   description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED

--- a/recipients-resolver/src/main/resources/application.properties
+++ b/recipients-resolver/src/main/resources/application.properties
@@ -54,7 +54,7 @@ quarkus.rest-client.it-s2s.url=https://ci.cloud.redhat.com
 # %prod. guard prevents the Quarkus TLS registry from seeing empty-string paths in dev/test mode.
 %prod.quarkus.tls.it-s2s.key-store.pem[0].cert=${IT_SERVICES_TLS_CERT_PATH:}
 %prod.quarkus.tls.it-s2s.key-store.pem[0].key=${IT_SERVICES_TLS_KEY_PATH:}
-%prod.quarkus.tls.it-s2s.trust-store.pem.certs=${IT_SERVICES_TLS_TRUST_STORE_CERTS:}
+%prod.quarkus.tls.it-s2s.trust-store.pem.certs=${IT_SERVICES_TLS_TRUST_STORE_CERTS}
 %prod.quarkus.rest-client.it-s2s.tls-configuration-name=${IT_SERVICES_TLS_CONFIG_NAME:}
 # Path to the PEM certificate used for startup expiry logging (empty = skip check).
 it.services.tls.cert-path=${IT_SERVICES_TLS_CERT_PATH:}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TLS trust store certificate configuration to use a concrete default path, improving system stability and security configuration management in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->