### PR TITLE
Add Sources API PSK integration support

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -191,6 +191,12 @@ objects:
               name: export-service-psk
               key: psk
               optional: true
+        - name: SOURCES_PSK
+          valueFrom:
+            secretKeyRef:
+              name: sources-api-psk
+              key: psk
+              optional: true
         - name: QUARKUS_OIDC_CLIENT_AUTH_SERVER_URL
           value: ${OIDC_ISSUER}
         - name: QUARKUS_OIDC_CLIENT_CLIENT_ENABLED

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -178,6 +178,15 @@ quarkus.rest-client.export-service.trust-store-type=${clowder.optional-private-e
 # Export service OIDC integration configuration for OIDC-based authentication
 quarkus.rest-client.export-service-oidc.url=${clowder.optional-private-endpoints.export-service-service.url:http://localhost:10010}
 
+# Sources API PSK-based integration configuration for internal communication
+# This is for the legacy /internal/v{1.0,2.0} paths that support PSK authentication
+sources-api.psk=development-value-456
+quarkus.rest-client.sources-psk.url=http://localhost:8000
+
+# Sources API OIDC integration configuration for OIDC-based authentication (E/W Gateway)
+# This will be used for the new /internal/sources/v{1,2} paths when OIDC integration is complete
+quarkus.rest-client.sources-oidc.url=http://localhost:8000
+
 # OIDC client configuration
 quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR


### PR DESCRIPTION
## Summary

Add configuration for PSK-based Sources API integration to enable in-cluster communication between notifications and sources services.

## Changes

- **ClowdApp**: Add `SOURCES_PSK` environment variable to engine deployment
- **Quarkus Config**: Add `sources-psk` REST client for PSK-based calls
- **Quarkus Config**: Add `sources-oidc` REST client for future OIDC calls
- **Development**: Add development PSK value for local testing

## Purpose

This enables notifications to call Sources internal endpoints using:
1. **PSK authentication** for legacy `/internal/v{1.0,2.0}` paths (current)
2. **OIDC authentication** for new `/internal/sources/v{1,2}` paths (future)

## Secret Configuration

The `SOURCES_PSK` secret reference expects:
- **Secret name**: `sources-api-psk`
- **Key**: `psk`
- **Optional**: true (follows export-service-psk pattern)

## Related Work

- App-interface MR: https://gitlab.cee.redhat.com/dcervant/app-interface/-/merge_requests/new?merge_request%5Bsource_branch%5D=enable-sources-psk-hccs01ue1-clean
- This adds the configuration needed for notifications-engine to use the PSK secret

## Testing

- ✅ Checkstyle validation passed
- ✅ Configuration follows export-service pattern
- 🔲 Integration testing pending app-interface deployment

## Notes

The Quarkus REST client names (`sources-psk` and `sources-oidc`) will need corresponding client implementations in the code to actually use these configurations. This PR only adds the infrastructure configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for connecting to the Sources API through legacy PSK-authenticated and newer OIDC-authenticated endpoints.
  - Added optional secret-backed configuration for Sources API authentication.
  - Preserved existing export-service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->