### PR TITLE
Revert "RHCLOUD-46541: feat(event-log): Add hasAction filter to exclude events with no notification actions"

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/db/repositories/EventRepository.java
@@ -51,7 +51,7 @@ public class EventRepository {
 
         hql += "WHERE e.orgId = :orgId";
 
-        hql = addHqlConditions(hql, useNormalized, bundlesNotEmpty, applicationsNotEmpty, eventTypeNameNotEmpty, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, null, Optional.empty(), true, false);
+        hql = addHqlConditions(hql, useNormalized, bundlesNotEmpty, applicationsNotEmpty, eventTypeNameNotEmpty, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, null, Optional.empty(), true);
         // we are looking for events with auth criterion only
         hql += " AND e.hasAuthorizationCriterion is true";
 
@@ -149,11 +149,11 @@ public class EventRepository {
     public List<Event> getEvents(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                       LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
                                       Set<Boolean> invocationResults, boolean fetchNotificationHistory, Set<NotificationStatus> status, Set<Severity> severities, Query query,
-                                      Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion, boolean hasAction) {
+                                      Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion) {
 
         Optional<Sort> sort = Sort.getSort(query, "created:DESC", Event.getSortFields(useNormalized));
 
-        List<UUID> eventIds = getEventIds(orgId, useNormalized, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, severities, query, uuidToExclude, includeEventsWithAuthCriterion, hasAction);
+        List<UUID> eventIds = getEventIds(orgId, useNormalized, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, severities, query, uuidToExclude, includeEventsWithAuthCriterion);
         if (eventIds.isEmpty()) {
             return new ArrayList<>();
         }
@@ -208,8 +208,7 @@ public class EventRepository {
     public Long count(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                       LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes,
                       Set<CompositeEndpointType> compositeEndpointTypes, Set<Boolean> invocationResults,
-                      Set<NotificationStatus> status, Set<Severity> severities, Optional<List<UUID>> uuidToExclude, Boolean includeEventsWithAuthCriterion,
-                      boolean hasAction) {
+                      Set<NotificationStatus> status, Set<Severity> severities, Optional<List<UUID>> uuidToExclude, Boolean includeEventsWithAuthCriterion) {
 
         // Calculate once for reuse
         boolean bundlesNotEmpty = bundleIds != null && !bundleIds.isEmpty();
@@ -233,7 +232,7 @@ public class EventRepository {
 
         hql += "WHERE e.orgId = :orgId";
 
-        hql = addHqlConditions(hql, useNormalized, bundlesNotEmpty, applicationsNotEmpty, eventTypeNameNotEmpty, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, severities, uuidToExclude, includeEventsWithAuthCriterion, hasAction);
+        hql = addHqlConditions(hql, useNormalized, bundlesNotEmpty, applicationsNotEmpty, eventTypeNameNotEmpty, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, severities, uuidToExclude, includeEventsWithAuthCriterion);
 
         TypedQuery<Long> query = entityManager.createQuery(hql, Long.class);
         setQueryParams(query, orgId, bundleIds, appIds, eventTypeDisplayName, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, severities, uuidToExclude);
@@ -251,8 +250,7 @@ public class EventRepository {
 
     private List<UUID> getEventIds(String orgId, boolean useNormalized, Set<UUID> bundleIds, Set<UUID> appIds, String eventTypeDisplayName,
                                         LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes, Set<CompositeEndpointType> compositeEndpointTypes,
-                                        Set<Boolean> invocationResults, Set<NotificationStatus> status, Set<Severity> severities, Query query, Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion,
-                                        boolean hasAction) {
+                                        Set<Boolean> invocationResults, Set<NotificationStatus> status, Set<Severity> severities, Query query, Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion) {
         boolean bundlesNotEmpty = bundleIds != null && !bundleIds.isEmpty();
         boolean applicationsNotEmpty = appIds != null && !appIds.isEmpty();
         boolean eventTypeNameNotEmpty = eventTypeDisplayName != null;
@@ -282,7 +280,7 @@ public class EventRepository {
 
         hql += "WHERE e.orgId = :orgId";
 
-        hql = addHqlConditions(hql, useNormalized, bundlesNotEmpty, applicationsNotEmpty, eventTypeNameNotEmpty, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, severities, uuidToExclude, includeEventsWithAuthCriterion, hasAction);
+        hql = addHqlConditions(hql, useNormalized, bundlesNotEmpty, applicationsNotEmpty, eventTypeNameNotEmpty, startDate, endDate, endpointTypes, compositeEndpointTypes, invocationResults, status, severities, uuidToExclude, includeEventsWithAuthCriterion);
 
         if (sort.isPresent()) {
             hql += getOrderBy(sort.get());
@@ -302,8 +300,7 @@ public class EventRepository {
     private String addHqlConditions(String hql, boolean useNormalized, boolean bundlesNotEmpty, boolean applicationsNotEmpty, boolean eventTypeNameNotEmpty,
                                            LocalDateTime startDate, LocalDateTime endDate, Set<EndpointType> endpointTypes,
                                            Set<CompositeEndpointType> compositeEndpointTypes, Set<Boolean> invocationResults,
-                                           Set<NotificationStatus> status, Set<Severity> severities, Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion,
-                                           boolean hasAction) {
+                                           Set<NotificationStatus> status, Set<Severity> severities, Optional<List<UUID>> uuidToExclude, boolean includeEventsWithAuthCriterion) {
 
         List<String> bundleOrAppsConditions = new ArrayList<>();
 
@@ -381,8 +378,6 @@ public class EventRepository {
             }
 
             hql += " AND EXISTS (SELECT 1 FROM NotificationHistory nh WHERE nh.event = e AND " + String.join(" AND ", subQueryConditions) + ")";
-        } else if (hasAction) {
-            hql += " AND EXISTS (SELECT 1 FROM NotificationHistory nh WHERE nh.event = e)";
         }
 
         return hql;

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/event/EventResource.java
@@ -127,8 +127,7 @@ public class EventResource {
                                          @RestQuery Set<String> endpointTypes, @RestQuery Set<Boolean> invocationResults,
                                          @RestQuery Set<EventLogEntryActionStatus> status, @RestQuery Set<Severity> severities,
                                          @BeanParam @Valid Query query,
-                                         @RestQuery boolean includeDetails, @RestQuery boolean includePayload, @RestQuery boolean includeActions,
-                                         @RestQuery boolean hasAction) {
+                                         @RestQuery boolean includeDetails, @RestQuery boolean includePayload, @RestQuery boolean includeActions) {
         LocalDateTime startDateTime = parseDate(startDate, "startDate", LocalDate::atStartOfDay);
         LocalDateTime endDateTime = parseDate(endDate, "endDate", date -> date.atTime(LocalTime.MAX));
 
@@ -179,11 +178,11 @@ public class EventResource {
                 if (uuidToExclude.isEmpty()) {
                     uuidToExclude = null;
                 }
-                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDateTime, endDateTime, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.ofNullable(uuidToExclude), true, hasAction);
-                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDateTime, endDateTime, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.ofNullable(uuidToExclude), true, hasAction);
+                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDateTime, endDateTime, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.ofNullable(uuidToExclude), true);
+                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDateTime, endDateTime, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.ofNullable(uuidToExclude), true);
             } else {
-                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDateTime, endDateTime, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.empty(), false, hasAction);
-                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDateTime, endDateTime, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.empty(), false, hasAction);
+                events = eventRepository.getEvents(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDateTime, endDateTime, basicTypes, compositeTypes, invocationResults, includeActions, notificationStatusSet, severities, query, Optional.empty(), false);
+                count = eventRepository.count(orgId, useNormalizedQueries, bundleIds, appIds, eventTypeDisplayName, startDateTime, endDateTime, basicTypes, compositeTypes, invocationResults, notificationStatusSet, severities, Optional.empty(), false);
             }
 
             if (events.isEmpty()) {

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/event/EventResourceTest.java
@@ -1013,10 +1013,9 @@ public class EventResourceTest extends DbIsolatedTest {
                 });
     }
 
-    private static Page<EventLogEntry> getEventLogPageWithHasAction(Header identityHeader, boolean hasAction) {
+    private static Page<EventLogEntry> getEventLogPageWithHasAction(Header identityHeader) {
         return given()
                 .header(identityHeader)
-                .param("hasAction", hasAction)
                 .param("includeActions", true)
                 .when().get(PATH)
                 .then()
@@ -1099,42 +1098,6 @@ public class EventResourceTest extends DbIsolatedTest {
         for (String key : expectedKeys) {
             assertTrue(links.containsKey(key));
         }
-    }
-
-    @ParameterizedTest
-    @CsvSource({"false,false", "false,true", "true,false", "true,true"})
-    void testHasActionFilter(boolean kesselEnabled, boolean useNormalizedQueries) {
-        when(backendConfig.isKesselEnabled(anyString())).thenReturn(kesselEnabled);
-        when(backendConfig.isNormalizedQueriesEnabled(anyString())).thenReturn(useNormalizedQueries);
-        if (kesselEnabled) {
-            mockDefaultKesselPermission(EVENTS_VIEW, ALLOWED_TRUE);
-        }
-
-        Header identityHeader = mockRbac(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER, FULL_ACCESS);
-
-        Bundle bundle = resourceHelpers.createBundle("bundle-ha", "Bundle HA");
-        Application app = resourceHelpers.createApplication(bundle.getId(), "app-ha", "App HA");
-        EventType eventType = resourceHelpers.createEventType(app.getId(), "et-ha", "ET HA", "ET HA");
-
-        // event with a notification action
-        Event eventWithAction = createEvent(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, bundle, app, eventType, NOW.minusDays(1L));
-        Endpoint endpoint = resourceHelpers.createEndpoint(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, WEBHOOK);
-        resourceHelpers.createNotificationHistory(eventWithAction, endpoint, NotificationStatus.SUCCESS);
-        endpointRepository.deleteEndpoint(DEFAULT_ORG_ID, endpoint.getId());
-
-        // event without any notification action
-        createEvent(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, bundle, app, eventType, NOW.minusDays(2L));
-
-        // hasAction=false (default): both events returned
-        Page<EventLogEntry> all = getEventLogPageWithHasAction(identityHeader, false);
-        assertEquals(2, all.getMeta().getCount());
-        assertEquals(2, all.getData().size());
-
-        // hasAction=true: only the event with an action returned
-        Page<EventLogEntry> filtered = getEventLogPageWithHasAction(identityHeader, true);
-        assertEquals(1, filtered.getMeta().getCount());
-        assertEquals(1, filtered.getData().size());
-        assertEquals(eventWithAction.getId(), filtered.getData().get(0).getId());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Revert "RHCLOUD-46541: feat(event-log): Add hasAction filter to exclude events with no notification actions (#4677)"

This reverts commit d80e749f7e170f591e0dd75e9facc3699cf8ba40.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the `hasAction` filter from event log requests.
  * Event log retrieval no longer supports filtering events by whether they have actions.
  * Updated event listing and count behavior to reflect the simplified filtering options.
  * Removed related test coverage for the retired query parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->