### PR TITLE
RHCLOUD-49576: add screenreader improvements to Lightwell email

### DIFF
--- a/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
@@ -1,9 +1,9 @@
 {@boolean renderTitleRightPart=true}
 {@boolean renderHeaderTitle=false}
-{@String renderLowTag='<table cellspacing="0" cellpadding="0" style="border-radius: 999px; border-color: #5e40be; border-width: 1px; border-style: solid; background-color: #ffffff; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/minor-purple.png" height="10px" style="margin-right: 4px;">Low</td></tr></table>'}
-{@String renderModerateTag='<table cellspacing="0" cellpadding="0" style="border-radius: 999px; border-color: #dba614; border-width: 1px; border-style: solid; background-color: #ffffff; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/moderate.png" height="10px" style="margin-right: 4px;">Moderate</td></tr></table>'}
-{@String renderImportantTag='<table cellspacing="0" cellpadding="0" style="border-radius: 999px; background-color: #ffcd17; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400;"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/important-black.png" height="10px" style="margin-right: 4px;">Important</td></tr></table>'}
-{@String renderCriticalTag='<table cellspacing="0" cellpadding="0" style="border-radius: 999px; background-color: #b0370b; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400; color: #ffffff;"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/critical-white.png" height="10px" style="margin-right: 4px;">Critical</td></tr></table>'}
+{@String renderLowTag='<table cellspacing="0" cellpadding="0" role="presentation" style="border-radius: 999px; border-color: #5e40be; border-width: 1px; border-style: solid; background-color: #ffffff; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/minor-purple.png" height="10px" style="margin-right: 4px;">Low</td></tr></table>'}
+{@String renderModerateTag='<table cellspacing="0" cellpadding="0" role="presentation" style="border-radius: 999px; border-color: #dba614; border-width: 1px; border-style: solid; background-color: #ffffff; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/moderate.png" height="10px" style="margin-right: 4px;">Moderate</td></tr></table>'}
+{@String renderImportantTag='<table cellspacing="0" cellpadding="0" role="presentation" style="border-radius: 999px; background-color: #ffcd17; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400;"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/important-black.png" height="10px" style="margin-right: 4px;">Important</td></tr></table>'}
+{@String renderCriticalTag='<table cellspacing="0" cellpadding="0" role="presentation" style="border-radius: 999px; background-color: #b0370b; vertical-align: middle; line-height: 18px;"><tr><td style="padding-top: 1px; padding-bottom: 1px; padding-left: 8px; padding-right: 8px; font-size: 12px; font-weight: 400; color: #ffffff;"><img src="https://console.redhat.com/apps/frontend-assets/email-assets/severities/critical-white.png" height="10px" style="margin-right: 4px;">Critical</td></tr></table>'}
 {#include email/Common/insightsEmailBody}
 {#content-header-logo}
     <a href="https://console.redhat.com/lightwell" target="_blank">
@@ -28,9 +28,9 @@
 <table style="{body-section-table-style}">
     <thead>
     <tr>
-        <th style="{body-section-table-th-style}">Package{#if eventsCount > 1}s{/if}</th>
-        <th style="{body-section-table-th-style} min-width: 90px;">Release</th>
-        <th style="{body-section-table-th-style}; min-width: 210px" colspan="2">Related CVE(s)</th>
+        <th scope="col" style="{body-section-table-th-style}">Package{#if eventsCount > 1}s{/if}</th>
+        <th scope="col" style="{body-section-table-th-style} min-width: 90px;">Release</th>
+        <th scope="col" style="{body-section-table-th-style}; min-width: 210px" colspan="2">Related CVE(s)</th>
     </tr>
     </thead>
     <tbody style="{body-section-table-tbody-style}">
@@ -49,7 +49,7 @@
                 {/for}
                 </td>
                 <td style="{body-section-table-td-style}{#if !release_isLast}; border-bottom-width: 0 !important;{/if}">
-                <table>
+                <table role="presentation">
                 {#for cve in release.related_cve}
                     <tr>
                     <td><a style="{body-section-table-td-a-style}" href="{cve.url}" target="_blank">{cve.cve}</a></td>


### PR DESCRIPTION
Adds small screenreader improvements to the Lightwell instant email template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lightwell email compatibility across email clients by updating table markup and accessibility roles.
  * Severity tags and CVE table content continue to render unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->