### PR TITLE
Update notifications-aggregator for cluster selection via unleash flag

### DIFF
--- a/.rhcicd/clowdapp-aggregator.yaml
+++ b/.rhcicd/clowdapp-aggregator.yaml
@@ -62,12 +62,17 @@ objects:
           value: ${ENV_NAME}
         - name: QUARKUS_UNLEASH_ACTIVE
           value: "true"
+        - name: NOTIFICATIONS_AGGREGATOR_CLUSTER_ID
+          value: ${CLUSTER_ID}
         - name: PROMETHEUS_PUSHGATEWAY_URL
           value: ${PROMETHEUS_PUSHGATEWAY}
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
   value: "false"
+- name: CLUSTER_ID
+  description: Cluster identifier for coordination (e.g., 'crcs' or 'hccs')
+  required: false
 - name: CRONTAB_AGGREGATION_JOB
   value: "0 0 * * *"
 - name: CPU_LIMIT

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -238,7 +238,7 @@ public class DailyEmailAggregationJob {
         // If Unleash disabled or unreachable, don't run (fail-safe when cluster ID is configured)
         // This includes: Unleash disabled, unreachable, variant disabled, invalid payload
         if (activeCluster.isEmpty()) {
-            Log.warn("Unable to determine active cluster from Unleash - failing safe by not running");
+            Log.info("Unable to determine active cluster from Unleash - failing safe by not running");
             return false;
         }
 

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -30,6 +30,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -66,6 +67,13 @@ public class DailyEmailAggregationJob {
 
     @ActivateRequestContext
     public void processDailyEmail() {
+        // Cluster coordination check - fail-safe if Unleash unreachable
+        if (!shouldRunOnThisCluster()) {
+            Log.infof("Aggregator run skipped on %s cluster due to Unleash flag",
+                aggregatorConfig.getClusterId().orElse("unknown"));
+            return; // Exit gracefully with success
+        }
+
         // Job start - SEC-MON-REQ-1 compliance (EOI-3 admin_action, EOI-5 process_status)
         Log.infof("[action: RUN_JOB][resource_type: daily_email_aggregation][principal: system][outcome: started] Daily email aggregation job started");
 
@@ -197,6 +205,55 @@ public class DailyEmailAggregationJob {
 
     Gauge getPairsProcessed() {
         return pairsProcessed;
+    }
+
+    /**
+     * Determines if this cluster should run the aggregation job.
+     *
+     * BACKWARD COMPATIBILITY:
+     * - If cluster ID is NOT configured, cluster coordination is disabled - returns true (run)
+     * - This allows existing single-cluster deployments to work without changes
+     *
+     * FAIL-SAFE BEHAVIOR (when cluster ID IS configured):
+     * Returns false (skip) in ALL error conditions:
+     * - Unleash variant is not enabled or unreachable
+     * - Unleash variant has invalid/missing payload
+     * - Unleash returns a cluster ID that doesn't match this instance
+     *
+     * Returns true (run) ONLY if:
+     * - Cluster ID is configured AND Unleash variant returns valid data
+     * - AND the returned cluster ID exactly matches this instance's CLUSTER_ID
+     */
+    private boolean shouldRunOnThisCluster() {
+        Optional<String> thisClusterId = aggregatorConfig.getClusterId();
+
+        // If no cluster ID configured, cluster coordination is disabled - allow run (backward compatibility)
+        if (thisClusterId.isEmpty()) {
+            Log.debug("NOTIFICATIONS_AGGREGATOR_CLUSTER_ID not configured - cluster coordination disabled, proceeding with aggregation");
+            return true;
+        }
+
+        Optional<String> activeCluster = aggregatorConfig.getActiveCluster();
+
+        // If Unleash disabled or unreachable, don't run (fail-safe when cluster ID is configured)
+        // This includes: Unleash disabled, unreachable, variant disabled, invalid payload
+        if (activeCluster.isEmpty()) {
+            Log.warn("Unable to determine active cluster from Unleash - failing safe by not running");
+            return false;
+        }
+
+        // Check if this cluster matches the active cluster
+        boolean shouldRun = thisClusterId.get().equals(activeCluster.get());
+
+        if (shouldRun) {
+            Log.infof("Cluster coordination check passed: this cluster (%s) matches active cluster (%s)",
+                thisClusterId.get(), activeCluster.get());
+        } else {
+            Log.infof("Cluster coordination check failed: this cluster (%s) does not match active cluster (%s)",
+                thisClusterId.get(), activeCluster.get());
+        }
+
+        return shouldRun;
     }
 
     // For automatic tests purpose

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
@@ -1,29 +1,95 @@
 package com.redhat.cloud.notifications.config;
 
+import com.redhat.cloud.notifications.unleash.ToggleRegistry;
+import io.getunleash.Unleash;
+import io.getunleash.variant.Payload;
+import io.getunleash.variant.Variant;
 import io.quarkus.logging.Log;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.Startup;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 
 @ApplicationScoped
 public class AggregatorConfig {
 
     /*
+     * Env vars configuration
+     */
+    private static final String CLUSTER_ID = "notifications.aggregator.cluster-id";
+
+    /*
      * Unleash configuration
      */
+    private String activeClusterToggle;
 
-    private static String toggleName(String feature) {
-        return String.format("notifications-aggregator.%s.enabled", feature);
+    @ConfigProperty(name = CLUSTER_ID)
+    Optional<String> clusterId;
+
+    @Inject
+    Unleash unleash;
+
+    @Inject
+    ToggleRegistry toggleRegistry;
+
+    @PostConstruct
+    void registerToggles() {
+        activeClusterToggle = toggleRegistry.register("notifications-aggregator-active-cluster", true);
+        Log.infof("Registered Unleash toggle: %s", activeClusterToggle);
+    }
+
+    public Optional<String> getClusterId() {
+        return clusterId;
+    }
+
+    /**
+     * Gets the active cluster ID from Unleash variant payload.
+     * Returns Optional.empty() if:
+     * - Unleash is disabled (variant will be disabled)
+     * - Unleash is unreachable
+     * - Variant is not enabled
+     * - Payload is missing or invalid
+     */
+    public Optional<String> getActiveCluster() {
+        try {
+            Variant variant = unleash.getVariant(activeClusterToggle);
+            if (!variant.isEnabled()) {
+                Log.warn("Unleash variant for active-cluster is not enabled");
+                return Optional.empty();
+            }
+
+            Optional<Payload> payload = variant.getPayload();
+            if (payload.isEmpty()) {
+                Log.warn("Unleash variant payload is empty");
+                return Optional.empty();
+            }
+
+            String value = payload.get().getValue();
+            if (value == null || value.isBlank()) {
+                Log.warn("Unleash variant payload value is null or blank");
+                return Optional.empty();
+            }
+
+            return Optional.of(value.trim());
+        } catch (Exception e) {
+            Log.error("Failed to retrieve active cluster from Unleash", e);
+            return Optional.empty();
+        }
     }
 
     void logConfigAtStartup(@Observes Startup event) {
         Map<String, Object> config = new TreeMap<>();
+        config.put(CLUSTER_ID, getClusterId().orElse("not-configured"));
+        if (activeClusterToggle != null) {
+            config.put(activeClusterToggle, getActiveCluster().orElse("unable-to-determine"));
+        }
         Log.info("=== Startup configuration ===");
-        config.forEach((key, value) -> {
-            Log.infof("%s=%s", key, value);
-        });
+        config.forEach((key, value) -> Log.infof("%s=%s", key, value));
     }
 }

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
@@ -45,7 +45,7 @@ public class AggregatorConfig {
     }
 
     public Optional<String> getClusterId() {
-        return clusterId;
+        return clusterId.map(String::trim).filter(value -> !value.isEmpty());
     }
 
     /**

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
@@ -60,25 +60,25 @@ public class AggregatorConfig {
         try {
             Variant variant = unleash.getVariant(activeClusterToggle);
             if (!variant.isEnabled()) {
-                Log.warn("Unleash variant for active-cluster is not enabled");
+                Log.info("Unleash variant for active-cluster is not enabled");
                 return Optional.empty();
             }
 
             Optional<Payload> payload = variant.getPayload();
             if (payload.isEmpty()) {
-                Log.warn("Unleash variant payload is empty");
+                Log.info("Unleash variant payload is empty");
                 return Optional.empty();
             }
 
             String value = payload.get().getValue();
             if (value == null || value.isBlank()) {
-                Log.warn("Unleash variant payload value is null or blank");
+                Log.info("Unleash variant payload value is null or blank");
                 return Optional.empty();
             }
 
             return Optional.of(value.trim());
         } catch (Exception e) {
-            Log.error("Failed to retrieve active cluster from Unleash", e);
+            Log.warn("Failed to retrieve active cluster from Unleash", e);
             return Optional.empty();
         }
     }

--- a/aggregator/src/main/resources/application.properties
+++ b/aggregator/src/main/resources/application.properties
@@ -42,5 +42,9 @@ quarkus.log.cloudwatch.access-key-secret=placeholder
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242
 
+# Cluster identifier for dual-cluster coordination (e.g., "crcs" or "hccs")
+# Must be set in deployment for cluster coordination to work
+# notifications.aggregator.cluster-id=
+
 # Uncomment to log Hibernate SQL statements
 #quarkus.hibernate-orm.log.sql=true

--- a/aggregator/src/test/java/com/redhat/cloud/notifications/ClusterCoordinationTest.java
+++ b/aggregator/src/test/java/com/redhat/cloud/notifications/ClusterCoordinationTest.java
@@ -1,0 +1,123 @@
+package com.redhat.cloud.notifications;
+
+import com.redhat.cloud.notifications.config.AggregatorConfig;
+import com.redhat.cloud.notifications.helpers.ResourceHelpers;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.reactive.messaging.memory.InMemoryConnector;
+import jakarta.enterprise.inject.Any;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for cluster coordination functionality.
+ */
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+class ClusterCoordinationTest {
+
+    @Inject
+    DailyEmailAggregationJob dailyEmailAggregationJob;
+
+    @InjectMock
+    AggregatorConfig aggregatorConfig;
+
+    @Inject
+    @Any
+    InMemoryConnector connector;
+
+    @Inject
+    ResourceHelpers helpers;
+
+    @AfterEach
+    void tearDown() {
+        connector.sink(DailyEmailAggregationJob.EGRESS_CHANNEL).clear();
+        helpers.purgeEventAggregations();
+    }
+
+    @Test
+    void shouldRunWhenClusterIdNotConfigured() {
+        // When cluster ID is not configured, aggregator runs normally (backward compatibility)
+        when(aggregatorConfig.getClusterId()).thenReturn(Optional.empty());
+
+        helpers.purgeAggregationOrgConfig();
+        addTestAggregation();
+        dailyEmailAggregationJob.setDefaultDailyDigestTime(
+            dailyEmailAggregationJob.computeScheduleExecutionTime().toLocalTime()
+        );
+
+        dailyEmailAggregationJob.processDailyEmail();
+
+        assertEquals(1, connector.sink(DailyEmailAggregationJob.EGRESS_CHANNEL).received().size());
+    }
+
+    @Test
+    void shouldRunWhenClusterIdMatchesUnleash() {
+        // When cluster ID matches Unleash active cluster, aggregator runs
+        when(aggregatorConfig.getClusterId()).thenReturn(Optional.of("test"));
+        when(aggregatorConfig.getActiveCluster()).thenReturn(Optional.of("test"));
+
+        helpers.purgeAggregationOrgConfig();
+        addTestAggregation();
+        dailyEmailAggregationJob.setDefaultDailyDigestTime(
+            dailyEmailAggregationJob.computeScheduleExecutionTime().toLocalTime()
+        );
+
+        dailyEmailAggregationJob.processDailyEmail();
+
+        assertEquals(1, connector.sink(DailyEmailAggregationJob.EGRESS_CHANNEL).received().size());
+    }
+
+    @Test
+    void shouldSkipWhenClusterIdDoesNotMatch() {
+        // When cluster ID does NOT match Unleash active cluster, aggregator skips
+        when(aggregatorConfig.getClusterId()).thenReturn(Optional.of("test"));
+        when(aggregatorConfig.getActiveCluster()).thenReturn(Optional.of("not-test"));
+
+        helpers.purgeAggregationOrgConfig();
+        addTestAggregation();
+        dailyEmailAggregationJob.setDefaultDailyDigestTime(
+            dailyEmailAggregationJob.computeScheduleExecutionTime().toLocalTime()
+        );
+
+        dailyEmailAggregationJob.processDailyEmail();
+
+        assertEquals(0, connector.sink(DailyEmailAggregationJob.EGRESS_CHANNEL).received().size());
+    }
+
+    @Test
+    void shouldSkipWhenUnleashReturnsEmpty() {
+        // When Unleash is unreachable/disabled (returns empty), aggregator skips (fail-safe)
+        when(aggregatorConfig.getClusterId()).thenReturn(Optional.of("test"));
+        when(aggregatorConfig.getActiveCluster()).thenReturn(Optional.empty());
+
+        helpers.purgeAggregationOrgConfig();
+        addTestAggregation();
+        dailyEmailAggregationJob.setDefaultDailyDigestTime(
+            dailyEmailAggregationJob.computeScheduleExecutionTime().toLocalTime()
+        );
+
+        dailyEmailAggregationJob.processDailyEmail();
+
+        assertEquals(0, connector.sink(DailyEmailAggregationJob.EGRESS_CHANNEL).received().size());
+    }
+
+    private void addTestAggregation() {
+        helpers.purgeAggregationOrgConfig();
+        helpers.addEventEmailAggregation(
+            "testOrgId",
+            "rhel",
+            "policies",
+            dailyEmailAggregationJob.computeScheduleExecutionTime().minusHours(5),
+            "{\"org_id\":\"testOrgId\",\"bundle\":\"rhel\",\"application\":\"policies\"}",
+            false
+        );
+    }
+}


### PR DESCRIPTION
Add code that allows for cluster selection for aggregator from unleash, helping with aggregator cluster migrations. 

Assisted-by: Claude Sonnet 4.5 (via Claude Code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional cluster coordination configuration for the notifications aggregator (including a new cluster identifier setting).
  * Daily email aggregation now runs only on the matching active cluster, using a safe fallback when the active cluster can’t be determined.
  * Startup logging now includes the configured cluster and active cluster status when available.
* **Bug Fixes**
  * Prevents duplicate processing by skipping aggregation when the cluster identifiers don’t match.
* **Tests**
  * Added coverage for the daily email aggregation cluster-coordination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->