### PR TITLE
Update Grafana Pager Duty metrics, since we get rid of Apache Camel for this connector

### DIFF
--- a/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
+++ b/.rhcicd/grafana/grafana-dashboard-notifications-general.configmap.yaml
@@ -109,7 +109,7 @@ data:
        "sizing": "auto",
        "text": {}
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "exemplar": true,
@@ -177,7 +177,7 @@ data:
        "sizing": "auto",
        "text": {}
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "exemplar": true,
@@ -264,7 +264,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -343,7 +343,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -422,7 +422,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -501,7 +501,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -580,7 +580,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -659,7 +659,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -738,7 +738,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -817,7 +817,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -888,7 +888,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -959,7 +959,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1030,7 +1030,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1101,7 +1101,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1172,7 +1172,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1243,7 +1243,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1314,7 +1314,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1385,7 +1385,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1480,7 +1480,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1575,7 +1575,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1670,7 +1670,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1765,7 +1765,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1860,7 +1860,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -1955,7 +1955,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2054,7 +2054,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2149,7 +2149,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2244,7 +2244,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2339,7 +2339,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2434,7 +2434,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2529,7 +2529,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2624,7 +2624,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2719,7 +2719,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2818,7 +2818,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2913,7 +2913,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -2992,7 +2992,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3071,7 +3071,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3140,7 +3140,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3208,7 +3208,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3286,7 +3286,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3357,7 +3357,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3428,7 +3428,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3497,7 +3497,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3565,7 +3565,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3635,7 +3635,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3730,7 +3730,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3825,7 +3825,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -3920,7 +3920,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4014,7 +4014,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4108,7 +4108,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4203,7 +4203,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4298,7 +4298,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4393,7 +4393,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4488,7 +4488,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4583,7 +4583,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4699,7 +4699,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4810,7 +4810,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -4965,7 +4965,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -5117,7 +5117,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -5244,7 +5244,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -5398,7 +5398,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -5517,7 +5517,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -5666,7 +5666,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -5811,7 +5811,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -5967,7 +5967,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -6089,7 +6089,7 @@ data:
         "sort": "desc"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -6199,7 +6199,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "exemplar": true,
@@ -6292,7 +6292,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -6356,7 +6356,7 @@ data:
        "textMode": "auto",
        "wideLayout": true
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "exemplar": true,
@@ -6490,7 +6490,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -6654,7 +6654,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -6849,7 +6849,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -7044,16 +7044,16 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
          "uid": "$datasource"
         },
         "disableTextWrap": false,
-        "editorMode": "builder",
+        "editorMode": "code",
         "exemplar": false,
-        "expr": "sum(increase(camel_exchanges_succeeded_total{service=\"notifications-connector-pagerduty-service\", routeId=\"success\"}[5m]))",
+        "expr": "sum(increase(notifications_connector_messages_succeeded_total{connector=\"pagerduty\"}[5m]))",
         "fullMetaSearch": false,
         "includeNullMetadata": true,
         "instant": false,
@@ -7068,8 +7068,8 @@ data:
          "uid": "$datasource"
         },
         "disableTextWrap": false,
-        "editorMode": "builder",
-        "expr": "sum(increase(camel_exchanges_failures_handled_total{service=\"notifications-connector-pagerduty-service\", routeId=\"teams\"}[5m]))",
+        "editorMode": "code",
+        "expr": "sum(increase(notifications_connector_messages_failed_total{connector=\"pagerduty\"}[5m]))",
         "fullMetaSearch": false,
         "hide": false,
         "includeNullMetadata": true,
@@ -7078,21 +7078,6 @@ data:
         "range": true,
         "refId": "Failure",
         "useBackend": false
-       },
-       {
-        "datasource": {
-         "type": "prometheus",
-         "uid": "$datasource"
-        },
-        "editorMode": "code",
-        "exemplar": false,
-        "expr": "sum(increase(camel_pagerduty_retry_counter_total[5m]))",
-        "hide": false,
-        "instant": false,
-        "interval": "",
-        "legendFormat": "Retry",
-        "range": true,
-        "refId": "Retry"
        }
       ],
       "title": "PagerDuty",
@@ -7221,7 +7206,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -7415,7 +7400,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -7610,7 +7595,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -7804,7 +7789,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -7998,7 +7983,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -8119,7 +8104,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -8214,7 +8199,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -8309,7 +8294,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -8406,7 +8391,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "exemplar": true,
@@ -8500,7 +8485,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "exemplar": true,
@@ -8594,7 +8579,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "exemplar": true,
@@ -8698,7 +8683,7 @@ data:
         "sort": "none"
        }
       },
-      "pluginVersion": "11.6.3",
+      "pluginVersion": "11.6.11",
       "targets": [
        {
         "datasource": {
@@ -10429,7 +10414,7 @@ data:
     "timezone": "",
     "title": "Notifications Dashboard",
     "uid": "KQIVyFuMk",
-    "version": 6
+    "version": 7
    }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Grafana dashboard panels to plugin version 11.6.11.
  * Improved PagerDuty connector monitoring with clearer success and failure metrics.
  * Updated the panel editor to use code mode for easier query management.
* **Improvements**
  * Incremented the dashboard version to reflect the latest monitoring updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->