### PR TITLE
Fix init container write path to use Clowder-provided mount

### DIFF
--- a/.rhcicd/clowdapp-recipients-resolver.yaml
+++ b/.rhcicd/clowdapp-recipients-resolver.yaml
@@ -33,7 +33,7 @@ objects:
             # Decode PKCS12 keystore if it exists (base64 encoded from rhcs-cert provider)
             if [ -f /mnt/it-services-cert-source/keystore.pkcs12.b64 ]; then
               echo "Decoding PKCS12 keystore from base64..."
-              base64 -d /mnt/it-services-cert-source/keystore.pkcs12.b64 > /mnt/it-services-cert-decoded/keystore.p12
+              base64 -d /mnt/it-services-cert-source/keystore.pkcs12.b64 > /mnt/it-services-cert-autorenew/keystore.p12
               echo "PKCS12 keystore decoded successfully"
             else
               echo "No PKCS12 keystore found to decode (this is expected in ephemeral/local)"


### PR DESCRIPTION
Clowder ignores init container volumeMounts and copies main container's volumeMounts instead. The main container mounts it-services-cert-decoded at /mnt/it-services-cert-autorenew, so the init container must write to that path, not /mnt/it-services-cert-decoded.

Error was: /mnt/it-services-cert-decoded/keystore.p12: No such file or directory

The init container's volumeMounts definition in the ClowdApp is ignored by Clowder - it uses the main container's paths instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate keystore handling during startup so the decoded certificate is stored in the correct location, helping renewals work more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->