### PR TITLE
Fix url in roadmap template

### DIFF
--- a/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailBody.html
@@ -45,7 +45,7 @@ Red Hat Enterprise Linux - Roadmap Monthly Report - {action.context.roadmap.repo
         sub-section-count-id = 'additionsCount'
         sub-section-description = 'Additions &amp; enhancements that could affect your systems'
         sub-section-icon = 'img_info.png'
-        sub-section-url = '/insights/planning/roadmap/?viewFilter=relevant&type=Addition&addedToRoadmap=lastMonthToDate'
+        sub-section-url = '/insights/planning/roadmap/?viewFilter=relevant&type=Enhancement%2CAddition&addedToRoadmap=lastMonthToDate'
         sub-section-not-the-last = 0
     }
     {#insert content-roadmap-section}{/}

--- a/common-template/src/test/java/email/TestRoadmapTemplate.java
+++ b/common-template/src/test/java/email/TestRoadmapTemplate.java
@@ -82,7 +82,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
         // Verify roadmap URLs are properly resolved with the environment base URL
         assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Deprecation"), "Deprecations link should contain resolved environment URL");
         assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Change"), "Changes link should contain resolved environment URL");
-        assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Addition"), "Additions link should contain resolved environment URL");
+        assertTrue(result.contains("href=\"https://localhost/insights/planning/roadmap/?viewFilter=relevant&type=Enhancement%2CAddition"), "Additions link should contain resolved environment URL");
         assertFalse(result.contains("href=\"{environment.url}"), "Links should not contain unresolved template expression");
     }
 


### PR DESCRIPTION
Add to the url 'Enhancement' to match the title of the section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the roadmap email link so the “Additions & enhancements” section now includes both enhancements and additions in the last-month-to-date view.
  * Adjusted the related email test expectations to match the updated link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->