### PR TITLE
Auto-refresh yarn.lock for Mintmaker dependency bump PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,16 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: admin-console/**
+      - name: Verify if admin-console package.json changed
+        id: package-json-changed
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: admin-console/src/main/webapp/package.json
       - name: Configure GPG signing
         # Needed before "Regenerate yarn.lock for Mintmaker branches" (so that
         # commit is signed too), not just before "Create PR for admin-console
         # updates" further down.
-        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref_name, 'konflux/mintmaker/'))
+        if: github.event_name == 'push' && ((steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.package-json-changed.outputs.any_changed == 'true' && startsWith(github.ref_name, 'konflux/mintmaker/')))
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -98,7 +103,7 @@ jobs:
           fi
       - name: Set up Node for Mintmaker lockfile refresh
         # Keep this version in sync with <nodeVersion> in admin-console/pom.xml.
-        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        if: steps.package-json-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
         uses: actions/setup-node@v5
         with:
           node-version: 22.20.0
@@ -109,7 +114,7 @@ jobs:
         # the branch is self-consistent before the real build runs. Relies on
         # the git identity and signing key set up by "Configure GPG signing"
         # so the pushed commit shows as Verified.
-        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        if: steps.package-json-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
         working-directory: admin-console/src/main/webapp
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
@@ -133,7 +138,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/push-admin-console.sh
       - name: Cleanup GPG key
-        if: always() && steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref_name, 'konflux/mintmaker/'))
+        if: always() && github.event_name == 'push' && ((steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.package-json-changed.outputs.any_changed == 'true' && startsWith(github.ref_name, 'konflux/mintmaker/')))
         run: |
           if [ -n "${GPG_KEY_FINGERPRINT}" ]; then
             gpg --batch --yes --delete-secret-and-public-key "${GPG_KEY_FINGERPRINT}" || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,33 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: admin-console/**
+      - name: Set up Node for Mintmaker lockfile refresh
+        # Keep this version in sync with <nodeVersion> in admin-console/pom.xml.
+        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.20.0
+      - name: Regenerate yarn.lock for Mintmaker branches
+        # Mintmaker bumps package.json dependency ranges but never runs yarn
+        # install, so yarn.lock goes stale and the immutable install in
+        # "Build admin-console" fails. Refresh and push the lockfile here so
+        # the branch is self-consistent before the real build runs.
+        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        working-directory: admin-console/src/main/webapp
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
+        run: |
+          corepack enable
+          yarn install
+          if git diff --quiet -- yarn.lock; then
+            echo "yarn.lock is already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add yarn.lock
+          git commit -m "Regenerate yarn.lock to match Mintmaker's dependency bump"
+          git push origin "HEAD:${{ github.ref_name }}"
       - name: Build admin-console
         if: steps.admin-console-changed.outputs.any_changed == 'true'
         run: ./mvnw clean verify -Padmin-console -pl :checkstyle,:notifications-admin-console --no-transfer-progress

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,39 +40,11 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: admin-console/**
-      - name: Set up Node for Mintmaker lockfile refresh
-        # Keep this version in sync with <nodeVersion> in admin-console/pom.xml.
-        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22.20.0
-      - name: Regenerate yarn.lock for Mintmaker branches
-        # Mintmaker bumps package.json dependency ranges but never runs yarn
-        # install, so yarn.lock goes stale and the immutable install in
-        # "Build admin-console" fails. Refresh and push the lockfile here so
-        # the branch is self-consistent before the real build runs.
-        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
-        working-directory: admin-console/src/main/webapp
-        env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
-          BRANCH_REF: ${{ github.ref_name }}
-        run: |
-          corepack enable
-          yarn install
-          if git diff --quiet -- yarn.lock; then
-            echo "yarn.lock is already up to date"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add yarn.lock
-          git commit -m "Regenerate yarn.lock to match Mintmaker's dependency bump"
-          git push origin "HEAD:${BRANCH_REF}"
-      - name: Build admin-console
-        if: steps.admin-console-changed.outputs.any_changed == 'true'
-        run: ./mvnw clean verify -Padmin-console -pl :checkstyle,:notifications-admin-console --no-transfer-progress
       - name: Configure GPG signing
-        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        # Needed before "Regenerate yarn.lock for Mintmaker branches" (so that
+        # commit is signed too), not just before "Create PR for admin-console
+        # updates" further down.
+        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref_name, 'konflux/mintmaker/'))
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -124,13 +96,44 @@ jobs:
               exit 1
             fi
           fi
+      - name: Set up Node for Mintmaker lockfile refresh
+        # Keep this version in sync with <nodeVersion> in admin-console/pom.xml.
+        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.20.0
+      - name: Regenerate yarn.lock for Mintmaker branches
+        # Mintmaker bumps package.json dependency ranges but never runs yarn
+        # install, so yarn.lock goes stale and the immutable install in
+        # "Build admin-console" fails. Refresh and push the lockfile here so
+        # the branch is self-consistent before the real build runs. Relies on
+        # the git identity and signing key set up by "Configure GPG signing"
+        # so the pushed commit shows as Verified.
+        if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        working-directory: admin-console/src/main/webapp
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
+          BRANCH_REF: ${{ github.ref_name }}
+        run: |
+          corepack enable
+          yarn install
+          if git diff --quiet -- yarn.lock; then
+            echo "yarn.lock is already up to date"
+            exit 0
+          fi
+          git add yarn.lock
+          git commit -S -m "Regenerate yarn.lock to match Mintmaker's dependency bump"
+          git push origin "HEAD:${BRANCH_REF}"
+      - name: Build admin-console
+        if: steps.admin-console-changed.outputs.any_changed == 'true'
+        run: ./mvnw clean verify -Padmin-console -pl :checkstyle,:notifications-admin-console --no-transfer-progress
       - name: Create PR for admin-console updates
         if: steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/push-admin-console.sh
       - name: Cleanup GPG key
-        if: always() && steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: always() && steps.admin-console-changed.outputs.any_changed == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref_name, 'konflux/mintmaker/'))
         run: |
           if [ -n "${GPG_KEY_FINGERPRINT}" ]; then
             gpg --batch --yes --delete-secret-and-public-key "${GPG_KEY_FINGERPRINT}" || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
         working-directory: admin-console/src/main/webapp
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
+          BRANCH_REF: ${{ github.ref_name }}
         run: |
           corepack enable
           yarn install
@@ -66,7 +67,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add yarn.lock
           git commit -m "Regenerate yarn.lock to match Mintmaker's dependency bump"
-          git push origin "HEAD:${{ github.ref_name }}"
+          git push origin "HEAD:${BRANCH_REF}"
       - name: Build admin-console
         if: steps.admin-console-changed.outputs.any_changed == 'true'
         run: ./mvnw clean verify -Padmin-console -pl :checkstyle,:notifications-admin-console --no-transfer-progress

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,16 +40,18 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: admin-console/**
-      - name: Verify if admin-console package.json changed
-        id: package-json-changed
+      - name: Verify if admin-console yarn files changed
+        id: yarn-files-changed
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          files: admin-console/src/main/webapp/package.json
+          files: |
+            admin-console/src/main/webapp/package.json
+            admin-console/src/main/webapp/yarn.lock
       - name: Configure GPG signing
         # Needed before "Regenerate yarn.lock for Mintmaker branches" (so that
         # commit is signed too), not just before "Create PR for admin-console
         # updates" further down.
-        if: github.event_name == 'push' && ((steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.package-json-changed.outputs.any_changed == 'true' && startsWith(github.ref_name, 'konflux/mintmaker/')))
+        if: github.event_name == 'push' && ((steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.yarn-files-changed.outputs.any_changed == 'true' && startsWith(github.ref_name, 'konflux/mintmaker/')))
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -103,18 +105,20 @@ jobs:
           fi
       - name: Set up Node for Mintmaker lockfile refresh
         # Keep this version in sync with <nodeVersion> in admin-console/pom.xml.
-        if: steps.package-json-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        if: steps.yarn-files-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
         uses: actions/setup-node@v5
         with:
           node-version: 22.20.0
       - name: Regenerate yarn.lock for Mintmaker branches
-        # Mintmaker bumps package.json dependency ranges but never runs yarn
-        # install, so yarn.lock goes stale and the immutable install in
-        # "Build admin-console" fails. Refresh and push the lockfile here so
-        # the branch is self-consistent before the real build runs. Relies on
-        # the git identity and signing key set up by "Configure GPG signing"
-        # so the pushed commit shows as Verified.
-        if: steps.package-json-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        # Mintmaker bumps package.json dependency ranges (or, for lock file
+        # maintenance PRs, rewrites yarn.lock itself) without necessarily
+        # producing a lockfile that satisfies the immutable install in
+        # "Build admin-console". Refresh and push the lockfile here so the
+        # branch is self-consistent before the real build runs; the diff
+        # check below makes this a no-op when nothing actually changes.
+        # Relies on the git identity and signing key set up by "Configure GPG
+        # signing" so the pushed commit shows as Verified.
+        if: steps.yarn-files-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
         working-directory: admin-console/src/main/webapp
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
@@ -138,7 +142,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/push-admin-console.sh
       - name: Cleanup GPG key
-        if: always() && github.event_name == 'push' && ((steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.package-json-changed.outputs.any_changed == 'true' && startsWith(github.ref_name, 'konflux/mintmaker/')))
+        if: always() && github.event_name == 'push' && ((steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.yarn-files-changed.outputs.any_changed == 'true' && startsWith(github.ref_name, 'konflux/mintmaker/')))
         run: |
           if [ -n "${GPG_KEY_FINGERPRINT}" ]; then
             gpg --batch --yes --delete-secret-and-public-key "${GPG_KEY_FINGERPRINT}" || true


### PR DESCRIPTION
## Summary
- Mintmaker bumps `admin-console` `package.json` dependency ranges (e.g. `monaco-editor` 0.55.1 -> 0.56.0 in #4750) but never runs `yarn install`, leaving `yarn.lock` stale.
- CI's immutable install then fails: Yarn refuses to let `yarn install` mutate the lockfile in CI (`YARN_ENABLE_IMMUTABLE_INSTALLS` auto-enables whenever `CI=true`, which GitHub Actions always sets).
- Adds a step, scoped to `push` events on `konflux/mintmaker/*` branches, that regenerates `yarn.lock` (with immutable installs explicitly disabled) and pushes the fix back onto the branch before the real, still-immutable "Build admin-console" step runs. Regular contributor PRs are unaffected and keep the full immutable-install safety net.

## Test plan
- [x] Validated workflow YAML with `actionlint` (only pre-existing, unrelated warning found: deprecated `set-output` in "Prepare cache key")
- [ ] Confirm a future Mintmaker branch push passes CI without manual lockfile intervention
- [ ] Confirm `GITHUB_TOKEN`'s `contents: write` permission is sufficient to push to `konflux/mintmaker/*` branches (no branch protection blocking it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI build workflow to use Node.js 22.20.0 for relevant admin-console dependency updates.
  * Added detection for changes to the admin-console dependency manifest/lockfile on Mintmaker branches; when triggered, the workflow refreshes the lockfile and pushes the update back to the same branch.
  * Broadened cryptographic signing and key cleanup to cover both master and Mintmaker lockfile refresh scenarios, while keeping the admin-console build gated on admin-console code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->