### PR TITLE
Add init container to decode base64-encoded PKCS12 keystore

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -23,6 +23,27 @@ objects:
           enabled: true
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
+        initContainers:
+        - name: decode-pkcs12-keystore
+          image: ${IMAGE}:${IMAGE_TAG}
+          command:
+          - /bin/sh
+          - -c
+          - |
+            # Decode PKCS12 keystore if it exists (base64 encoded from rhcs-cert provider)
+            if [ -f /mnt/it-services-cert-source/keystore.pkcs12.b64 ]; then
+              echo "Decoding PKCS12 keystore from base64..."
+              base64 -d /mnt/it-services-cert-source/keystore.pkcs12.b64 > /mnt/it-services-cert-decoded/keystore.p12
+              echo "PKCS12 keystore decoded successfully"
+            else
+              echo "No PKCS12 keystore found to decode (this is expected in ephemeral/local)"
+            fi
+          volumeMounts:
+          - name: it-services-cert-autorenew
+            readOnly: true
+            mountPath: /mnt/it-services-cert-source
+          - name: it-services-cert-decoded
+            mountPath: /mnt/it-services-cert-decoded
         resources:
           requests:
             cpu: ${CPU_REQUEST}
@@ -36,6 +57,8 @@ objects:
             secretName: it-services-cert
             defaultMode: 420
             optional: true
+        - name: it-services-cert-decoded
+          emptyDir: {}
         - name: keystore
           secret:
             secretName: it-services
@@ -45,7 +68,7 @@ objects:
             defaultMode: 420
             optional: true
         volumeMounts:
-        - name: it-services-cert-autorenew
+        - name: it-services-cert-decoded
           readOnly: true
           mountPath: /mnt/it-services-cert-autorenew
         - name: keystore


### PR DESCRIPTION
## Summary
  Adds an init container to decode the base64-encoded PKCS12 keystore provided by the `rhcs-cert` app-interface provider.

  ## Problem
  The `rhcs-cert` provider with `certificate_format: PKCS12` creates a secret with:
  - `keystore.pkcs12.b64` - base64-encoded PKCS12 file (not binary)
  - No `password` key in the secret

  The application expects a binary PKCS12 file at `/mnt/it-services-cert-autorenew/keystore.p12`, but the rhcs-cert provider stores it as base64-encoded text.

  ## Solution
  Added an init container that:
  1. Reads the base64-encoded file from `it-services-cert` secret
  2. Decodes it using `base64 -d`
  3. Writes the binary PKCS12 to an `emptyDir` volume
  4. Main container mounts the decoded file

  ## Technical Details

  ### Volume Strategy
  - **Source volume**: `it-services-cert-autorenew` (secret, read-only) → contains `keystore.pkcs12.b64`
  - **Decoded volume**: `it-services-cert-decoded` (emptyDir) → receives `keystore.p12`
  - Main container mounts `it-services-cert-decoded` at `/mnt/it-services-cert-autorenew/`

  ### Init Container Logic
  ```sh
  if [ -f /mnt/it-services-cert-source/keystore.pkcs12.b64 ]; then
    base64 -d /mnt/it-services-cert-source/keystore.pkcs12.b64 > /mnt/it-services-cert-decoded/keystore.p12
  else
    echo "No PKCS12 keystore found (expected in ephemeral/local)"
  fi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup handling to automatically prepare the application’s keystore from an encoded file.
  * Introduced a temporary storage area for the decoded keystore, improving how certificate data is made available to the app.
  * Updated the app to use the decoded keystore location while keeping the existing mount path unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->