### PR TITLE
RHCLOUD-49576: Add Lightwell instant email template for java-remediated

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/TemplateService.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/TemplateService.java
@@ -7,6 +7,7 @@ import com.redhat.cloud.notifications.qute.templates.mapping.AnsibleAutomationPl
 import com.redhat.cloud.notifications.qute.templates.mapping.Console;
 import com.redhat.cloud.notifications.qute.templates.mapping.DefaultInstantEmailTemplates;
 import com.redhat.cloud.notifications.qute.templates.mapping.DefaultTemplates;
+import com.redhat.cloud.notifications.qute.templates.mapping.Lightwell;
 import com.redhat.cloud.notifications.qute.templates.mapping.OpenShift;
 import com.redhat.cloud.notifications.qute.templates.mapping.Rhel;
 import com.redhat.cloud.notifications.qute.templates.mapping.SecureEmailTemplates;
@@ -64,6 +65,7 @@ public class TemplateService {
             templatesConfigMap.putAll(DefaultTemplates.templatesMap);
             templatesConfigMap.putAll(AnsibleAutomationPlatform.templatesMap);
             templatesConfigMap.putAll(Console.templatesMap);
+            templatesConfigMap.putAll(Lightwell.templatesMap);
             templatesConfigMap.putAll(OpenShift.templatesMap);
             templatesConfigMap.putAll(Rhel.templatesMap);
             templatesConfigMap.putAll(SubscriptionServices.templatesMap);

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Lightwell.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Lightwell.java
@@ -1,0 +1,22 @@
+package com.redhat.cloud.notifications.qute.templates.mapping;
+
+import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
+
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_BODY;
+import static java.util.Map.entry;
+
+public class Lightwell {
+    public static final String BUNDLE_NAME = "lightwell";
+
+    public static final String LIGHTWELL_APP_NAME = "lightwell";
+    static final String LIGHTWELL_FOLDER_NAME = "Lightwell/";
+
+    public static final String LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE = "java_remediated";
+
+    public static final Map<TemplateDefinition, String> templatesMap = Map.ofEntries(
+
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, LIGHTWELL_APP_NAME, null), LIGHTWELL_FOLDER_NAME + "lightwellDefaultEmailBody.html")
+    );
+}

--- a/common-template/src/main/resources/templates/email/Common/insightsEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Common/insightsEmailBody.html
@@ -46,12 +46,14 @@
                                         {/}
                                     </td>
                                 </tr>
-                                <tr>
-                                    <td style="color: rgb(0, 0, 0); padding-bottom: 0; padding-top: 22px; text-align: center;">
-                                        <h2 id="app-title" style="font-size: 20px; font-weight: 500; line-height: 20px; margin-top: 0; margin-bottom: 10px">{#insert content-header-title}{/}</h2>
-                                        <h3 style="font-size: 14px; font-weight: 500; line-height: 14px; margin-bottom: 0; margin-top: 0;">(Org ID: {action.orgId})</h3>
-                                    </td>
-                                </tr>
+                                {#if renderHeaderTitle.or(true)}
+                                    <tr>
+                                        <td style="color: rgb(0, 0, 0); padding-bottom: 0; padding-top: 22px; text-align: center;">
+                                            <h2 id="app-title" style="font-size: 20px; font-weight: 500; line-height: 20px; margin-top: 0; margin-bottom: 10px">{#insert content-header-title}{/}</h2>
+                                            <h3 style="font-size: 14px; font-weight: 500; line-height: 14px; margin-bottom: 0; margin-top: 0;">(Org ID: {action.orgId})</h3>
+                                        </td>
+                                    </tr>
+                                {/if}
                             </table>
                         </td>
                     </tr>
@@ -192,12 +194,14 @@
                             <table border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td style="color: rgb(255, 255, 255); font-size: 14px; font-weight: 400; text-align: center;">
+                                        {#insert content-footer}
                                         {#if ignore_user_preferences??}
                                             This email was sent by Red Hat Hybrid Cloud Console, it is critical or requires action.<br/>
                                             Therefore, you are receiving this message regardless of your email preferences.
                                         {#else}
                                             This email was sent by Red Hat Hybrid Cloud Console | <a href="{environment.url}/user-preferences/notifications/notifications?bundle={action.bundle.or("")}&app={action.application.or("")}" target="_blank" style="color: rgb(31, 167, 248); font-size: 14px; font-weight: 400; text-align: center; text-decoration-color: rgb(31, 167, 248); text-decoration-line: none; text-decoration-style: solid;">Manage email preferences</a>
                                         {/if}
+                                        {/}
                                     </td>
                                 </tr>
                             </table>

--- a/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
@@ -1,0 +1,82 @@
+{@boolean renderTitleRightPart=true}
+{@boolean renderHeaderTitle=false}
+{@String renderLowTag='<table cellspacing="0" cellpadding="0" style="border-radius: 999px; border-color: #5e40be; border-width: 1px; border-style: solid; background-color: #ffffff; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/minor-purple.png" height="10px" style="margin-right: 4px;">Low</td></tr></table>'}
+{@String renderModerateTag='<table cellspacing="0" cellpadding="0" style="border-radius: 999px; border-color: #dba614; border-width: 1px; border-style: solid; background-color: #ffffff; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/moderate.png" height="10px" style="margin-right: 4px;">Moderate</td></tr></table>'}
+{@String renderImportantTag='<table cellspacing="0" cellpadding="0" style="border-radius: 999px; background-color: #ffcd17; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400;"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/important-black.png" height="10px" style="margin-right: 4px;">Important</td></tr></table>'}
+{@String renderCriticalTag='<table cellspacing="0" cellpadding="0" style="border-radius: 999px; background-color: #b0370b; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400; color: #ffffff;"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/critical-white.png" height="10px" style="margin-right: 4px;">Critical</td></tr></table>'}
+{#include email/Common/insightsEmailBody}
+{#content-header-logo}
+    <a href="https://console.redhat.com/lightwell" target="_blank">
+        <img src="https://console.redhat.com/apps/frontend-assets/email-assets/Logo_lightwell_dark.png" alt="Lightwell logo" width="340" />
+    </a>
+{/content-header-logo}
+{#content-title}
+    New Package{#if action.events.size() > 1}s{/if} Available for {source.event_type.display_name}
+{/content-title}
+{#content-title-right-part}
+    <a style="{title-right-part-link-style}" href="https://console.redhat.com/lightwell" target="_blank">{action.events.size()}</a>
+{/content-title-right-part}
+{#content-body}
+<p style="{body-section-p-style}">
+    {#if action.events.size() > 1}
+    These following packages were fixed by Lightwell in the {source.event_type.display_name} and are available for your access.
+    {#else}
+    The following package was fixed by Lightwell in the {source.event_type.display_name} and is available for your access.
+    {/if}
+</p>
+<table style="{body-section-table-style}">
+    <thead>
+    <tr>
+        <th style="{body-section-table-th-style}">Package{#if action.events.size() > 1}s{/if}</th>
+        <th style="{body-section-table-th-style} min-width: 90px;">Release</th>
+        <th style="{body-section-table-th-style}" colspan="2">Related CVE(s)</th>
+    </tr>
+    </thead>
+    <tbody style="{body-section-table-tbody-style}">
+        {#each action.events}
+            {#each it.payload.releases}
+            <tr>
+                <td style="{body-section-table-td-style}{#if !it_isLast}; border-bottom-width: 0 !important;{/if}">
+
+                    {#if it_isFirst}
+                        <a style="{body-section-table-td-a-style}" href="{it.meta.package_link}" target="_blank">{it.meta.package_name}</a>
+                    {/if}
+                </td>
+                <td style="{body-section-table-td-style}{#if !it_isLast}; border-bottom-width: 0 !important;{/if}">
+                {#each it.release_names}
+                    {it.name}{#if it_hasNext}<br>{/if}
+                {/each}
+                </td>
+                <td style="{body-section-table-td-style}{#if !it_isLast}; border-bottom-width: 0 !important;{/if}">
+                <table>
+                {#each it.related_cve}
+                    <tr>
+                    <td><a style="{body-section-table-td-a-style}" href="{it.url}" target="_blank">{it.cve}</a></td>
+                    <td style="min-width: 90px">{#switch it.payload.total_risk}
+                        {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                        {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                        {#case 'important'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                        {#case 'critical'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {/switch}
+                    </td>
+                    </tr>
+                {/each}
+                </table>
+                </td>
+            </tr>
+            {/each}
+        {/each}
+    </tbody>
+</table>
+{/content-body}
+{#content-footer}
+    {#if ignore_user_preferences??}
+        This email was sent by Lightwell, it is critical or requires action.<br/>
+        Therefore, you are receiving this message regardless of your email preferences.
+    {#else}
+        This email was sent by Lightwell | <a href="https://console.redhat.com/lightwell" target="_blank" style="color: rgb(31, 167, 248); font-size: 14px; font-weight: 400; text-align: center; text-decoration-color: rgb(31, 167, 248); text-decoration-line: none; text-decoration-style: solid;">Manage email preferences</a>
+    {/if}
+{/content-footer}
+{#content-button-href}https://console.redhat.com/lightwell{/content-button-href}
+{#content-button-service-name}Lightwell{/content-button-service-name}
+{/include}

--- a/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
@@ -17,8 +17,9 @@
     <a style="{title-right-part-link-style}" href="https://console.redhat.com/lightwell" target="_blank">{action.events.size()}</a>
 {/content-title-right-part}
 {#content-body}
+{#let eventsCount=action.events.size()}
 <p style="{body-section-p-style}">
-    {#if action.events.size() > 1}
+    {#if eventsCount > 1}
     These following packages were fixed by Lightwell in the {source.event_type.display_name} and are available for your access.
     {#else}
     The following package was fixed by Lightwell in the {source.event_type.display_name} and is available for your access.
@@ -27,7 +28,7 @@
 <table style="{body-section-table-style}">
     <thead>
     <tr>
-        <th style="{body-section-table-th-style}">Package{#if action.events.size() > 1}s{/if}</th>
+        <th style="{body-section-table-th-style}">Package{#if eventsCount > 1}s{/if}</th>
         <th style="{body-section-table-th-style} min-width: 90px;">Release</th>
         <th style="{body-section-table-th-style}" colspan="2">Related CVE(s)</th>
     </tr>
@@ -52,7 +53,8 @@
                 {#each it.related_cve}
                     <tr>
                     <td><a style="{body-section-table-td-a-style}" href="{it.url}" target="_blank">{it.cve}</a></td>
-                    <td style="min-width: 90px">{#switch it.payload.total_risk}
+                    <td style="min-width: 90px">
+                    {#switch it.severity}
                         {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
                         {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
                         {#case 'important'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
@@ -68,6 +70,7 @@
         {/each}
     </tbody>
 </table>
+{/let}
 {/content-body}
 {#content-footer}
     {#if ignore_user_preferences??}

--- a/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
@@ -34,27 +34,27 @@
     </tr>
     </thead>
     <tbody style="{body-section-table-tbody-style}">
-        {#each action.events}
-            {#each it.payload.releases}
+        {#for event in action.events}
+            {#for release in event.payload.releases}
             <tr>
-                <td style="{body-section-table-td-style}{#if !it_isLast}; border-bottom-width: 0 !important;{/if}">
+                <td style="{body-section-table-td-style}{#if !release_isLast}; border-bottom-width: 0 !important;{/if}">
 
-                    {#if it_isFirst}
-                        <a style="{body-section-table-td-a-style}" href="{it.meta.package_link}" target="_blank">{it.meta.package_name}</a>
+                    {#if release_isFirst}
+                        <a style="{body-section-table-td-a-style}" href="{event.payload.package_link}" target="_blank">{event.payload.package_name}</a>
                     {/if}
                 </td>
-                <td style="{body-section-table-td-style}{#if !it_isLast}; border-bottom-width: 0 !important;{/if}">
-                {#each it.release_names}
-                    {it.name}{#if it_hasNext}<br>{/if}
-                {/each}
+                <td style="{body-section-table-td-style}{#if !release_isLast}; border-bottom-width: 0 !important;{/if}">
+                {#for releaseName in release.release_names}
+                    {releaseName.name}{#if releaseName_hasNext}<br>{/if}
+                {/for}
                 </td>
-                <td style="{body-section-table-td-style}{#if !it_isLast}; border-bottom-width: 0 !important;{/if}">
+                <td style="{body-section-table-td-style}{#if !release_isLast}; border-bottom-width: 0 !important;{/if}">
                 <table>
-                {#each it.related_cve}
+                {#for cve in release.related_cve}
                     <tr>
-                    <td><a style="{body-section-table-td-a-style}" href="{it.url}" target="_blank">{it.cve}</a></td>
+                    <td><a style="{body-section-table-td-a-style}" href="{cve.url}" target="_blank">{cve.cve}</a></td>
                     <td style="min-width: 90px">
-                    {#switch it.severity}
+                    {#switch cve.severity}
                         {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
                         {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
                         {#case 'important'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
@@ -62,12 +62,12 @@
                     {/switch}
                     </td>
                     </tr>
-                {/each}
+                {/for}
                 </table>
                 </td>
             </tr>
-            {/each}
-        {/each}
+            {/for}
+        {/for}
     </tbody>
 </table>
 {/let}

--- a/common-template/src/main/resources/templates/email/Secure/Common/insightsEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/Common/insightsEmailBody.html
@@ -47,12 +47,14 @@
                                         {/}
                                     </td>
                                 </tr>
-                                <tr>
-                                    <td style="color: rgb(0, 0, 0); padding-bottom: 0; padding-top: 22px; text-align: center;">
-                                        <h2 id="app-title" style="font-size: 20px; font-weight: 500; line-height: 20px; margin-top: 0; margin-bottom: 10px">{#insert content-header-title}{/}</h2>
-                                        <h3 style="font-size: 14px; font-weight: 500; line-height: 14px; margin-bottom: 0; margin-top: 0;">(Org ID: {action.orgId})</h3>
-                                    </td>
-                                </tr>
+                                {#if renderHeaderTitle.or(true)}
+                                    <tr>
+                                        <td style="color: rgb(0, 0, 0); padding-bottom: 0; padding-top: 22px; text-align: center;">
+                                            <h2 id="app-title" style="font-size: 20px; font-weight: 500; line-height: 20px; margin-top: 0; margin-bottom: 10px">{#insert content-header-title}{/}</h2>
+                                            <h3 style="font-size: 14px; font-weight: 500; line-height: 14px; margin-bottom: 0; margin-top: 0;">(Org ID: {action.orgId})</h3>
+                                        </td>
+                                    </tr>
+                                {/if}
                             </table>
                         </td>
                     </tr>
@@ -191,12 +193,14 @@
                             <table border="0" align="center" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td style="color: rgb(255, 255, 255); font-size: 14px; font-weight: 400; text-align: center;">
+                                        {#insert content-footer}
                                         {#if ignore_user_preferences??}
                                             This email was sent by Red Hat Hybrid Cloud Console, it is critical or requires action.<br/>
                                             Therefore, you are receiving this message regardless of your email preferences.
                                         {#else}
                                             This email was sent by Red Hat Hybrid Cloud Console | <a href="{environment.url}/user-preferences/notifications/notifications?bundle={action.bundle.or("")}&app={action.application.or("")}" target="_blank" style="color: rgb(31, 167, 248); font-size: 14px; font-weight: 400; text-align: center; text-decoration-color: rgb(31, 167, 248); text-decoration-line: none; text-decoration-style: solid;">Manage email preferences</a>
                                         {/if}
+                                        {/}
                                     </td>
                                 </tr>
                             </table>

--- a/common-template/src/test/java/email/TestLightwellTemplate.java
+++ b/common-template/src/test/java/email/TestLightwellTemplate.java
@@ -96,7 +96,7 @@ public class TestLightwellTemplate extends EmailTemplatesRendererHelper {
     @Test
     public void testJavaRemediatedEmailBodySingleEvent() {
         Action action = createLightwellActionWithReleases(List.of(
-            buildRelease("org.glassfish.jaxb:codemodel", List.of("4.0.4.rhlw003"), List.of(
+            buildRelease(List.of("4.0.4.rhlw003"), List.of(
                 buildCve("CVE-2026-1234", "critical")
             ))
         ));
@@ -113,7 +113,7 @@ public class TestLightwellTemplate extends EmailTemplatesRendererHelper {
     @Test
     public void testJavaRemediatedEmailBodyAllSeverityLevels() {
         Action action = createLightwellActionWithReleases(List.of(
-            buildRelease("org.glassfish.jaxb:codemodel", List.of("4.0.4.rhlw003"), List.of(
+            buildRelease(List.of("4.0.4.rhlw003"), List.of(
                 buildCve("CVE-2026-1001", "low"),
                 buildCve("CVE-2026-1002", "moderate"),
                 buildCve("CVE-2026-1003", "important"),
@@ -176,61 +176,61 @@ public class TestLightwellTemplate extends EmailTemplatesRendererHelper {
         action.setContext(new Context.ContextBuilder().build());
         action.setEvents(List.of(
             buildPackageEvent("org.glassfish.jaxb:codemodel", List.of(
-                buildRelease("org.glassfish.jaxb:codemodel", List.of("4.0.4.rhlw003", "4.0.4.rhlw004"), List.of(
+                buildRelease(List.of("4.0.4.rhlw003", "4.0.4.rhlw004"), List.of(
                     buildCve("CVE-2026-1234", "critical"),
                     buildCve("CVE-2026-5678", "critical"),
                     buildCve("CVE-2026-9999", "critical")
                 )),
-                buildRelease("org.glassfish.jaxb:codemodel", List.of("5.0.0.rhlw001"), List.of(
+                buildRelease(List.of("5.0.0.rhlw001"), List.of(
                     buildCve("CVE-2026-1234", "critical"),
                     buildCve("CVE-2026-5678", "critical"),
                     buildCve("CVE-2026-9999", "critical")
                 )),
-                buildRelease("org.glassfish.jaxb:codemodel", List.of("5.5.5.rhlw001"), List.of(
+                buildRelease(List.of("5.5.5.rhlw001"), List.of(
                     buildCve("CVE-2026-1234", "critical"),
                     buildCve("CVE-2026-5678", "critical"),
                     buildCve("CVE-2026-9999", "critical")
                 ))
             )),
             buildPackageEvent("org.glassfish.jaxb:jaxb-core", List.of(
-                buildRelease("org.glassfish.jaxb:jaxb-core", List.of("4.0.4.rhlw003"), List.of(
+                buildRelease(List.of("4.0.4.rhlw003"), List.of(
                     buildCve("CVE-2026-1111", "important"),
                     buildCve("CVE-2026-2222", "important"),
                     buildCve("CVE-2026-9999", "critical")
                 ))
             )),
             buildPackageEvent("org.glassfish.jaxb:jaxb-jxc", List.of(
-                buildRelease("org.glassfish.jaxb:jaxb-jxc", List.of("4.0.4.rhlw003"), List.of(
+                buildRelease(List.of("4.0.4.rhlw003"), List.of(
                     buildCve("CVE-2026-2222", "important")
                 ))
             )),
             buildPackageEvent("org.glassfish.jaxb:jaxb-runtime", List.of(
-                buildRelease("org.glassfish.jaxb:jaxb-runtime", List.of("4.0.4.rhlw003"), List.of(
+                buildRelease(List.of("4.0.4.rhlw003"), List.of(
                     buildCve("CVE-2026-3333", "important")
                 ))
             )),
             buildPackageEvent("org.glassfish.jaxb:jaxb-xjc", List.of(
-                buildRelease("org.glassfish.jaxb:jaxb-xjc", List.of("4.1.0.rhlw001"), List.of(
+                buildRelease(List.of("4.1.0.rhlw001"), List.of(
                     buildCve("CVE-2026-4242", "important")
                 ))
             )),
             buildPackageEvent("org.glassfish.jaxb:txw2", List.of(
-                buildRelease("org.glassfish.jaxb:txw2", List.of("4.1.0.rhlw001"), List.of(
+                buildRelease(List.of("4.1.0.rhlw001"), List.of(
                     buildCve("CVE-2026-4242", "important")
                 ))
             )),
             buildPackageEvent("org.glassfish.jaxb:txwc2", List.of(
-                buildRelease("org.glassfish.jaxb:txwc2", List.of("4.1.0.rhlw001"), List.of(
+                buildRelease(List.of("4.1.0.rhlw001"), List.of(
                     buildCve("CVE-2026-4242", "important")
                 ))
             )),
             buildPackageEvent("org.glassfish.jaxb:xsom", List.of(
-                buildRelease("org.glassfish.jaxb:xsom", List.of("4.0.4.rhlw003"), List.of(
+                buildRelease(List.of("4.0.4.rhlw003"), List.of(
                     buildCve("CVE-2026-0909", "critical")
                 ))
             )),
             buildPackageEvent("org.json:json", List.of(
-                buildRelease("org.json:json", List.of("20220320.0.0.rhlw-00002", "20220320.0.0.rhlw-00001"), List.of(
+                buildRelease(List.of("20220320.0.0.rhlw-00002", "20220320.0.0.rhlw-00001"), List.of(
                     buildCve("CVE-2026-0909", "critical")
                 ))
             ))
@@ -244,18 +244,15 @@ public class TestLightwellTemplate extends EmailTemplatesRendererHelper {
             .withPayload(
                 new Payload.PayloadBuilder()
                     .withAdditionalProperty("package_name", packageName)
+                    .withAdditionalProperty("package_link", "https://console.redhat.com/lightwell/packages/" + packageName)
                     .withAdditionalProperty("releases", releases)
                     .build()
             )
             .build();
     }
 
-    private static Map<String, Object> buildRelease(String packageName, List<String> releaseNames, List<Map<String, Object>> relatedCves) {
+    private static Map<String, Object> buildRelease(List<String> releaseNames, List<Map<String, Object>> relatedCves) {
         return Map.of(
-            "meta", Map.of(
-                "package_name", packageName,
-                "package_link", "https://console.redhat.com/lightwell/packages/" + packageName
-            ),
             "release_names", releaseNames.stream().map(name -> Map.of("name", (Object) name)).toList(),
             "related_cve", relatedCves
         );

--- a/common-template/src/test/java/email/TestLightwellTemplate.java
+++ b/common-template/src/test/java/email/TestLightwellTemplate.java
@@ -1,0 +1,273 @@
+package email;
+
+import com.redhat.cloud.notifications.ingress.Action;
+import com.redhat.cloud.notifications.ingress.Context;
+import com.redhat.cloud.notifications.ingress.Event;
+import com.redhat.cloud.notifications.ingress.Metadata;
+import com.redhat.cloud.notifications.ingress.Payload;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static com.redhat.cloud.notifications.qute.templates.mapping.Lightwell.LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE;
+import static helpers.TestHelpers.DEFAULT_ORG_ID;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class TestLightwellTemplate extends EmailTemplatesRendererHelper {
+
+    @Override
+    protected String getApp() {
+        return "lightwell";
+    }
+
+    @Override
+    protected String getBundle() {
+        return "lightwell";
+    }
+
+    @Override
+    protected String getBundleDisplayName() {
+        return "Lightwell";
+    }
+
+    @Override
+    protected String getAppDisplayName() {
+        return "Lightwell";
+    }
+
+    static final String LIGHTWELL_LOGO = "Logo_lightwell_dark.png";
+
+    @Test
+    public void testJavaRemediatedEmailBody() {
+        Action action = createLightwellAction();
+        eventTypeDisplayName = "Java Remediated";
+        String result = generateEmailBody(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE, action, false);
+
+        assertTrue(result.contains(LIGHTWELL_LOGO));
+
+        // Plural title, intro text and events counter badge
+        assertTrue(result.contains("New Packages Available for Java Remediated"));
+        assertTrue(result.contains("These following packages were fixed by Lightwell in the Java Remediated and are available for your access."));
+        assertTrue(result.contains(">9</a>"));
+
+        // CTA button
+        assertTrue(result.contains("href=\"https://console.redhat.com/lightwell\" target=\"_blank\""));
+        assertTrue(result.contains("Go to Lightwell"));
+
+        // Packages
+        assertTrue(result.contains("org.glassfish.jaxb:codemodel"));
+        assertTrue(result.contains("https://console.redhat.com/lightwell/packages/org.glassfish.jaxb:codemodel"));
+        assertTrue(result.contains("org.glassfish.jaxb:jaxb-core"));
+        assertTrue(result.contains("org.glassfish.jaxb:jaxb-jxc"));
+        assertTrue(result.contains("org.glassfish.jaxb:jaxb-runtime"));
+        assertTrue(result.contains("org.glassfish.jaxb:jaxb-xjc"));
+        assertTrue(result.contains("org.glassfish.jaxb:txw2"));
+        assertTrue(result.contains("org.glassfish.jaxb:txwc2"));
+        assertTrue(result.contains("org.glassfish.jaxb:xsom"));
+        assertTrue(result.contains("org.json:json"));
+
+        // Releases
+        assertTrue(result.contains("4.0.4.rhlw003"));
+        assertTrue(result.contains("4.0.4.rhlw004"));
+        assertTrue(result.contains("5.0.0.rhlw001"));
+        assertTrue(result.contains("5.5.5.rhlw001"));
+        assertTrue(result.contains("4.1.0.rhlw001"));
+        assertTrue(result.contains("20220320.0.0.rhlw-00001"));
+        assertTrue(result.contains("20220320.0.0.rhlw-00002"));
+
+        // CVEs and severities
+        assertTrue(result.contains("CVE-2026-1234"));
+        assertTrue(result.contains("CVE-2026-5678"));
+        assertTrue(result.contains("CVE-2026-9999"));
+        assertTrue(result.contains("CVE-2026-1111"));
+        assertTrue(result.contains("CVE-2026-2222"));
+        assertTrue(result.contains("CVE-2026-3333"));
+        assertTrue(result.contains("CVE-2026-4242"));
+        assertTrue(result.contains("CVE-2026-0909"));
+        assertTrue(result.contains(">Critical</td>"));
+        assertTrue(result.contains(">Important</td>"));
+    }
+
+    @Test
+    public void testJavaRemediatedEmailBodySingleEvent() {
+        Action action = createLightwellActionWithReleases(List.of(
+            buildRelease("org.glassfish.jaxb:codemodel", List.of("4.0.4.rhlw003"), List.of(
+                buildCve("CVE-2026-1234", "critical")
+            ))
+        ));
+        eventTypeDisplayName = "Java Remediated";
+        String result = generateEmailBody(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE, action, false);
+
+        assertTrue(result.contains("New Package Available for Java Remediated"));
+        assertFalse(result.contains("New Packages Available"));
+        assertTrue(result.contains("The following package was fixed by Lightwell in the Java Remediated and is available for your access."));
+        assertFalse(result.contains("These following packages were fixed"));
+        assertTrue(result.contains(">1</a>"));
+    }
+
+    @Test
+    public void testJavaRemediatedEmailBodyAllSeverityLevels() {
+        Action action = createLightwellActionWithReleases(List.of(
+            buildRelease("org.glassfish.jaxb:codemodel", List.of("4.0.4.rhlw003"), List.of(
+                buildCve("CVE-2026-1001", "low"),
+                buildCve("CVE-2026-1002", "moderate"),
+                buildCve("CVE-2026-1003", "important"),
+                buildCve("CVE-2026-1004", "critical")
+            ))
+        ));
+        eventTypeDisplayName = "Java Remediated";
+        String result = generateEmailBody(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE, action, false);
+
+        assertTrue(result.contains(">Low</td>"));
+        assertTrue(result.contains(">Moderate</td>"));
+        assertTrue(result.contains(">Important</td>"));
+        assertTrue(result.contains(">Critical</td>"));
+        assertTrue(result.contains("alt=\"Low\""));
+        assertTrue(result.contains("alt=\"Moderate\""));
+        assertTrue(result.contains("alt=\"Important\""));
+        assertTrue(result.contains("alt=\"Critical\""));
+    }
+
+    @Test
+    public void testJavaRemediatedEmailBodyDefaultFooterShowsPreferencesLink() {
+        Action action = createLightwellAction();
+        eventTypeDisplayName = "Java Remediated";
+        String result = generateEmailBody(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE, action, null, false);
+
+        assertTrue(result.contains("This email was sent by Lightwell | "));
+        assertTrue(result.contains("Manage email preferences"));
+        assertFalse(result.contains("it is critical or requires action"));
+    }
+
+    @Test
+    public void testJavaRemediatedEmailBodyIgnoresUserPreferencesFooter() {
+        Action action = createLightwellAction();
+        eventTypeDisplayName = "Java Remediated";
+        String result = generateEmailBody(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE, action, null, true);
+
+        assertTrue(result.contains("This email was sent by Lightwell, it is critical or requires action."));
+        assertFalse(result.contains("Manage email preferences"));
+    }
+
+    private static Action createLightwellActionWithReleases(List<Map<String, Object>> releases) {
+        Action action = new Action();
+        action.setBundle("lightwell");
+        action.setApplication("lightwell");
+        action.setTimestamp(LocalDateTime.now());
+        action.setEventType(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE);
+        action.setOrgId(DEFAULT_ORG_ID);
+        action.setContext(new Context.ContextBuilder().build());
+        action.setEvents(List.of(buildPackageEvent("org.glassfish.jaxb:codemodel", releases)));
+        return action;
+    }
+
+    private static Action createLightwellAction() {
+        Action action = new Action();
+        action.setBundle("lightwell");
+        action.setApplication("lightwell");
+        action.setTimestamp(LocalDateTime.now());
+        action.setEventType(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE);
+        action.setOrgId(DEFAULT_ORG_ID);
+        action.setContext(new Context.ContextBuilder().build());
+        action.setEvents(List.of(
+            buildPackageEvent("org.glassfish.jaxb:codemodel", List.of(
+                buildRelease("org.glassfish.jaxb:codemodel", List.of("4.0.4.rhlw003", "4.0.4.rhlw004"), List.of(
+                    buildCve("CVE-2026-1234", "critical"),
+                    buildCve("CVE-2026-5678", "critical"),
+                    buildCve("CVE-2026-9999", "critical")
+                )),
+                buildRelease("org.glassfish.jaxb:codemodel", List.of("5.0.0.rhlw001"), List.of(
+                    buildCve("CVE-2026-1234", "critical"),
+                    buildCve("CVE-2026-5678", "critical"),
+                    buildCve("CVE-2026-9999", "critical")
+                )),
+                buildRelease("org.glassfish.jaxb:codemodel", List.of("5.5.5.rhlw001"), List.of(
+                    buildCve("CVE-2026-1234", "critical"),
+                    buildCve("CVE-2026-5678", "critical"),
+                    buildCve("CVE-2026-9999", "critical")
+                ))
+            )),
+            buildPackageEvent("org.glassfish.jaxb:jaxb-core", List.of(
+                buildRelease("org.glassfish.jaxb:jaxb-core", List.of("4.0.4.rhlw003"), List.of(
+                    buildCve("CVE-2026-1111", "important"),
+                    buildCve("CVE-2026-2222", "important"),
+                    buildCve("CVE-2026-9999", "critical")
+                ))
+            )),
+            buildPackageEvent("org.glassfish.jaxb:jaxb-jxc", List.of(
+                buildRelease("org.glassfish.jaxb:jaxb-jxc", List.of("4.0.4.rhlw003"), List.of(
+                    buildCve("CVE-2026-2222", "important")
+                ))
+            )),
+            buildPackageEvent("org.glassfish.jaxb:jaxb-runtime", List.of(
+                buildRelease("org.glassfish.jaxb:jaxb-runtime", List.of("4.0.4.rhlw003"), List.of(
+                    buildCve("CVE-2026-3333", "important")
+                ))
+            )),
+            buildPackageEvent("org.glassfish.jaxb:jaxb-xjc", List.of(
+                buildRelease("org.glassfish.jaxb:jaxb-xjc", List.of("4.1.0.rhlw001"), List.of(
+                    buildCve("CVE-2026-4242", "important")
+                ))
+            )),
+            buildPackageEvent("org.glassfish.jaxb:txw2", List.of(
+                buildRelease("org.glassfish.jaxb:txw2", List.of("4.1.0.rhlw001"), List.of(
+                    buildCve("CVE-2026-4242", "important")
+                ))
+            )),
+            buildPackageEvent("org.glassfish.jaxb:txwc2", List.of(
+                buildRelease("org.glassfish.jaxb:txwc2", List.of("4.1.0.rhlw001"), List.of(
+                    buildCve("CVE-2026-4242", "important")
+                ))
+            )),
+            buildPackageEvent("org.glassfish.jaxb:xsom", List.of(
+                buildRelease("org.glassfish.jaxb:xsom", List.of("4.0.4.rhlw003"), List.of(
+                    buildCve("CVE-2026-0909", "critical")
+                ))
+            )),
+            buildPackageEvent("org.json:json", List.of(
+                buildRelease("org.json:json", List.of("20220320.0.0.rhlw-00002", "20220320.0.0.rhlw-00001"), List.of(
+                    buildCve("CVE-2026-0909", "critical")
+                ))
+            ))
+        ));
+        return action;
+    }
+
+    private static Event buildPackageEvent(String packageName, List<Map<String, Object>> releases) {
+        return new Event.EventBuilder()
+            .withMetadata(new Metadata.MetadataBuilder().build())
+            .withPayload(
+                new Payload.PayloadBuilder()
+                    .withAdditionalProperty("package_name", packageName)
+                    .withAdditionalProperty("releases", releases)
+                    .build()
+            )
+            .build();
+    }
+
+    private static Map<String, Object> buildRelease(String packageName, List<String> releaseNames, List<Map<String, Object>> relatedCves) {
+        return Map.of(
+            "meta", Map.of(
+                "package_name", packageName,
+                "package_link", "https://console.redhat.com/lightwell/packages/" + packageName
+            ),
+            "release_names", releaseNames.stream().map(name -> Map.of("name", (Object) name)).toList(),
+            "related_cve", relatedCves
+        );
+    }
+
+    private static Map<String, Object> buildCve(String cveId, String totalRisk) {
+        String severity = Character.toUpperCase(totalRisk.charAt(0)) + totalRisk.substring(1);
+        return Map.of(
+            "cve", cveId,
+            "url", "https://console.redhat.com/api/lightwell/cves/" + cveId + ".json",
+            "severity", severity,
+            "payload", Map.of("total_risk", totalRisk)
+        );
+    }
+}

--- a/common-template/src/test/java/email/TestLightwellTemplate.java
+++ b/common-template/src/test/java/email/TestLightwellTemplate.java
@@ -261,13 +261,11 @@ public class TestLightwellTemplate extends EmailTemplatesRendererHelper {
         );
     }
 
-    private static Map<String, Object> buildCve(String cveId, String totalRisk) {
-        String severity = Character.toUpperCase(totalRisk.charAt(0)) + totalRisk.substring(1);
+    private static Map<String, Object> buildCve(String cveId, String severity) {
         return Map.of(
             "cve", cveId,
             "url", "https://console.redhat.com/api/lightwell/cves/" + cveId + ".json",
-            "severity", severity,
-            "payload", Map.of("total_risk", totalRisk)
+            "severity", severity
         );
     }
 }

--- a/docs/template-guidelines.md
+++ b/docs/template-guidelines.md
@@ -44,6 +44,7 @@ Templates are registered in static `Map<TemplateDefinition, String>` fields insi
 | `Console` | `console` |
 | `SubscriptionServices` | `subscription-services` |
 | `AnsibleAutomationPlatform` | `ansible-automation-platform` |
+| `Lightwell` | `lightwell` |
 | `DefaultTemplates` | System defaults (bundle=null) |
 | `SecureEmailTemplates` | Secured environment overrides |
 | `DefaultInstantEmailTemplates` | Stage-only fallback (bundle=null) |


### PR DESCRIPTION
## Summary

Implements the Qute instant email template for the Lightwell bundle's `java_remediated` event type, per [RHCLOUD-49576](https://redhat.atlassian.net/browse/RHCLOUD-49576) (part of the RHCLOUD-49566 epic).

- Adds `lightwellDefaultEmailBody.html`, rendering the list of remediated packages/releases/CVEs (with severity badges) from the event payload.
- Adds `Lightwell.java` mapping class registering the template for the `lightwell`/`lightwell` bundle/app, and wires it into `TemplateService`.
- Extends the shared `Common/insightsEmailBody.html` with a `renderHeaderTitle` toggle and a `content-footer` insertion point, needed by the Lightwell template's custom header/footer.
- Adds `TestLightwellTemplate` covering: multi-package rendering, singular vs. plural wording, the full severity matrix (low/moderate/important/critical), the events-counter badge, the CTA button, and both footer variants (`ignore_user_preferences` true/false).

Note: the same template is used for both `java_remediated` and the upcoming `python_remediated` event type — it's mapped at the application level (`Lightwell.templatesMap`) rather than per-event-type, since the payload/rendering is identical for both. This mapping can be revisited if the event types diverge later.

## Test plan

- [x] `./mvnw validate -pl :notifications-common-template` (checkstyle)
- [x] `./mvnw test -pl :notifications-common-template -Dtest=TestLightwellTemplate` (5/5 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-49576]: https://redhat.atlassian.net/browse/RHCLOUD-49576

<img width="700" height="1249" alt="image" src="https://github.com/user-attachments/assets/32f67c2e-1fa7-4649-bd75-b3c9eacf6b42" />

Linked Json payload is:

```
  {
    "version": "2.0.0",
    "bundle": "lightwell",
    "application": "lightwell",
    "event_type": "java-remediated",
    "timestamp": "2026-08-05T12:18:34.081804291",
    "org_id": "123456",
    "context": {},
    "events": [
      {
        "metadata": {},
        "payload": {
          "package_name": "org.glassfish.jaxb:codemodel",
          "package_link": "https://console.redhat.com/lightwell/packages/org.glassfish.jaxb:codemodel",
          "releases": [
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-1234.json", "cve": "CVE-2026-1234", "severity": "critical" },
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-5678.json", "cve": "CVE-2026-5678", "severity": "critical" },
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-9999.json", "cve": "CVE-2026-9999", "severity": "critical" }
              ],
              "release_names": [
                { "name": "4.0.4.rhlw003" },
                { "name": "4.0.4.rhlw004" }
              ]
            },
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-1234.json", "cve": "CVE-2026-1234", "severity": "critical" },
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-5678.json", "cve": "CVE-2026-5678", "severity": "critical" },
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-9999.json", "cve": "CVE-2026-9999", "severity": "critical" }
              ],
              "release_names": [
                { "name": "5.0.0.rhlw001" }
              ]
            },
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-1234.json", "cve": "CVE-2026-1234", "severity": "critical" },
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-5678.json", "cve": "CVE-2026-5678", "severity": "critical" },
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-9999.json", "cve": "CVE-2026-9999", "severity": "critical" }
              ],
              "release_names": [
                { "name": "5.5.5.rhlw001" }
              ]
            }
          ]
        }
      },
      {
        "metadata": {},
        "payload": {
          "package_name": "org.glassfish.jaxb:jaxb-core",
          "package_link": "https://console.redhat.com/lightwell/packages/org.glassfish.jaxb:jaxb-core",
          "releases": [
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-1111.json", "cve": "CVE-2026-1111", "severity": "important" },
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-2222.json", "cve": "CVE-2026-2222", "severity": "important" },
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-9999.json", "cve": "CVE-2026-9999", "severity": "critical" }
              ],
              "release_names": [
                { "name": "4.0.4.rhlw003" }
              ]
            }
          ]
        }
      },
      {
        "metadata": {},
        "payload": {
          "package_name": "org.glassfish.jaxb:jaxb-jxc",
          "package_link": "https://console.redhat.com/lightwell/packages/org.glassfish.jaxb:jaxb-jxc",
          "releases": [
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-2222.json", "cve": "CVE-2026-2222", "severity": "important" }
              ],
              "release_names": [
                { "name": "4.0.4.rhlw003" }
              ]
            }
          ]
        }
      },
      {
        "metadata": {},
        "payload": {
          "package_name": "org.glassfish.jaxb:jaxb-runtime",
          "package_link": "https://console.redhat.com/lightwell/packages/org.glassfish.jaxb:jaxb-runtime",
          "releases": [
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-3333.json", "cve": "CVE-2026-3333", "severity": "important" }
              ],
              "release_names": [
                { "name": "4.0.4.rhlw003" }
              ]
            }
          ]
        }
      },
      {
        "metadata": {},
        "payload": {
          "package_name": "org.glassfish.jaxb:jaxb-xjc",
          "package_link": "https://console.redhat.com/lightwell/packages/org.glassfish.jaxb:jaxb-xjc",
          "releases": [
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-4242.json", "cve": "CVE-2026-4242", "severity": "important" }
              ],
              "release_names": [
                { "name": "4.1.0.rhlw001" }
              ]
            }
          ]
        }
      },
      {
        "metadata": {},
        "payload": {
          "package_name": "org.glassfish.jaxb:txw2",
          "package_link": "https://console.redhat.com/lightwell/packages/org.glassfish.jaxb:txw2",
          "releases": [
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-4242.json", "cve": "CVE-2026-4242", "severity": "important" }
              ],
              "release_names": [
                { "name": "4.1.0.rhlw001" }
              ]
            }
          ]
        }
      },
      {
        "metadata": {},
        "payload": {
          "package_name": "org.glassfish.jaxb:txwc2",
          "package_link": "https://console.redhat.com/lightwell/packages/org.glassfish.jaxb:txwc2",
          "releases": [
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-4242.json", "cve": "CVE-2026-4242", "severity": "important" }
              ],
              "release_names": [
                { "name": "4.1.0.rhlw001" }
              ]
            }
          ]
        }
      },
      {
        "metadata": {},
        "payload": {
          "package_name": "org.glassfish.jaxb:xsom",
          "package_link": "https://console.redhat.com/lightwell/packages/org.glassfish.jaxb:xsom",
          "releases": [
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-0909.json", "cve": "CVE-2026-0909", "severity": "critical" }
              ],
              "release_names": [
                { "name": "4.0.4.rhlw003" }
              ]
            }
          ]
        }
      },
      {
        "metadata": {},
        "payload": {
          "package_name": "org.json:json",
          "package_link": "https://console.redhat.com/lightwell/packages/org.json:json",
          "releases": [
            {
              "related_cve": [
                { "url": "https://console.redhat.com/api/lightwell/cves/CVE-2026-0909.json", "cve": "CVE-2026-0909", "severity": "critical" }
              ],
              "release_names": [
                { "name": "20220320.0.0.rhlw-00002" },
                { "name": "20220320.0.0.rhlw-00001" }
              ]
            }
          ]
        }
      }
    ],
    "recipients": []
  }
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lightwell-branded email notifications for Java remediation events.
  * Included package, release, CVE, severity, branding, and action-link details.
  * Added support for conditional header titles and organization information.

* **Bug Fixes**
  * Improved footer rendering while preserving preference and critical-message behavior.

* **Documentation**
  * Documented the Lightwell template mapping and bundle identifier.

* **Tests**
  * Added coverage for single and multiple packages, severity levels, links, branding, and footer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->