### PR TITLE
[RHCLOUD-44010] Simplify and optimize email aggregation logic

### DIFF
--- a/common-template/src/main/resources/templates/email/Inventory/dailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Inventory/dailyEmailBody.html
@@ -1,38 +1,38 @@
-{@boolean renderSection1=action.context.inventory.errors.size}
-{@boolean renderSection2=(action.context.inventory.new_systems.orEmpty.size || action.context.inventory.stale_systems.orEmpty.size || action.context.inventory.deleted_systems.orEmpty.size)}
+{@boolean renderSection1=action.context.inventory.total_errors}
+{@boolean renderSection2=(action.context.inventory.total_new_systems || action.context.inventory.total_stale_systems || action.context.inventory.total_deleted_systems)}
 {@boolean renderCustomLinks=true}
 {@boolean renderTitleRightPart=true}
 {#include email/Common/insightsEmailBodyLight}
 {#content-render-custom-links-section}
-    {#if action.context.inventory.errors.size() > 0}
-        <a style="{body-section-table-td-a-style}" href="#inventory-section1">{#insert content-title-section1}{/} ({action.context.inventory.errors.size()})</a>
+    {#if action.context.inventory.total_errors > 0}
+        <a style="{body-section-table-td-a-style}" href="#inventory-section1">{#insert content-title-section1}{/} ({action.context.inventory.total_errors})</a>
     {/if}
-    {#if action.context.inventory.new_systems.size() > 0}
+    {#if action.context.inventory.total_new_systems > 0}
         <!-- next section -->
-        <a style="{body-section-table-td-a-style}" href="#inventory-section2-1">New systems registered ({action.context.inventory.new_systems.size()})</a>
+        <a style="{body-section-table-td-a-style}" href="#inventory-section2-1">New systems registered ({action.context.inventory.total_new_systems})</a>
     {/if}
-    {#if action.context.inventory.stale_systems.size() > 0}
+    {#if action.context.inventory.total_stale_systems > 0}
         <!-- next section -->
-        <a style="{body-section-table-td-a-style}" href="#inventory-section2-2">Stale systems ({action.context.inventory.stale_systems.size()})</a>
+        <a style="{body-section-table-td-a-style}" href="#inventory-section2-2">Stale systems ({action.context.inventory.total_stale_systems})</a>
     {/if}
-    {#if action.context.inventory.deleted_systems.size() > 0}
+    {#if action.context.inventory.total_deleted_systems > 0}
         <!-- next section -->
-        <a style="{body-section-table-td-a-style}" href="#inventory-section2-3">Systems deleted ({action.context.inventory.deleted_systems.size()})</a>
+        <a style="{body-section-table-td-a-style}" href="#inventory-section2-3">Systems deleted ({action.context.inventory.total_deleted_systems})</a>
     {/if}
 {/content-render-custom-links-section}
 {#content-title-section1}
-    Host{#if action.context.inventory.errors.size() > 1}s{/if} with validation error
+    Host{#if action.context.inventory.total_errors > 1}s{/if} with validation error
 {/content-title-section1}
 {#content-title-right-part}
-{action.context.inventory.errors.size()}
+{action.context.inventory.total_errors}
 {/content-title-right-part}
 {#content-body-section1}
     <p style="{body-section-p-style}">
-        Red Hat Lightspeed has identified {action.context.inventory.errors.size()} host{#if action.context.inventory.errors.size() > 1}s{/if} that presented a validation error.
+        Red Hat Lightspeed has identified {action.context.inventory.total_errors} host{#if action.context.inventory.total_errors > 1}s{/if} that presented a validation error.
         For errors in updating hosts, please review the Red Hat Lightspeed Inventory service to further assess and determine next steps.
     </p>
     <p style="{body-section-p-style}">
-        If no hosts were created by {#if action.context.inventory.errors.size() > 1}these changes, these errors{#else}this change, this error{/if} will not appear in the service.
+        If no hosts were created by {#if action.context.inventory.total_errors > 1}these changes, these errors{#else}this change, this error{/if} will not appear in the service.
     </p>
 
     <table style="{body-section-table-style}">
@@ -57,15 +57,15 @@
     Inventory
 {/content-title-section2}
 {#content-title-right-part-section2}
-    {action.context.inventory.new_systems.size() + action.context.inventory.stale_systems.size() + action.context.inventory.deleted_systems.size()}
+    {action.context.inventory.total_new_systems + action.context.inventory.total_stale_systems + action.context.inventory.total_deleted_systems}
 {/content-title-right-part-section2}
 {#content-body-section2}
-    {#let total_systems_state_change=(action.context.inventory.new_systems.size() + action.context.inventory.stale_systems.size() + action.context.inventory.deleted_systems.size())}
+    {#let total_systems_state_change=(action.context.inventory.total_new_systems + action.context.inventory.total_stale_systems + action.context.inventory.total_deleted_systems)}
         <p style="{body-section-p-style}">{total_systems_state_change} system{#if total_systems_state_change > 1}s{/if} changed state:</p>
     {/let}
-{#if action.context.inventory.new_systems.size() > 0}
+{#if action.context.inventory.total_new_systems > 0}
     <a id="inventory-section2-1" name="inventory-section2-1"></a>
-    {#if action.context.inventory.stale_systems.orEmpty.size() > 0 || action.context.inventory.deleted_systems.orEmpty.size > 0}
+    {#if action.context.inventory.total_stale_systems > 0 || action.context.inventory.total_deleted_systems > 0}
         <table style="border: solid 1px #b8bbbe; border-radius: 16px; padding: 0 8px 0 8px; width: 100%;"><tr><td>
     {/if}
 
@@ -83,13 +83,13 @@
             {/each}
         </tbody>
     </table>
-    {#if action.context.inventory.stale_systems.orEmpty.size() > 0 || action.context.inventory.deleted_systems.orEmpty.size > 0}
+    {#if action.context.inventory.total_stale_systems > 0 || action.context.inventory.total_deleted_systems > 0}
         </td></tr></table><div style="height: 24px">&#xA0;</div>
     {/if}
 {/if}
-{#if action.context.inventory.stale_systems.size() > 0}
+{#if action.context.inventory.total_stale_systems > 0}
     <a id="inventory-section2-2" name="inventory-section2-2"></a>
-    {#if action.context.inventory.new_systems.orEmpty.size() > 0 || action.context.inventory.deleted_systems.orEmpty.size > 0}
+    {#if action.context.inventory.total_new_systems > 0 || action.context.inventory.total_deleted_systems > 0}
         <table style="border: solid 1px #b8bbbe; border-radius: 16px; padding: 0 8px 0 8px; width: 100%;"><tr><td>
     {/if}
     <table style="{body-section-table-style}">
@@ -106,16 +106,16 @@
         {/each}
         </tbody>
     </table>
-    {#if action.context.inventory.new_systems.orEmpty.size() > 0 || action.context.inventory.deleted_systems.orEmpty.size > 0}
+    {#if action.context.inventory.total_new_systems > 0 || action.context.inventory.total_deleted_systems > 0}
         </td></tr></table>
     {/if}
-    {#if action.context.inventory.deleted_systems.orEmpty.size > 0}
+    {#if action.context.inventory.total_deleted_systems > 0}
         <div style="height: 24px">&#xA0;</div>
     {/if}
 {/if}
-{#if action.context.inventory.deleted_systems.size() > 0}
+{#if action.context.inventory.total_deleted_systems > 0}
     <a id="inventory-section2-3" name="inventory-section2-3"></a>
-    {#if action.context.inventory.new_systems.orEmpty.size() > 0 || action.context.inventory.stale_systems.orEmpty.size > 0}
+    {#if action.context.inventory.total_new_systems > 0 || action.context.inventory.total_stale_systems > 0}
         <table style="border: solid 1px #b8bbbe; border-radius: 16px; padding: 0 8px 0 8px; width: 100%;"><tr><td>
     {/if}
     <table style="{body-section-table-style}">
@@ -132,7 +132,7 @@
         {/each}
         </tbody>
     </table>
-    {#if action.context.inventory.new_systems.orEmpty.size() > 0 || action.context.inventory.stale_systems.orEmpty.size > 0}
+    {#if action.context.inventory.total_new_systems > 0 || action.context.inventory.total_stale_systems > 0}
         </td></tr></table>
     {/if}
 {/if}

--- a/common-template/src/main/resources/templates/email/Vulnerability/dailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Vulnerability/dailyEmailBody.html
@@ -5,10 +5,10 @@
     CVEs identified
 {/content-title-section1}
 {#content-title-counter}
-({action.context.vulnerability.reported_cves.size()})
+({action.context.vulnerability.total_unique_cves})
 {/content-title-counter}
 {#content-title-right-part}
-{action.context.vulnerability.reported_cves.size()}
+{action.context.vulnerability.total_unique_cves}
 {/content-title-right-part}
 {#content-body-section1}
     <p style="{body-section-p-style}">

--- a/common-template/src/test/java/email/TestInventoryTemplate.java
+++ b/common-template/src/test/java/email/TestInventoryTemplate.java
@@ -47,7 +47,11 @@ public class TestInventoryTemplate extends EmailTemplatesRendererHelper {
         "      ]," +
         "      \"new_systems\":[]," +
         "      \"stale_systems\":[]," +
-        "      \"deleted_systems\":[]" +
+        "      \"deleted_systems\":[]," +
+        "      \"total_errors\":2," +
+        "      \"total_new_systems\":0," +
+        "      \"total_stale_systems\":0," +
+        "      \"total_deleted_systems\":0" +
         "   }," +
         "   \"start_time\":null," +
         "   \"end_time\":null" +
@@ -93,7 +97,11 @@ public class TestInventoryTemplate extends EmailTemplatesRendererHelper {
                  {
                     "display_name":"second-deleted-system-display-name"
                  }
-              ]
+              ],
+              "total_errors":2,
+              "total_new_systems":2,
+              "total_stale_systems":2,
+              "total_deleted_systems":2
            },
            "start_time":null,
            "end_time":null
@@ -200,12 +208,14 @@ public class TestInventoryTemplate extends EmailTemplatesRendererHelper {
         assertSystems(result, deletedSystemsMap, false, !deletedSystemsMap.isEmpty());
     }
 
-    private static void addToAggregationContext(String category, Map<UUID, String> newSystemsMap, Map<String, Object> aggregationContext) {
-        for (final Map.Entry<UUID, String> entry : newSystemsMap.entrySet()) {
-            ((ArrayList<Map<String, Object>>) ((Map<String, Object>) aggregationContext.get("inventory")).get(category)).add(
+    private static void addToAggregationContext(String category, Map<UUID, String> systemsMap, Map<String, Object> aggregationContext) {
+        Map<String, Object> inventory = (Map<String, Object>) aggregationContext.get("inventory");
+        for (final Map.Entry<UUID, String> entry : systemsMap.entrySet()) {
+            ((ArrayList<Map<String, Object>>) inventory.get(category)).add(
                 Map.of("inventory_id", entry.getKey(), "display_name",  entry.getValue())
             );
         }
+        inventory.put("total_" + category, systemsMap.size());
     }
 
     /**

--- a/common-template/src/test/java/helpers/TestHelpers.java
+++ b/common-template/src/test/java/helpers/TestHelpers.java
@@ -302,7 +302,7 @@ public class TestHelpers {
 
         emailActionMessage.setContext(
             new Context.ContextBuilder()
-                .withAdditionalProperty("vulnerability", Map.of("reported_cves", List.of("CVE1", "CVE2", "CVE3")))
+                .withAdditionalProperty("vulnerability", Map.of("reported_cves", List.of("CVE1", "CVE2", "CVE3"), "total_unique_cves", 3))
                 .build()
         );
 
@@ -333,7 +333,7 @@ public class TestHelpers {
             new Context.ContextBuilder()
                 .withAdditionalProperty("display_name", "test-system")
                 .withAdditionalProperty("inventory_id", "b8125066-0db2-47df-b37a-09e71979269f")
-                .withAdditionalProperty("vulnerability", Map.of("reported_cves", List.of("CVE1", "CVE2", "CVE3")))
+                .withAdditionalProperty("vulnerability", Map.of("reported_cves", List.of("CVE1", "CVE2", "CVE3"), "total_unique_cves", 3))
                 .build()
         );
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -2,6 +2,7 @@ package com.redhat.cloud.notifications.processors.email;
 
 import com.redhat.cloud.event.parser.ConsoleCloudEventParser;
 import com.redhat.cloud.event.parser.exceptions.ConsoleCloudEventParsingException;
+import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
@@ -85,6 +86,15 @@ public class EmailAggregator {
     @ConfigProperty(name = "notifications.aggregation.max-page-size", defaultValue = "100")
     int maxPageSize;
 
+    @ConfigProperty(name = "notifications.aggregation.inventory.max-displayed-systems", defaultValue = "50")
+    int inventoryMaxDisplayedSystems;
+
+    @ConfigProperty(name = "notifications.aggregation.vulnerability.max-displayed-cves", defaultValue = "100")
+    int vulnerabilityMaxDisplayedCves;
+
+    @ConfigProperty(name = "notifications.aggregation.resource-optimization.max-tracked-systems", defaultValue = "10000")
+    int resourceOptimizationMaxTrackedSystems;
+
     public Map<User, Map<String, Object>> getAggregated(UUID appId, EventAggregationCriterion aggregationKey, SubscriptionType subscriptionType, LocalDateTime start, LocalDateTime end) {
 
         Map<User, AbstractEmailPayloadAggregator> aggregated = new HashMap<>();
@@ -165,16 +175,19 @@ public class EmailAggregator {
                  * Let's populate the Map that will be returned by the method.
                  */
                 recipients.forEach(recipient -> {
-                    final Set<SubscribedEventTypeSeverities> userSubscribedSeverities;
+                    final Map<UUID, Map<Severity, Boolean>> severitiesByEventType;
                     if (subscribersWithSeverities.isPresent() && subscribersWithSeverities.get().containsKey(recipient.getUsername())) {
-                        userSubscribedSeverities = subscribersWithSeverities.get().get(recipient.getUsername());
+                        severitiesByEventType = subscribersWithSeverities.get().get(recipient.getUsername()).stream()
+                            .collect(toMap(SubscribedEventTypeSeverities::eventTypeId, SubscribedEventTypeSeverities::severities));
                     } else {
-                        userSubscribedSeverities = null;
+                        severitiesByEventType = null;
                     }
 
                     // We may or may not have already initialized an aggregator for the recipient.
                     AbstractEmailPayloadAggregator aggregator = aggregated
-                        .computeIfAbsent(recipient, notUsed -> EmailPayloadAggregatorFactory.by(eventAggregationCriteria, recipient.getUsername(), userSubscribedSeverities));
+                        .computeIfAbsent(recipient, notUsed -> EmailPayloadAggregatorFactory.by(
+                            eventAggregationCriteria, recipient.getUsername(), severitiesByEventType,
+                            inventoryMaxDisplayedSystems, vulnerabilityMaxDisplayedCves, resourceOptimizationMaxTrackedSystems));
 
                     // It's aggregation time!
                     EmailAggregation eventDataToAggregate = new EmailAggregation(aggregation.getOrgId(), eventAggregationCriteria.getBundle(), eventAggregationCriteria.getApplication(), baseTransformer.toJsonObject(aggregation), aggregation.getSeverity(), aggregation.getEventType().getId());

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AbstractEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AbstractEmailPayloadAggregator.java
@@ -1,20 +1,19 @@
 package com.redhat.cloud.notifications.processors.email.aggregators;
 
+import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.models.EmailAggregation;
-import com.redhat.cloud.notifications.processors.email.SubscribedEventTypeSeverities;
 import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonObject;
 
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.UUID;
 
 public abstract class AbstractEmailPayloadAggregator {
 
     private String orgId;
 
     public String userName;
-    public Set<SubscribedEventTypeSeverities> userSeverities;
+    public Map<UUID, Map<Severity, Boolean>> severitiesByEventType;
     JsonObject context = new JsonObject();
 
     abstract void processEmailAggregation(EmailAggregation aggregation);
@@ -27,12 +26,10 @@ public abstract class AbstractEmailPayloadAggregator {
         }
 
         boolean shouldAggregateThisEvent = true;
-        if (userSeverities != null) {
-            Optional<SubscribedEventTypeSeverities> userPrevForThisEventType = userSeverities.stream()
-                .filter(userSeverity -> aggregation.getEventTypeId().equals(userSeverity.eventTypeId())).findFirst();
-
-            if (userPrevForThisEventType.isPresent() && userPrevForThisEventType.get().severities().containsKey(aggregation.getSeverity())) {
-                shouldAggregateThisEvent = userPrevForThisEventType.get().severities().get(aggregation.getSeverity());
+        if (severitiesByEventType != null) {
+            Map<Severity, Boolean> severities = severitiesByEventType.get(aggregation.getEventTypeId());
+            if (severities != null && severities.containsKey(aggregation.getSeverity())) {
+                shouldAggregateThisEvent = severities.get(aggregation.getSeverity());
             } else {
                 shouldAggregateThisEvent = false;
             }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
@@ -3,6 +3,7 @@ package com.redhat.cloud.notifications.processors.email.aggregators;
 import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.models.EventAggregationCriterion;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -47,8 +48,8 @@ public class EmailPayloadAggregatorFactory {
                                                                     int inventoryMaxDisplayed, int vulnerabilityMaxDisplayed, int resourceOptMaxTracked) {
         String key = bundle + "/" + application;
         AggregatorCreator creator = AGGREGATORS.get(key);
-        if (creator == null) {
-            creator = AGGREGATORS.get(bundle + "/" + application.toLowerCase());
+        if (creator == null && application != null) {
+            creator = AGGREGATORS.get(bundle + "/" + application.toLowerCase(Locale.ROOT));
         }
         return creator != null ? creator.create(inventoryMaxDisplayed, vulnerabilityMaxDisplayed, resourceOptMaxTracked) : null;
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
@@ -1,87 +1,55 @@
 package com.redhat.cloud.notifications.processors.email.aggregators;
 
+import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.models.EventAggregationCriterion;
-import com.redhat.cloud.notifications.processors.email.SubscribedEventTypeSeverities;
-import java.util.Set;
+
+import java.util.Map;
+import java.util.UUID;
 
 public class EmailPayloadAggregatorFactory {
 
-    private static final String RHEL = "rhel";
-    private static final String SUBSCRIPTION_SERVICES = "subscription-services";
-    private static final String APPLICATION_SERVICES = "application-services";
-    private static final String ADVISOR = "advisor";
+    @FunctionalInterface
+    interface AggregatorCreator {
+        AbstractEmailPayloadAggregator create(int inventoryMax, int vulnerabilityMax, int resourceOptMax);
+    }
 
-    private static final String COMPLIANCE = "compliance";
-    private static final String ANSIBLE = "ansible";
-    private static final String PATCH = "patch";
-    private static final String VULNERABILITY = "vulnerability";
-    private static final String INVENTORY = "inventory";
-    private static final String RESOURCE_OPTIMIZATION = "resource-optimization";
-    private static final String ERRATA = "errata-notifications";
+    private static final Map<String, AggregatorCreator> AGGREGATORS = Map.ofEntries(
+        Map.entry("application-services/ansible",               (i, v, r) -> new AnsibleEmailAggregator()),
+        Map.entry("subscription-services/errata-notifications", (i, v, r) -> new ErrataEmailPayloadAggregator()),
+        Map.entry("subscription-services/application-services", (i, v, r) -> new ApplicationServicesEmailPayloadAggregator()),
+        Map.entry("rhel/advisor",                               (i, v, r) -> new AdvisorEmailAggregator()),
+        Map.entry("rhel/compliance",                            (i, v, r) -> new ComplianceEmailAggregator()),
+        Map.entry("rhel/inventory",                             (i, v, r) -> new InventoryEmailAggregator(i)),
+        Map.entry("rhel/patch",                                 (i, v, r) -> new PatchEmailPayloadAggregator()),
+        Map.entry("rhel/resource-optimization",                 (i, v, r) -> new ResourceOptimizationPayloadAggregator(r)),
+        Map.entry("rhel/vulnerability",                         (i, v, r) -> new VulnerabilityEmailPayloadAggregator(v))
+    );
 
     private EmailPayloadAggregatorFactory() {
 
     }
 
-    public static AbstractEmailPayloadAggregator by(EventAggregationCriterion aggregationKey, String username, Set<SubscribedEventTypeSeverities> userSeverities) {
+    public static AbstractEmailPayloadAggregator by(EventAggregationCriterion aggregationKey, String username,
+                                                       Map<UUID, Map<Severity, Boolean>> severitiesByEventType,
+                                                       int inventoryMaxDisplayed, int vulnerabilityMaxDisplayed, int resourceOptMaxTracked) {
         String bundle = aggregationKey.getBundle();
         String application = aggregationKey.getApplication();
 
-        AbstractEmailPayloadAggregator aggregator = getAggregator(bundle, application);
+        AbstractEmailPayloadAggregator aggregator = getAggregator(bundle, application, inventoryMaxDisplayed, vulnerabilityMaxDisplayed, resourceOptMaxTracked);
         if (aggregator != null) {
             aggregator.userName = username;
-            aggregator.userSeverities = userSeverities;
+            aggregator.severitiesByEventType = severitiesByEventType;
         }
         return aggregator;
     }
 
-    private static AbstractEmailPayloadAggregator getAggregator(String bundle, String application) {
-        switch (bundle) {
-            case APPLICATION_SERVICES:
-                switch (application.toLowerCase()) { // TODO Remove toLowerCase if possible
-                    case ANSIBLE:
-                        return new AnsibleEmailAggregator();
-                    default:
-                        // Do nothing.
-                        break;
-                }
-                break;
-            case SUBSCRIPTION_SERVICES:
-                switch (application) {
-                    case ERRATA:
-                        return new ErrataEmailPayloadAggregator();
-                    case APPLICATION_SERVICES:
-                        return new ApplicationServicesEmailPayloadAggregator();
-                    default:
-                        // Do nothing.
-                        break;
-                }
-                break;
-            case RHEL:
-                switch (application) {
-                    case ADVISOR:
-                        return new AdvisorEmailAggregator();
-                    case COMPLIANCE:
-                        return new ComplianceEmailAggregator();
-                    case INVENTORY:
-                        return new InventoryEmailAggregator();
-                    case PATCH:
-                        return new PatchEmailPayloadAggregator();
-
-                    case RESOURCE_OPTIMIZATION:
-                        return new ResourceOptimizationPayloadAggregator();
-                    case VULNERABILITY:
-                        return new VulnerabilityEmailPayloadAggregator();
-                    default:
-                        // Do nothing
-                        break;
-                }
-                break;
-            default:
-                // Do nothing.
-                break;
+    private static AbstractEmailPayloadAggregator getAggregator(String bundle, String application,
+                                                                    int inventoryMaxDisplayed, int vulnerabilityMaxDisplayed, int resourceOptMaxTracked) {
+        String key = bundle + "/" + application;
+        AggregatorCreator creator = AGGREGATORS.get(key);
+        if (creator == null) {
+            creator = AGGREGATORS.get(bundle + "/" + application.toLowerCase());
         }
-
-        return null;
+        return creator != null ? creator.create(inventoryMaxDisplayed, vulnerabilityMaxDisplayed, resourceOptMaxTracked) : null;
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregator.java
@@ -15,17 +15,19 @@ public class InventoryEmailAggregator extends AbstractEmailPayloadAggregator {
     public static final String NEW_SYSTEMS = "new_systems";
     public static final String STALE_SYSTEMS = "stale_systems";
     private static final String ERRORS = "errors";
+    public static final String TOTAL_NEW_SYSTEMS = "total_new_systems";
+    public static final String TOTAL_STALE_SYSTEMS = "total_stale_systems";
+    public static final String TOTAL_DELETED_SYSTEMS = "total_deleted_systems";
+    public static final String TOTAL_ERRORS = "total_errors";
 
     public static final String EVENT_TYPE_NEW_SYSTEM_REGISTERED = "new-system-registered";
     public static final String EVENT_TYPE_SYSTEM_BECAME_STALE = "system-became-stale";
     public static final String EVENT_TYPE_SYSTEM_DELETED = "system-deleted";
 
+    public static final int DEFAULT_MAX_DISPLAYED_SYSTEMS = 50;
+
     private static final List<String> EVENT_TYPES = Arrays.asList(VALIDATION_ERROR);
 
-    /**
-     * Represents the list of new event types with a new payload object that
-     * is sent by Inventory.
-     */
     private static final List<String> NEW_EVENT_TYPES = List.of(
         EVENT_TYPE_NEW_SYSTEM_REGISTERED,
         EVENT_TYPE_SYSTEM_BECAME_STALE,
@@ -42,13 +44,28 @@ public class InventoryEmailAggregator extends AbstractEmailPayloadAggregator {
 
     public static final String INVENTORY_ID_KEY = "inventory_id";
 
+    private final int maxDisplayedSystems;
+    private int totalNewSystems;
+    private int totalStaleSystems;
+    private int totalDeletedSystems;
+    private int totalErrors;
+
     public InventoryEmailAggregator() {
+        this(DEFAULT_MAX_DISPLAYED_SYSTEMS);
+    }
+
+    public InventoryEmailAggregator(int maxDisplayedSystems) {
+        this.maxDisplayedSystems = maxDisplayedSystems;
         JsonObject inventory = new JsonObject();
 
         inventory.put(DELETED_SYSTEMS, new JsonArray());
         inventory.put(ERRORS, new JsonArray());
         inventory.put(NEW_SYSTEMS, new JsonArray());
         inventory.put(STALE_SYSTEMS, new JsonArray());
+        inventory.put(TOTAL_NEW_SYSTEMS, 0);
+        inventory.put(TOTAL_STALE_SYSTEMS, 0);
+        inventory.put(TOTAL_DELETED_SYSTEMS, 0);
+        inventory.put(TOTAL_ERRORS, 0);
 
         context.put(INVENTORY_KEY, inventory);
     }
@@ -67,30 +84,52 @@ public class InventoryEmailAggregator extends AbstractEmailPayloadAggregator {
                 String errorMessage = receivedErrorObject.getString(MESSAGE_KEY);
                 String displayName = payload.getString(DISPLAY_NAME_KEY);
 
-                JsonObject error = new JsonObject();
-
-                error.put("message", errorMessage);
-                error.put("display_name", displayName);
-
-                inventory.getJsonArray(ERRORS).add(error);
+                totalErrors++;
+                if (inventory.getJsonArray(ERRORS).size() < maxDisplayedSystems) {
+                    JsonObject error = new JsonObject();
+                    error.put("message", errorMessage);
+                    error.put("display_name", displayName);
+                    inventory.getJsonArray(ERRORS).add(error);
+                }
             });
+            inventory.put(TOTAL_ERRORS, totalErrors);
         } else if (NEW_EVENT_TYPES.contains(eventType)) {
             final JsonArray systemsList;
+            final String totalKey;
             if (EVENT_TYPE_NEW_SYSTEM_REGISTERED.equals(eventType)) {
                 systemsList = inventory.getJsonArray(NEW_SYSTEMS);
+                totalNewSystems++;
+                totalKey = TOTAL_NEW_SYSTEMS;
             } else if (EVENT_TYPE_SYSTEM_BECAME_STALE.equals(eventType)) {
                 systemsList = inventory.getJsonArray(STALE_SYSTEMS);
+                totalStaleSystems++;
+                totalKey = TOTAL_STALE_SYSTEMS;
             } else {
                 systemsList = inventory.getJsonArray(DELETED_SYSTEMS);
+                totalDeletedSystems++;
+                totalKey = TOTAL_DELETED_SYSTEMS;
             }
 
-            final JsonObject context = notificationJson.getJsonObject(CONTEXT_KEY);
+            if (systemsList.size() < maxDisplayedSystems) {
+                final JsonObject ctx = notificationJson.getJsonObject(CONTEXT_KEY);
 
-            final JsonObject system = new JsonObject();
-            system.put(INVENTORY_ID_KEY, context.getString(INVENTORY_ID_KEY));
-            system.put(DISPLAY_NAME_KEY, context.getString(DISPLAY_NAME_KEY));
+                final JsonObject system = new JsonObject();
+                system.put(INVENTORY_ID_KEY, ctx.getString(INVENTORY_ID_KEY));
+                system.put(DISPLAY_NAME_KEY, ctx.getString(DISPLAY_NAME_KEY));
 
-            systemsList.add(system);
+                systemsList.add(system);
+            }
+            inventory.put(totalKey, getTotalForEventType(eventType));
+        }
+    }
+
+    private int getTotalForEventType(String eventType) {
+        if (EVENT_TYPE_NEW_SYSTEM_REGISTERED.equals(eventType)) {
+            return totalNewSystems;
+        } else if (EVENT_TYPE_SYSTEM_BECAME_STALE.equals(eventType)) {
+            return totalStaleSystems;
+        } else {
+            return totalDeletedSystems;
         }
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregator.java
@@ -20,9 +20,18 @@ public class ResourceOptimizationPayloadAggregator extends AbstractEmailPayloadA
     public static final String STATE = "state";
     public static final String SYSTEM_COUNT = "system_count";
 
+    public static final int DEFAULT_MAX_TRACKED_SYSTEMS = 10_000;
+
     private final Map</* inventory_id */ String, /* current_state */ String> currentStates = new HashMap<>();
+    private final int maxTrackedSystems;
+    private int totalSystemsTriggered;
 
     ResourceOptimizationPayloadAggregator() {
+        this(DEFAULT_MAX_TRACKED_SYSTEMS);
+    }
+
+    ResourceOptimizationPayloadAggregator(int maxTrackedSystems) {
+        this.maxTrackedSystems = maxTrackedSystems;
         context.put(AGGREGATED_DATA, new JsonObject());
     }
 
@@ -60,13 +69,18 @@ public class ResourceOptimizationPayloadAggregator extends AbstractEmailPayloadA
                 Log.warn("Missing or blank inventory_id field found in resource-optimization aggregation payload");
             }
 
-            /*
-             * For each system, we'll only keep the latest current_state field value.
-             */
-            currentStates.put(inventoryId, payload.getString("current_state"));
+            String currentState = payload.getString("current_state");
+            if (currentStates.containsKey(inventoryId)) {
+                currentStates.put(inventoryId, currentState);
+            } else {
+                totalSystemsTriggered++;
+                if (currentStates.size() < maxTrackedSystems) {
+                    currentStates.put(inventoryId, currentState);
+                }
+            }
         }
 
-        aggregatedData.put(SYSTEMS_TRIGGERED, currentStates.keySet().size());
+        aggregatedData.put(SYSTEMS_TRIGGERED, totalSystemsTriggered);
 
         /*
          * This transforms the currentStates map into another map where each state becomes a key

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregator.java
@@ -6,7 +6,9 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
@@ -22,9 +24,9 @@ public class ResourceOptimizationPayloadAggregator extends AbstractEmailPayloadA
 
     public static final int DEFAULT_MAX_TRACKED_SYSTEMS = 10_000;
 
+    private final Set<String> allSeenIds = new HashSet<>();
     private final Map</* inventory_id */ String, /* current_state */ String> currentStates = new HashMap<>();
     private final int maxTrackedSystems;
-    private int totalSystemsTriggered;
 
     ResourceOptimizationPayloadAggregator() {
         this(DEFAULT_MAX_TRACKED_SYSTEMS);
@@ -72,15 +74,14 @@ public class ResourceOptimizationPayloadAggregator extends AbstractEmailPayloadA
             String currentState = payload.getString("current_state");
             if (currentStates.containsKey(inventoryId)) {
                 currentStates.put(inventoryId, currentState);
-            } else {
-                totalSystemsTriggered++;
+            } else if (allSeenIds.add(inventoryId)) {
                 if (currentStates.size() < maxTrackedSystems) {
                     currentStates.put(inventoryId, currentState);
                 }
             }
         }
 
-        aggregatedData.put(SYSTEMS_TRIGGERED, totalSystemsTriggered);
+        aggregatedData.put(SYSTEMS_TRIGGERED, allSeenIds.size());
 
         /*
          * This transforms the currentStates map into another map where each state becomes a key

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregator.java
@@ -41,9 +41,9 @@ public class VulnerabilityEmailPayloadAggregator extends AbstractEmailPayloadAgg
 
     public static final int DEFAULT_MAX_DISPLAYED_CVES = 100;
 
-    private final Set<String> uniqueCves = new HashSet<>();
+    private final Set<String> allSeenCves = new HashSet<>();
+    private final Set<String> displayedCves = new HashSet<>();
     private final int maxDisplayedCves;
-    private int totalUniqueCves;
 
     public VulnerabilityEmailPayloadAggregator() {
         this(DEFAULT_MAX_DISPLAYED_CVES);
@@ -70,14 +70,11 @@ public class VulnerabilityEmailPayloadAggregator extends AbstractEmailPayloadAgg
             JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
 
             String cve = payload.getString(REPORTED_CVE);
-            if (!uniqueCves.contains(cve)) {
-                totalUniqueCves++;
-                if (uniqueCves.size() < maxDisplayedCves) {
-                    uniqueCves.add(cve);
-                }
+            if (allSeenCves.add(cve) && displayedCves.size() < maxDisplayedCves) {
+                displayedCves.add(cve);
             }
         });
-        vulnerability.put(REPORTED_CVES, uniqueCves);
-        vulnerability.put(TOTAL_UNIQUE_CVES, totalUniqueCves);
+        vulnerability.put(REPORTED_CVES, displayedCves);
+        vulnerability.put(TOTAL_UNIQUE_CVES, allSeenCves.size());
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregator.java
@@ -20,6 +20,7 @@ public class VulnerabilityEmailPayloadAggregator extends AbstractEmailPayloadAgg
     // Vulnerability aggregator
     private static final String VULNERABILITY_KEY = "vulnerability";
     private static final String REPORTED_CVES = "reported_cves";
+    public static final String TOTAL_UNIQUE_CVES = "total_unique_cves";
 
     // Vulnerability event types
     private static final String CVSS_EVENT = "new-cve-cvss";
@@ -38,12 +39,19 @@ public class VulnerabilityEmailPayloadAggregator extends AbstractEmailPayloadAgg
                     SYSTEM_CVE_SEVERITY_EVENT, SYSTEM_CVE_CVSS_EVENT,
                     SYSTEM_CVE_SECURITY_RULE_EVENT, SYSTEM_CVE_ALL_EVENT));
 
-    // Vulnerability final payload helpers
+    public static final int DEFAULT_MAX_DISPLAYED_CVES = 100;
+
     private final Set<String> uniqueCves = new HashSet<>();
+    private final int maxDisplayedCves;
+    private int totalUniqueCves;
 
     public VulnerabilityEmailPayloadAggregator() {
-        JsonObject vulnerability = new JsonObject();
+        this(DEFAULT_MAX_DISPLAYED_CVES);
+    }
 
+    public VulnerabilityEmailPayloadAggregator(int maxDisplayedCves) {
+        this.maxDisplayedCves = maxDisplayedCves;
+        JsonObject vulnerability = new JsonObject();
         context.put(VULNERABILITY_KEY, vulnerability);
     }
 
@@ -62,8 +70,14 @@ public class VulnerabilityEmailPayloadAggregator extends AbstractEmailPayloadAgg
             JsonObject payload = event.getJsonObject(PAYLOAD_KEY);
 
             String cve = payload.getString(REPORTED_CVE);
-            uniqueCves.add(cve);
+            if (!uniqueCves.contains(cve)) {
+                totalUniqueCves++;
+                if (uniqueCves.size() < maxDisplayedCves) {
+                    uniqueCves.add(cve);
+                }
+            }
         });
         vulnerability.put(REPORTED_CVES, uniqueCves);
+        vulnerability.put(TOTAL_UNIQUE_CVES, totalUniqueCves);
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactoryTest.java
@@ -1,0 +1,53 @@
+package com.redhat.cloud.notifications.processors.email.aggregators;
+
+import com.redhat.cloud.notifications.models.EventAggregationCriterion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EmailPayloadAggregatorFactoryTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "application-services, ansible,               AnsibleEmailAggregator",
+        "subscription-services, errata-notifications,  ErrataEmailPayloadAggregator",
+        "subscription-services, application-services,  ApplicationServicesEmailPayloadAggregator",
+        "rhel, advisor,                                AdvisorEmailAggregator",
+        "rhel, compliance,                             ComplianceEmailAggregator",
+        "rhel, inventory,                              InventoryEmailAggregator",
+        "rhel, patch,                                  PatchEmailPayloadAggregator",
+        "rhel, resource-optimization,                  ResourceOptimizationPayloadAggregator",
+        "rhel, vulnerability,                          VulnerabilityEmailPayloadAggregator"
+    })
+    void shouldReturnCorrectAggregator(String bundle, String application, String expectedClassName) {
+        EventAggregationCriterion key = createKey(bundle, application.trim());
+        AbstractEmailPayloadAggregator aggregator = EmailPayloadAggregatorFactory.by(key, "user", null, 50, 100, 10000);
+        assertNotNull(aggregator, "Expected aggregator for " + bundle + "/" + application.trim());
+        assertTrue(aggregator.getClass().getSimpleName().equals(expectedClassName.trim()),
+            "Expected " + expectedClassName.trim() + " but got " + aggregator.getClass().getSimpleName());
+    }
+
+    @Test
+    void shouldReturnNullForUnknownBundleApplication() {
+        EventAggregationCriterion key = createKey("unknown-bundle", "unknown-app");
+        assertNull(EmailPayloadAggregatorFactory.by(key, "user", null, 50, 100, 10000));
+    }
+
+    private static EventAggregationCriterion createKey(String bundle, String application) {
+        return new EventAggregationCriterion("org-1", UUID.randomUUID(), UUID.randomUUID(), bundle, application);
+    }
+
+    @Test
+    void shouldHandleCaseInsensitiveApplicationFallback() {
+        EventAggregationCriterion key = createKey("application-services", "Ansible");
+        AbstractEmailPayloadAggregator aggregator = EmailPayloadAggregatorFactory.by(key, "user", null, 50, 100, 10000);
+        assertNotNull(aggregator, "Should match via toLowerCase fallback");
+        assertTrue(aggregator instanceof AnsibleEmailAggregator);
+    }
+}

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/InventoryEmailAggregatorTest.java
@@ -36,6 +36,61 @@ public class InventoryEmailAggregatorTest {
     }
 
     @Test
+    void shouldCapCollectionsAndTrackTotals() {
+        int cap = 3;
+        InventoryEmailAggregator cappedAggregator = new InventoryEmailAggregator(cap);
+
+        int totalSystems = cap + 5;
+
+        for (int i = 0; i < totalSystems; i++) {
+            cappedAggregator.aggregate(InventoryTestHelpers.createMinimalEmailAggregationV2(
+                InventoryEmailAggregator.EVENT_TYPE_NEW_SYSTEM_REGISTERED, UUID.randomUUID(), "new-system-" + i));
+            cappedAggregator.aggregate(InventoryTestHelpers.createMinimalEmailAggregationV2(
+                InventoryEmailAggregator.EVENT_TYPE_SYSTEM_BECAME_STALE, UUID.randomUUID(), "stale-system-" + i));
+            cappedAggregator.aggregate(InventoryTestHelpers.createMinimalEmailAggregationV2(
+                InventoryEmailAggregator.EVENT_TYPE_SYSTEM_DELETED, UUID.randomUUID(), "deleted-system-" + i));
+        }
+
+        Map<String, Object> context = cappedAggregator.getContext();
+        JsonObject inventory = JsonObject.mapFrom(context).getJsonObject("inventory");
+
+        Assertions.assertEquals(cap, inventory.getJsonArray(InventoryEmailAggregator.NEW_SYSTEMS).size(),
+            "new_systems array should be capped");
+        Assertions.assertEquals(cap, inventory.getJsonArray(InventoryEmailAggregator.STALE_SYSTEMS).size(),
+            "stale_systems array should be capped");
+        Assertions.assertEquals(cap, inventory.getJsonArray(InventoryEmailAggregator.DELETED_SYSTEMS).size(),
+            "deleted_systems array should be capped");
+
+        Assertions.assertEquals(totalSystems, inventory.getInteger(InventoryEmailAggregator.TOTAL_NEW_SYSTEMS),
+            "total_new_systems should reflect actual count");
+        Assertions.assertEquals(totalSystems, inventory.getInteger(InventoryEmailAggregator.TOTAL_STALE_SYSTEMS),
+            "total_stale_systems should reflect actual count");
+        Assertions.assertEquals(totalSystems, inventory.getInteger(InventoryEmailAggregator.TOTAL_DELETED_SYSTEMS),
+            "total_deleted_systems should reflect actual count");
+    }
+
+    @Test
+    void shouldCapErrorsAndTrackTotal() {
+        int cap = 2;
+        InventoryEmailAggregator cappedAggregator = new InventoryEmailAggregator(cap);
+
+        int totalErrors = cap + 3;
+        for (int i = 0; i < totalErrors; i++) {
+            cappedAggregator.aggregate(InventoryTestHelpers.createEmailAggregation("tenant", "rhel", "inventory", "error event " + i));
+        }
+
+        Map<String, Object> context = cappedAggregator.getContext();
+        JsonObject inventory = JsonObject.mapFrom(context).getJsonObject("inventory");
+
+        // Each createEmailAggregation produces 2 error events in the payload
+        int expectedTotalErrors = totalErrors * 2;
+        Assertions.assertTrue(inventory.getJsonArray("errors").size() <= cap,
+            "errors array should be capped");
+        Assertions.assertEquals(expectedTotalErrors, inventory.getInteger(InventoryEmailAggregator.TOTAL_ERRORS),
+            "total_errors should reflect actual count");
+    }
+
+    @Test
     void validatePayload() {
         // Add a "validation error" event type to the aggregation.
         this.aggregator.aggregate(InventoryTestHelpers.createEmailAggregation("tenant", "rhel", "inventory", "test event"));
@@ -93,6 +148,11 @@ public class InventoryEmailAggregatorTest {
         this.assertInventoryContainsExpectedElements(deletedSystemsMap, deletedSystems, "deleted systems");
         this.assertInventoryContainsExpectedElements(newSystemsMap, newSystems, "new systems");
         this.assertInventoryContainsExpectedElements(staleSystemsMap, staleSystems, "stale systems");
+
+        Assertions.assertEquals(2, inventory.getInteger(InventoryEmailAggregator.TOTAL_NEW_SYSTEMS));
+        Assertions.assertEquals(2, inventory.getInteger(InventoryEmailAggregator.TOTAL_STALE_SYSTEMS));
+        Assertions.assertEquals(2, inventory.getInteger(InventoryEmailAggregator.TOTAL_DELETED_SYSTEMS));
+        Assertions.assertEquals(2, inventory.getInteger(InventoryEmailAggregator.TOTAL_ERRORS));
     }
 
     /**

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregatorTest.java
@@ -76,6 +76,53 @@ public class ResourceOptimizationPayloadAggregatorTest {
         }
     }
 
+    @Test
+    void shouldCapTrackedSystemsAndTrackTotal() {
+        int cap = 3;
+        ResourceOptimizationPayloadAggregator cappedAggregator = new ResourceOptimizationPayloadAggregator(cap);
+
+        int totalSystems = cap + 5;
+        for (int i = 0; i < totalSystems; i++) {
+            cappedAggregator.aggregate(buildEmailAggregation(100, UUID.randomUUID().toString(), IDLING));
+        }
+
+        JsonObject aggregatedData = JsonObject.mapFrom(cappedAggregator.getContext().get(AGGREGATED_DATA));
+        assertEquals(cap, aggregatedData.getJsonArray(STATES).getJsonObject(0).getInteger(SYSTEM_COUNT),
+            "tracked systems should be capped");
+        assertEquals(totalSystems, aggregatedData.getInteger(SYSTEMS_TRIGGERED),
+            "systems_triggered should reflect actual count");
+    }
+
+    @Test
+    void shouldStillUpdateExistingEntriesBeyondCap() {
+        int cap = 2;
+        ResourceOptimizationPayloadAggregator cappedAggregator = new ResourceOptimizationPayloadAggregator(cap);
+
+        String id1 = UUID.randomUUID().toString();
+        String id2 = UUID.randomUUID().toString();
+        String id3 = UUID.randomUUID().toString();
+
+        cappedAggregator.aggregate(buildEmailAggregation(10, id1, IDLING));
+        cappedAggregator.aggregate(buildEmailAggregation(10, id2, IDLING));
+        // id3 beyond cap — tracked in total but not in map
+        cappedAggregator.aggregate(buildEmailAggregation(10, id3, IDLING));
+        // update id1 state (already in map, should update)
+        cappedAggregator.aggregate(buildEmailAggregation(10, id1, UNDER_PRESSURE));
+
+        JsonObject aggregatedData = JsonObject.mapFrom(cappedAggregator.getContext().get(AGGREGATED_DATA));
+        assertEquals(3, aggregatedData.getInteger(SYSTEMS_TRIGGERED));
+
+        JsonArray states = aggregatedData.getJsonArray(STATES);
+        for (int i = 0; i < states.size(); i++) {
+            JsonObject state = states.getJsonObject(i);
+            if (IDLING.equals(state.getString(STATE))) {
+                assertEquals(1, state.getInteger(SYSTEM_COUNT));
+            } else if (UNDER_PRESSURE.equals(state.getString(STATE))) {
+                assertEquals(1, state.getInteger(SYSTEM_COUNT));
+            }
+        }
+    }
+
     private static EmailAggregation buildEmailAggregation(int systemsWithSuggestions, String inventoryId, String currentState) {
 
         Action action = buildAction(systemsWithSuggestions, inventoryId, currentState);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/ResourceOptimizationPayloadAggregatorTest.java
@@ -94,6 +94,28 @@ public class ResourceOptimizationPayloadAggregatorTest {
     }
 
     @Test
+    void shouldNotInflateCountForRepeatedUntrackedIds() {
+        int cap = 2;
+        ResourceOptimizationPayloadAggregator cappedAggregator = new ResourceOptimizationPayloadAggregator(cap);
+
+        String id1 = UUID.randomUUID().toString();
+        String id2 = UUID.randomUUID().toString();
+        String id3 = UUID.randomUUID().toString();
+
+        cappedAggregator.aggregate(buildEmailAggregation(10, id1, IDLING));
+        cappedAggregator.aggregate(buildEmailAggregation(10, id2, IDLING));
+        // id3 beyond cap
+        cappedAggregator.aggregate(buildEmailAggregation(10, id3, IDLING));
+        // repeat id3 — should NOT inflate count
+        cappedAggregator.aggregate(buildEmailAggregation(10, id3, UNDER_PRESSURE));
+        cappedAggregator.aggregate(buildEmailAggregation(10, id3, UNKNOWN));
+
+        JsonObject aggregatedData = JsonObject.mapFrom(cappedAggregator.getContext().get(AGGREGATED_DATA));
+        assertEquals(3, aggregatedData.getInteger(SYSTEMS_TRIGGERED),
+            "repeated untracked ID should not inflate systems_triggered");
+    }
+
+    @Test
     void shouldStillUpdateExistingEntriesBeyondCap() {
         int cap = 2;
         ResourceOptimizationPayloadAggregator cappedAggregator = new ResourceOptimizationPayloadAggregator(cap);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/aggregators/VulnerabilityEmailPayloadAggregatorTest.java
@@ -1,11 +1,13 @@
 package com.redhat.cloud.notifications.processors.email.aggregators;
 
 import com.redhat.cloud.notifications.VulnerabilityTestHelpers;
+import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 
@@ -79,6 +81,47 @@ public class VulnerabilityEmailPayloadAggregatorTest {
         testCves.forEach(cve -> {
             Assertions.assertTrue(uniqueCves.contains(cve));
         });
+    }
+
+    @Test
+    void shouldCapCvesAndTrackTotal() {
+        int cap = 3;
+        VulnerabilityEmailPayloadAggregator cappedAggregator = new VulnerabilityEmailPayloadAggregator(cap);
+
+        int totalUniqueCves = cap + 5;
+        for (int i = 0; i < totalUniqueCves; i++) {
+            cappedAggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(
+                bundle, application, CVSS_EVENT, "CVE-2024-" + String.format("%04d", i)));
+        }
+
+        Map<String, Object> context = cappedAggregator.getContext();
+        JsonObject vulnerability = JsonObject.mapFrom(context).getJsonObject("vulnerability");
+
+        List<?> reportedCves = vulnerability.getJsonArray("reported_cves").getList();
+        Assertions.assertEquals(cap, reportedCves.size(), "reported_cves should be capped");
+        Assertions.assertEquals(totalUniqueCves, vulnerability.getInteger(VulnerabilityEmailPayloadAggregator.TOTAL_UNIQUE_CVES),
+            "total_unique_cves should reflect actual count");
+    }
+
+    @Test
+    void shouldNotCountDuplicatesBeyondCap() {
+        int cap = 2;
+        VulnerabilityEmailPayloadAggregator cappedAggregator = new VulnerabilityEmailPayloadAggregator(cap);
+
+        // Add 2 unique CVEs to fill the cap
+        cappedAggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, CVSS_EVENT, "CVE-2024-0001"));
+        cappedAggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, CVSS_EVENT, "CVE-2024-0002"));
+        // Re-add existing CVE (already in set, should not increment total)
+        cappedAggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, CVSS_EVENT, "CVE-2024-0001"));
+        // Add new CVE beyond cap
+        cappedAggregator.aggregate(VulnerabilityTestHelpers.createEmailAggregation(bundle, application, CVSS_EVENT, "CVE-2024-0003"));
+
+        Map<String, Object> context = cappedAggregator.getContext();
+        JsonObject vulnerability = JsonObject.mapFrom(context).getJsonObject("vulnerability");
+
+        Assertions.assertEquals(cap, vulnerability.getJsonArray("reported_cves").size());
+        Assertions.assertEquals(3, vulnerability.getInteger(VulnerabilityEmailPayloadAggregator.TOTAL_UNIQUE_CVES),
+            "duplicate CVEs should not be counted twice");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Cap unbounded collections in 3 aggregators (Inventory, Vulnerability, ResourceOptimization) with configurable limits via `@ConfigProperty` to prevent excessive memory usage during daily digest processing for large orgs
- Optimize severity filtering from O(n) stream scan to O(1) Map lookup per event per user
- Simplify `EmailPayloadAggregatorFactory` by replacing nested switch statements with a `Map<String, AggregatorCreator>` dispatch table

## Details

### Capped aggregators
| Aggregator | Collection | Default cap | Config property |
|---|---|---|---|
| InventoryEmailAggregator | 4 JsonArrays (new/stale/deleted/errors) | 50 | `notifications.aggregation.inventory.max-displayed-systems` |
| VulnerabilityEmailPayloadAggregator | CVE HashSet | 100 | `notifications.aggregation.vulnerability.max-displayed-cves` |
| ResourceOptimizationPayloadAggregator | State HashMap | 10,000 | `notifications.aggregation.resource-optimization.max-tracked-systems` |

Each aggregator tracks a `total_*` counter that reflects the true count while the displayed collection is capped. Templates updated to use total counters for display text.

### Severity filtering optimization
Changed `AbstractEmailPayloadAggregator.userSeverities` from `Set<SubscribedEventTypeSeverities>` (linear scan) to `Map<UUID, Map<Severity, Boolean>>` (direct lookup). Conversion happens once at aggregator creation in `EmailAggregator`.

### Factory simplification
Replaced nested `switch(bundle) { switch(application) }` with a flat `Map.ofEntries(...)` keyed by `"bundle/application"`, with a `toLowerCase()` fallback for case-insensitive application matching.

## Test plan
- [x] Unit tests for all 3 capped aggregators verify arrays are capped and total counters are accurate
- [x] Unit test for duplicate handling beyond cap (Vulnerability)
- [x] Unit test for last-write-wins update semantics beyond cap (ResourceOptimization)
- [x] Unit test for factory dispatch covering all known bundle/application pairs, unknown pairs, and case-insensitive fallback
- [x] Template tests updated with `total_*` fields in test data
- [x] Existing aggregator tests continue to pass
- [x] Checkstyle passes
- [x] Full engine module build passes

JIRA: https://issues.redhat.com/browse/RHCLOUD-44010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email summaries now include accurate total counts for inventory changes (new/stale/deleted), validation errors, vulnerabilities (unique CVEs), and resource optimization triggers.
  * Vulnerability and inventory email lists are capped for readability while totals reflect the full aggregation.
  * Resource optimization tracking now counts all triggered systems while limiting stored detail.
* **Bug Fixes**
  * Inventory and vulnerability emails now show section links and table content only when relevant totals are greater than zero.
  * Improved email filtering to respect configured severity preferences more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->