### PR TITLE
scheduler templates - remove query parameters from export urls

### DIFF
--- a/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
@@ -1,5 +1,5 @@
 {#include drawer/Common/commonDrawerNotification.md}
 {#body}
-A scheduled export **[{data.context.job_name}]({environment.url}/api/export/v1/exports/{data.context.export_id}?{query_params})** has completed.
+A scheduled export **[{data.context.job_name}]({environment.url}/api/export/v1/exports/{data.context.export_id})** has completed.
 {/body}
 {/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
@@ -8,7 +8,7 @@
 {#content-body}
     <p style="{body-section-p-style}">
         The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}?{query_params}" target="_blank">{action.context.job_name}</a> scheduled export has completed successfully.
-        <a style="{body-section-underline-link-style}" href="{environment.url}/api/export/v1/exports/{action.context.export_id}?{query_params}" target="_blank">Download exported data</a>.
+        <a style="{body-section-underline-link-style}" href="{environment.url}/api/export/v1/exports/{action.context.export_id}" target="_blank">Download exported data</a>.
     </p>
 {/content-body}
 {#content-button-href}{environment.url}/insights/jobs/{action.context.job_id}{/content-button-href}

--- a/common-template/src/test/java/drawer/TestSchedulerTemplate.java
+++ b/common-template/src/test/java/drawer/TestSchedulerTemplate.java
@@ -28,7 +28,7 @@ class TestSchedulerTemplate {
         String result = renderTemplate(SCHEDULER_EXPORT_COMPLETE, action);
         assertTrue(result.contains("A scheduled export"));
         assertTrue(result.contains("**[Test Export Job]"));
-        assertTrue(result.contains("/api/export/v1/exports/export-67890?from=notifications&integration=drawer)**"));
+        assertTrue(result.contains("/api/export/v1/exports/export-67890)**"));
         assertTrue(result.contains("has completed"));
     }
 


### PR DESCRIPTION
scheduler templates - remove query parameters from export urls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated scheduled export download links in notifications and emails to use the direct export URL without unnecessary query parameters.
  * Improved link consistency across export completion messages.

* **Tests**
  * Updated validation to reflect the simplified export download URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->