### PR TITLE
Revert --immutable on admin-console yarn install

### DIFF
--- a/admin-console/pom.xml
+++ b/admin-console/pom.xml
@@ -37,7 +37,7 @@
                             <goal>corepack</goal>
                         </goals>
                         <configuration>
-                            <arguments>yarn install --immutable</arguments>
+                            <arguments>yarn install</arguments>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Renovate/Mintmaker's bot environment runs global Yarn Classic 1.22.22 without corepack enabled, so it can no longer regenerate yarn.lock now that package.json pins packageManager to yarn@4.17.0. This leaves dependency-bump PRs (e.g. #4726) with a package.json/yarn.lock mismatch that --immutable then turns into a hard CI failure. Dropping --immutable restores the previous tolerant behavior so those PRs can build while the underlying Renovate/corepack incompatibility is addressed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to allow Yarn dependencies to be installed without enforcing an immutable lockfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->