### PR TITLE
CHAINSAW-825: List security errata first in daily digest email

### DIFF
--- a/common-template/src/main/resources/templates/email/Errata/dailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Errata/dailyEmailBody.html
@@ -10,17 +10,17 @@
 {@String renderCriticalTag='<table cellspacing="0" cellpadding="0" style="border-radius: 999px; background-color: #b0370b; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400; color: #ffffff;"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/critical-white.png" height="10px" style="margin-right: 4px;">Critical</td></tr></table>'}
 {#include email/Common/insightsEmailBodyLight}
 {#content-render-custom-links-section}
+    {#if action.context.errata.new-subscription-security-errata.size() > 0}
+        <!-- next section -->
+        <a style="{body-section-table-td-a-style}" href="#errata-notifications-section1-1">Security updates ({action.context.errata.new-subscription-security-errata.size()})</a>
+    {/if}
     {#if action.context.errata.new-subscription-bugfix-errata.size() > 0}
         <!-- next section -->
-        <a style="{body-section-table-td-a-style}" href="#errata-notifications-section1-1">Bug fixes ({action.context.errata.new-subscription-bugfix-errata.size()})</a>
+        <a style="{body-section-table-td-a-style}" href="#errata-notifications-section1-2">Bug fixes ({action.context.errata.new-subscription-bugfix-errata.size()})</a>
     {/if}
     {#if action.context.errata.new-subscription-enhancement-errata.size() > 0}
         <!-- next section -->
-        <a style="{body-section-table-td-a-style}" href="#errata-notifications-section1-2">Enhancements ({action.context.errata.new-subscription-enhancement-errata.size()})</a>
-    {/if}
-    {#if action.context.errata.new-subscription-security-errata.size() > 0}
-        <!-- next section -->
-        <a style="{body-section-table-td-a-style}" href="#errata-notifications-section1-3">Security updates ({action.context.errata.new-subscription-security-errata.size()})</a>
+        <a style="{body-section-table-td-a-style}" href="#errata-notifications-section1-3">Enhancements ({action.context.errata.new-subscription-enhancement-errata.size()})</a>
     {/if}
 {/content-render-custom-links-section}
 {#content-title-section1}
@@ -30,70 +30,8 @@
     {action.context.errata.new-subscription-bugfix-errata.size() + action.context.errata.new-subscription-enhancement-errata.size() + action.context.errata.new-subscription-security-errata.size()}
 {/content-title-right-part}
 {#content-body-section1}
-{#if action.context.errata.new-subscription-bugfix-errata.size() > 0}
-    <a id="errata-notifications-section1-1" name="errata-notifications-section1-1"></a>
-    {#if action.context.errata.new-subscription-bugfix-errata.size() == 1}
-        <p style="{body-section-p-style}">There is 1 bug fix affecting your subscriptions:</p>
-    {#else}
-        <p style="{body-section-p-style}">There are {action.context.errata.new-subscription-bugfix-errata.size()} bug fixes affecting your subscriptions.</p>
-    {/if}
-<table style="border: solid 1px #b8bbbe; border-radius: 16px; padding: 0 8px 0px 8px; width: 100%;"><tr><td>
-    <table style="{body-section-table-style}">
-        <thead>
-            <tr>
-              <th style="{body-section-table-th-style} width: 30%;">Bugfix</th>
-              <th style="{body-section-table-th-style}">Synopsis</th>
-            </tr>
-        </thead>
-        <tbody>
-            {#if action.context.errata.new-subscription-bugfix-errata.size() > 0}
-                {#each action.context.errata.new-subscription-bugfix-errata.sortErrataArray}
-                <tr style="font-size: 14px;">
-                    <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="{action.context.errata.base_url}{it.id}" target="_blank">{it.id}</a></td>
-                    <td style="{body-section-table-td-style}">{it.synopsis}</td>
-                </tr>
-                {/each}
-            {/if}
-        </tbody>
-    </table>
-    </td></tr></table>
-    {#if action.context.errata.new-subscription-enhancement-errata.orEmpty.size() > 0 || action.context.errata.new-subscription-security-errata.orEmpty.size > 0}
-        <div style="height: 24px">&#xA0;</div>
-    {/if}
-{/if}
-{#if action.context.errata.new-subscription-enhancement-errata.size() > 0}
-    <a id="errata-notifications-section1-2" name="errata-notifications-section1-2"></a>
-    {#if action.context.errata.new-subscription-enhancement-errata.size() == 1}
-        <p style="{body-section-p-style}">There is 1 enhancement affecting your subscriptions:</p>
-    {#else}
-        <p style="{body-section-p-style}">There are {action.context.errata.new-subscription-enhancement-errata.size()} enhancements affecting your subscriptions.</p>
-    {/if}
-    <table style="border: solid 1px #b8bbbe; border-radius: 16px; padding: 0 8px 0 8px; width: 100%;"><tr><td>
-    <table style="{body-section-table-style}">
-        <thead>
-            <tr>
-              <th style="{body-section-table-th-style} width: 30%;">Enhancement</th>
-              <th style="{body-section-table-th-style}">Synopsis</th>
-            </tr>
-        </thead>
-        <tbody>
-            {#if action.context.errata.new-subscription-enhancement-errata.size() > 0}
-                {#each action.context.errata.new-subscription-enhancement-errata.sortErrataArray}
-                <tr style="font-size: 14px;">
-                    <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="{action.context.errata.base_url}{it.id}" target="_blank">{it.id}</a></td>
-                    <td style="{body-section-table-td-style}">{it.synopsis}</td>
-                </tr>
-                {/each}
-            {/if}
-        </tbody>
-    </table>
-    </td></tr></table>
-    {#if action.context.errata.new-subscription-security-errata.orEmpty.size > 0}
-        <div style="height: 24px">&#xA0;</div>
-    {/if}
-{/if}
 {#if action.context.errata.new-subscription-security-errata.size() > 0}
-    <a id="errata-notifications-section1-3" name="errata-notifications-section1-3"></a>
+    <a id="errata-notifications-section1-1" name="errata-notifications-section1-1"></a>
     {#if action.context.errata.new-subscription-security-errata.size() == 1}
         <p style="{body-section-p-style}">There is 1 security update affecting your subscriptions:</p>
     {#else}
@@ -121,6 +59,68 @@
                             {#case 'critical'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                         {/switch}
                     </td>
+                    <td style="{body-section-table-td-style}">{it.synopsis}</td>
+                </tr>
+                {/each}
+            {/if}
+        </tbody>
+    </table>
+    </td></tr></table>
+    {#if action.context.errata.new-subscription-bugfix-errata.orEmpty.size() > 0 || action.context.errata.new-subscription-enhancement-errata.orEmpty.size() > 0}
+        <div style="height: 24px">&#xA0;</div>
+    {/if}
+{/if}
+{#if action.context.errata.new-subscription-bugfix-errata.size() > 0}
+    <a id="errata-notifications-section1-2" name="errata-notifications-section1-2"></a>
+    {#if action.context.errata.new-subscription-bugfix-errata.size() == 1}
+        <p style="{body-section-p-style}">There is 1 bug fix affecting your subscriptions:</p>
+    {#else}
+        <p style="{body-section-p-style}">There are {action.context.errata.new-subscription-bugfix-errata.size()} bug fixes affecting your subscriptions.</p>
+    {/if}
+<table style="border: solid 1px #b8bbbe; border-radius: 16px; padding: 0 8px 0px 8px; width: 100%;"><tr><td>
+    <table style="{body-section-table-style}">
+        <thead>
+            <tr>
+              <th style="{body-section-table-th-style} width: 30%;">Bugfix</th>
+              <th style="{body-section-table-th-style}">Synopsis</th>
+            </tr>
+        </thead>
+        <tbody>
+            {#if action.context.errata.new-subscription-bugfix-errata.size() > 0}
+                {#each action.context.errata.new-subscription-bugfix-errata.sortErrataArray}
+                <tr style="font-size: 14px;">
+                    <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="{action.context.errata.base_url}{it.id}" target="_blank">{it.id}</a></td>
+                    <td style="{body-section-table-td-style}">{it.synopsis}</td>
+                </tr>
+                {/each}
+            {/if}
+        </tbody>
+    </table>
+    </td></tr></table>
+    {#if action.context.errata.new-subscription-enhancement-errata.orEmpty.size() > 0}
+        <div style="height: 24px">&#xA0;</div>
+    {/if}
+{/if}
+{#if action.context.errata.new-subscription-enhancement-errata.size() > 0}
+    <a id="errata-notifications-section1-3" name="errata-notifications-section1-3"></a>
+    {#if action.context.errata.new-subscription-enhancement-errata.size() == 1}
+        <p style="{body-section-p-style}">There is 1 enhancement affecting your subscriptions:</p>
+    {#else}
+        <p style="{body-section-p-style}">There are {action.context.errata.new-subscription-enhancement-errata.size()} enhancements affecting your subscriptions.</p>
+    {/if}
+    <table style="border: solid 1px #b8bbbe; border-radius: 16px; padding: 0 8px 0 8px; width: 100%;"><tr><td>
+    <table style="{body-section-table-style}">
+        <thead>
+            <tr>
+              <th style="{body-section-table-th-style} width: 30%;">Enhancement</th>
+              <th style="{body-section-table-th-style}">Synopsis</th>
+            </tr>
+        </thead>
+        <tbody>
+            {#if action.context.errata.new-subscription-enhancement-errata.size() > 0}
+                {#each action.context.errata.new-subscription-enhancement-errata.sortErrataArray}
+                <tr style="font-size: 14px;">
+                    <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="{action.context.errata.base_url}{it.id}" target="_blank">{it.id}</a></td>
                     <td style="{body-section-table-td-style}">{it.synopsis}</td>
                 </tr>
                 {/each}

--- a/common-template/src/test/java/email/TestErrataTemplate.java
+++ b/common-template/src/test/java/email/TestErrataTemplate.java
@@ -141,6 +141,21 @@ public class TestErrataTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains("There are 24 security updates affecting your subscriptions"));
         assertEquals(51, StringUtils.countMatches(result, "https://access.redhat.com/errata/RHSA-2024:"));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
+
+        // Sections must appear in order of importance: security, then bugfix, then enhancement.
+        int securityIndex = result.indexOf("There are 24 security updates affecting your subscriptions");
+        int bugfixIndex = result.indexOf("There are 9 bug fixes affecting your subscriptions.");
+        int enhancementIndex = result.indexOf("There are 18 enhancements affecting your subscriptions.");
+        assertTrue(securityIndex >= 0 && bugfixIndex >= 0 && enhancementIndex >= 0);
+        assertTrue(securityIndex < bugfixIndex, "Security section should appear before bugfix");
+        assertTrue(bugfixIndex < enhancementIndex, "Bugfix section should appear before enhancement");
+
+        int securityLinkIndex = result.indexOf(">Security updates (24)<");
+        int bugfixLinkIndex = result.indexOf(">Bug fixes (9)<");
+        int enhancementLinkIndex = result.indexOf(">Enhancements (18)<");
+        assertTrue(securityLinkIndex >= 0 && bugfixLinkIndex >= 0 && enhancementLinkIndex >= 0);
+        assertTrue(securityLinkIndex < bugfixLinkIndex, "Security link should appear before bugfix");
+        assertTrue(bugfixLinkIndex < enhancementLinkIndex, "Bugfix link should appear before enhancement");
     }
 
     public static final String JSON_ERRATA_DEFAULT_AGGREGATION_CONTEXT = "{" +


### PR DESCRIPTION
Reorder subscription daily digest sections to security, then bugfix, then enhancement so the most important advisories appear first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the daily errata email layout so sections now appear in the order: security updates, then bug fixes, then enhancements.
  * Adjusted the corresponding “next section” navigation links to match the new section order.
  * Improved spacing between sections when multiple categories are present.
* **Tests**
  * Strengthened coverage to verify the ordering of both email sections and their related navigation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->