### PR TITLE
RHCLOUD-49576: Exclude Lightwell events from the pendo email message

### DIFF
--- a/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
@@ -30,7 +30,7 @@
     <tr>
         <th style="{body-section-table-th-style}">Package{#if eventsCount > 1}s{/if}</th>
         <th style="{body-section-table-th-style} min-width: 90px;">Release</th>
-        <th style="{body-section-table-th-style}" colspan="2">Related CVE(s)</th>
+        <th style="{body-section-table-th-style}; min-width: 210px" colspan="2">Related CVE(s)</th>
     </tr>
     </thead>
     <tbody style="{body-section-table-tbody-style}">
@@ -53,7 +53,7 @@
                 {#for cve in release.related_cve}
                     <tr>
                     <td><a style="{body-section-table-td-a-style}" href="{cve.url}" target="_blank">{cve.cve}</a></td>
-                    <td style="min-width: 90px">
+                    <td style="min-width: 85px">
                     {#switch cve.severity}
                         {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
                         {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailPendoResolver.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailPendoResolver.java
@@ -39,6 +39,8 @@ public class EmailPendoResolver {
         // pendo message must not be shown on OCM and environment with emails only mode
         final String bundle = event.getEventType().getApplication().getBundle().getName();
         final String application = event.getEventType().getApplication().getName();
-        return !EmailActorsResolver.isOCMApp(bundle, application) && !engineConfig.isEmailsOnlyModeEnabled() && !forcedEmail;
+        return !EmailActorsResolver.isOCMApp(bundle, application)
+                && !EmailActorsResolver.isLightwellApp(bundle, application)
+                && !engineConfig.isEmailsOnlyModeEnabled() && !forcedEmail;
     }
 }

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailPendoResolverTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailPendoResolverTest.java
@@ -76,14 +76,13 @@ class EmailPendoResolverTest {
     }
 
     /**
-     * Tests that the pendo message is still shown for Lightwell events (only OCM is excluded).
+     * Tests that the pendo message is not shown for Lightwell events.
      */
-    @Test
-    void testLightwellPendoMessage() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testLightwellPendoMessage(boolean ignoreUserPreferences) {
         Event event = buildEvent(null, "lightwell", "lightwell");
-        assertEquals(String.format(GENERAL_PENDO_MESSAGE, environment.url(), environment.url()), emailPendoResolver.getPendoEmailMessage(event, false, false).getPendoMessage(), "unexpected email pendo message returned from the function under test");
-        assertEquals(GENERAL_PENDO_TITLE, emailPendoResolver.getPendoEmailMessage(event, false, false).getPendoTitle(), "unexpected email pendo title returned from the function under test");
-        assertNull(emailPendoResolver.getPendoEmailMessage(event, true, false), "current pendo message should not be generated in case of forced email (ignoreUserPreferences)");
+        assertNull(emailPendoResolver.getPendoEmailMessage(event, ignoreUserPreferences, false), "unexpected email pendo message returned from the function under test");
     }
 
     private static Event buildEvent(String sourceEnvironment, String bundleName, String appName) {


### PR DESCRIPTION
## Summary
- The general pendo "Did you know?" message must not be shown for Lightwell events, in addition to the existing OCM exclusion.
- Minor width tweak to the Lightwell instant email template's Related CVE(s) column to avoid wrapping.

Jira: https://redhat.atlassian.net/browse/RHCLOUD-49576

## Test plan
- [x] Updated `EmailPendoResolverTest` to assert `getPendoEmailMessage` returns `null` for Lightwell bundle/app events
- [x] `./mvnw validate -pl :notifications-engine` (checkstyle)
- [x] `./mvnw test -pl :notifications-engine -Dtest=EmailPendoResolverTest` (9/9 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email layout by adjusting the widths of the “Related CVE(s)” and severity columns for better readability.
  - Suppressed Pendo messages in Lightwell application emails, including when user preference settings would otherwise allow them.
  - Updated behavior consistently across supported email preference modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->