### PR TITLE
RHCLOUD-41298: Improve OIDC resilience across all modules

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
@@ -121,12 +121,16 @@ public class KesselCheckClient {
 
     @Retry(maxRetries = 3, delay = 100, retryOn = KesselTransientException.class)
     public CheckResponse check(CheckRequest request) {
+        // Capture the channel backing this call so, on failure, we can act on the exact channel that failed
+        // rather than the shared field, which another thread may have concurrently reinitialized.
+        KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub client = getClient();
+        ManagedChannel channel = grpcChannel;
         try {
-            return getClient()
+            return client
                 .withDeadlineAfter(backendConfig.getKesselTimeoutMs(), TimeUnit.MILLISECONDS)
                 .check(request);
         } catch (StatusRuntimeException e) {
-            throw handleGrpcException(e);
+            throw handleGrpcException(e, channel);
         } catch (OAuth2Exception e) {
             Log.warnf("Transient error fetching Kessel OAuth2 credentials (may retry): %s", e.getMessage());
             throw new KesselTransientException(e);
@@ -135,19 +139,23 @@ public class KesselCheckClient {
 
     @Retry(maxRetries = 3, delay = 100, retryOn = KesselTransientException.class)
     public CheckForUpdateResponse checkForUpdate(CheckForUpdateRequest request) {
+        // Capture the channel backing this call so, on failure, we can act on the exact channel that failed
+        // rather than the shared field, which another thread may have concurrently reinitialized.
+        KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub client = getClient();
+        ManagedChannel channel = grpcChannel;
         try {
-            return getClient()
+            return client
                 .withDeadlineAfter(backendConfig.getKesselTimeoutMs(), TimeUnit.MILLISECONDS)
                 .checkForUpdate(request);
         } catch (StatusRuntimeException e) {
-            throw handleGrpcException(e);
+            throw handleGrpcException(e, channel);
         } catch (OAuth2Exception e) {
             Log.warnf("Transient error fetching Kessel OAuth2 credentials (may retry): %s", e.getMessage());
             throw new KesselTransientException(e);
         }
     }
 
-    private RuntimeException handleGrpcException(StatusRuntimeException e) {
+    private RuntimeException handleGrpcException(StatusRuntimeException e, ManagedChannel failedChannel) {
         Status.Code code = e.getStatus().getCode();
 
         meterRegistry.counter(KESSEL_GRPC_ERROR_COUNTER_NAME, Tags.of(KESSEL_GRPC_ERROR_TAG_ERROR_TYPE, code.name())).increment();
@@ -155,10 +163,6 @@ public class KesselCheckClient {
         // UNAUTHENTICATED usually means the OAuth2 token expired. Recreate channel with fresh credentials.
         if (code == UNAUTHENTICATED) {
             Log.warnf("Transient gRPC error from Kessel (may retry): %s - %s. Recreating channel with fresh credentials.", code, e.getMessage());
-            // Capture the current channel before reinitializing. If credential refresh fails, we shut down this
-            // specific (failed) channel rather than the shared field, so a channel that another thread concurrently
-            // reinitialized to a healthy state cannot be torn down here.
-            ManagedChannel failedChannel = grpcChannel;
             try {
                 initializeChannel("unauthenticated");
             } catch (OAuth2Exception oauthEx) {

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
@@ -80,7 +80,9 @@ public class KesselCheckClient {
         initializeChannel("startup");
     }
 
-    private void initializeChannel(String reason) {
+    // Synchronized so concurrent callers replace and shut down channels sequentially: each call captures the
+    // holder it actually displaces and closes it, so no newly created channel can be overwritten and leaked.
+    private synchronized void initializeChannel(String reason) {
         // Capture before overwriting so we can shut it down after.
         ChannelHolder oldHolder = channelHolder;
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
@@ -15,6 +15,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.project_kessel.api.auth.OAuth2ClientCredentials;
+import org.project_kessel.api.auth.OAuth2Exception;
 import org.project_kessel.api.inventory.v1beta2.CheckForUpdateRequest;
 import org.project_kessel.api.inventory.v1beta2.CheckForUpdateResponse;
 import org.project_kessel.api.inventory.v1beta2.CheckRequest;
@@ -126,6 +127,9 @@ public class KesselCheckClient {
                 .check(request);
         } catch (StatusRuntimeException e) {
             throw handleGrpcException(e);
+        } catch (OAuth2Exception e) {
+            Log.warnf("Transient error fetching Kessel OAuth2 credentials (may retry): %s", e.getMessage());
+            throw new KesselTransientException(e);
         }
     }
 
@@ -137,6 +141,9 @@ public class KesselCheckClient {
                 .checkForUpdate(request);
         } catch (StatusRuntimeException e) {
             throw handleGrpcException(e);
+        } catch (OAuth2Exception e) {
+            Log.warnf("Transient error fetching Kessel OAuth2 credentials (may retry): %s", e.getMessage());
+            throw new KesselTransientException(e);
         }
     }
 
@@ -148,7 +155,12 @@ public class KesselCheckClient {
         // UNAUTHENTICATED usually means the OAuth2 token expired. Recreate channel with fresh credentials.
         if (code == UNAUTHENTICATED) {
             Log.warnf("Transient gRPC error from Kessel (may retry): %s - %s. Recreating channel with fresh credentials.", code, e.getMessage());
-            initializeChannel("unauthenticated");
+            try {
+                initializeChannel("unauthenticated");
+            } catch (OAuth2Exception oauthEx) {
+                Log.warnf("Failed to refresh OAuth2 credentials after UNAUTHENTICATED error: %s", oauthEx.getMessage());
+                return new KesselTransientException(oauthEx);
+            }
             return new KesselTransientException(e);
         }
 

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
@@ -64,9 +64,16 @@ public class KesselCheckClient {
     @Inject
     BackendConfig backendConfig;
 
-    // Volatile: these fields are read by multiple request threads and written during channel initialization.
-    private volatile KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub grpcClient;
-    private volatile ManagedChannel grpcChannel;
+    /**
+     * Immutable pairing of a gRPC stub and the channel that backs it. Holding both in a single
+     * volatile reference lets request threads read a consistent (stub, channel) pair with one
+     * volatile read, so a concurrent channel reinitialization can never leave a thread with a stub
+     * from one channel and a reference to a different channel.
+     */
+    record ChannelHolder(KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub stub, ManagedChannel channel) { }
+
+    // Volatile: read by multiple request threads and written during channel initialization.
+    private volatile ChannelHolder channelHolder;
 
     @PostConstruct
     void postConstruct() {
@@ -75,7 +82,7 @@ public class KesselCheckClient {
 
     private void initializeChannel(String reason) {
         // Capture before overwriting so we can shut it down after.
-        ManagedChannel oldGrpcChannel = grpcChannel;
+        ChannelHolder oldHolder = channelHolder;
 
         Pair<KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub, ManagedChannel> clientAndChannel;
         /*
@@ -97,40 +104,41 @@ public class KesselCheckClient {
                 .build();
         }
 
-        grpcClient = clientAndChannel.getLeft();
-        grpcChannel = clientAndChannel.getRight();
+        channelHolder = new ChannelHolder(clientAndChannel.getLeft(), clientAndChannel.getRight());
 
         Log.debugf("Kessel gRPC channel initialized: %s", reason);
         meterRegistry.counter(KESSEL_CHANNEL_INIT_COUNTER_NAME, Tags.of(KESSEL_CHANNEL_INIT_TAG_REASON, reason)).increment();
 
         // Shutdown old gRPC channel without waiting (let in-flight requests drain in background).
-        if (oldGrpcChannel != null) {
-            oldGrpcChannel.shutdown();
+        if (oldHolder != null && oldHolder.channel() != null) {
+            oldHolder.channel().shutdown();
         }
     }
 
-    private KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub getClient() {
+    private ChannelHolder getClient() {
+        ChannelHolder holder = channelHolder;
         // SHUTDOWN state is terminal - channel cannot recover and must be recreated.
-        if (grpcChannel != null && grpcChannel.getState(false) != ConnectivityState.SHUTDOWN) {
-            return grpcClient;
+        if (holder != null && holder.channel() != null && holder.channel().getState(false) != ConnectivityState.SHUTDOWN) {
+            return holder;
         }
         Log.warn("Kessel gRPC channel is unhealthy, recreating");
         initializeChannel("unhealthy_channel");
-        return grpcClient;
+        return channelHolder;
     }
 
     @Retry(maxRetries = 3, delay = 100, retryOn = KesselTransientException.class)
     public CheckResponse check(CheckRequest request) {
-        // Capture the channel backing this call so, on failure, we can act on the exact channel that failed
-        // rather than the shared field, which another thread may have concurrently reinitialized.
-        KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub client = getClient();
-        ManagedChannel channel = grpcChannel;
+        // getClient() is inside the try so an OAuth2Exception thrown while lazily reinitializing the channel is
+        // wrapped in KesselTransientException and retried, instead of propagating past the @Retry interceptor.
+        // The holder gives us a consistent (stub, channel) snapshot for this call from a single volatile read.
+        ChannelHolder holder = null;
         try {
-            return client
+            holder = getClient();
+            return holder.stub()
                 .withDeadlineAfter(backendConfig.getKesselTimeoutMs(), TimeUnit.MILLISECONDS)
                 .check(request);
         } catch (StatusRuntimeException e) {
-            throw handleGrpcException(e, channel);
+            throw handleGrpcException(e, holder);
         } catch (OAuth2Exception e) {
             Log.warnf("Transient error fetching Kessel OAuth2 credentials (may retry): %s", e.getMessage());
             throw new KesselTransientException(e);
@@ -139,23 +147,24 @@ public class KesselCheckClient {
 
     @Retry(maxRetries = 3, delay = 100, retryOn = KesselTransientException.class)
     public CheckForUpdateResponse checkForUpdate(CheckForUpdateRequest request) {
-        // Capture the channel backing this call so, on failure, we can act on the exact channel that failed
-        // rather than the shared field, which another thread may have concurrently reinitialized.
-        KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub client = getClient();
-        ManagedChannel channel = grpcChannel;
+        // getClient() is inside the try so an OAuth2Exception thrown while lazily reinitializing the channel is
+        // wrapped in KesselTransientException and retried, instead of propagating past the @Retry interceptor.
+        // The holder gives us a consistent (stub, channel) snapshot for this call from a single volatile read.
+        ChannelHolder holder = null;
         try {
-            return client
+            holder = getClient();
+            return holder.stub()
                 .withDeadlineAfter(backendConfig.getKesselTimeoutMs(), TimeUnit.MILLISECONDS)
                 .checkForUpdate(request);
         } catch (StatusRuntimeException e) {
-            throw handleGrpcException(e, channel);
+            throw handleGrpcException(e, holder);
         } catch (OAuth2Exception e) {
             Log.warnf("Transient error fetching Kessel OAuth2 credentials (may retry): %s", e.getMessage());
             throw new KesselTransientException(e);
         }
     }
 
-    private RuntimeException handleGrpcException(StatusRuntimeException e, ManagedChannel failedChannel) {
+    private RuntimeException handleGrpcException(StatusRuntimeException e, ChannelHolder failedHolder) {
         Status.Code code = e.getStatus().getCode();
 
         meterRegistry.counter(KESSEL_GRPC_ERROR_COUNTER_NAME, Tags.of(KESSEL_GRPC_ERROR_TAG_ERROR_TYPE, code.name())).increment();
@@ -167,8 +176,10 @@ public class KesselCheckClient {
                 initializeChannel("unauthenticated");
             } catch (OAuth2Exception oauthEx) {
                 Log.warnf("Failed to refresh OAuth2 credentials after UNAUTHENTICATED error: %s", oauthEx.getMessage());
-                if (failedChannel != null) {
-                    failedChannel.shutdown();
+                // Shut down only the exact channel that produced this failed call, so a channel another thread
+                // concurrently reinitialized to a healthy state is never torn down here.
+                if (failedHolder != null && failedHolder.channel() != null) {
+                    failedHolder.channel().shutdown();
                 }
                 return new KesselTransientException(oauthEx);
             }
@@ -190,17 +201,19 @@ public class KesselCheckClient {
 
     @PreDestroy
     void preDestroy() {
-        if (grpcChannel == null) {
+        ChannelHolder holder = channelHolder;
+        if (holder == null || holder.channel() == null) {
             return;
         }
-        grpcChannel.shutdown();
+        ManagedChannel channel = holder.channel();
+        channel.shutdown();
         try {
-            if (!grpcChannel.awaitTermination(CHANNEL_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            if (!channel.awaitTermination(CHANNEL_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 Log.warn("Kessel gRPC channel did not terminate gracefully, forcing shutdown");
-                grpcChannel.shutdownNow();
+                channel.shutdownNow();
             }
         } catch (InterruptedException e) {
-            grpcChannel.shutdownNow();
+            channel.shutdownNow();
             Thread.currentThread().interrupt();
         }
     }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
@@ -159,6 +159,9 @@ public class KesselCheckClient {
                 initializeChannel("unauthenticated");
             } catch (OAuth2Exception oauthEx) {
                 Log.warnf("Failed to refresh OAuth2 credentials after UNAUTHENTICATED error: %s", oauthEx.getMessage());
+                if (grpcChannel != null) {
+                    grpcChannel.shutdown();
+                }
                 return new KesselTransientException(oauthEx);
             }
             return new KesselTransientException(e);

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClient.java
@@ -155,12 +155,16 @@ public class KesselCheckClient {
         // UNAUTHENTICATED usually means the OAuth2 token expired. Recreate channel with fresh credentials.
         if (code == UNAUTHENTICATED) {
             Log.warnf("Transient gRPC error from Kessel (may retry): %s - %s. Recreating channel with fresh credentials.", code, e.getMessage());
+            // Capture the current channel before reinitializing. If credential refresh fails, we shut down this
+            // specific (failed) channel rather than the shared field, so a channel that another thread concurrently
+            // reinitialized to a healthy state cannot be torn down here.
+            ManagedChannel failedChannel = grpcChannel;
             try {
                 initializeChannel("unauthenticated");
             } catch (OAuth2Exception oauthEx) {
                 Log.warnf("Failed to refresh OAuth2 credentials after UNAUTHENTICATED error: %s", oauthEx.getMessage());
-                if (grpcChannel != null) {
-                    grpcChannel.shutdown();
+                if (failedChannel != null) {
+                    failedChannel.shutdown();
                 }
                 return new KesselTransientException(oauthEx);
             }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselTransientException.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/kessel/KesselTransientException.java
@@ -1,6 +1,7 @@
 package com.redhat.cloud.notifications.auth.kessel;
 
 import io.grpc.StatusRuntimeException;
+import org.project_kessel.api.auth.OAuth2Exception;
 
 /**
  * Marker exception for transient Kessel client failures. Only this exception type triggers retry.
@@ -8,5 +9,9 @@ import io.grpc.StatusRuntimeException;
 public class KesselTransientException extends RuntimeException {
     public KesselTransientException(StatusRuntimeException cause) {
         super("Transient Kessel failure: " + cause.getStatus().getCode(), cause);
+    }
+
+    public KesselTransientException(OAuth2Exception cause) {
+        super("Transient Kessel failure: OAuth2 credentials fetch failed", cause);
     }
 }

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacWorkspacesOidcClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacWorkspacesOidcClient.java
@@ -3,11 +3,14 @@ package com.redhat.cloud.notifications.auth.rbac;
 import com.redhat.cloud.notifications.auth.rbac.workspace.RbacWorkspace;
 import com.redhat.cloud.notifications.routers.models.Page;
 import io.quarkus.oidc.client.filter.OidcClientFilter;
+import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
@@ -27,7 +30,7 @@ public interface RbacWorkspacesOidcClient {
     @GET
     @Path("/api/rbac/v2/workspaces/")
     @Produces(MediaType.APPLICATION_JSON)
-    @Retry(maxRetries = 3)
+    @Retry(maxRetries = 3, retryOn = {ProcessingException.class, ServerErrorException.class}, abortOn = ClientErrorException.class)
     Page<RbacWorkspace> getWorkspaces(
         @HeaderParam("x-rh-rbac-org-id") String orgId,
         @QueryParam("type") String workspaceType,

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacWorkspacesOidcClient.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/RbacWorkspacesOidcClient.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -26,6 +27,7 @@ public interface RbacWorkspacesOidcClient {
     @GET
     @Path("/api/rbac/v2/workspaces/")
     @Produces(MediaType.APPLICATION_JSON)
+    @Retry(maxRetries = 3)
     Page<RbacWorkspace> getWorkspaces(
         @HeaderParam("x-rh-rbac-org-id") String orgId,
         @QueryParam("type") String workspaceType,

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
@@ -33,7 +33,7 @@ public class WorkspaceUtils {
      * @return the identifier of the workspace.
      */
     @CacheResult(cacheName = "kessel-rbac-workspace-id")
-    @Retry(maxRetries = 3, delay = 100)
+    @Retry(maxRetries = 3, delay = 100, retryOn = {OAuth2Exception.class, IOException.class})
     public UUID getDefaultWorkspaceId(final String orgId) {
 
         OAuth2ClientCredentials credentials;

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
@@ -33,7 +33,7 @@ public class WorkspaceUtils {
      * @return the identifier of the workspace.
      */
     @CacheResult(cacheName = "kessel-rbac-workspace-id")
-    @Retry(maxRetries = 3, delay = 100, retryOn = {OAuth2Exception.class, IOException.class})
+    @Retry(maxRetries = 3, delay = 100, retryOn = OAuth2Exception.class)
     public UUID getDefaultWorkspaceId(final String orgId) {
 
         OAuth2ClientCredentials credentials;

--- a/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/auth/rbac/workspace/WorkspaceUtils.java
@@ -6,8 +6,10 @@ import io.quarkus.cache.CacheResult;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.faulttolerance.Retry;
 import org.project_kessel.api.auth.OAuth2AuthRequest;
 import org.project_kessel.api.auth.OAuth2ClientCredentials;
+import org.project_kessel.api.auth.OAuth2Exception;
 import org.project_kessel.api.rbac.v2.FetchWorkspace;
 import org.project_kessel.api.rbac.v2.Workspace;
 
@@ -31,9 +33,16 @@ public class WorkspaceUtils {
      * @return the identifier of the workspace.
      */
     @CacheResult(cacheName = "kessel-rbac-workspace-id")
+    @Retry(maxRetries = 3, delay = 100)
     public UUID getDefaultWorkspaceId(final String orgId) {
 
-        OAuth2ClientCredentials credentials = oauth2ClientCredentialsCache.getCredentials();
+        OAuth2ClientCredentials credentials;
+        try {
+            credentials = oauth2ClientCredentialsCache.getCredentials();
+        } catch (OAuth2Exception e) {
+            Log.warnf("Transient error fetching OAuth2 credentials for RBAC workspace lookup (may retry): %s", e.getMessage());
+            throw e;
+        }
         OAuth2AuthRequest authRequest = new OAuth2AuthRequest(credentials);
 
         Workspace workspace;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -60,6 +60,9 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
+quarkus.oidc-client.connection-delay=2S
+quarkus.oidc-client.connection-retry-count=3
+quarkus.oidc-client.connection-timeout=10S
 
 internal.admin-role=crc-notifications-team
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -60,9 +60,7 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
-quarkus.oidc-client.connection-delay=2S
-quarkus.oidc-client.connection-retry-count=3
-quarkus.oidc-client.connection-timeout=10S
+quarkus.oidc-client.connection-delay=20S
 
 internal.admin-role=crc-notifications-team
 

--- a/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClientTest.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/auth/kessel/KesselCheckClientTest.java
@@ -85,9 +85,8 @@ public class KesselCheckClientTest {
         // Unwrap the CDI proxy to get the actual bean instance
         KesselCheckClient actualBean = ClientProxy.unwrap(kesselCheckClient);
 
-        // Inject mocks via reflection into the actual bean
-        injectField(actualBean, "grpcClient", mockStub);
-        injectField(actualBean, "grpcChannel", mockChannel);
+        // Inject mocks via reflection into the actual bean, as a single (stub, channel) holder
+        injectField(actualBean, "channelHolder", new KesselCheckClient.ChannelHolder(mockStub, mockChannel));
 
         // Save current counter values before each test
         saveCounterValues();

--- a/connector-pagerduty/src/main/resources/application.properties
+++ b/connector-pagerduty/src/main/resources/application.properties
@@ -39,9 +39,7 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
-quarkus.oidc-client.connection-delay=2S
-quarkus.oidc-client.connection-retry-count=3
-quarkus.oidc-client.connection-timeout=10S
+quarkus.oidc-client.connection-delay=20S
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/connector-pagerduty/src/main/resources/application.properties
+++ b/connector-pagerduty/src/main/resources/application.properties
@@ -39,6 +39,9 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
+quarkus.oidc-client.connection-delay=2S
+quarkus.oidc-client.connection-retry-count=3
+quarkus.oidc-client.connection-timeout=10S
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/connector-servicenow/src/main/resources/application.properties
+++ b/connector-servicenow/src/main/resources/application.properties
@@ -35,6 +35,9 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
+quarkus.oidc-client.connection-delay=2S
+quarkus.oidc-client.connection-retry-count=3
+quarkus.oidc-client.connection-timeout=10S
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/connector-servicenow/src/main/resources/application.properties
+++ b/connector-servicenow/src/main/resources/application.properties
@@ -35,9 +35,7 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
-quarkus.oidc-client.connection-delay=2S
-quarkus.oidc-client.connection-retry-count=3
-quarkus.oidc-client.connection-timeout=10S
+quarkus.oidc-client.connection-delay=20S
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/connector-splunk/src/main/resources/application.properties
+++ b/connector-splunk/src/main/resources/application.properties
@@ -38,9 +38,7 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
-quarkus.oidc-client.connection-delay=2S
-quarkus.oidc-client.connection-retry-count=3
-quarkus.oidc-client.connection-timeout=10S
+quarkus.oidc-client.connection-delay=20S
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/connector-splunk/src/main/resources/application.properties
+++ b/connector-splunk/src/main/resources/application.properties
@@ -38,6 +38,9 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
+quarkus.oidc-client.connection-delay=2S
+quarkus.oidc-client.connection-retry-count=3
+quarkus.oidc-client.connection-timeout=10S
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/connector-webhook/src/main/resources/application.properties
+++ b/connector-webhook/src/main/resources/application.properties
@@ -32,9 +32,7 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
-quarkus.oidc-client.connection-delay=2S
-quarkus.oidc-client.connection-retry-count=3
-quarkus.oidc-client.connection-timeout=10S
+quarkus.oidc-client.connection-delay=20S
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/connector-webhook/src/main/resources/application.properties
+++ b/connector-webhook/src/main/resources/application.properties
@@ -32,6 +32,9 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
+quarkus.oidc-client.connection-delay=2S
+quarkus.oidc-client.connection-retry-count=3
+quarkus.oidc-client.connection-timeout=10S
 
 quarkus.unleash.active=false
 quarkus.unleash.url=http://localhost:4242

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -183,9 +183,7 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
-quarkus.oidc-client.connection-delay=2S
-quarkus.oidc-client.connection-retry-count=3
-quarkus.oidc-client.connection-timeout=10S
+quarkus.oidc-client.connection-delay=20S
 
 # Quarkus caches
 quarkus.cache.caffeine.drawer-template.expire-after-write=PT5M

--- a/engine/src/main/resources/application.properties
+++ b/engine/src/main/resources/application.properties
@@ -183,6 +183,9 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
+quarkus.oidc-client.connection-delay=2S
+quarkus.oidc-client.connection-retry-count=3
+quarkus.oidc-client.connection-timeout=10S
 
 # Quarkus caches
 quarkus.cache.caffeine.drawer-template.expire-after-write=PT5M

--- a/recipients-resolver/src/main/resources/application.properties
+++ b/recipients-resolver/src/main/resources/application.properties
@@ -44,9 +44,7 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
-quarkus.oidc-client.connection-delay=2S
-quarkus.oidc-client.connection-retry-count=3
-quarkus.oidc-client.connection-timeout=10S
+quarkus.oidc-client.connection-delay=20S
 
 quarkus.log.category."io.quarkus.cache.runtime.caffeine.CaffeineCacheManagerBuilder".level=DEBUG
 

--- a/recipients-resolver/src/main/resources/application.properties
+++ b/recipients-resolver/src/main/resources/application.properties
@@ -44,6 +44,9 @@ quarkus.oidc-client.auth-server-url=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.client-id=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.credentials.secret=REPLACE_ME_FROM_ENV_VAR
 quarkus.oidc-client.grant.type=client
+quarkus.oidc-client.connection-delay=2S
+quarkus.oidc-client.connection-retry-count=3
+quarkus.oidc-client.connection-timeout=10S
 
 quarkus.log.category."io.quarkus.cache.runtime.caffeine.CaffeineCacheManagerBuilder".level=DEBUG
 


### PR DESCRIPTION
## Summary
- Add OIDC client startup retry config (`connection-delay=2S`, `connection-retry-count=3`, `connection-timeout=10S`) to all 7 modules using `quarkus-oidc-client`, so services survive brief OIDC issuer outages during boot
- Align backend Kessel OAuth2 error handling with recipients-resolver: catch `OAuth2Exception` in `KesselCheckClient` and wrap as retryable `KesselTransientException`
- Harden `handleGrpcException` so credential refresh failures during UNAUTHENTICATED recovery are also retryable instead of propagating raw
- Add `@Retry` and `OAuth2Exception` handling to `WorkspaceUtils` (had no retry or OIDC error handling)
- Add missing `@Retry(maxRetries = 3)` to `RbacWorkspacesOidcClient` (only OIDC REST client without retry)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary authentication and credential-service failures.
  - Authentication channel recovery now safely retries after unauthenticated errors.
  - Workspace and authorization lookups retry transient failures while avoiding retries for client-side errors.

- **Reliability Improvements**
  - Improved recovery when credentials cannot be refreshed.
  - Updated OIDC connection behavior with a longer 20-second connection delay to reduce failures from temporary identity-provider connectivity issues.
  - Improved consistency during authentication channel updates to prevent requests from using mismatched connection details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->