### PR TITLE
Add NOTIFICATIONS_USE_DEFAULT_TEMPLATE to email connector ClowdApp

### DIFF
--- a/.rhcicd/clowdapp-connector-email.yaml
+++ b/.rhcicd/clowdapp-connector-email.yaml
@@ -124,6 +124,8 @@ objects:
           value: ${NOTIFICATIONS_CONNECTOR_MAX_RECIPIENTS_PER_EMAIL}
         - name: NOTIFICATIONS_EMAILS_INTERNAL_ONLY_ENABLED
           value: ${NOTIFICATIONS_EMAILS_INTERNAL_ONLY_ENABLED}
+        - name: NOTIFICATIONS_USE_DEFAULT_TEMPLATE
+          value: ${NOTIFICATIONS_USE_DEFAULT_TEMPLATE}
         - name: QUARKUS_HTTP_PORT
           value: ${QUARKUS_HTTP_PORT}
         - name: QUARKUS_LOG_CATEGORY__COM_REDHAT_CLOUD_NOTIFICATIONS__LEVEL
@@ -242,6 +244,8 @@ parameters:
   description: If an email has more recipients (to/cc/bcc) than this value, it will be split into several emails with the same content but fewer recipients
   value: "50"
 - name: NOTIFICATIONS_EMAILS_INTERNAL_ONLY_ENABLED
+  value: "false"
+- name: NOTIFICATIONS_USE_DEFAULT_TEMPLATE
   value: "false"
 - name: QUARKUS_HTTP_PORT
   description: Quarkus HTTP server port


### PR DESCRIPTION
## Summary
- Adds the `NOTIFICATIONS_USE_DEFAULT_TEMPLATE` parameter/env var to `clowdapp-connector-email.yaml`, matching the existing definitions in `clowdapp-backend.yaml` and `clowdapp-engine.yaml`.
- This was previously missing from the email connector's ClowdApp config, creating an inconsistency across deployed components.

## Test plan
- [ ] Confirm the ClowdApp template still validates/renders correctly in the deployment pipeline
- [ ] Verify the `NOTIFICATIONS_USE_DEFAULT_TEMPLATE` env var is present on the email connector pod after deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to enable or disable the default notification email template.
  * The option is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->