### PR TITLE
fix(templates): use subscription_id instead of internal_cluster_id in generalNotification URLs

### DIFF
--- a/common-template/src/main/resources/templates/email/OCM/generalNotificationInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/OCM/generalNotificationInstantEmailBody.html
@@ -39,11 +39,11 @@
 {#switch global_vars.template_sub_type.or("")}
 {#case 'osd-trial-creation-template'}
     <p style="{body-section-p-style}">
-        To learn more about the OpenShift Dedicated trial, please refer to <a style="{body-section-underline-link-style}" href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a style="{body-section-underline-link-style}" href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+        To learn more about the OpenShift Dedicated trial, please refer to <a style="{body-section-underline-link-style}" href="https://access.redhat.com/articles/5990101" target="_blank">our documentation</a>. You can upgrade your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a style="{body-section-underline-link-style}" href="https://cloud.redhat.com/openshift/details/s/{action.events[0].payload.global_vars.subscription_id}#overview" target="_blank">OpenShift Cluster Manager</a>.
     </p>
 {#case 'osd-trial-reminder-template'}
     <p style="{body-section-p-style}">
-        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a style="{body-section-underline-link-style}" href="https://cloud.redhat.com/openshift/details/{action.events[0].payload.global_vars.internal_cluster_id}" target="_blank">OpenShift Cluster Manager</a>.
+        You will be notified once your cluster is deleted. You can prevent this automatic deletion by upgrading your trial to a paid subscription at any time by clicking "Upgrade from trial" in <a style="{body-section-underline-link-style}" href="https://cloud.redhat.com/openshift/details/s/{action.events[0].payload.global_vars.subscription_id}#overview" target="_blank">OpenShift Cluster Manager</a>.
     </p>
 {#case 'osd-trial-deletion-template'}
     <p style="{body-section-p-style}">


### PR DESCRIPTION
## Summary
- Fixed two broken URLs in the `generalNotificationInstant` email template (`osd-trial-creation-template` and `osd-trial-reminder-template` cases)
- Both URLs were using `internal_cluster_id` with the `/details/` path, which produces broken links when `internal_cluster_id` is empty or malformed
- Changed to use `subscription_id` with the `/details/s/` path, consistent with every other URL in the same template

## Test plan
- [ ] Verify the OSD trial creation email renders the correct "Upgrade from trial" URL using `subscription_id`
- [ ] Verify the OSD trial reminder email renders the correct "Upgrade from trial" URL using `subscription_id`
- [ ] Confirm other template cases (deletion, approved-access, default) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OpenShift Cluster Manager links in trial creation and reminder emails so they direct recipients to the correct subscription page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->