### PR TITLE
RHCLOUD-49573: Add dedicated email sender for Lightwell events

### DIFF
--- a/.rhcicd/clowdapp-engine.yaml
+++ b/.rhcicd/clowdapp-engine.yaml
@@ -127,6 +127,8 @@ objects:
           value: ${NOTIFICATIONS_EMAILS_ONLY_MODE_ENABLED}
         - name: NOTIFICATIONS_EMAIL_SENDER_HYBRID_CLOUD_CONSOLE
           value: ${NOTIFICATIONS_EMAIL_SENDER_HYBRID_CLOUD_CONSOLE}
+        - name: NOTIFICATIONS_EMAIL_SENDER_LIGHTWELL
+          value: ${NOTIFICATIONS_EMAIL_SENDER_LIGHTWELL}
         - name: NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE
           value: ${NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE}
         - name: NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD
@@ -358,6 +360,9 @@ parameters:
 - name: NOTIFICATIONS_EMAIL_SENDER_HYBRID_CLOUD_CONSOLE
   description: The email sender address for the Red Hat Hybrid Cloud Console.
   value: "\"Red Hat Hybrid Cloud Console\" noreply@redhat.com"
+- name: NOTIFICATIONS_EMAIL_SENDER_LIGHTWELL
+  description: The email sender address for the Lightwell application.
+  value: "\"Lightwell\" noreply@redhat.com"
 - name: NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE
   description: The email sender address for the OpenShift domain in stage.
   value: "\"Red Hat OpenShift (staging)\" noreply@redhat.com"

--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -42,9 +42,11 @@ public class EngineConfig {
     private static final String RH_HCC_SENDER = "\"Red Hat Hybrid Cloud Console\" noreply@redhat.com";
     private static final String OPENSHIFT_SENDER_STAGE_NOREPLY_REDHAT = "\"Red Hat OpenShift (staging)\" noreply@redhat.com";
     private static final String OPENSHIFT_SENDER_PROD_NOREPLY_REDHAT = "\"Red Hat OpenShift\" noreply@redhat.com";
+    private static final String LIGHTWELL_SENDER_NOREPLY_REDHAT = "\"Lightwell\" noreply@redhat.com";
     private static final String NOTIFICATIONS_EMAIL_SENDER_HYBRID_CLOUD_CONSOLE = "notifications.email.sender.hybrid.cloud.console";
     private static final String NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE = "notifications.email.sender.openshift.stage";
     private static final String NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD = "notifications.email.sender.openshift.prod";
+    private static final String NOTIFICATIONS_EMAIL_SENDER_LIGHTWELL = "notifications.email.sender.lightwell";
     private static final String NOTIFICATIONS_INGRESSREPLAY_START_TIME = "notifications.ingressreplay.start.time";
     private static final String NOTIFICATIONS_INGRESSREPLAY_END_TIME = "notifications.ingressreplay.end.time";
     private static final String EVENTS_EXPORT_PAGE_SIZE = "notifications.events.export.page-size";
@@ -118,6 +120,12 @@ public class EngineConfig {
     String rhHccSender;
 
     /**
+     * The email sender address for Lightwell
+     */
+    @ConfigProperty(name = NOTIFICATIONS_EMAIL_SENDER_LIGHTWELL, defaultValue = LIGHTWELL_SENDER_NOREPLY_REDHAT)
+    String rhLightwellSender;
+
+    /**
      * The email sender address for OpenShift in stage.
      */
     @ConfigProperty(name = NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE, defaultValue = OPENSHIFT_SENDER_STAGE_NOREPLY_REDHAT)
@@ -188,6 +196,7 @@ public class EngineConfig {
         config.put(NOTIFICATIONS_EMAIL_SENDER_HYBRID_CLOUD_CONSOLE, rhHccSender);
         config.put(NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_STAGE, rhOpenshiftSenderStage);
         config.put(NOTIFICATIONS_EMAIL_SENDER_OPENSHIFT_PROD, rhOpenshiftSenderProd);
+        config.put(NOTIFICATIONS_EMAIL_SENDER_LIGHTWELL, rhLightwellSender);
         config.put(NOTIFICATIONS_INGRESSREPLAY_START_TIME, replayStartTime);
         config.put(NOTIFICATIONS_INGRESSREPLAY_END_TIME, replayEndTime);
         config.put(toggleKafkaOutgoingHighVolumeTopic, isOutgoingKafkaHighVolumeTopicEnabled());
@@ -347,5 +356,9 @@ public class EngineConfig {
 
     public int getEventsExportPageSize() {
         return eventsExportPageSize;
+    }
+
+    public String getLightwellSender() {
+        return rhLightwellSender;
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolver.java
@@ -24,7 +24,11 @@ public class EmailActorsResolver {
      */
     public String getEmailSender(final Event event) {
         try {
-            if (isOCMApp(event)) {
+            final String bundle = event.getEventType().getApplication().getBundle().getName();
+            final String application = event.getEventType().getApplication().getName();
+            if (isLightwellApp(bundle, application)) {
+                return engineConfig.getLightwellSender();
+            } else if (isOCMApp(bundle, application)) {
                 return getOCMEmailSender(event);
             }
         } catch (Exception e) {
@@ -41,9 +45,11 @@ public class EmailActorsResolver {
         }
     }
 
-    public static boolean isOCMApp(Event event) {
-        String bundle = event.getEventType().getApplication().getBundle().getName();
-        String application = event.getEventType().getApplication().getName();
+    public static boolean isOCMApp(final String bundle, final String application) {
         return "openshift".equals(bundle) && "cluster-manager".equals(application);
+    }
+
+    public static boolean isLightwellApp(final String bundle, final String application) {
+        return "lightwell".equals(bundle) && "lightwell".equals(application);
     }
 }

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailPendoResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailPendoResolver.java
@@ -37,6 +37,8 @@ public class EmailPendoResolver {
 
     private boolean isPendoMessageEnabled(final Event event, boolean forcedEmail) {
         // pendo message must not be shown on OCM and environment with emails only mode
-        return !EmailActorsResolver.isOCMApp(event) && !engineConfig.isEmailsOnlyModeEnabled() && !forcedEmail;
+        final String bundle = event.getEventType().getApplication().getBundle().getName();
+        final String application = event.getEventType().getApplication().getName();
+        return !EmailActorsResolver.isOCMApp(bundle, application) && !engineConfig.isEmailsOnlyModeEnabled() && !forcedEmail;
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolverTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailActorsResolverTest.java
@@ -47,6 +47,15 @@ class EmailActorsResolverTest {
         assertEquals(engineConfig.getRhOpenshiftSenderProd(), emailActorsResolver.getEmailSender(event), "unexpected email sender returned from the function under test");
     }
 
+    /**
+     * Tests that the Lightwell sender is returned for Lightwell events.
+     */
+    @Test
+    void testLightwellEmailSender() {
+        Event event = buildEvent(null, "lightwell", "lightwell");
+        assertEquals(engineConfig.getLightwellSender(), emailActorsResolver.getEmailSender(event), "unexpected email sender returned from the function under test");
+    }
+
     private static Event buildEvent(String sourceEnvironment, String bundleName, String appName) {
 
         Bundle bundle = new Bundle();

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailPendoResolverTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailPendoResolverTest.java
@@ -75,6 +75,17 @@ class EmailPendoResolverTest {
         assertNull(emailPendoResolver.getPendoEmailMessage(event, ignoreUserPreferences, false), "unexpected email pendo message returned from the function under test");
     }
 
+    /**
+     * Tests that the pendo message is still shown for Lightwell events (only OCM is excluded).
+     */
+    @Test
+    void testLightwellPendoMessage() {
+        Event event = buildEvent(null, "lightwell", "lightwell");
+        assertEquals(String.format(GENERAL_PENDO_MESSAGE, environment.url(), environment.url()), emailPendoResolver.getPendoEmailMessage(event, false, false).getPendoMessage(), "unexpected email pendo message returned from the function under test");
+        assertEquals(GENERAL_PENDO_TITLE, emailPendoResolver.getPendoEmailMessage(event, false, false).getPendoTitle(), "unexpected email pendo title returned from the function under test");
+        assertNull(emailPendoResolver.getPendoEmailMessage(event, true, false), "current pendo message should not be generated in case of forced email (ignoreUserPreferences)");
+    }
+
     private static Event buildEvent(String sourceEnvironment, String bundleName, String appName) {
 
         Bundle bundle = new Bundle();


### PR DESCRIPTION
## Summary
- Add a configurable `NOTIFICATIONS_EMAIL_SENDER_LIGHTWELL` sender address, defaulting to `"Lightwell" noreply@redhat.com`
- Return that sender for events from the `lightwell`/`lightwell` bundle/application, alongside the existing OCM sender resolution
- Wire the new env var through `.rhcicd/clowdapp-engine.yaml`
- Add unit test coverage for the new Lightwell sender resolution and pendo message behavior

Jira: https://redhat.atlassian.net/browse/RHCLOUD-49573

## Test plan
- [x] `./mvnw validate -pl :notifications-engine --no-transfer-progress` (checkstyle)
- [x] `./mvnw test -pl :notifications-engine -Dtest=EmailActorsResolverTest,EmailPendoResolverTest --no-transfer-progress` (12/12 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Lightwell email sender configuration.
  * Lightwell notifications now use the configured sender address.
  * Lightwell events receive the appropriate general Pendo message and title.

* **Bug Fixes**
  * Preserved forced-email behavior while improving Lightwell notification handling.

* **Tests**
  * Added coverage validating Lightwell sender resolution and message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->