### PR TITLE
Fix init container volume mounts for PKCS12 decoding

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -68,6 +68,9 @@ objects:
             defaultMode: 420
             optional: true
         volumeMounts:
+        - name: it-services-cert-autorenew
+          readOnly: true
+          mountPath: /mnt/it-services-cert-source
         - name: it-services-cert-decoded
           readOnly: true
           mountPath: /mnt/it-services-cert-autorenew


### PR DESCRIPTION
  ## Problem
  PR #4674 added an init container to decode PKCS12 keystores, but the init container couldn't access the source secret because Clowder doesn't preserve init container-specific `volumeMounts` - it copies the main container's `volumeMounts` to all init containers.

  This caused the error:
  IT services keystore file not found: /mnt/it-services-cert-autorenew/keystore.p12

  ## Root Cause
  Clowder doesn't preserve init container-specific `volumeMounts`. It copies the main container's `volumeMounts` to all init containers.

  ## The Fix
  Added the source volume mount (`it-services-cert-autorenew` → `/mnt/it-services-cert-source`) to the main container's `volumeMounts` list. This ensures both the init container and main container have access to the source secret.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a certificate mount path used during startup, helping notification services initialize certificates correctly and avoid related deployment issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->