### PR TITLE
RHCLOUD-49579: Map Severity.UNDEFINED to null instead of throwing

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/models/dto/v2/subscriptions/SubscriptionMapper.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/models/dto/v2/subscriptions/SubscriptionMapper.java
@@ -9,16 +9,18 @@ import org.mapstruct.MappingConstants;
 import org.mapstruct.ValueMapping;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.CDI)
 public interface SubscriptionMapper {
 
-    // ANY_REMAINING keeps normal by-name matching for every constant that has a SeverityDTO
-    // counterpart, and only catches the ones that don't (currently just UNDEFINED, which is
-    // slated for removal from Severity) without naming it explicitly, so this needs no
-    // follow-up change once that removal happens.
+    // UNDEFINED means "no severity was provided" and has no SeverityDTO counterpart, so it's
+    // mapped to null and filtered out wherever this mapping is used instead of being surfaced by
+    // the API. ANY_REMAINING keeps normal by-name matching for every other constant, and throws
+    // if a future Severity value is added without a matching SeverityDTO counterpart.
+    @ValueMapping(source = "UNDEFINED", target = MappingConstants.NULL)
     @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.THROW_EXCEPTION)
     SeverityDTO severityToSeverityDTO(Severity severity);
 
@@ -45,6 +47,7 @@ public interface SubscriptionMapper {
         return severities.stream()
             .sorted()
             .map(this::severityToSeverityDTO)
+            .filter(Objects::nonNull)
             .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/userconfig/UserConfigResourceV2.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/userconfig/UserConfigResourceV2.java
@@ -50,6 +50,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -235,6 +236,7 @@ public class UserConfigResourceV2 {
                 .map(Map.Entry::getKey)
                 .sorted()
                 .map(subscriptionMapper::severityToSeverityDTO)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
             channel.setSubscribedSeverities(subscribedSeverities);
         }

--- a/backend/src/test/java/com/redhat/cloud/notifications/models/dto/v2/subscriptions/SubscriptionMapperTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/models/dto/v2/subscriptions/SubscriptionMapperTest.java
@@ -7,7 +7,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @QuarkusTest
 class SubscriptionMapperTest {
@@ -33,10 +33,10 @@ class SubscriptionMapperTest {
     }
 
     @Test
-    void shouldThrowWhenMappingASeverityWithNoDTOCounterpart() {
+    void shouldMapUndefinedSeverityToNull() {
         // Severity.UNDEFINED has no SeverityDTO counterpart and must never be surfaced by this API;
-        // the ANY_REMAINING/THROW_EXCEPTION value mapping on severityToSeverityDTO() is what enforces that.
-        assertThrows(IllegalArgumentException.class, () -> subscriptionMapper.severityToSeverityDTO(Severity.UNDEFINED));
+        // callers filter out the null this returns instead of exposing it.
+        assertNull(subscriptionMapper.severityToSeverityDTO(Severity.UNDEFINED));
     }
 
     @Test

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/userconfig/UserConfigResourceV2Test.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/userconfig/UserConfigResourceV2Test.java
@@ -12,9 +12,11 @@ import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
+import com.redhat.cloud.notifications.db.repositories.SubscriptionRepository;
 import com.redhat.cloud.notifications.models.Application;
 import com.redhat.cloud.notifications.models.Bundle;
 import com.redhat.cloud.notifications.models.EventType;
+import com.redhat.cloud.notifications.models.SubscriptionType;
 import com.redhat.cloud.notifications.models.dto.v2.subscriptions.ApplicationSubscriptionUpdateDTO;
 import com.redhat.cloud.notifications.models.dto.v2.subscriptions.BundleSubscriptionDTO;
 import com.redhat.cloud.notifications.models.dto.v2.subscriptions.BundleSubscriptionUpdateDTO;
@@ -64,6 +66,9 @@ public class UserConfigResourceV2Test extends DbIsolatedTest {
 
     @Inject
     ApplicationRepository applicationRepository;
+
+    @Inject
+    SubscriptionRepository subscriptionRepository;
 
     @InjectMock
     BackendConfig backendConfig;
@@ -165,6 +170,29 @@ public class UserConfigResourceV2Test extends DbIsolatedTest {
         assertChannelSeverities(subscribedByDefault.getSubscriptions(), SubscriptionTypeDTO.INSTANT, allSeverities);
         assertChannelSeverities(subscribedByDefault.getSubscriptions(), SubscriptionTypeDTO.DAILY, allSeverities);
         assertChannelSeverities(subscribedByDefault.getSubscriptions(), SubscriptionTypeDTO.DRAWER, allSeverities);
+    }
+
+    @Test
+    void testGetSubscriptionsExcludesUndefinedSeverity() {
+        // Severity.UNDEFINED has no SeverityDTO counterpart. It can end up in an event type's
+        // available severities, or in a stored subscription's severities map (e.g. legacy data),
+        // even though the write side of this API can never produce it. The GET side must ignore
+        // it rather than fail the whole request.
+        Bundle bundle = resourceHelpers.createBundle("bundle-undefined", "Bundle Undefined");
+        Application application = resourceHelpers.createApplication(bundle.getId(), "app-a", "App A");
+        EventType eventType = createEventType(application.getId(), "event-a",
+            Set.of(Severity.CRITICAL, Severity.UNDEFINED), false);
+
+        Map<Severity, Boolean> severities = new HashMap<>();
+        severities.put(Severity.CRITICAL, true);
+        severities.put(Severity.UNDEFINED, true);
+        subscriptionRepository.updateSubscription(DEFAULT_ORG_ID, DEFAULT_USER, eventType.getId(), SubscriptionType.INSTANT, true, severities);
+
+        List<BundleSubscriptionDTO> tree = getSubscriptions("bundle-undefined", "app-a", "event-a");
+
+        var eventTypeDTO = tree.get(0).getApplications().get(0).getEventTypes().get(0);
+        assertEquals(List.of(SeverityDTO.CRITICAL), eventTypeDTO.getAvailableSeverities());
+        assertChannelSeverities(eventTypeDTO.getSubscriptions(), SubscriptionTypeDTO.INSTANT, List.of(SeverityDTO.CRITICAL));
     }
 
     private void assertChannelSeverities(List<SubscriptionChannelDTO> channels, SubscriptionTypeDTO type, List<SeverityDTO> expected) {


### PR DESCRIPTION
## Jira

https://redhat.atlassian.net/browse/RHCLOUD-49579

## Summary

The v2 subscriptions read path (`GET` subscriptions tree) could hit `Severity.UNDEFINED` when building the available and subscribed severities for an event type — either because an event type's severity set includes it, or because a stored subscription's severities map contains it (e.g. legacy data). `Severity.UNDEFINED` has no `SeverityDTO` counterpart, so `SubscriptionMapper#severityToSeverityDTO` was configured to throw via `ANY_REMAINING`/`THROW_EXCEPTION`, which failed the entire GET request instead of just omitting that value.

This PR changes the mapping so `UNDEFINED` maps to `null`, and filters the null out at both call sites (`SubscriptionMapper#severitySetToSeverityDTOList` and `UserConfigResourceV2`) so it's silently excluded rather than surfaced or fatal.

## Changes

- `SubscriptionMapper`: map `Severity.UNDEFINED` to `null` explicitly instead of relying on `ANY_REMAINING` to throw; filter nulls out of `severitySetToSeverityDTOList`.
- `UserConfigResourceV2`: filter nulls out of the subscribed-severities stream when building the response.
- Updated `SubscriptionMapperTest` to assert `UNDEFINED` maps to `null` instead of throwing.
- Added `UserConfigResourceV2Test#testGetSubscriptionsExcludesUndefinedSeverity` covering an event type with `UNDEFINED` in its available severities and a stored subscription containing `UNDEFINED`, verifying the GET response excludes it from both available and subscribed severities.

## Test plan

- [x] `./mvnw clean verify -pl :notifications-backend -am --no-transfer-progress`
- [x] New/updated unit tests pass (`SubscriptionMapperTest`, `UserConfigResourceV2Test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription responses now safely ignore undefined severity values.
  * Event-type availability and saved subscription data display only supported severities.
  * Prevented errors when undefined severity values are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->