### PR TITLE
Bump Quarkus to 3.37.1

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -20,6 +20,11 @@ quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.notifications.db
 # Flyway minimal config properties
 quarkus.flyway.migrate-at-start=true
 
+# Disabled: Quarkus 3.37's reflection-free Jackson serializers don't correctly resolve
+# EXTERNAL_PROPERTY-style @JsonTypeInfo polymorphism (e.g. EndpointDTO.properties), causing
+# 500s when deserializing/serializing abstract EndpointPropertiesDTO subtypes.
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false
+
 # OpenAPI path
 quarkus.smallrye-openapi.path=/openapi.json
 mp.openapi.extensions.smallrye.operationIdStrategy=CLASS_METHOD

--- a/helpers/docker-compose.yaml
+++ b/helpers/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   postgres:
-    image: postgres:12
+    image: postgres:16
     ports:
       - "5432:5432"
     environment:

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.36.3</quarkus.platform.version>
+        <quarkus.platform.version>3.37.1</quarkus.platform.version>
         <redhat.event-schemas.version>1.5.0</redhat.event-schemas.version>
         <com.networknt.json-schema-validator.version>2.0.2</com.networknt.json-schema-validator.version>
 


### PR DESCRIPTION
- Bump quarkus.platform.version from 3.36.3 to 3.37.1.

- Disable Quarkus's new reflection-free Jackson serializer optimization (quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false) in backend. It's on by default in 3.37 but doesn't correctly resolve EXTERNAL_PROPERTY-style @JsonTypeInfo polymorphism, which EndpointDTO.properties relies on — without this, EndpointResourceTest fails with InvalidDefinitionException: Cannot construct instance of EndpointPropertiesDTO and a wave of 500s on endpoint create/update.

- Bump local dev Postgres (helpers/docker-compose.yaml) from postgres:12 to postgres:16, since Hibernate ORM 7.4 (bundled with Quarkus 3.37) raises the minimum supported PostgreSQL version to 14. Tests (Testcontainers, already on 16) and prod (rhel9/postgresql-16) were unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability for users of polymorphic API responses.
  * Updated the database container image to a newer PostgreSQL version for a more current local/test environment.

* **Chores**
  * Upgraded the application platform to the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->