### PR TITLE
RHCLOUD-49304 - MCP tool fix for getLinkedEndpoints and updateEventTypeEndpoints 

### DIFF
--- a/mcp/src/main/java/com/redhat/cloud/notifications/mcp/BackendRestClient.java
+++ b/mcp/src/main/java/com/redhat/cloud/notifications/mcp/BackendRestClient.java
@@ -140,12 +140,12 @@ public interface BackendRestClient {
     void updateEndpoint(@RestHeader("x-rh-identity") String xRhIdentity, @RestPath UUID id, EndpointDTO endpoint);
 
     @GET
-    @Path("/api/notifications/v1.0/eventTypes/{eventTypeId}/endpoints")
+    @Path("/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/endpoints")
     @Produces(APPLICATION_JSON)
     String getLinkedEndpoints(@RestHeader("x-rh-identity") String xRhIdentity, @RestPath UUID eventTypeId, @RestQuery Integer limit, @RestQuery Integer offset);
 
     @PUT
-    @Path("/api/notifications/v1.0/eventTypes/{eventTypeId}/endpoints")
+    @Path("/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/endpoints")
     @Consumes(APPLICATION_JSON)
     void updateEventTypeEndpoints(@RestHeader("x-rh-identity") String xRhIdentity, @RestPath UUID eventTypeId, java.util.Set<UUID> endpointIds);
 

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredNotificationToolsTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/McpAssuredNotificationToolsTest.java
@@ -232,7 +232,7 @@ public class McpAssuredNotificationToolsTest extends McpAssuredTestBase {
                 {"data":[{"id":"endpoint-1","name":"Webhook 1","type":"webhook"},{"id":"endpoint-2","name":"Slack Integration","type":"camel"}],"meta":{"count":2}}
                 """;
         MockServerLifecycleManager.getClient().stubFor(
-                get(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody(endpointsJson))
@@ -252,7 +252,7 @@ public class McpAssuredNotificationToolsTest extends McpAssuredTestBase {
     @Test
     public void testGetLinkedIntegrationsBackendReturns404() {
         MockServerLifecycleManager.getClient().stubFor(
-                get(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .willReturn(aResponse().withStatus(404))
         );
 
@@ -270,7 +270,7 @@ public class McpAssuredNotificationToolsTest extends McpAssuredTestBase {
     @Test
     public void testUpdateEventTypeIntegrations() {
         MockServerLifecycleManager.getClient().stubFor(
-                put(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                put(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .willReturn(aResponse().withStatus(200))
         );
 
@@ -285,14 +285,14 @@ public class McpAssuredNotificationToolsTest extends McpAssuredTestBase {
                 .thenAssertResults();
 
         MockServerLifecycleManager.getClient().verify(
-                putRequestedFor(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                putRequestedFor(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
         );
     }
 
     @Test
     public void testUpdateEventTypeIntegrationsBackendReturns403() {
         MockServerLifecycleManager.getClient().stubFor(
-                put(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                put(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .willReturn(aResponse().withStatus(403))
         );
 

--- a/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/NotificationToolsTest.java
+++ b/mcp/src/test/java/com/redhat/cloud/notifications/mcp/tools/NotificationToolsTest.java
@@ -340,7 +340,7 @@ public class NotificationToolsTest extends McpTestBase {
                 }
                 """;
         MockServerLifecycleManager.getClient().stubFor(
-                get(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .withHeader("x-rh-identity", equalTo(validIdentity()))
                         .willReturn(aResponse()
                                 .withHeader("Content-Type", "application/json")
@@ -354,7 +354,7 @@ public class NotificationToolsTest extends McpTestBase {
         micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
 
         MockServerLifecycleManager.getClient().verify(
-                getRequestedFor(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                getRequestedFor(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .withHeader("x-rh-identity", equalTo(validIdentity()))
         );
     }
@@ -367,7 +367,7 @@ public class NotificationToolsTest extends McpTestBase {
     @Test
     public void testGetLinkedEndpointsWhenBackendReturns404() {
         MockServerLifecycleManager.getClient().stubFor(
-                get(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .willReturn(aResponse().withStatus(404))
         );
 
@@ -381,7 +381,7 @@ public class NotificationToolsTest extends McpTestBase {
     @Test
     public void testGetLinkedEndpointsWhenBackendReturns403() {
         MockServerLifecycleManager.getClient().stubFor(
-                get(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                get(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .willReturn(aResponse().withStatus(403))
         );
 
@@ -427,7 +427,7 @@ public class NotificationToolsTest extends McpTestBase {
     @Test
     public void testUpdateEventTypeEndpointsWithValidIdentity() {
         MockServerLifecycleManager.getClient().stubFor(
-                put(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                put(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .withHeader("x-rh-identity", equalTo(validIdentity()))
                         .willReturn(aResponse().withStatus(200))
         );
@@ -438,7 +438,7 @@ public class NotificationToolsTest extends McpTestBase {
         micrometerAssertionHelper.assertCounterIncrement(AUTH_SUCCESS_COUNTER, 1);
 
         MockServerLifecycleManager.getClient().verify(
-                putRequestedFor(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                putRequestedFor(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .withHeader("x-rh-identity", equalTo(validIdentity()))
         );
     }
@@ -446,7 +446,7 @@ public class NotificationToolsTest extends McpTestBase {
     @Test
     public void testUpdateEventTypeEndpointsWithEmptySet() {
         MockServerLifecycleManager.getClient().stubFor(
-                put(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                put(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .withHeader("x-rh-identity", equalTo(validIdentity()))
                         .willReturn(aResponse().withStatus(200))
         );
@@ -465,7 +465,7 @@ public class NotificationToolsTest extends McpTestBase {
     @Test
     public void testUpdateEventTypeEndpointsWhenBackendReturns400() {
         MockServerLifecycleManager.getClient().stubFor(
-                put(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                put(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .willReturn(aResponse().withStatus(400))
         );
 
@@ -479,7 +479,7 @@ public class NotificationToolsTest extends McpTestBase {
     @Test
     public void testUpdateEventTypeEndpointsWhenBackendReturns403() {
         MockServerLifecycleManager.getClient().stubFor(
-                put(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                put(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .willReturn(aResponse().withStatus(403))
         );
 
@@ -493,7 +493,7 @@ public class NotificationToolsTest extends McpTestBase {
     @Test
     public void testUpdateEventTypeEndpointsWhenBackendReturns404() {
         MockServerLifecycleManager.getClient().stubFor(
-                put(urlPathEqualTo("/api/notifications/v1.0/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
+                put(urlPathEqualTo("/api/notifications/v1.0/notifications/eventTypes/550e8400-e29b-41d4-a716-446655440000/endpoints"))
                         .willReturn(aResponse().withStatus(404))
         );
 


### PR DESCRIPTION
getLinkedEndpoints and updateEventTypeEndpoints were using wrong path to backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated notification endpoint integration so retrieving and updating linked integrations uses the correct API route.
  * Improved handling of related success and error scenarios for linked integration operations.

* **Tests**
  * Updated automated coverage to validate the corrected notification API paths and response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->