### PR TITLE
RHCLOUD-49576: Add Lightwell email title template and unit tests

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Lightwell.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Lightwell.java
@@ -14,7 +14,7 @@ public class Lightwell {
     public static final String LIGHTWELL_APP_NAME = "lightwell";
     static final String LIGHTWELL_FOLDER_NAME = "Lightwell/";
 
-    public static final String LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE = "java_remediated";
+    public static final String LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE = "java-remediated";
 
     public static final Map<TemplateDefinition, String> templatesMap = Map.ofEntries(
 

--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Lightwell.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/mapping/Lightwell.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.qute.templates.TemplateDefinition;
 import java.util.Map;
 
 import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_BODY;
+import static com.redhat.cloud.notifications.qute.templates.IntegrationType.EMAIL_TITLE;
 import static java.util.Map.entry;
 
 public class Lightwell {
@@ -17,6 +18,7 @@ public class Lightwell {
 
     public static final Map<TemplateDefinition, String> templatesMap = Map.ofEntries(
 
-        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, LIGHTWELL_APP_NAME, null), LIGHTWELL_FOLDER_NAME + "lightwellDefaultEmailBody.html")
+        entry(new TemplateDefinition(EMAIL_BODY, BUNDLE_NAME, LIGHTWELL_APP_NAME, null), LIGHTWELL_FOLDER_NAME + "lightwellDefaultEmailBody.html"),
+        entry(new TemplateDefinition(EMAIL_TITLE, BUNDLE_NAME, LIGHTWELL_APP_NAME, null), LIGHTWELL_FOLDER_NAME + "lightwellDefaultEmailTitle.txt")
     );
 }

--- a/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailTitle.txt
+++ b/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailTitle.txt
@@ -1,0 +1,1 @@
+{action.severity.or('').severityAsEmailTitle}Instant notification - {source.event_type.display_name} - {source.bundle.display_name}

--- a/common-template/src/test/java/email/TestLightwellTemplate.java
+++ b/common-template/src/test/java/email/TestLightwellTemplate.java
@@ -5,6 +5,7 @@ import com.redhat.cloud.notifications.ingress.Context;
 import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 import com.redhat.cloud.notifications.ingress.Payload;
+import com.redhat.cloud.notifications.qute.templates.Severity;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +15,7 @@ import java.util.Map;
 
 import static com.redhat.cloud.notifications.qute.templates.mapping.Lightwell.LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE;
 import static helpers.TestHelpers.DEFAULT_ORG_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -91,6 +93,27 @@ public class TestLightwellTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains("CVE-2026-0909"));
         assertTrue(result.contains(">Critical</td>"));
         assertTrue(result.contains(">Important</td>"));
+    }
+
+    @Test
+    public void testJavaRemediatedEmailTitle() {
+        Action action = createLightwellAction();
+        eventTypeDisplayName = "Java Remediated";
+
+        String result = generateEmailSubject(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE, action);
+        assertEquals("Instant notification - Java Remediated - Lightwell", result);
+
+        action.setSeverity(Severity.CRITICAL.name());
+        String criticalResult = generateEmailSubject(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE, action);
+        assertEquals("[CRITICAL] Instant notification - Java Remediated - Lightwell", criticalResult);
+
+        action.setSeverity(Severity.NONE.name());
+        String noneResult = generateEmailSubject(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE, action);
+        assertEquals("Instant notification - Java Remediated - Lightwell", noneResult);
+
+        action.setSeverity(Severity.UNDEFINED.name());
+        String undefinedResult = generateEmailSubject(LIGHTWELL_JAVA_REMEDIATED_EVENT_TYPE, action);
+        assertEquals("Instant notification - Java Remediated - Lightwell", undefinedResult);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Register the `EMAIL_TITLE` template for the Lightwell `java_remediated` event type
- Add unit test coverage for the new email title template, including severity prefix behavior

## Jira
https://redhat.atlassian.net/browse/RHCLOUD-49576

## Test plan
- [x] `./mvnw test -pl :notifications-common-template -Dtest=TestLightwellTemplate` passes (6/6)
- [x] `./mvnw validate -pl :notifications-common-template` (checkstyle) passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added default email titles for Lightwell notifications.
  * Email titles now include event severity, event type, and bundle name.
  * Added support for Java remediation notification titles.

* **Bug Fixes**
  * Improved email subject handling for default, critical, unspecified, and undefined severity scenarios.
  * Corrected the Java remediation event type used in notification titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->