### PR TITLE
[RHCLOUD-43868] Add internal API to cleanup orphan email integrations

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -21,6 +21,8 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 
 import javax.annotation.Nullable;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -546,16 +548,25 @@ public class EndpointRepository {
     }
 
     @Transactional
-    public int deleteOrphanEmailIntegrations() {
-        String query = "DELETE FROM Endpoint e "
+    public int deleteOrphanEmailIntegrations(String orgId) {
+        StringBuilder hql = new StringBuilder("DELETE FROM Endpoint e "
             + "WHERE e.compositeType.type = :endpointType "
+            + "AND e.created < :gracePeriod "
             + "AND NOT EXISTS (SELECT 1 FROM EndpointEventType eet WHERE eet.endpoint = e) "
             + "AND NOT EXISTS (SELECT 1 FROM BehaviorGroupAction bga WHERE bga.endpoint = e) "
-            + "AND NOT EXISTS (SELECT 1 FROM NotificationHistory nh WHERE nh.endpoint = e)";
-        int deleted = entityManager.createQuery(query)
+            + "AND NOT EXISTS (SELECT 1 FROM NotificationHistory nh WHERE nh.endpoint = e)");
+        if (orgId != null) {
+            hql.append(" AND e.orgId = :orgId");
+        }
+        var query = entityManager.createQuery(hql.toString())
             .setParameter("endpointType", EndpointType.EMAIL_SUBSCRIPTION)
-            .executeUpdate();
-        Log.infof("Deleted %d orphan email integrations", deleted);
+            .setParameter("gracePeriod", LocalDateTime.now(ZoneId.of("UTC")).minusHours(1));
+        if (orgId != null) {
+            query.setParameter("orgId", orgId);
+        }
+        int deleted = query.executeUpdate();
+        Log.infof("[action: DELETE][resource_type: endpoint][org_id: %s][outcome: success] Deleted %d orphan email integrations",
+            orgId != null ? orgId : "all", deleted);
         return deleted;
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EndpointRepository.java
@@ -544,4 +544,18 @@ public class EndpointRepository {
             .setMaxResults(limit)
             .getResultList();
     }
+
+    @Transactional
+    public int deleteOrphanEmailIntegrations() {
+        String query = "DELETE FROM Endpoint e "
+            + "WHERE e.compositeType.type = :endpointType "
+            + "AND NOT EXISTS (SELECT 1 FROM EndpointEventType eet WHERE eet.endpoint = e) "
+            + "AND NOT EXISTS (SELECT 1 FROM BehaviorGroupAction bga WHERE bga.endpoint = e) "
+            + "AND NOT EXISTS (SELECT 1 FROM NotificationHistory nh WHERE nh.endpoint = e)";
+        int deleted = entityManager.createQuery(query)
+            .setParameter("endpointType", EndpointType.EMAIL_SUBSCRIPTION)
+            .executeUpdate();
+        Log.infof("Deleted %d orphan email integrations", deleted);
+        return deleted;
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -717,6 +717,7 @@ public class InternalResource {
     @DELETE
     @Path("/orphanEmailIntegrations")
     @Produces(APPLICATION_JSON)
+    @Transactional
     @TransactionConfiguration(timeout = 600)
     public Response deleteOrphanEmailIntegrations(@RestQuery String orgId) {
         int deleted = endpointRepository.deleteOrphanEmailIntegrations(orgId);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -72,6 +72,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.resteasy.reactive.RestHeader;
 import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.resteasy.reactive.RestQuery;
 
 import java.net.URI;
 import java.time.LocalTime;
@@ -716,10 +717,9 @@ public class InternalResource {
     @DELETE
     @Path("/orphanEmailIntegrations")
     @Produces(APPLICATION_JSON)
-    @Transactional
-    public Response deleteOrphanEmailIntegrations(@RestParam String orgId) {
-    // pass the orgId to EndpointRepository and optionally restrict the query to a specific org ID if provided, or to all orgs if not.
-        int deleted = endpointRepository.deleteOrphanEmailIntegrations();
+    @TransactionConfiguration(timeout = 600)
+    public Response deleteOrphanEmailIntegrations(@RestQuery String orgId) {
+        int deleted = endpointRepository.deleteOrphanEmailIntegrations(orgId);
         return Response.ok(new JsonObject().put("deleted", deleted).encode()).build();
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -712,4 +712,13 @@ public class InternalResource {
 
         return this.generalCommunicationsService.sendGeneralCommunication();
     }
+
+    @DELETE
+    @Path("/orphanEmailIntegrations")
+    @Produces(APPLICATION_JSON)
+    @Transactional
+    public Response deleteOrphanEmailIntegrations() {
+        int deleted = endpointRepository.deleteOrphanEmailIntegrations();
+        return Response.ok(new JsonObject().put("deleted", deleted).encode()).build();
+    }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/internal/InternalResource.java
@@ -717,7 +717,8 @@ public class InternalResource {
     @Path("/orphanEmailIntegrations")
     @Produces(APPLICATION_JSON)
     @Transactional
-    public Response deleteOrphanEmailIntegrations() {
+    public Response deleteOrphanEmailIntegrations(@RestParam String orgId) {
+    // pass the orgId to EndpointRepository and optionally restrict the query to a specific org ID if provided, or to all orgs if not.
         int deleted = endpointRepository.deleteOrphanEmailIntegrations();
         return Response.ok(new JsonObject().put("deleted", deleted).encode()).build();
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/db/ResourceHelpers.java
@@ -256,6 +256,21 @@ public class ResourceHelpers {
         return stats;
     }
 
+    @Transactional
+    public Event createEvent(String accountId, String orgId, Bundle bundle, Application app, EventType eventType) {
+        Event event = new Event();
+        event.setAccountId(accountId);
+        event.setOrgId(orgId);
+        event.setBundleId(bundle.getId());
+        event.setBundleDisplayName(bundle.getDisplayName());
+        event.setApplicationId(app.getId());
+        event.setApplicationDisplayName(app.getDisplayName());
+        event.setEventType(eventType);
+        event.setEventTypeDisplayName(eventType.getDisplayName());
+        entityManager.persist(event);
+        return event;
+    }
+
     public NotificationHistory createNotificationHistory(Event event, Endpoint endpoint, NotificationStatus status) {
         return createNotificationHistory(event, endpoint, status, null);
     }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalResourceTest.java
@@ -5,13 +5,18 @@ import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
+import com.redhat.cloud.notifications.db.repositories.BehaviorGroupRepository;
+import com.redhat.cloud.notifications.db.repositories.EndpointEventTypeRepository;
 import com.redhat.cloud.notifications.db.repositories.SubscriptionRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Environment;
+import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.NotificationStatus;
 import com.redhat.cloud.notifications.routers.dailydigest.TriggerDailyDigestRequest;
 import com.redhat.cloud.notifications.routers.engine.DailyDigestService;
 import com.redhat.cloud.notifications.routers.engine.GeneralCommunicationsService;
@@ -125,6 +130,12 @@ public class InternalResourceTest extends DbIsolatedTest {
 
     @InjectSpy
     SubscriptionRepository subscriptionRepository;
+
+    @Inject
+    BehaviorGroupRepository behaviorGroupRepository;
+
+    @Inject
+    EndpointEventTypeRepository endpointEventTypeRepository;
 
     @Test
     void testCreateNullBundle() {
@@ -1142,10 +1153,25 @@ public class InternalResourceTest extends DbIsolatedTest {
         String orgId = "orphan-email-test-org";
         String accountId = "orphan-email-test-account";
 
-        resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
-        resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
+        Endpoint orphan1 = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
+        Endpoint orphan2 = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
 
-        resourceHelpers.createEndpoint(accountId, orgId, EndpointType.WEBHOOK);
+        Bundle bundle = resourceHelpers.createBundle("orphan-test-bundle", "Orphan Test Bundle");
+        Application app = resourceHelpers.createApplication(bundle.getId(), "orphan-test-app", "Orphan Test App");
+        EventType eventType = resourceHelpers.createEventType(app.getId(), "orphan-test-event", "Orphan Test Event", "desc");
+
+        Endpoint linkedToEventType = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
+        endpointEventTypeRepository.addEventTypeToEndpoint(eventType.getId(), linkedToEventType.getId(), orgId);
+
+        BehaviorGroup bg = resourceHelpers.createBehaviorGroup(accountId, orgId, "orphan-test-bg", bundle.getId());
+        Endpoint linkedToBehaviorGroup = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
+        behaviorGroupRepository.updateBehaviorGroupActions(orgId, bg.getId(), List.of(linkedToBehaviorGroup.getId()));
+
+        Endpoint linkedToHistory = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
+        Event event = resourceHelpers.createEvent(accountId, orgId, bundle, app, eventType);
+        resourceHelpers.createNotificationHistory(event, linkedToHistory, NotificationStatus.SUCCESS);
+
+        Endpoint webhook = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.WEBHOOK);
 
         String response = given()
             .header(identity)
@@ -1161,18 +1187,20 @@ public class InternalResourceTest extends DbIsolatedTest {
         int deleted = json.getInteger("deleted");
         assertTrue(deleted >= 2, "Expected at least 2 orphan email endpoints to be deleted, got " + deleted);
 
-        Long remainingOrphans = entityManager.createQuery(
+        Long remainingEmail = entityManager.createQuery(
             "SELECT COUNT(e) FROM Endpoint e WHERE e.orgId = :orgId AND e.compositeType.type = :type", Long.class)
             .setParameter("orgId", orgId)
             .setParameter("type", EndpointType.EMAIL_SUBSCRIPTION)
             .getSingleResult();
-        assertEquals(0L, remainingOrphans);
+        assertEquals(3L, remainingEmail);
 
-        Long remainingWebhooks = entityManager.createQuery(
-            "SELECT COUNT(e) FROM Endpoint e WHERE e.orgId = :orgId AND e.compositeType.type = :type", Long.class)
-            .setParameter("orgId", orgId)
-            .setParameter("type", EndpointType.WEBHOOK)
-            .getSingleResult();
-        assertEquals(1L, remainingWebhooks);
+        Assertions.assertNotNull(entityManager.find(Endpoint.class, linkedToEventType.getId()));
+        Assertions.assertNotNull(entityManager.find(Endpoint.class, linkedToBehaviorGroup.getId()));
+        Assertions.assertNotNull(entityManager.find(Endpoint.class, linkedToHistory.getId()));
+
+        Assertions.assertNull(entityManager.find(Endpoint.class, orphan1.getId()));
+        Assertions.assertNull(entityManager.find(Endpoint.class, orphan2.getId()));
+
+        Assertions.assertNotNull(entityManager.find(Endpoint.class, webhook.getId()));
     }
 }

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalResourceTest.java
@@ -1153,8 +1153,9 @@ public class InternalResourceTest extends DbIsolatedTest {
         String orgId = "orphan-email-test-org";
         String accountId = "orphan-email-test-account";
 
-        Endpoint orphan1 = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
-        Endpoint orphan2 = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
+        LocalDateTime oldTimestamp = LocalDateTime.now(java.time.ZoneOffset.UTC).minusHours(2);
+        Endpoint orphan1 = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION, null, UUID.randomUUID().toString(), "orphan1", null, false, oldTimestamp);
+        Endpoint orphan2 = resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION, null, UUID.randomUUID().toString(), "orphan2", null, false, oldTimestamp);
 
         Bundle bundle = resourceHelpers.createBundle("orphan-test-bundle", "Orphan Test Bundle");
         Application app = resourceHelpers.createApplication(bundle.getId(), "orphan-test-app", "Orphan Test App");
@@ -1185,7 +1186,7 @@ public class InternalResourceTest extends DbIsolatedTest {
 
         JsonObject json = new JsonObject(response);
         int deleted = json.getInteger("deleted");
-        assertTrue(deleted >= 2, "Expected at least 2 orphan email endpoints to be deleted, got " + deleted);
+        assertEquals(2, deleted);
 
         Long remainingEmail = entityManager.createQuery(
             "SELECT COUNT(e) FROM Endpoint e WHERE e.orgId = :orgId AND e.compositeType.type = :type", Long.class)

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/internal/InternalResourceTest.java
@@ -9,6 +9,7 @@ import com.redhat.cloud.notifications.db.repositories.SubscriptionRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.BehaviorGroup;
 import com.redhat.cloud.notifications.models.Bundle;
+import com.redhat.cloud.notifications.models.EndpointType;
 import com.redhat.cloud.notifications.models.Environment;
 import com.redhat.cloud.notifications.models.EventType;
 import com.redhat.cloud.notifications.routers.dailydigest.TriggerDailyDigestRequest;
@@ -1133,5 +1134,45 @@ public class InternalResourceTest extends DbIsolatedTest {
         // Assert that the received response from the back end is the same as
         // the one received from the engine.
         Assertions.assertEquals(response, receivedResponse, "the received response from the back end is not the same as the one received from the engine");
+    }
+
+    @Test
+    void testDeleteOrphanEmailIntegrations() {
+        Header identity = TestHelpers.createTurnpikeIdentityHeader("user", adminRole);
+        String orgId = "orphan-email-test-org";
+        String accountId = "orphan-email-test-account";
+
+        resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
+        resourceHelpers.createEndpoint(accountId, orgId, EndpointType.EMAIL_SUBSCRIPTION);
+
+        resourceHelpers.createEndpoint(accountId, orgId, EndpointType.WEBHOOK);
+
+        String response = given()
+            .header(identity)
+            .basePath(API_INTERNAL)
+            .when()
+            .delete("/orphanEmailIntegrations")
+            .then()
+            .statusCode(OK)
+            .extract()
+            .asString();
+
+        JsonObject json = new JsonObject(response);
+        int deleted = json.getInteger("deleted");
+        assertTrue(deleted >= 2, "Expected at least 2 orphan email endpoints to be deleted, got " + deleted);
+
+        Long remainingOrphans = entityManager.createQuery(
+            "SELECT COUNT(e) FROM Endpoint e WHERE e.orgId = :orgId AND e.compositeType.type = :type", Long.class)
+            .setParameter("orgId", orgId)
+            .setParameter("type", EndpointType.EMAIL_SUBSCRIPTION)
+            .getSingleResult();
+        assertEquals(0L, remainingOrphans);
+
+        Long remainingWebhooks = entityManager.createQuery(
+            "SELECT COUNT(e) FROM Endpoint e WHERE e.orgId = :orgId AND e.compositeType.type = :type", Long.class)
+            .setParameter("orgId", orgId)
+            .setParameter("type", EndpointType.WEBHOOK)
+            .getSingleResult();
+        assertEquals(1L, remainingWebhooks);
     }
 }

--- a/database/src/main/resources/db/migration/V1.136.0__RHCLOUD-43868_cleanup_orphan_email_integrations.sql
+++ b/database/src/main/resources/db/migration/V1.136.0__RHCLOUD-43868_cleanup_orphan_email_integrations.sql
@@ -1,0 +1,5 @@
+DELETE FROM endpoints ep
+WHERE ep.endpoint_type_v2 = 'EMAIL_SUBSCRIPTION'
+    AND NOT EXISTS (SELECT 1 FROM endpoint_event_type eet WHERE eet.endpoint_id = ep.id)
+    AND NOT EXISTS (SELECT 1 FROM behavior_group_action bga WHERE bga.endpoint_id = ep.id)
+    AND NOT EXISTS (SELECT 1 FROM notification_history nh WHERE nh.endpoint_id = ep.id);

--- a/database/src/main/resources/db/migration/V1.136.0__RHCLOUD-43868_cleanup_orphan_email_integrations.sql
+++ b/database/src/main/resources/db/migration/V1.136.0__RHCLOUD-43868_cleanup_orphan_email_integrations.sql
@@ -1,5 +1,0 @@
-DELETE FROM endpoints ep
-WHERE ep.endpoint_type_v2 = 'EMAIL_SUBSCRIPTION'
-    AND NOT EXISTS (SELECT 1 FROM endpoint_event_type eet WHERE eet.endpoint_id = ep.id)
-    AND NOT EXISTS (SELECT 1 FROM behavior_group_action bga WHERE bga.endpoint_id = ep.id)
-    AND NOT EXISTS (SELECT 1 FROM notification_history nh WHERE nh.endpoint_id = ep.id);


### PR DESCRIPTION
## Summary
- Add on-demand internal API endpoint (`DELETE /internal/orphanEmailIntegrations`) to delete orphan `EMAIL_SUBSCRIPTION` endpoints
- Orphans are endpoints with no event type, behavior group, or notification history associations
- Useful when UI migrates from legacy API to common endpoint API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal endpoint to remove unused email integrations.
  * Supports optional organization-specific cleanup.
  * Only orphaned email integrations are removed; integrations linked to event types, actions, notification history, or other supported channels are preserved.

* **Tests**
  * Added coverage verifying that orphaned email integrations are deleted while referenced integrations and webhooks remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->