### PR TITLE
[RHCLOUD-43867] Consolidate redundant system endpoint get-or-create logic

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -193,17 +193,7 @@ public class EndpointRepository {
     }
 
     @Transactional
-    public Optional<Endpoint> getSystemSubscriptionEndpoint(String orgId, SystemSubscriptionProperties properties, EndpointType endpointType) {
-        List<Endpoint> endpoints = getEndpointsPerCompositeType(orgId, null, Set.of(new CompositeEndpointType(endpointType)), null, null, false);
-        loadProperties(endpoints);
-        return endpoints
-            .stream()
-            .filter(endpoint -> properties.hasSameProperties(endpoint.getProperties(SystemSubscriptionProperties.class)))
-            .findFirst();
-    }
-
-    @Transactional
-    public Endpoint createSystemSubscriptionEndpoint(String accountId, String orgId, SystemSubscriptionProperties properties, EndpointType endpointType) {
+    public Endpoint getOrCreateSystemSubscriptionEndpoint(String accountId, String orgId, SystemSubscriptionProperties properties, EndpointType endpointType) {
         String label = "Email";
         if (EndpointType.DRAWER == endpointType) {
             label = "Drawer";

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/endpoint/EndpointResource.java
@@ -365,12 +365,7 @@ public class EndpointResource extends EndpointResourceCommon {
         if (null != requestProps.getGroupId()) {
             properties.setGroupIds(Set.of(requestProps.getGroupId()));
         }
-        Optional<Endpoint> getEndpoint = endpointRepository.getSystemSubscriptionEndpoint(orgId, properties, endpointType);
-        if (getEndpoint.isPresent()) {
-            return getEndpoint.get();
-        } else {
-            return endpointRepository.createSystemSubscriptionEndpoint(accountId, orgId, properties, endpointType);
-        }
+        return endpointRepository.getOrCreateSystemSubscriptionEndpoint(accountId, orgId, properties, endpointType);
     }
 
     private void getOrCreateInternalEndpointCommonChecks(RequestSystemSubscriptionProperties requestProps, RhIdPrincipal principal) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -78,7 +78,6 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -546,12 +545,7 @@ public class InternalResource {
             if (p.getEndpointType() != null && p.getEndpointType() == DRAWER) {
                 endpointType = DRAWER;
             }
-            Optional<Endpoint> getEndpoint = endpointRepository.getSystemSubscriptionEndpoint(null, properties, endpointType);
-            if (getEndpoint.isPresent()) {
-                return getEndpoint.get();
-            } else {
-                return endpointRepository.createSystemSubscriptionEndpoint(null, null, properties, endpointType);
-            }
+            return endpointRepository.getOrCreateSystemSubscriptionEndpoint(null, null, properties, endpointType);
         }).collect(Collectors.toList());
         behaviorGroupRepository.updateDefaultBehaviorGroupActions(
                 behaviorGroupId,

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/userpreferencesmigration/PatchUserPreferencesMigrationResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/userpreferencesmigration/PatchUserPreferencesMigrationResource.java
@@ -162,7 +162,6 @@ public class PatchUserPreferencesMigrationResource {
         SystemSubscriptionProperties properties = new SystemSubscriptionProperties();
         properties.setOnlyAdmins(false);
 
-        Optional<Endpoint> getEndpoint = endpointRepository.getSystemSubscriptionEndpoint(orgId, properties, EndpointType.EMAIL_SUBSCRIPTION);
-        return getEndpoint.orElseGet(() -> endpointRepository.createSystemSubscriptionEndpoint(accountId, orgId, properties, EndpointType.EMAIL_SUBSCRIPTION));
+        return endpointRepository.getOrCreateSystemSubscriptionEndpoint(accountId, orgId, properties, EndpointType.EMAIL_SUBSCRIPTION);
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -219,7 +219,7 @@ public class ResourceHelpers {
         return endpointRepository.createEndpoint(endpoint);
     }
 
-    public Endpoint createSystemEndpoint(String accountId, String orgId, SystemSubscriptionProperties properties, EndpointType endpointType) {
+    public Endpoint getOrCreateSystemEndpoint(String accountId, String orgId, SystemSubscriptionProperties properties, EndpointType endpointType) {
         return endpointRepository.getOrCreateSystemSubscriptionEndpoint(accountId, orgId, properties, endpointType);
     }
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -220,7 +220,7 @@ public class ResourceHelpers {
     }
 
     public Endpoint createSystemEndpoint(String accountId, String orgId, SystemSubscriptionProperties properties, EndpointType endpointType) {
-        return endpointRepository.createSystemSubscriptionEndpoint(accountId, orgId, properties, endpointType);
+        return endpointRepository.getOrCreateSystemSubscriptionEndpoint(accountId, orgId, properties, endpointType);
     }
 
     public Stats createTestEndpoints(String accountId, String orgId, int count) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/notification/NotificationResourceTest.java
@@ -2312,7 +2312,7 @@ public class NotificationResourceTest extends DbIsolatedTest {
             .findFirst().get().getId();
         UUID endpointId1 = helpers.createWebhookEndpoint(accountId, orgId, "endpoint1");
         UUID endpointId2 = helpers.createWebhookEndpoint(accountId, orgId, "endpoint2");
-        Endpoint emailEndpoint = helpers.createSystemEndpoint(accountId, orgId, new SystemSubscriptionProperties(), EndpointType.EMAIL_SUBSCRIPTION);
+        Endpoint emailEndpoint = helpers.getOrCreateSystemEndpoint(accountId, orgId, new SystemSubscriptionProperties(), EndpointType.EMAIL_SUBSCRIPTION);
 
         List<EventType> eventTypes = applicationRepository.getEventTypes(appId);
         final EventType retictedRecipientsIntegrationEventType = helpers.createEventType(appId, RandomStringUtils.randomAlphabetic(10).toLowerCase(), "restricted event type 2", "description", true);


### PR DESCRIPTION
## Summary
- Merged `getSystemSubscriptionEndpoint` and `createSystemSubscriptionEndpoint` into a single `getOrCreateSystemSubscriptionEndpoint` method in `EndpointRepository`
- Simplified all three callers (`EndpointResource`, `InternalResource`, `PatchUserPreferencesMigrationResource`) to use the consolidated method directly
- Removed redundant duplicate-existence checks that were performed by both callers and the repository method itself

[RHCLOUD-43867](https://redhat.atlassian.net/browse/RHCLOUD-43867)

[RHCLOUD-43867]: https://redhat.atlassian.net/browse/RHCLOUD-43867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoint setup is now idempotent: requesting a system subscription endpoint returns an existing matching endpoint or creates it if none exists.
* **Bug Fixes**
  * Reduced duplicate endpoint creation across account, notification, default behavior group, and user preference migration flows.
  * Simplified endpoint handling so related operations behave consistently.
* **Tests**
  * Updated backend tests and helpers to use the new idempotent get-or-create behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->