### PR TITLE
Fix incorrect Roadmap filter links in notification

### DIFF
--- a/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
@@ -19,7 +19,7 @@ Red Hat Enterprise Linux - Roadmap Monthly Report - {action.context.roadmap.repo
         sub-section-count-id = 'deprecationsCount'
         sub-section-description = 'Deprecations that could affect your systems'
         sub-section-icon = 'img_incident.png'
-        sub-section-url = '/insights/planning/roadmap/?viewFilter=relevant&type=Deprecations&addedToRoadmap=lastMonthToDate'
+        sub-section-url = '/insights/planning/roadmap/?viewFilter=relevant&type=Deprecation&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 1
     }
     {#insert content-roadmap-section}{/}
@@ -32,7 +32,7 @@ Red Hat Enterprise Linux - Roadmap Monthly Report - {action.context.roadmap.repo
         sub-section-count-id = 'changesCount'
         sub-section-description = 'Changes that could affect your systems'
         sub-section-icon = 'img_warning.png'
-        sub-section-url = '/insights/planning/roadmap/?viewFilter=relevant&type=Changes&addedToRoadmap=lastMonthToDate'
+        sub-section-url = '/insights/planning/roadmap/?viewFilter=relevant&type=Change&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 1
     }
     {#insert content-roadmap-section}{/}

--- a/common-template/src/test/java/email/TestRoadmapTemplate.java
+++ b/common-template/src/test/java/email/TestRoadmapTemplate.java
@@ -80,8 +80,8 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains("id=\"changesCount\">3<"), "Body should contain changes count");
         assertTrue(result.contains("id=\"additionsCount\">4<"), "Body should contain additions count");
         // Verify roadmap URLs are properly resolved with the environment base URL
-        assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Deprecations"), "Deprecations link should contain resolved environment URL");
-        assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Changes"), "Changes link should contain resolved environment URL");
+        assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Deprecation"), "Deprecations link should contain resolved environment URL");
+        assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Change"), "Changes link should contain resolved environment URL");
         assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Addition"), "Additions link should contain resolved environment URL");
         assertFalse(result.contains("href=\"{environment.url}"), "Links should not contain unresolved template expression");
     }


### PR DESCRIPTION
The filter links for Deprecations and Changes had incorrect links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query parameter formatting in roadmap email links to ensure proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->