### PR TITLE
Support Map<String, Object> action in ActionExtension.toPrettyJson

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/ActionExtension.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/ActionExtension.java
@@ -11,6 +11,8 @@ import com.redhat.cloud.notifications.ingress.Parser;
 import com.redhat.cloud.notifications.ingress.Payload;
 import io.quarkus.qute.TemplateExtension;
 
+import java.util.Map;
+
 public class ActionExtension {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -44,6 +46,15 @@ public class ActionExtension {
         try {
             String encodedAction = consoleCloudEventParser.toJson(event);
             return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(encodedAction));
+        } catch (JsonProcessingException jpe) {
+            throw new RuntimeException("Error while transforming action to json", jpe);
+        }
+    }
+
+    @TemplateExtension
+    public static String toPrettyJson(Map<String, Object> action) {
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(action);
         } catch (JsonProcessingException jpe) {
             throw new RuntimeException("Error while transforming action to json", jpe);
         }

--- a/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/extensions/ActionExtensionTest.java
+++ b/common-template/src/test/java/com/redhat/cloud/notifications/qute/templates/extensions/ActionExtensionTest.java
@@ -1,0 +1,74 @@
+package com.redhat.cloud.notifications.qute.templates.extensions;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ActionExtensionTest {
+
+    @Test
+    void testToPrettyJsonFromAction() {
+        Action action = Action.builder()
+            .withBundle("console")
+            .withApplication("notifications")
+            .withEventType("instant-email")
+            .withTimestamp(LocalDateTime.of(2026, 7, 24, 12, 0))
+            .withOrgId("org-123")
+            .withEvents(List.of())
+            .build();
+
+        String prettyJson = ActionExtension.toPrettyJson(action);
+
+        assertTrue(prettyJson.contains("\"bundle\" : \"console\""));
+        assertTrue(prettyJson.contains("\"application\" : \"notifications\""));
+        assertTrue(prettyJson.contains("\"org_id\" : \"org-123\""));
+        assertTrue(prettyJson.contains("\n"), "Pretty-printed JSON should be multi-line");
+    }
+
+    @Test
+    void testToPrettyJsonFromMap() {
+        Map<String, Object> action = new LinkedHashMap<>();
+        action.put("bundle", "console");
+        action.put("application", "notifications");
+        action.put("org_id", "org-123");
+
+        String prettyJson = ActionExtension.toPrettyJson(action);
+
+        assertTrue(prettyJson.contains("\"bundle\" : \"console\""));
+        assertTrue(prettyJson.contains("\"application\" : \"notifications\""));
+        assertTrue(prettyJson.contains("\"org_id\" : \"org-123\""));
+        assertTrue(prettyJson.contains("\n"), "Pretty-printed JSON should be multi-line");
+    }
+
+    @Test
+    void testToPrettyJsonFromMapWithNestedStructures() {
+        Map<String, Object> action = new LinkedHashMap<>();
+        action.put("bundle", "console");
+        action.put("context", Map.of("display_name", "Some Resource"));
+        action.put("events", List.of(Map.of("payload", Map.of("key", "value"))));
+
+        String prettyJson = ActionExtension.toPrettyJson(action);
+
+        assertTrue(prettyJson.contains("\"display_name\" : \"Some Resource\""));
+        assertTrue(prettyJson.contains("\"key\" : \"value\""));
+    }
+
+    @Test
+    void testToPrettyJsonFromEmptyMap() {
+        String prettyJson = ActionExtension.toPrettyJson(Map.of());
+        assertTrue(prettyJson.contains("{ }") || prettyJson.trim().equals("{ }"));
+    }
+
+    @Test
+    void testToPrettyJsonFromNullMap() {
+        String prettyJson = ActionExtension.toPrettyJson((Map<String, Object>) null);
+        assertEquals("null", prettyJson);
+    }
+}

--- a/common-template/src/test/java/email/TestDefaultTemplate.java
+++ b/common-template/src/test/java/email/TestDefaultTemplate.java
@@ -7,9 +7,12 @@ import com.redhat.cloud.notifications.qute.templates.Severity;
 import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
 import com.redhat.cloud.notifications.qute.templates.TemplateService;
 import email.pojo.NotificationsConsoleCloudEvent;
+import helpers.BaseTransformer;
 import helpers.TestHelpers;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
+import io.vertx.core.json.JsonObject;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,6 +29,9 @@ public class TestDefaultTemplate extends EmailTemplatesRendererHelper {
 
     @InjectSpy
     protected TemplateService templateService;
+
+    @Inject
+    BaseTransformer baseTransformerHelper;
 
     @Override
     protected String getApp() {
@@ -115,6 +121,27 @@ public class TestDefaultTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains("You are receiving this email because the email template associated with this event type is not configured properly"));
     }
 
+    /**
+     * connector-email renders this same Default template but with "action" as a plain
+     * {@code Map<String, Object>} (the deserialized {@code event_data} of the Kafka message it
+     * consumes) rather than an {@link Action} instance, so {@code action.toPrettyJson()} must
+     * also resolve against a {@code Map}.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testInstantEmailBodyFromMapAction(boolean useBetaTemplate) {
+        Action baseAction = TestHelpers.createPoliciesAction("", "my-bundle", "my-app", "FooMachine");
+        JsonObject actionJson = baseTransformerHelper.toJsonObject(baseAction);
+        actionJson.put("orgId", baseAction.getOrgId());
+        eventTypeDisplayName = "Test Event Type";
+        TemplateDefinition templateDefinition = new TemplateDefinition(IntegrationType.EMAIL_BODY, getBundle(), getApp(), EVENT_TYPE_NAME, useBetaTemplate);
+        String result = generateEmail(templateDefinition, actionJson.getMap(), null, false);
+
+        assertTrue(result.contains("Red Hat Enterprise Linux/Test App/Test Event Type notification was triggered"), "Body should contain bundle/app/event-type");
+        assertTrue(result.contains("You are receiving this email because the email template associated with this event type is not configured properly"));
+        assertTrue(result.contains("my-bundle"), "Raw action content section should render the map as pretty JSON");
+        assertTrue(result.contains(TestHelpers.POLICY_ID_1), "Raw action content section should render nested map/list values");
+    }
 
     @Test
     public void testInstantEmailTitleCloudEvents() {


### PR DESCRIPTION
## Summary

connector-email renders the shared `Default/instantEmailBody.html` email template with `action` as a plain `Map<String, Object>` (the deserialized `event_data` payload of the Kafka message it consumes), instead of an `Action` POJO like most other rendering paths (engine, backend template preview). Because `ActionExtension.toPrettyJson()` only had overloads for `Action` and `ConsoleCloudEvent`, Qute couldn't resolve `action.toPrettyJson()` when the base object was a `Map`, breaking the raw-action-content section of the default fallback email template for connector-email.

- Added a `toPrettyJson(Map<String, Object> action)` `@TemplateExtension` overload in `ActionExtension`, alongside the existing `Action`/`ConsoleCloudEvent` ones, so the same Qute expression resolves regardless of which shape `action` has.
- Added `ActionExtensionTest` covering `toPrettyJson` for `Action`, flat/nested `Map`, empty map, and null map.
- Added a test case to `TestDefaultTemplate` that renders the real `Default/instantEmailBody.html` template (through the actual Qute engine, not just the extension method in isolation) with `action` built as a `Map<String, Object>` from an `Action` (mirroring how `BaseTransformer`/connector-email produce it), to verify the fix end-to-end.

## Test plan

- [x] `./mvnw validate -pl :notifications-common-template` — checkstyle clean
- [x] `./mvnw clean verify -pl :notifications-common-template -am -Dtest=ActionExtensionTest` — all tests pass
- [x] `./mvnw clean verify -pl :notifications-common-template -am -Dtest=TestDefaultTemplate` — all tests pass, including the new Map-based rendering case
- [x] `./mvnw clean verify -pl :notifications-common-template -am` — full module test suite passes (414/414)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering map-based action data as readable, formatted JSON.
  * Default email templates now support action payloads provided as maps, including nested configuration and policy details.

* **Bug Fixes**
  * Improved compatibility when displaying action data in email content.

* **Tests**
  * Added coverage for formatted JSON output, nested data, empty and null maps, and map-based email rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->