### PR TITLE
Add a parameter to configure IQE user in post-deploy tests

### DIFF
--- a/.rhcicd/stage-backend-post-deployment-tests.yaml
+++ b/.rhcicd/stage-backend-post-deployment-tests.yaml
@@ -13,9 +13,13 @@ objects:
     testing:
       iqe:
         debug: false
-        dynaconfEnvName: stage_post_deploy
-        filter: ''
-        marker: 'notif_backend and api'
+        env:
+          - name: 'ENV_FOR_DYNACONF'
+            value: 'stage_post_deploy'
+          - name: 'DYNACONF_DEFAULT_USER'
+            value: ${DYNACONF_DEFAULT_USER}
+          - name: 'IQE_MARKER_EXPRESSION'
+            value: 'notif_backend and api'
 parameters:
 - name: IMAGE_TAG
   value: ''
@@ -24,3 +28,6 @@ parameters:
   description: "Unique CJI name suffix"
   generate: expression
   from: "[a-z0-9]{6}"
+- name: DYNACONF_DEFAULT_USER
+  description: The user to be impersonated in the tests
+  value: "notifications_admin"


### PR DESCRIPTION
This will help us reusing the same test definition file with different users to target different clusters 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated post-deployment backend test configuration to use explicit environment settings.
  * Added support for configuring the default test user used during validation.
  * Refined test marker handling for more targeted execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->