### PR TITLE
Remove readOnly flag from emptyDir volume mount

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -72,7 +72,6 @@ objects:
           readOnly: true
           mountPath: /mnt/it-services-cert-source
         - name: it-services-cert-decoded
-          readOnly: true
           mountPath: /mnt/it-services-cert-autorenew
         - name: keystore
           readOnly: true


### PR DESCRIPTION
The it-services-cert-decoded emptyDir must be writable by the init container to write the decoded keystore.p12 file. Since Clowder copies main container volumeMounts to init containers, setting readOnly=true prevented the init container from writing the decoded file.

Error was: /mnt/it-services-cert-decoded/keystore.p12: No such file or directory

Fixes: #4676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for certificate-related file access to better support runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->