### PR TITLE
Add OpenShift Migration Advisor (OMA) email templates

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/OpenShift.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/OpenShift.java
@@ -23,6 +23,14 @@ public class OpenShift {
     public static final String CLUSTER_MANAGER_APP_NAME = "cluster-manager";
     static final String CLUSTER_MANAGER_FOLDER_NAME = "OCM/";
 
+    public static final String MIGRATION_ADVISOR_APP_NAME = "migration-advisor";
+    static final String MIGRATION_ADVISOR_FOLDER_NAME = "Oma/";
+
+    public static final String MIGRATION_ADVISOR_PARTNERSHIP_REQUEST = "partnership-request";
+    public static final String MIGRATION_ADVISOR_PARTNERSHIP_RESPONSE = "partnership-response";
+    public static final String MIGRATION_ADVISOR_ASSESSMENT_SHARED = "assessment-shared";
+    public static final String MIGRATION_ADVISOR_ASSESSMENT_CREATED = "assessment-created";
+
     public static final String ADVISOR_NEW_RECOMMENDATION = "new-recommendation";
 
     public static final String COST_MANAGEMENT_MISSING_COST_MODEL = "missing-cost-model";
@@ -86,6 +94,12 @@ public class OpenShift {
 
         entry(new TemplateDefinition(GOOGLE_CHAT, BUNDLE_NAME, CLUSTER_MANAGER_APP_NAME, null), CLUSTER_MANAGER_FOLDER_NAME + "ocmDefault.json"),
         entry(new TemplateDefinition(MS_TEAMS, BUNDLE_NAME, CLUSTER_MANAGER_APP_NAME, null), CLUSTER_MANAGER_FOLDER_NAME + "ocmDefault.json"),
-        entry(new TemplateDefinition(SLACK, BUNDLE_NAME, CLUSTER_MANAGER_APP_NAME, null), CLUSTER_MANAGER_FOLDER_NAME + "ocmDefault.json")
+        entry(new TemplateDefinition(SLACK, BUNDLE_NAME, CLUSTER_MANAGER_APP_NAME, null), CLUSTER_MANAGER_FOLDER_NAME + "ocmDefault.json"),
+
+        // Migration Advisor
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, MIGRATION_ADVISOR_APP_NAME, MIGRATION_ADVISOR_PARTNERSHIP_REQUEST), MIGRATION_ADVISOR_FOLDER_NAME + "partnershipRequestInstantEmailBody.html"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, MIGRATION_ADVISOR_APP_NAME, MIGRATION_ADVISOR_PARTNERSHIP_RESPONSE), MIGRATION_ADVISOR_FOLDER_NAME + "partnershipResponseInstantEmailBody.html"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, MIGRATION_ADVISOR_APP_NAME, MIGRATION_ADVISOR_ASSESSMENT_SHARED), MIGRATION_ADVISOR_FOLDER_NAME + "assessmentSharedInstantEmailBody.html"),
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, MIGRATION_ADVISOR_APP_NAME, MIGRATION_ADVISOR_ASSESSMENT_CREATED), MIGRATION_ADVISOR_FOLDER_NAME + "assessmentCreatedInstantEmailBody.html")
     );
 }

--- a/common-template/src/main/resources/templates/email/Oma/assessmentCreatedInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Oma/assessmentCreatedInstantEmailBody.html
@@ -1,0 +1,25 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    OpenShift - Migration Advisor
+{/content-header-title}
+{#content-title}
+    New Assessment Created
+{/content-title}
+{#content-body}
+<p style="{body-section-p-style}">
+    Dear customer,
+</p>
+<p style="{body-section-p-style}">
+    This is an automated notification from the OpenShift Migration Advisor (OMA) platform.
+</p>
+<p style="{body-section-p-style}">
+    A new assessment has been created on your behalf.
+    You can review the details of this assessment by logging in to the OpenShift Migration Advisor administrative dashboard.
+</p>
+<p style="{body-section-p-style}">
+    If you have any questions regarding this action, please contact your partner representative or visit the support portal.
+</p>
+{/content-body}
+{#content-button-href}{environment.url}/openshift/migration-advisor/assessments/{action.context.assessment_id}?{query_params}{/content-button-href}
+{#content-button-service-name}OpenShift Migration Advisor{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/Oma/assessmentSharedInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Oma/assessmentSharedInstantEmailBody.html
@@ -1,0 +1,25 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    OpenShift - Migration Advisor
+{/content-header-title}
+{#content-title}
+    New Assessment Shared
+{/content-title}
+{#content-body}
+<p style="{body-section-p-style}">
+    Dear partner,
+</p>
+<p style="{body-section-p-style}">
+    This is an automated notification from the OpenShift Migration Advisor (OMA) platform.
+</p>
+<p style="{body-section-p-style}">
+    A new assessment has been shared with your organization.
+    You can access the shared assessment to review the data and collaborate on the migration initiative by logging in to the OpenShift Migration Advisor administrative dashboard.
+</p>
+<p style="{body-section-p-style}">
+    If you have any questions, please contact the customer directly or visit the support portal.
+</p>
+{/content-body}
+{#content-button-href}{environment.url}/openshift/migration-advisor/assessments/{action.context.assessment_id}?{query_params}{/content-button-href}
+{#content-button-service-name}OpenShift Migration Advisor{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/Oma/partnershipRequestInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Oma/partnershipRequestInstantEmailBody.html
@@ -1,0 +1,28 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    OpenShift - Migration Advisor
+{/content-header-title}
+{#content-title}
+    New Partnership Request
+{/content-title}
+{#content-body}
+<p style="{body-section-p-style}">
+    Dear partner,
+</p>
+<p style="{body-section-p-style}">
+    This is an automated notification from the OpenShift Migration Advisor (OMA) platform.
+</p>
+<p style="{body-section-p-style}">
+    A request has been submitted to establish a formal partnership with your organization.
+    Establishing this partnership will enable the secure sharing of migration assessments and facilitate closer collaboration on your joint initiatives.
+</p>
+<p style="{body-section-p-style}">
+    To review this request and choose whether to accept or decline, please log in to the OpenShift Migration Advisor.
+</p>
+<p style="{body-section-p-style}">
+    If you have any questions regarding this request, please contact your organization's account administrator or visit the support portal.
+</p>
+{/content-body}
+{#content-button-href}{environment.url}/openshift/migration-advisor/partnerships?{query_params}{/content-button-href}
+{#content-button-service-name}OpenShift Migration Advisor{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/Oma/partnershipResponseInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Oma/partnershipResponseInstantEmailBody.html
@@ -1,0 +1,32 @@
+{#include email/Common/insightsEmailBody}
+{#content-header-title}
+    OpenShift - Migration Advisor
+{/content-header-title}
+{#content-title}
+    Update on Your Partnership Request
+{/content-title}
+{#content-body}
+<p style="{body-section-p-style}">
+    Dear customer,
+</p>
+<p style="{body-section-p-style}">
+    This is an automated notification from the OpenShift Migration Advisor (OMA) platform.
+</p>
+<p style="{body-section-p-style}">
+    Your request to establish a partnership has been <b>{action.context.decision}</b>.
+</p>
+{#if action.context.decision.or('') == 'Declined'}
+<p style="{body-section-p-style}">
+    Reason for decision: {action.context.reason.or('No reason provided')}
+</p>
+{/if}
+<p style="{body-section-p-style}">
+    You can view the status of your request and any additional details by logging in to the OpenShift Migration Advisor administrative dashboard.
+</p>
+<p style="{body-section-p-style}">
+    If you have any questions regarding this decision, please contact your organization's account administrator or visit the support portal.
+</p>
+{/content-body}
+{#content-button-href}{environment.url}/openshift/migration-advisor/partnerships?{query_params}{/content-button-href}
+{#content-button-service-name}OpenShift Migration Advisor{/content-button-service-name}
+{/include}

--- a/common-template/src/test/java/email/TestOmaTemplate.java
+++ b/common-template/src/test/java/email/TestOmaTemplate.java
@@ -1,0 +1,164 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.qute.templates.Severity;
+import helpers.TestHelpers;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestOmaTemplate extends EmailTemplatesRendererHelper {
+
+    private static final String PARTNERSHIP_REQUEST = "partnership-request";
+    private static final String PARTNERSHIP_RESPONSE = "partnership-response";
+    private static final String ASSESSMENT_SHARED = "assessment-shared";
+    private static final String ASSESSMENT_CREATED = "assessment-created";
+
+    @Override
+    protected String getApp() {
+        return "migration-advisor";
+    }
+
+    @Override
+    protected String getBundle() {
+        return "openshift";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "OpenShift";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Migration Advisor";
+    }
+
+    @Test
+    public void testInstantEmailTitle() {
+        eventTypeDisplayName = "Partnership Request";
+        Action action = createOmaAction();
+
+        String result = generateEmailSubject(PARTNERSHIP_REQUEST, action);
+        assertEquals("Instant notification - Partnership Request - Migration Advisor - OpenShift", result);
+
+        action.setSeverity(Severity.IMPORTANT.name());
+        String severityResult = generateEmailSubject(PARTNERSHIP_REQUEST, action);
+        assertEquals("[IMPORTANT] Instant notification - Partnership Request - Migration Advisor - OpenShift", severityResult);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testPartnershipRequestEmailBody(boolean useBetaTemplate) {
+        Action action = createOmaAction();
+
+        String result = generateEmailBody(PARTNERSHIP_REQUEST, action, useBetaTemplate);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("OpenShift - Migration Advisor"));
+        assertTrue(result.contains("New Partnership Request"));
+        assertTrue(result.contains("/openshift/migration-advisor/partnerships"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testPartnershipResponseAcceptedEmailBody(boolean useBetaTemplate) {
+        Action action = createOmaActionWithDecision("Accepted", null);
+
+        String result = generateEmailBody(PARTNERSHIP_RESPONSE, action, useBetaTemplate);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("OpenShift - Migration Advisor"));
+        assertTrue(result.contains("Update on Your Partnership Request"));
+        assertTrue(result.contains("Accepted"));
+        assertFalse(result.contains("Reason for decision"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testPartnershipResponseDeclinedEmailBody(boolean useBetaTemplate) {
+        Action action = createOmaActionWithDecision("Declined", "Not a good fit at this time");
+
+        String result = generateEmailBody(PARTNERSHIP_RESPONSE, action, useBetaTemplate);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("Declined"));
+        assertTrue(result.contains("Reason for decision"));
+        assertTrue(result.contains("Not a good fit at this time"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAssessmentSharedEmailBody(boolean useBetaTemplate) {
+        Action action = createOmaActionWithAssessment(ASSESSMENT_SHARED, "assessment-123");
+
+        String result = generateEmailBody(ASSESSMENT_SHARED, action, useBetaTemplate);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("OpenShift - Migration Advisor"));
+        assertTrue(result.contains("New Assessment Shared"));
+        assertTrue(result.contains("/openshift/migration-advisor/assessments/assessment-123"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAssessmentCreatedEmailBody(boolean useBetaTemplate) {
+        Action action = createOmaActionWithAssessment(ASSESSMENT_CREATED, "assessment-456");
+
+        String result = generateEmailBody(ASSESSMENT_CREATED, action, useBetaTemplate);
+        assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+        assertTrue(result.contains("OpenShift - Migration Advisor"));
+        assertTrue(result.contains("New Assessment Created"));
+        assertTrue(result.contains("/openshift/migration-advisor/assessments/assessment-456"));
+    }
+
+    private static Action createOmaAction() {
+        Action action = new Action();
+        action.setBundle("openshift");
+        action.setApplication("migration-advisor");
+        action.setTimestamp(LocalDateTime.now());
+        action.setEventType(PARTNERSHIP_REQUEST);
+        action.setOrgId(DEFAULT_ORG_ID);
+        action.setContext(new Context.ContextBuilder().build());
+        action.setEvents(List.of(
+            new Event.EventBuilder()
+                .withMetadata(new Metadata.MetadataBuilder().build())
+                .withPayload(new Payload.PayloadBuilder().build())
+                .build()
+        ));
+        return action;
+    }
+
+    private static Action createOmaActionWithDecision(String decision, String reason) {
+        Action action = createOmaAction();
+        action.setEventType(PARTNERSHIP_RESPONSE);
+        Context.ContextBuilder contextBuilder = new Context.ContextBuilder();
+        contextBuilder.withAdditionalProperty("decision", decision);
+        if (reason != null) {
+            contextBuilder.withAdditionalProperty("reason", reason);
+        }
+        action.setContext(contextBuilder.build());
+        return action;
+    }
+
+    private static Action createOmaActionWithAssessment(String eventType, String assessmentId) {
+        Action action = createOmaAction();
+        action.setEventType(eventType);
+        action.setContext(
+            new Context.ContextBuilder()
+                .withAdditionalProperty("assessment_id", assessmentId)
+                .build()
+        );
+        return action;
+    }
+}


### PR DESCRIPTION
Add instant email templates for the migration-adviser application in the openshift bundle. These templates notify partners and customers about key collaboration events on the OMA platform:

- partnership-request: sent to a partner when a customer submits a request to establish a formal partnership
- partnership-response: sent to a customer when a partner accepts or declines their partnership request (includes decline reason)
- assessment-shared: sent to a partner when a customer shares a migration assessment with their organization
- assessment-created: sent to a customer when a partner creates a migration assessment on their behalf

Each event type has a dedicated email body and subject line template. All templates reuse the common insightsEmailBody layout.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShift Migration Advisor email notifications for partnership requests, partnership responses, shared assessments, and newly created assessments.
  * Notifications include event-specific messaging and links to relevant Migration Advisor pages.
  * Partnership response emails display the decision and, when declined, the provided reason.
  * Added default Slack template support for the Cluster Manager integration.
* **Tests**
  * Added coverage for notification subjects and event-specific email content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->