### PR TITLE
[RHCLOUD-44010] Simplify EmailAggregator and EmailAggregationProcessor

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
@@ -160,54 +160,57 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
 
         List<AggregationCommand> aggregationCommands = new ArrayList<>();
         Timer.Sample consumedTimer = Timer.start(registry);
+        String bundle = "unknown";
 
         try {
-            Action action = actionParser.fromJsonString(event.getPayload());
-            Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+            try {
+                Action action = actionParser.fromJsonString(event.getPayload());
+                Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
-            for (com.redhat.cloud.notifications.ingress.Event actionEvent : action.getEvents()) {
-                try {
-                    AggregationCommand command = objectMapper.convertValue(actionEvent.getPayload().getAdditionalProperties(), AggregationCommand.class);
+                for (com.redhat.cloud.notifications.ingress.Event actionEvent : action.getEvents()) {
                     try {
-                        JsonObject aggregationKey = new JsonObject(actionEvent.getPayload().getAdditionalProperties()).getJsonObject("aggregationKey");
-                        EventAggregationCriterion key = objectMapper.convertValue(aggregationKey, EventAggregationCriterion.class);
-                        Set<ConstraintViolation<EventAggregationCriterion>> constraintViolations = validator.validate(key);
-                        if (constraintViolations.isEmpty()) {
-                            command.setAggregationKey(key);
+                        AggregationCommand command = objectMapper.convertValue(actionEvent.getPayload().getAdditionalProperties(), AggregationCommand.class);
+                        try {
+                            JsonObject aggregationKey = new JsonObject(actionEvent.getPayload().getAdditionalProperties()).getJsonObject("aggregationKey");
+                            EventAggregationCriterion key = objectMapper.convertValue(aggregationKey, EventAggregationCriterion.class);
+                            Set<ConstraintViolation<EventAggregationCriterion>> constraintViolations = validator.validate(key);
+                            if (constraintViolations.isEmpty()) {
+                                command.setAggregationKey(key);
+                            }
+                        } catch (Exception e) {
+                            Log.error("Kafka aggregation payload parsing key failed to be cast as 'EventAggregationCriteria' for event: " + event.getId() + ", aggregation: " + actionEvent.toString(), e);
                         }
+                        if (command.getAggregationKey() == null) {
+                            Log.warnf("Skipping aggregation command with null key for event: %s", event.getId());
+                            rejectedAggregationCommandCount.increment();
+                            continue;
+                        }
+                        aggregationCommands.add(command);
                     } catch (Exception e) {
-                        Log.error("Kafka aggregation payload parsing key failed to be cast as 'EventAggregationCriteria' for event: " + event.getId() + ", aggregation: " + actionEvent.toString(), e);
-                    }
-                    if (command.getAggregationKey() == null) {
-                        Log.warnf("Skipping aggregation command with null key for event: %s", event.getId());
+                        Log.error("Kafka aggregation payload parsing failed for event: " + event.getId() + ", aggregation: " + actionEvent.toString(), e);
                         rejectedAggregationCommandCount.increment();
-                        continue;
                     }
-                    aggregationCommands.add(command);
-                } catch (Exception e) {
-                    Log.error("Kafka aggregation payload parsing failed for event: " + event.getId() + ", aggregation: " + actionEvent.toString(), e);
-                    rejectedAggregationCommandCount.increment();
                 }
+            } catch (Exception e) {
+                Log.error("Kafka aggregation payload parsing failed for event " + event.getId(), e);
+                rejectedAggregationCommandCount.increment();
+                return;
             }
-        } catch (Exception e) {
-            Log.error("Kafka aggregation payload parsing failed for event " + event.getId(), e);
-            rejectedAggregationCommandCount.increment();
-            return;
-        }
 
-        if (aggregationCommands.isEmpty()) {
-            Log.warnf("No valid aggregation commands parsed from event %s", event.getId());
-            return;
-        }
+            if (aggregationCommands.isEmpty()) {
+                Log.warnf("No valid aggregation commands parsed from event %s", event.getId());
+                return;
+            }
 
-        final String bundle = aggregationCommands.get(0).getAggregationKey().getBundle();
+            bundle = aggregationCommands.get(0).getAggregationKey().getBundle();
 
-        processedAggregationCommandCount.increment(aggregationCommands.size());
-        try {
-            processBundleAggregation(aggregationCommands, event);
-        } catch (Exception e) {
-            Log.warn("Error while processing aggregation", e);
-            failedAggregationCommandCount.increment();
+            processedAggregationCommandCount.increment(aggregationCommands.size());
+            try {
+                processBundleAggregation(aggregationCommands, event);
+            } catch (Exception e) {
+                Log.warn("Error while processing aggregation", e);
+                failedAggregationCommandCount.increment();
+            }
         } finally {
             consumedTimer.stop(registry.timer(
                 AGGREGATION_CONSUMED_TIMER_NAME,

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
@@ -221,10 +221,7 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
         final String bundleName = aggregationCommands.get(0).getAggregationKey().getBundle();
         // Patch event display name for event log rendering
         Bundle bundle = bundleRepository.getBundle(bundleName)
-                .orElseThrow(() -> {
-                    String exceptionMsg = String.format("Bundle not found: %s", bundleName);
-                    return new IllegalArgumentException(exceptionMsg);
-                });
+                .orElseThrow(() -> new IllegalArgumentException("Bundle not found: " + bundleName));
 
         String eventTypeDisplayName = String.format("%s - %s",
             aggregatorEvent.getEventTypeDisplayName(),
@@ -233,74 +230,96 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
 
         Endpoint endpoint = endpointRepository.getOrCreateDefaultSystemSubscription(null, aggregatorEvent.getOrgId(), EndpointType.EMAIL_SUBSCRIPTION);
 
-        //Store every aggregated application data for each user
+        Map<User, List<ApplicationAggregatedData>> userData = aggregateByApplication(aggregationCommands);
+
+        Map<List<ApplicationAggregatedData>, Set<User>> usersWithSameData = groupUsersByAggregatedData(userData);
+
+        sendAggregatedEmails(usersWithSameData, bundle, aggregatorEvent, endpoint);
+    }
+
+    /*
+     * Aggregates event data per application and collects results per user.
+     * Each application's aggregation command is processed independently; errors in one
+     * application do not prevent others from being aggregated.
+     */
+    private Map<User, List<ApplicationAggregatedData>> aggregateByApplication(List<AggregationCommand> aggregationCommands) {
         Map<User, List<ApplicationAggregatedData>> userData = new HashMap<>();
 
-        for (AggregationCommand applicationAggregationCommand : aggregationCommands) {
-            Log.debugf("Processing aggregation command: %s", applicationAggregationCommand);
+        for (AggregationCommand cmd : aggregationCommands) {
+            Log.debugf("Processing aggregation command: %s", cmd);
 
             try {
-                Application app = applicationRepository.getApplication(applicationAggregationCommand.getAggregationKey().getBundle(), applicationAggregationCommand.getAggregationKey().getApplication())
-                        .orElseThrow(() -> {
-                            String exceptionMsg = String.format("Application not found: %s/%s",
-                                    applicationAggregationCommand.getAggregationKey().getBundle(), applicationAggregationCommand.getAggregationKey().getApplication());
-                            return new IllegalArgumentException(exceptionMsg);
-                        });
-                Map<User, Map<String, Object>> applicationAggregatedContextByUser = emailAggregator.getAggregated(app.getId(), applicationAggregationCommand.getAggregationKey(),
-                    applicationAggregationCommand.getSubscriptionType(),
-                    applicationAggregationCommand.getStart(),
-                    applicationAggregationCommand.getEnd());
+                Application app = applicationRepository.getApplication(
+                        cmd.getAggregationKey().getBundle(),
+                        cmd.getAggregationKey().getApplication())
+                    .orElseThrow(() -> new IllegalArgumentException(String.format(
+                        "Application not found: %s/%s",
+                        cmd.getAggregationKey().getBundle(),
+                        cmd.getAggregationKey().getApplication())));
 
-                applicationAggregatedContextByUser.entrySet().stream().forEach(userAggregation -> {
-                    userData.computeIfAbsent(userAggregation.getKey(), unused -> new ArrayList<>())
-                        .add(new ApplicationAggregatedData(userAggregation.getValue(), applicationAggregationCommand.getAggregationKey().getApplication()));
-                });
+                Map<User, Map<String, Object>> aggregatedByUser = emailAggregator.getAggregated(
+                    app.getId(), cmd.getAggregationKey(),
+                    cmd.getSubscriptionType(), cmd.getStart(), cmd.getEnd());
+
+                aggregatedByUser.forEach((user, data) ->
+                    userData.computeIfAbsent(user, unused -> new ArrayList<>())
+                        .add(new ApplicationAggregatedData(data, cmd.getAggregationKey().getApplication())));
             } catch (Exception ex) {
-                Log.error("Error processing " + applicationAggregationCommand.getAggregationKey(), ex);
+                Log.error("Error processing " + cmd.getAggregationKey(), ex);
             }
         }
+        return userData;
+    }
 
-        // Group users with same aggregated data
-        Map<List<ApplicationAggregatedData>, Set<User>> usersWithSameAggregatedData = userData.keySet().stream()
+    /*
+     * Groups users who have identical aggregated data so they can share a single rendered email.
+     */
+    private Map<List<ApplicationAggregatedData>, Set<User>> groupUsersByAggregatedData(
+            Map<User, List<ApplicationAggregatedData>> userData) {
+        Map<List<ApplicationAggregatedData>, Set<User>> grouped = userData.keySet().stream()
             .collect(Collectors.groupingBy(userData::get, Collectors.toSet()));
+        Log.debugf("Users with same aggregated data: %s", grouped);
+        return grouped;
+    }
 
-        Log.debugf("Users with same aggregated data: %s", usersWithSameAggregatedData);
-
+    /*
+     * Sends one aggregated email per group of users with identical data.
+     * Recipients are determined at an earlier stage (see EmailAggregator) using the
+     * recipients-resolver app and the subscription records from the database.
+     */
+    private void sendAggregatedEmails(Map<List<ApplicationAggregatedData>, Set<User>> usersWithSameData,
+                                      Bundle bundle, Event aggregatorEvent, Endpoint endpoint) {
         Map<String, Object> mapDataTitle = Map.of("source", Map.of("bundle", Map.of("display_name", bundle.getDisplayName())));
         TemplateDefinition templateTitleDefinition = new TemplateDefinition(IntegrationType.EMAIL_DAILY_DIGEST_BUNDLE_AGGREGATION_TITLE, null, null, null);
-        String emailTitle = commonQuteTemplateService.renderTemplateWithCustomDataMap(templateTitleDefinition, mapDataTitle);
+        commonQuteTemplateService.renderTemplateWithCustomDataMap(templateTitleDefinition, mapDataTitle);
 
-        // for each set of users, generate email subject + body and send it to email connector
-        usersWithSameAggregatedData.entrySet().stream().forEach(listApplicationWithUserCollection -> {
-
-            // Format data to send to the connector.
-            Set<String> recipientsUsernames = listApplicationWithUserCollection.getValue().stream().map(User::getUsername).collect(Collectors.toSet());
+        usersWithSameData.forEach((appDataList, users) -> {
+            Set<String> recipientsUsernames = users.stream().map(User::getUsername).collect(Collectors.toSet());
             Set<RecipientSettings> recipientSettings = extractAndTransformRecipientSettings(aggregatorEvent, List.of(endpoint));
 
-            Map<String, Object> aggregatedDataToRenderOnConnector = buildFullConnectorTemplateContext(listApplicationWithUserCollection.getKey(), bundle);
+            Map<String, Object> templateContext = buildFullConnectorTemplateContext(appDataList, bundle);
 
-            // Prepare all the data to be sent to the connector.
+            /*
+             * The recipients are determined at an earlier stage (see EmailAggregator) using the
+             * recipients-resolver app and the subscription records from the database.
+             * The subscribedByDefault value below simply means that recipients-resolver will consider
+             * the subscribers passed in the request as the recipients candidates of the aggregation email.
+             * Because the recipient list has already been computed using authz constraints, we don't
+             * need to pass them again for the aggregated email.
+             */
             final EmailNotification emailNotification = new EmailNotification(
                 this.emailActorsResolver.getEmailSender(aggregatorEvent),
                 aggregatorEvent.getOrgId(),
                 recipientSettings,
-                /*
-                 * The recipients are determined at an earlier stage (see EmailAggregator) using the
-                 * recipients-resolver app and the subscription records from the database.
-                 * The subscribedByDefault value below simply means that recipients-resolver will consider
-                 * the subscribers passed in the request as the recipients candidates of the aggregation email.
-                 */
                 recipientsUsernames,
                 Collections.emptySet(),
                 false,
-                // because recipient list has already been computed using authz constraints, we don't need it for the aggregated email
                 null,
-                aggregatedDataToRenderOnConnector,
+                templateContext,
                 true
             );
 
             connectorSender.send(aggregatorEvent, endpoint, JsonObject.mapFrom(emailNotification));
-
             Log.debugf("Sent aggregation email notification to connector: %s", emailNotification);
         });
     }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
@@ -294,7 +294,6 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
                                       Bundle bundle, Event aggregatorEvent, Endpoint endpoint) {
         Map<String, Object> mapDataTitle = Map.of("source", Map.of("bundle", Map.of("display_name", bundle.getDisplayName())));
         TemplateDefinition templateTitleDefinition = new TemplateDefinition(IntegrationType.EMAIL_DAILY_DIGEST_BUNDLE_AGGREGATION_TITLE, null, null, null);
-        commonQuteTemplateService.renderTemplateWithCustomDataMap(templateTitleDefinition, mapDataTitle);
 
         usersWithSameData.forEach((appDataList, users) -> {
             Set<String> recipientsUsernames = users.stream().map(User::getUsername).collect(Collectors.toSet());

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
@@ -278,7 +278,7 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
             Map<User, List<ApplicationAggregatedData>> userData) {
         Map<List<ApplicationAggregatedData>, Set<User>> grouped = userData.keySet().stream()
             .collect(Collectors.groupingBy(userData::get, Collectors.toSet()));
-        Log.debugf("Users with same aggregated data: %s", grouped);
+        Log.debugf("Grouped %d users into %d aggregated-data groups", userData.size(), grouped.size());
         return grouped;
     }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregationProcessor.java
@@ -178,6 +178,11 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
                     } catch (Exception e) {
                         Log.error("Kafka aggregation payload parsing key failed to be cast as 'EventAggregationCriteria' for event: " + event.getId() + ", aggregation: " + actionEvent.toString(), e);
                     }
+                    if (command.getAggregationKey() == null) {
+                        Log.warnf("Skipping aggregation command with null key for event: %s", event.getId());
+                        rejectedAggregationCommandCount.increment();
+                        continue;
+                    }
                     aggregationCommands.add(command);
                 } catch (Exception e) {
                     Log.error("Kafka aggregation payload parsing failed for event: " + event.getId() + ", aggregation: " + actionEvent.toString(), e);
@@ -187,6 +192,11 @@ public class EmailAggregationProcessor extends SystemEndpointTypeProcessor {
         } catch (Exception e) {
             Log.error("Kafka aggregation payload parsing failed for event " + event.getId(), e);
             rejectedAggregationCommandCount.increment();
+            return;
+        }
+
+        if (aggregationCommands.isEmpty()) {
+            Log.warnf("No valid aggregation commands parsed from event %s", event.getId());
             return;
         }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -172,6 +172,12 @@ public class EmailAggregator {
                 recipient,
                 notUsed -> EmailPayloadAggregatorFactory.by(eventAggregationCriteria, recipient.getUsername(), userSubscribedSeverities));
 
+            if (aggregator == null) {
+                Log.warnf("No aggregator found for %s/%s, skipping recipient %s",
+                    eventAggregationCriteria.getBundle(), eventAggregationCriteria.getApplication(), recipient.getUsername());
+                return;
+            }
+
             EmailAggregation eventDataToAggregate = new EmailAggregation(
                 aggregation.getOrgId(),
                 eventAggregationCriteria.getBundle(),

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -120,70 +120,74 @@ public class EmailAggregator {
 
         List<Event> aggregations;
         do {
-            // First, we retrieve paginated aggregations that match the given key.
             aggregations = emailAggregationRepository.getEmailAggregationBasedOnEvent(eventAggregationCriteria, start, end, offset, maxPageSize);
             offset += maxPageSize;
 
-            // For each aggregation...
             for (Event aggregation : aggregations) {
-                // We need its event type to determine the target endpoints.
-                EventType eventType = aggregation.getEventType();
-
-                // Let's retrieve these targets.
-                Set<Endpoint> endpoints = Set.copyOf(endpointRepository
-                    .getTargetEmailSubscriptionEndpoints(aggregation.getOrgId(), aggregation.getEventType().getId()));
-
-                /*
-                 * Now we want to determine who will actually receive the aggregation email.
-                 * All users who subscribed to the current application and subscription type combination are recipients candidates.
-                 * The actual recipients list may differ from the candidates depending on the endpoint properties and the action settings.
-                 * The target endpoints properties will determine whether each candidate will actually receive an email.
-                 */
-
-                Set<String> subscribers = subscribersByEventType.getOrDefault(eventType.getName(), Collections.emptySet());
-                Set<String> unsubscribers = unsubscribersByEventType.getOrDefault(eventType.getName(), Collections.emptySet());
-
-                aggregation.setEventWrapper(getEventWrapper(aggregation.getPayload()));
-                RecipientsAuthorizationCriterion externalAuthorizationCriterion = recipientsAuthorizationCriterionExtractor.extract(aggregation);
-
-                Set<User> recipients = externalRecipientsResolver.recipientUsers(
-                    aggregation.getOrgId(),
-                    Stream.concat(
-                        endpoints
-                            .stream()
-                            .map(EndpointRecipientSettings::new),
-                        getActionRecipientSettings(new JsonObject(aggregation.getPayload()))
-                    ).collect(toSet()),
-                    subscribers,
-                    unsubscribers,
-                    eventType.isSubscribedByDefault(),
-                    externalAuthorizationCriterion
-                ).stream().filter(user -> user.getEmail() != null && !user.getEmail().isBlank()).collect(toSet());
-
-                /*
-                 * We now have the final recipients list.
-                 * Let's populate the Map that will be returned by the method.
-                 */
-                recipients.forEach(recipient -> {
-                    final Set<SubscribedEventTypeSeverities> userSubscribedSeverities;
-                    if (subscribersWithSeverities.isPresent() && subscribersWithSeverities.get().containsKey(recipient.getUsername())) {
-                        userSubscribedSeverities = subscribersWithSeverities.get().get(recipient.getUsername());
-                    } else {
-                        userSubscribedSeverities = null;
-                    }
-
-                    // We may or may not have already initialized an aggregator for the recipient.
-                    AbstractEmailPayloadAggregator aggregator = aggregated
-                        .computeIfAbsent(recipient, notUsed -> EmailPayloadAggregatorFactory.by(eventAggregationCriteria, recipient.getUsername(), userSubscribedSeverities));
-
-                    // It's aggregation time!
-                    EmailAggregation eventDataToAggregate = new EmailAggregation(aggregation.getOrgId(), eventAggregationCriteria.getBundle(), eventAggregationCriteria.getApplication(), baseTransformer.toJsonObject(aggregation), aggregation.getSeverity(), aggregation.getEventType().getId());
-                    aggregator.aggregate(eventDataToAggregate);
-                });
+                Set<User> recipients = resolveRecipients(aggregation, subscribersByEventType, unsubscribersByEventType);
+                aggregateForRecipients(recipients, aggregation, eventAggregationCriteria, subscribersWithSeverities, aggregated);
             }
             totalAggregatedElements += aggregations.size();
         } while (maxPageSize == aggregations.size());
         Log.infof("%d elements were aggregated for key %s", totalAggregatedElements, eventAggregationCriteria);
+    }
+
+    /*
+     * Determines who will actually receive the aggregation email for a single event.
+     * All users who subscribed to the current application and subscription type combination are recipient candidates.
+     * The actual recipients list may differ from the candidates depending on the endpoint properties and the action settings.
+     * The target endpoint properties will determine whether each candidate will actually receive an email.
+     */
+    private Set<User> resolveRecipients(Event aggregation,
+                                        Map<String, Set<String>> subscribersByEventType,
+                                        Map<String, Set<String>> unsubscribersByEventType) {
+        EventType eventType = aggregation.getEventType();
+
+        Set<Endpoint> endpoints = Set.copyOf(endpointRepository
+            .getTargetEmailSubscriptionEndpoints(aggregation.getOrgId(), eventType.getId()));
+
+        Set<String> subscribers = subscribersByEventType.getOrDefault(eventType.getName(), Collections.emptySet());
+        Set<String> unsubscribers = unsubscribersByEventType.getOrDefault(eventType.getName(), Collections.emptySet());
+
+        aggregation.setEventWrapper(getEventWrapper(aggregation.getPayload()));
+        RecipientsAuthorizationCriterion externalAuthorizationCriterion = recipientsAuthorizationCriterionExtractor.extract(aggregation);
+
+        return externalRecipientsResolver.recipientUsers(
+            aggregation.getOrgId(),
+            Stream.concat(
+                endpoints.stream().map(EndpointRecipientSettings::new),
+                getActionRecipientSettings(new JsonObject(aggregation.getPayload()))
+            ).collect(toSet()),
+            subscribers,
+            unsubscribers,
+            eventType.isSubscribedByDefault(),
+            externalAuthorizationCriterion
+        ).stream().filter(user -> user.getEmail() != null && !user.getEmail().isBlank()).collect(toSet());
+    }
+
+    private void aggregateForRecipients(Set<User> recipients,
+                                        Event aggregation,
+                                        EventAggregationCriterion eventAggregationCriteria,
+                                        Optional<Map<String, Set<SubscribedEventTypeSeverities>>> subscribersWithSeverities,
+                                        Map<User, AbstractEmailPayloadAggregator> aggregated) {
+        recipients.forEach(recipient -> {
+            Set<SubscribedEventTypeSeverities> userSubscribedSeverities = subscribersWithSeverities
+                .map(map -> map.get(recipient.getUsername()))
+                .orElse(null);
+
+            AbstractEmailPayloadAggregator aggregator = aggregated.computeIfAbsent(
+                recipient,
+                notUsed -> EmailPayloadAggregatorFactory.by(eventAggregationCriteria, recipient.getUsername(), userSubscribedSeverities));
+
+            EmailAggregation eventDataToAggregate = new EmailAggregation(
+                aggregation.getOrgId(),
+                eventAggregationCriteria.getBundle(),
+                eventAggregationCriteria.getApplication(),
+                baseTransformer.toJsonObject(aggregation),
+                aggregation.getSeverity(),
+                aggregation.getEventType().getId());
+            aggregator.aggregate(eventDataToAggregate);
+        });
     }
 
     private EventWrapper<?, ?> getEventWrapper(String payload) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -1,15 +1,9 @@
 package com.redhat.cloud.notifications.processors.email;
 
-import com.redhat.cloud.event.parser.ConsoleCloudEventParser;
-import com.redhat.cloud.event.parser.exceptions.ConsoleCloudEventParsingException;
 import com.redhat.cloud.notifications.config.EngineConfig;
 import com.redhat.cloud.notifications.db.repositories.EmailAggregationRepository;
 import com.redhat.cloud.notifications.db.repositories.EndpointRepository;
 import com.redhat.cloud.notifications.db.repositories.SubscriptionRepository;
-import com.redhat.cloud.notifications.events.EventWrapper;
-import com.redhat.cloud.notifications.events.EventWrapperAction;
-import com.redhat.cloud.notifications.events.EventWrapperCloudEvent;
-import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Recipient;
 import com.redhat.cloud.notifications.ingress.RecipientsAuthorizationCriterion;
 import com.redhat.cloud.notifications.models.EmailAggregation;
@@ -17,7 +11,6 @@ import com.redhat.cloud.notifications.models.Endpoint;
 import com.redhat.cloud.notifications.models.Event;
 import com.redhat.cloud.notifications.models.EventAggregationCriterion;
 import com.redhat.cloud.notifications.models.EventType;
-import com.redhat.cloud.notifications.models.NotificationsConsoleCloudEvent;
 import com.redhat.cloud.notifications.models.SubscriptionType;
 import com.redhat.cloud.notifications.processors.email.aggregators.AbstractEmailPayloadAggregator;
 import com.redhat.cloud.notifications.processors.email.aggregators.EmailPayloadAggregatorFactory;
@@ -26,8 +19,6 @@ import com.redhat.cloud.notifications.recipients.recipientsresolver.ExternalReci
 import com.redhat.cloud.notifications.recipients.request.ActionRecipientSettings;
 import com.redhat.cloud.notifications.recipients.request.EndpointRecipientSettings;
 import com.redhat.cloud.notifications.transformers.BaseTransformer;
-import com.redhat.cloud.notifications.utils.ActionParser;
-import com.redhat.cloud.notifications.utils.ActionParsingException;
 import com.redhat.cloud.notifications.utils.RecipientsAuthorizationCriterionExtractor;
 import io.quarkus.logging.Log;
 import io.vertx.core.json.JsonArray;
@@ -66,15 +57,10 @@ public class EmailAggregator {
     SubscriptionRepository subscriptionRepository;
 
     @Inject
-    ActionParser actionParser;
-
-    @Inject
     EngineConfig engineConfig;
 
     @Inject
     BaseTransformer baseTransformer;
-
-    ConsoleCloudEventParser cloudEventParser = new ConsoleCloudEventParser();
 
     // This is manually used from the JSON payload instead of converting it to an Action and using getEventType()
     private static final String RECIPIENTS_KEY = "recipients";
@@ -149,7 +135,7 @@ public class EmailAggregator {
         Set<String> subscribers = subscribersByEventType.getOrDefault(eventType.getName(), Collections.emptySet());
         Set<String> unsubscribers = unsubscribersByEventType.getOrDefault(eventType.getName(), Collections.emptySet());
 
-        aggregation.setEventWrapper(getEventWrapper(aggregation.getPayload()));
+        // extract() sets the event wrapper on the aggregation if not already set
         RecipientsAuthorizationCriterion externalAuthorizationCriterion = recipientsAuthorizationCriterionExtractor.extract(aggregation);
 
         return externalRecipientsResolver.recipientUsers(
@@ -188,27 +174,6 @@ public class EmailAggregator {
                 aggregation.getEventType().getId());
             aggregator.aggregate(eventDataToAggregate);
         });
-    }
-
-    private EventWrapper<?, ?> getEventWrapper(String payload) {
-        try {
-            Action action = actionParser.fromJsonString(payload);
-            return new EventWrapperAction(action);
-        } catch (ActionParsingException actionParseException) {
-            // Try to load it as a CloudEvent
-            try {
-                EventWrapperCloudEvent eventWrapperCloudEvent = new EventWrapperCloudEvent(cloudEventParser.fromJsonString(payload, NotificationsConsoleCloudEvent.class));
-                return eventWrapperCloudEvent;
-            } catch (ConsoleCloudEventParsingException cloudEventParseException) {
-                /*
-                 * An exception (most likely UncheckedIOException) was thrown during the payload parsing. The message
-                 * is therefore considered rejected.
-                 */
-
-                actionParseException.addSuppressed(cloudEventParseException);
-                throw actionParseException;
-            }
-        }
     }
 
     private Stream<ActionRecipientSettings> getActionRecipientSettings(JsonObject payload) {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -106,6 +106,7 @@ public class EmailAggregator {
 
         List<Event> aggregations;
         do {
+            // Retrieve paginated aggregations that match the given key.
             aggregations = emailAggregationRepository.getEmailAggregationBasedOnEvent(eventAggregationCriteria, start, end, offset, maxPageSize);
             offset += maxPageSize;
 
@@ -151,6 +152,11 @@ public class EmailAggregator {
         ).stream().filter(user -> user.getEmail() != null && !user.getEmail().isBlank()).collect(toSet());
     }
 
+    /*
+     * For each recipient, creates or retrieves an existing aggregator and feeds the event into it.
+     * A single aggregator instance is shared across all events for a given user, accumulating data
+     * throughout the aggregation window.
+     */
     private void aggregateForRecipients(Set<User> recipients,
                                         Event aggregation,
                                         EventAggregationCriterion eventAggregationCriteria,
@@ -161,6 +167,7 @@ public class EmailAggregator {
                 .map(map -> map.get(recipient.getUsername()))
                 .orElse(null);
 
+            // We may or may not have already initialized an aggregator for the recipient.
             AbstractEmailPayloadAggregator aggregator = aggregated.computeIfAbsent(
                 recipient,
                 notUsed -> EmailPayloadAggregatorFactory.by(eventAggregationCriteria, recipient.getUsername(), userSubscribedSeverities));

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AbstractEmailPayloadAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/AbstractEmailPayloadAggregator.java
@@ -13,8 +13,8 @@ public abstract class AbstractEmailPayloadAggregator {
 
     private String orgId;
 
-    public String userName;
-    public Set<SubscribedEventTypeSeverities> userSeverities;
+    private String userName;
+    private Set<SubscribedEventTypeSeverities> userSeverities;
     JsonObject context = new JsonObject();
 
     abstract void processEmailAggregation(EmailAggregation aggregation);
@@ -55,6 +55,14 @@ public abstract class AbstractEmailPayloadAggregator {
 
     void copyStringField(JsonObject to, JsonObject from, final String field) {
         to.put(field, from.getString(field));
+    }
+
+    void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    void setUserSeverities(Set<SubscribedEventTypeSeverities> userSeverities) {
+        this.userSeverities = userSeverities;
     }
 
     String getOrgId() {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/aggregators/EmailPayloadAggregatorFactory.java
@@ -29,8 +29,8 @@ public class EmailPayloadAggregatorFactory {
 
         AbstractEmailPayloadAggregator aggregator = getAggregator(bundle, application);
         if (aggregator != null) {
-            aggregator.userName = username;
-            aggregator.userSeverities = userSeverities;
+            aggregator.setUserName(username);
+            aggregator.setUserSeverities(userSeverities);
         }
         return aggregator;
     }


### PR DESCRIPTION
## Summary
- **Fix NPE bug** in `processAggregationSync`: skip aggregation commands with null keys and return early when no valid commands are parsed
- **Extract helper methods** from `EmailAggregator.aggregationBasedOnEvent()`: `resolveRecipients()` and `aggregateForRecipients()` reduce the method from ~75 lines to ~25 lines of pagination + delegation
- **Remove duplicate code**: `EmailAggregator.getEventWrapper()` duplicated `RecipientsAuthorizationCriterionExtractor.getEventWrapper()` — the extractor's `extract(Event)` already handles null event wrappers
- **Extract helper methods** from `EmailAggregationProcessor.processBundleAggregation()`: `aggregateByApplication()`, `groupUsersByAggregatedData()`, and `sendAggregatedEmails()` each handle one phase
- **Tighten field visibility** in `AbstractEmailPayloadAggregator`: `userName` and `userSeverities` are now private with package-private setters

## Corner cases for team discussion
These are patterns I noticed during the refactoring that may warrant discussion with the team/PM. I'll add them as inline review comments on the relevant lines.

1. **`AnsibleEmailAggregator.processEmailAggregation()`** throws `RuntimeException("Not implemented yet")` — registered in factory but explodes at runtime
2. **`AbstractEmailPayloadAggregator.aggregate()`** — when severity filtering is enabled but event type is not in user's subscription map, event is silently dropped
3. **`EmailPayloadAggregatorFactory.getAggregator()`** — unknown bundle/application returns null; callers don't guard against NPE
4. **`EmailAggregationProcessor.groupUsersByAggregatedData()`** — grouping relies on List/Map equality; non-deterministic ordering in aggregated data could prevent deduplication

## Test plan
- [x] Checkstyle passes (`./mvnw validate`)
- [x] Full engine build with tests passes (`./mvnw clean verify -pl :notifications-engine -am`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skips invalid email aggregation commands that lack an aggregation key, logs a warning, and counts them as rejected.
  * Exits early when no valid aggregation commands are available to process.
  * Improves aggregated email generation by using a consistent template context and more reliable recipient filtering.

* **Refactor**
  * Reworks email aggregation into clearer stages: per-user aggregation, grouping by identical results, then rendering and dispatching aggregated emails.
  * Streamlines recipient resolution and per-recipient aggregation flow for improved maintainability and predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->