### PR TITLE
[RHCLOUD-49051] Downgrade Quarkus version to 3.33.2.1 LTS

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -20,11 +20,6 @@ quarkus.hibernate-orm.physical-naming-strategy=com.redhat.cloud.notifications.db
 # Flyway minimal config properties
 quarkus.flyway.migrate-at-start=true
 
-# Disabled: Quarkus 3.37's reflection-free Jackson serializers don't correctly resolve
-# EXTERNAL_PROPERTY-style @JsonTypeInfo polymorphism (e.g. EndpointDTO.properties), causing
-# 500s when deserializing/serializing abstract EndpointPropertiesDTO subtypes.
-quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false
-
 # OpenAPI path
 quarkus.smallrye-openapi.path=/openapi.json
 mp.openapi.extensions.smallrye.operationIdStrategy=CLASS_METHOD

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.36.3</quarkus.platform.version>
+        <quarkus.platform.version>3.33.2.1</quarkus.platform.version>
         <redhat.event-schemas.version>1.5.0</redhat.event-schemas.version>
         <com.networknt.json-schema-validator.version>2.0.2</com.networknt.json-schema-validator.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.1</quarkus.platform.version>
+        <quarkus.platform.version>3.36.3</quarkus.platform.version>
         <redhat.event-schemas.version>1.5.0</redhat.event-schemas.version>
         <com.networknt.json-schema-validator.version>2.0.2</com.networknt.json-schema-validator.version>
 

--- a/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/rest/RecipientResolverResourceUsersFilterTest.java
+++ b/recipients-resolver/src/test/java/com/redhat/cloud/notifications/recipients/rest/RecipientResolverResourceUsersFilterTest.java
@@ -1,0 +1,74 @@
+package com.redhat.cloud.notifications.recipients.rest;
+
+import com.redhat.cloud.notifications.recipients.model.User;
+import com.redhat.cloud.notifications.recipients.resolver.FetchUsersFromExternalServices;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.common.mapper.TypeRef;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Reproducer for a regression introduced by the Quarkus 3.37 upgrade: the "reflection-free"
+ * Jackson (de)serializers fail to populate {@code RecipientSettings.users} (a private field
+ * exposed only through a getter, with no setter) when the request comes in as real JSON over
+ * HTTP. As a result, the "users" filter is silently ignored and the full org user list is
+ * returned instead of just the requested users.
+ *
+ * Unlike {@link com.redhat.cloud.notifications.recipients.resolver.RecipientsResolverTest},
+ * which builds {@code RecipientSettings} instances directly in Java and therefore never
+ * exercises Jackson deserialization, this test sends the raw JSON payload through the real
+ * "/internal/recipients-resolver" endpoint.
+ */
+@QuarkusTest
+public class RecipientResolverResourceUsersFilterTest {
+
+    private static final String ORG_ID = "12341234";
+
+    @InjectMock
+    FetchUsersFromExternalServices fetchUsersFromExternalServices;
+
+    @Test
+    void testUsersFilterIsAppliedWhenDeserializedFromJson() {
+        User user1 = createUser("userId1", "user-1");
+        User user2 = createUser("userId2", "user-2");
+        User user3 = createUser("userId3", "user-3");
+
+        when(fetchUsersFromExternalServices.getUsers(eq(ORG_ID), eq(false)))
+                .thenReturn(List.of(user1, user2, user3));
+
+        String requestBody = "{"
+                + "\"org_id\": \"" + ORG_ID + "\","
+                + "\"recipient_settings\": [{\"admins_only\": false, \"ignore_user_preferences\": false, \"users\": [\"user-1\"]}],"
+                + "\"subscribed_by_default\": true"
+                + "}";
+
+        List<User> recipients = given()
+                .when()
+                .contentType(JSON)
+                .body(requestBody)
+                .put("/internal/recipients-resolver")
+                .then()
+                .statusCode(200)
+                .extract().response().as(new TypeRef<>() { });
+
+        // Only "user-1" was requested via the "users" filter: the response must not include
+        // "user-2" or "user-3", even though they belong to the same org and are subscribed by default.
+        assertEquals(Set.of(user1), Set.copyOf(recipients));
+    }
+
+    private static User createUser(String userId, String username) {
+        User user = new User();
+        user.setId(userId);
+        user.setUsername(username);
+        return user;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recipient filtering so requests specifying selected users (sent as JSON) return only the intended recipients.
  * Reverted to default framework behavior for serializer handling, improving compatibility with polymorphic/deserialization scenarios.
  * Updated the Quarkus platform version to stay aligned with supported releases.

* **Tests**
  * Added an integration test covering user-based recipient filtering to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->