### PR TITLE
[RHINENG-27749] Update email subject for Lifecycle and Roadmap

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.DRAWER;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_BODY;
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_DAILY_DIGEST_BODY;
+import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_TITLE;
 import static java.util.Map.entry;
 
 public class Rhel {
@@ -62,6 +63,7 @@ public class Rhel {
 
     public static final String ROADMAP_REPORT = "roadmap-monthly-report";
 
+    public static final String MONTHLY_EMAIL_TITLE = "Common/insightsMonthlyEmailTitle.txt";
 
     public static final String TASK_EXECUTED_TASK_COMPLETED = "executed-task-completed";
     public static final String TASK_JOB_FAILED = "job-failed";
@@ -118,11 +120,12 @@ public class Rhel {
         // Lifecycle
         entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), LIFECYCLE_FOLDER_NAME + "retiringLifecycleBody.md"),
         entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), LIFECYCLE_FOLDER_NAME + "retiringLifecycleInstantEmailBody.html"),
+        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), MONTHLY_EMAIL_TITLE),
 
         // Roadmap
         entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP_REPORT), ROADMAP_FOLDER_NAME + "roadmapBody.md"),
         entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP_REPORT), ROADMAP_FOLDER_NAME + "roadmapInstantEmailBody.html"),
-
+        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP_REPORT), MONTHLY_EMAIL_TITLE),
 
         // Resource optimization
         entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, RESOURCE_OPTIMIZATION_APP_NAME, null), RESOURCE_OPTIMIZATION_FOLDER_NAME + "dailyEmailBody.html"),

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Rhel.java
@@ -63,8 +63,6 @@ public class Rhel {
 
     public static final String ROADMAP_REPORT = "roadmap-monthly-report";
 
-    public static final String MONTHLY_EMAIL_TITLE = "Common/insightsMonthlyEmailTitle.txt";
-
     public static final String TASK_EXECUTED_TASK_COMPLETED = "executed-task-completed";
     public static final String TASK_JOB_FAILED = "job-failed";
 
@@ -120,12 +118,12 @@ public class Rhel {
         // Lifecycle
         entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), LIFECYCLE_FOLDER_NAME + "retiringLifecycleBody.md"),
         entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), LIFECYCLE_FOLDER_NAME + "retiringLifecycleInstantEmailBody.html"),
-        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), MONTHLY_EMAIL_TITLE),
+        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, LIFECYCLE_APP_NAME, RETIRING_LIFECYCLE_REPORT), LIFECYCLE_FOLDER_NAME + "retiringLifecycleInstantEmailTitle.txt"),
 
         // Roadmap
         entry(new TemplateDefinition(DRAWER, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP_REPORT), ROADMAP_FOLDER_NAME + "roadmapBody.md"),
         entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP_REPORT), ROADMAP_FOLDER_NAME + "roadmapInstantEmailBody.html"),
-        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP_REPORT), MONTHLY_EMAIL_TITLE),
+        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, ROADMAP_APP_NAME, ROADMAP_REPORT), ROADMAP_FOLDER_NAME + "roadmapInstantEmailTitle.txt"),
 
         // Resource optimization
         entry(new TemplateDefinition(EMAIL_DAILY_DIGEST_BODY, BUNDLE_NAME, RESOURCE_OPTIMIZATION_APP_NAME, null), RESOURCE_OPTIMIZATION_FOLDER_NAME + "dailyEmailBody.html"),

--- a/common-template/src/main/resources/templates/email/Common/insightsMonthlyEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Common/insightsMonthlyEmailTitle.txt
@@ -1,1 +1,0 @@
-{action.severity.or('').severityAsEmailTitle}Monthly notification - {source.event_type.display_name} - {source.application.display_name} - {source.bundle.display_name}

--- a/common-template/src/main/resources/templates/email/Common/insightsMonthlyEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Common/insightsMonthlyEmailTitle.txt
@@ -1,0 +1,1 @@
+{action.severity.or('').severityAsEmailTitle}Monthly notification - {source.event_type.display_name} - {source.application.display_name} - {source.bundle.display_name}

--- a/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailTitle.txt
@@ -1,0 +1,1 @@
+{action.severity.or('').severityAsEmailTitle}Monthly report - {source.application.display_name} - {source.bundle.display_name}

--- a/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Roadmap/roadmapInstantEmailTitle.txt
@@ -1,0 +1,1 @@
+{action.severity.or('').severityAsEmailTitle}Monthly report - {source.application.display_name} - {source.bundle.display_name}

--- a/common-template/src/test/java/email/TestLifecycleTemplate.java
+++ b/common-template/src/test/java/email/TestLifecycleTemplate.java
@@ -70,7 +70,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
     public void testRetiringLifecycleEmailTitle() {
         eventTypeDisplayName = "life cycle monthly report";
         String result = generateEmailSubject(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
-        assertEquals("Monthly notification - life cycle monthly report - Life Cycle - Red Hat Enterprise Linux", result);
+        assertEquals("Monthly report - Life Cycle - Red Hat Enterprise Linux", result);
     }
 
     @Test

--- a/common-template/src/test/java/email/TestLifecycleTemplate.java
+++ b/common-template/src/test/java/email/TestLifecycleTemplate.java
@@ -70,7 +70,7 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
     public void testRetiringLifecycleEmailTitle() {
         eventTypeDisplayName = "life cycle monthly report";
         String result = generateEmailSubject(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
-        assertEquals("Instant notification - life cycle monthly report - Life Cycle - Red Hat Enterprise Linux", result);
+        assertEquals("Monthly notification - life cycle monthly report - Life Cycle - Red Hat Enterprise Linux", result);
     }
 
     @Test

--- a/common-template/src/test/java/email/TestRoadmapTemplate.java
+++ b/common-template/src/test/java/email/TestRoadmapTemplate.java
@@ -69,7 +69,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
     public void testRoadmapEmailTitle() {
         eventTypeDisplayName = "roadmap monthly report";
         String result = generateEmailSubject(ROADMAP_REPORT, createRoadmapAction());
-        assertEquals("Monthly notification - roadmap monthly report - Roadmap - Red Hat Enterprise Linux", result);
+        assertEquals("Monthly report - Roadmap - Red Hat Enterprise Linux", result);
     }
 
     @Test

--- a/common-template/src/test/java/email/TestRoadmapTemplate.java
+++ b/common-template/src/test/java/email/TestRoadmapTemplate.java
@@ -69,7 +69,7 @@ public class TestRoadmapTemplate extends EmailTemplatesRendererHelper {
     public void testRoadmapEmailTitle() {
         eventTypeDisplayName = "roadmap monthly report";
         String result = generateEmailSubject(ROADMAP_REPORT, createRoadmapAction());
-        assertEquals("Instant notification - roadmap monthly report - Roadmap - Red Hat Enterprise Linux", result);
+        assertEquals("Monthly notification - roadmap monthly report - Roadmap - Red Hat Enterprise Linux", result);
     }
 
     @Test


### PR DESCRIPTION
* Update email subject for Lifecycle from `Instant notification - life cycle monthly report - Life Cycle - Red Hat Enterprise Linux` to `Monthly report - Life Cycle - Red Hat Enterprise Linux`.

* Update email subject for Roadmap from `Instant notification - life cycle monthly report - Life Cycle - Red Hat Enterprise Linux` to `Monthly report - Roadmap - Red Hat Enterprise Linux`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for monthly email titles/subject lines for selected lifecycle and roadmap monthly report emails.

* **Tests**
  * Updated lifecycle and roadmap email title assertions to expect the new “Monthly notification” subject prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->