### PR TITLE
Add params to customize the post-deploy jobs that will run in multiple clusters

### DIFF
--- a/.rhcicd/stage-backend-post-deployment-tests.yaml
+++ b/.rhcicd/stage-backend-post-deployment-tests.yaml
@@ -7,7 +7,7 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: notifications-backend-tests-${UID}
+    name: ${NAME_STUB}-${UID}
   spec:
     appName: notifications-backend
     testing:
@@ -24,6 +24,9 @@ parameters:
 - name: IMAGE_TAG
   value: ''
   required: true
+- name: NAME_STUB
+  description: "Basename for the automation pods"
+  value: "notifications-backend-tests"
 - name: UID
   description: "Unique CJI name suffix"
   generate: expression

--- a/.rhcicd/stage-engine-post-deployment-tests.yaml
+++ b/.rhcicd/stage-engine-post-deployment-tests.yaml
@@ -7,15 +7,19 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: notifications-engine-tests-${UID}
+    name: ${NAME_STUB}-${UID}
   spec:
     appName: notifications-backend
     testing:
       iqe:
         debug: false
-        dynaconfEnvName: stage_post_deploy
-        filter: ''
-        marker: 'notif_engine and api'
+        env:
+          - name: 'ENV_FOR_DYNACONF'
+            value: 'stage_post_deploy'
+          - name: 'DYNACONF_DEFAULT_USER'
+            value: ${DYNACONF_DEFAULT_USER}
+          - name: 'IQE_MARKER_EXPRESSION'
+            value: 'notif_engine and api'
 parameters:
 - name: IMAGE_TAG
   value: ''
@@ -24,3 +28,9 @@ parameters:
   description: "Unique CJI name suffix"
   generate: expression
   from: "[a-z0-9]{6}"
+- name: NAME_STUB
+  description: "Basename for the automation pods"
+  value: "notifications-engine-tests"
+- name: DYNACONF_DEFAULT_USER
+  description: The user to be impersonated in the tests
+  value: "notifications_admin"


### PR DESCRIPTION
Add parameters to customize the backend and engine post-deploy jobs that run in multi-cluster mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved post-deployment test configuration for backend and engine services.
  * Added configurable test invocation naming to support clearer identification of test runs.
  * Standardized engine test environment settings and marker selection.
  * Added configurable test-user settings for engine validation.
* **Chores**
  * Updated deployment automation templates to make test execution more flexible and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->