### PR TITLE
RHCLOUD-28931 - implement event granular queries

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -16,7 +16,6 @@ import jakarta.persistence.TypedQuery;
 import jakarta.transaction.Transactional;
 
 import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -36,7 +35,7 @@ public class EventRepository {
     RecipientsAuthorizationCriterionExtractor recipientsAuthorizationCriterionExtractor;
 
     public List<EventAuthorizationCriterion> getEventsWithCriterion(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
-                                                                    LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
+                                                                    LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                                                     Set<Boolean> invocationResults, Set<NotificationStatus> status) {
 
         boolean bundlesNotEmpty = bundleIds != null && !bundleIds.isEmpty();
@@ -148,7 +147,7 @@ public class EventRepository {
     }
 
     public List<Event> getEvents(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
-                                      LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
+                                      LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                       Set<Boolean> invocationResults, boolean fetchNotificationHistory, Set<NotificationStatus> status, Set<Severity> severities, Query query,
                                       Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion, boolean hasAction) {
 
@@ -207,7 +206,7 @@ public class EventRepository {
     }
 
     public Long count(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
-                      LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes,
+                      LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes,
                       Set<CompositeEndpointType> compositeEndpointTypes, Set<Boolean> invocationResults,
                       Set<NotificationStatus> status, Set<Severity> severities, Optional<List<UUID>> uuidToExclude, Boolean includeEventsWithAuthCriterion,
                       boolean hasAction) {
@@ -251,7 +250,7 @@ public class EventRepository {
     }
 
     private List<UUID> getEventIds(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
-                                        LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
+                                        LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                         Set<Boolean> invocationResults, Set<NotificationStatus> status, Set<Severity> severities, Query query, Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion,
                                         boolean hasAction) {
         boolean bundlesNotEmpty = bundleIds != null && !bundleIds.isEmpty();
@@ -301,7 +300,7 @@ public class EventRepository {
     }
 
     private String addHqlConditions(String hql, boolean useNormalized, boolean bundlesNotEmpty, boolean applicationsNotEmpty, boolean eventTypeNameNotEmpty,
-                                           LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes,
+                                           LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes,
                                            Set<CompositeEndpointType> compositeEndpointTypes, Set<Boolean> invocationResults,
                                            Set<NotificationStatus> status, Set<Severity> severities, Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion,
                                            boolean hasAction) {
@@ -390,7 +389,7 @@ public class EventRepository {
     }
 
     private void setQueryParams(TypedQuery<?> query, String orgId, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeName,
-                                       LocalDate startDate, LocalDate endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
+                                       LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                        Set<Boolean> invocationResults, Set<NotificationStatus> status, Set<Severity> severities, Optional<List<UUID>> uuidToExclude) {
         query.setParameter("orgId", orgId);
         if (uuidToExclude.isPresent()) {
@@ -406,10 +405,10 @@ public class EventRepository {
             query.setParameter("eventTypeDisplayName", "%" + eventTypeName.toLowerCase() + "%");
         }
         if (startDate != null) {
-            query.setParameter("startDate", Timestamp.valueOf(startDate.atStartOfDay()));
+            query.setParameter("startDate", Timestamp.valueOf(startDate));
         }
         if (endDate != null) {
-            query.setParameter("endDate", Timestamp.valueOf(endDate.atTime(LocalTime.MAX))); // at end of day
+            query.setParameter("endDate", Timestamp.valueOf(endDate));
         }
         if (severities != null && !severities.isEmpty()) {
             query.setParameter("severities", severities);

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -40,6 +40,8 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.jboss.resteasy.reactive.RestQuery;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -99,15 +101,56 @@ public class EventResource {
         description = "Number of items per page, if not specified " + DEFAULT_RESULTS_PER_PAGE + " is used.",
         schema = @Schema(type = SchemaType.INTEGER, defaultValue = DEFAULT_RESULTS_PER_PAGE + "")
     )
+    @Parameter(
+        name = "startDate",
+        in = ParameterIn.QUERY,
+        description = "Start date of the date range filter, expanded to the beginning of that day (00:00:00). "
+            + "Cannot be used together with startDateTime.",
+        schema = @Schema(type = SchemaType.STRING, format = "date")
+    )
+    @Parameter(
+        name = "endDate",
+        in = ParameterIn.QUERY,
+        description = "End date of the date range filter, expanded to the end of that day (23:59:59.999999999). "
+            + "Cannot be used together with endDateTime.",
+        schema = @Schema(type = SchemaType.STRING, format = "date")
+    )
+    @Parameter(
+        name = "startDateTime",
+        in = ParameterIn.QUERY,
+        description = "Start date and time of the date range filter in ISO 8601 format (e.g. 2024-01-15T10:30:00). "
+            + "Cannot be used together with startDate.",
+        schema = @Schema(type = SchemaType.STRING, format = "date-time")
+    )
+    @Parameter(
+        name = "endDateTime",
+        in = ParameterIn.QUERY,
+        description = "End date and time of the date range filter in ISO 8601 format (e.g. 2024-01-15T18:00:00). "
+            + "Cannot be used together with endDate.",
+        schema = @Schema(type = SchemaType.STRING, format = "date-time")
+    )
     @Authorization(legacyRBACRole = ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS_EVENTS, workspacePermissions = EVENTS_VIEW)
     public Page<EventLogEntry> getEvents(@Context SecurityContext securityContext, @Context UriInfo uriInfo,
                                          @RestQuery Set<UUID> bundleIds, @RestQuery Set<UUID> appIds,
                                          @RestQuery String eventTypeDisplayName, @RestQuery LocalDate startDate, @RestQuery LocalDate endDate,
+                                         @RestQuery LocalDateTime startDateTime, @RestQuery LocalDateTime endDateTime,
                                          @RestQuery Set<String> endpointTypes, @RestQuery Set<Boolean> invocationResults,
                                          @RestQuery Set<EventLogEntryActionStatus> status, @RestQuery Set<Severity> severities,
                                          @BeanParam @Valid Query query,
                                          @RestQuery boolean includeDetails, @RestQuery boolean includePayload, @RestQuery boolean includeActions,
                                          @RestQuery boolean hasAction) {
+        if (startDate != null && startDateTime != null) {
+            throw new BadRequestException("Cannot specify both startDate and startDateTime. Use one or the other.");
+        }
+        if (endDate != null && endDateTime != null) {
+            throw new BadRequestException("Cannot specify both endDate and endDateTime. Use one or the other.");
+        }
+
+        LocalDateTime effectiveStart = startDateTime != null ? startDateTime
+            : startDate != null ? startDate.atStartOfDay() : null;
+        LocalDateTime effectiveEnd = endDateTime != null ? endDateTime
+            : endDate != null ? endDate.atTime(LocalTime.MAX) : null;
+
         Set<EndpointType> basicTypes = Collections.emptySet();
         Set<CompositeEndpointType> compositeTypes = Collections.emptySet();
         Set<NotificationStatus> notificationStatusSet = status == null ? Set.of() : toNotificationStatus(status);
@@ -139,7 +182,7 @@ public class EventResource {
             Long count;
             if (backendConfig.isKesselChecksOnEventLogEnabled(orgId)) {
                 Log.info("Check for events with authorization criterion");
-                List<EventAuthorizationCriterion> listEventsAuthCriterion = eventRepository.getEventsWithCriterion(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet);
+                List<EventAuthorizationCriterion> listEventsAuthCriterion = eventRepository.getEventsWithCriterion(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, effectiveStart, effectiveEnd, basicTypes, compositeTypes, invocationResults, notificationStatusSet);
                 List<UUID> uuidToExclude = new ArrayList<>();
                 Map<Integer, Boolean> criterionResultCache = new HashMap<>();
                 for (EventAuthorizationCriterion eventAuthorizationCriterion : listEventsAuthCriterion) {
@@ -155,11 +198,11 @@ public class EventResource {
                 if (uuidToExclude.isEmpty()) {
                     uuidToExclude = null;
                 }
-                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.ofNullable(uuidToExclude), true, hasAction);
-                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.ofNullable(uuidToExclude), true, hasAction);
+                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, effectiveStart, effectiveEnd, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.ofNullable(uuidToExclude), true, hasAction);
+                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, effectiveStart, effectiveEnd, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.ofNullable(uuidToExclude), true, hasAction);
             } else {
-                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.empty(), false, hasAction);
-                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.empty(), false, hasAction);
+                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, effectiveStart, effectiveEnd, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.empty(), false, hasAction);
+                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, effectiveStart, effectiveEnd, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.empty(), false, hasAction);
             }
 
             if (events.isEmpty()) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -1026,6 +1026,51 @@ public class EventResourceTest extends DbIsolatedTest {
                 });
     }
 
+    private static Page<EventLogEntry> getEventLogPageWithDateTimeParams(
+            Header identityHeader, String startDate, String endDate, String startDateTime, String endDateTime) {
+        RequestSpecification request = given().header(identityHeader);
+        if (startDate != null) {
+            request.param("startDate", startDate);
+        }
+        if (endDate != null) {
+            request.param("endDate", endDate);
+        }
+        if (startDateTime != null) {
+            request.param("startDateTime", startDateTime);
+        }
+        if (endDateTime != null) {
+            request.param("endDateTime", endDateTime);
+        }
+        request.param("includeActions", true);
+        return request
+                .when().get(PATH)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(JSON)
+                .extract().body().as(new TypeRef<>() {
+                });
+    }
+
+    private static void getEventLogPageExpect400(
+            Header identityHeader, String startDate, String endDate, String startDateTime, String endDateTime) {
+        RequestSpecification request = given().header(identityHeader);
+        if (startDate != null) {
+            request.param("startDate", startDate);
+        }
+        if (endDate != null) {
+            request.param("endDate", endDate);
+        }
+        if (startDateTime != null) {
+            request.param("startDateTime", startDateTime);
+        }
+        if (endDateTime != null) {
+            request.param("endDateTime", endDateTime);
+        }
+        request.when().get(PATH)
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
     private static void assertSameEvent(EventLogEntry eventLogEntry, Event event, NotificationHistory... historyEntries) {
         assertEquals(event.getId(), eventLogEntry.getId());
         assertEquals(event.getExternalId(), eventLogEntry.getExternalId());
@@ -1466,5 +1511,76 @@ public class EventResourceTest extends DbIsolatedTest {
         endpointRepository.deleteEndpoint(DEFAULT_ORG_ID, endpoint.getId());
     }
 
+    @ParameterizedTest
+    @CsvSource({"false,false", "false,true", "true,false", "true,true"})
+    void testDateTimeQueryParams(boolean kesselEnabled, boolean useNormalizedQueries) {
+        when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
+        when(backendConfig.isNormalizedQueriesEnabled(anyString())).thenReturn(useNormalizedQueries);
+        if (kesselEnabled) {
+            mockDefaultKesselPermission(EVENTS_VIEW, ALLOWED_TRUE);
+        }
 
+        Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
+
+        Bundle bundle = resourceHelpers.createBundle("bundle-dt", "Bundle DT");
+        Application app = resourceHelpers.createApplication(bundle.getId(), "app-dt", "App DT");
+        EventType eventType = resourceHelpers.createEventType(app.getId(), "et-dt", "ET DT", "ET DT");
+
+        Event eventA = createEvent(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, bundle, app, eventType, NOW.minusHours(4L));
+        Event eventB = createEvent(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, bundle, app, eventType, NOW.minusHours(2L));
+        Event eventC = createEvent(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, bundle, app, eventType, NOW.minusMinutes(30L));
+
+        // Case 1: datetime-only, both bounds -- only eventB falls within the window
+        Page<EventLogEntry> page = getEventLogPageWithDateTimeParams(identityHeader, null, null,
+                NOW.minusHours(3L).toString(), NOW.minusHours(1L).toString());
+        assertEquals(1, page.getMeta().getCount());
+        assertEquals(eventB.getId(), page.getData().get(0).getId());
+
+        // Case 2: datetime-only start, no end -- open-ended forward range
+        page = getEventLogPageWithDateTimeParams(identityHeader, null, null, NOW.minusHours(3L).toString(), null);
+        assertEquals(2, page.getMeta().getCount());
+        assertTrue(page.getData().stream().anyMatch(e -> e.getId().equals(eventB.getId())));
+        assertTrue(page.getData().stream().anyMatch(e -> e.getId().equals(eventC.getId())));
+
+        // Case 3: datetime-only end, no start -- open-ended backward range
+        page = getEventLogPageWithDateTimeParams(identityHeader, null, null, null, NOW.minusHours(1L).toString());
+        assertEquals(2, page.getMeta().getCount());
+        assertTrue(page.getData().stream().anyMatch(e -> e.getId().equals(eventA.getId())));
+        assertTrue(page.getData().stream().anyMatch(e -> e.getId().equals(eventB.getId())));
+
+        // Case 4: mixed startDateTime + endDate -- start uses exact time, end expands to end of day
+        page = getEventLogPageWithDateTimeParams(identityHeader, null, NOW.toLocalDate().toString(),
+                NOW.minusHours(1L).toString(), null);
+        assertEquals(1, page.getMeta().getCount());
+        assertEquals(eventC.getId(), page.getData().get(0).getId());
+
+        // Case 5: mixed startDate + endDateTime -- start expands to start of day, end uses exact time
+        page = getEventLogPageWithDateTimeParams(identityHeader, NOW.toLocalDate().toString(), null,
+                null, NOW.minusHours(1L).toString());
+        assertEquals(2, page.getMeta().getCount());
+        assertTrue(page.getData().stream().anyMatch(e -> e.getId().equals(eventA.getId())));
+        assertTrue(page.getData().stream().anyMatch(e -> e.getId().equals(eventB.getId())));
+
+        // Case 6: date-only (regression) -- behavior identical to pre-change
+        page = getEventLogPageWithDateTimeParams(identityHeader, NOW.toLocalDate().toString(), NOW.toLocalDate().toString(), null, null);
+        assertEquals(3, page.getMeta().getCount());
+
+        // Case 7: zero params (regression) -- unbounded, all events returned
+        page = getEventLogPageWithDateTimeParams(identityHeader, null, null, null, null);
+        assertEquals(3, page.getMeta().getCount());
+    }
+
+    @Test
+    void testDateTimeAmbiguityValidation() {
+        Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
+
+        // Case 8: ambiguity on start
+        getEventLogPageExpect400(identityHeader, NOW.toLocalDate().toString(), null, NOW.toString(), null);
+
+        // Case 9: ambiguity on end
+        getEventLogPageExpect400(identityHeader, null, NOW.toLocalDate().toString(), null, NOW.toString());
+
+        // Case 10: ambiguity on both
+        getEventLogPageExpect400(identityHeader, NOW.toLocalDate().toString(), NOW.toLocalDate().toString(), NOW.toString(), NOW.toString());
+    }
 }


### PR DESCRIPTION
based on https://redhat.atlassian.net/browse/RHCLOUD-28931
Assisted-by: Claude Sonnet 5 (via Claude Code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date-time filtering for event logs using `startDateTime` and `endDateTime` query parameters.
  * Existing date-only filters remain supported.

* **Bug Fixes**
  * Prevented ambiguous requests that combine date-only and date-time filters for the same boundary.
  * Improved filtering precision by honoring exact date and time values.

* **Tests**
  * Added coverage for date-time filtering, mixed filter scenarios, and invalid combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->