### PR TITLE
[RHCLOUD-53075] Use filled severity icons in email templates

### DIFF
--- a/common-template/src/main/resources/templates/email/Advisor/dailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Advisor/dailyEmailBody.html
@@ -42,10 +42,10 @@
                 </td>
                 <td style="{body-section-table-td-style}">
                     {#switch action.context.advisor.new_recommendations.get(rec).total_risk}
-                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                     {/switch}
                 </td>
                 <td style="{body-section-table-td-style}">{action.context.advisor.new_recommendations.get(rec).systems}</td>
@@ -83,10 +83,10 @@
                 </td>
                 <td style="{body-section-table-td-style}">
                   {#switch action.context.advisor.resolved_recommendations.get(rec).total_risk}
-                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                   {/switch}
                 </td>
                 <td style="{body-section-table-td-style}">{action.context.advisor.resolved_recommendations.get(rec).systems}</td>
@@ -123,10 +123,10 @@
                 </td>
                 <td style="{body-section-table-td-style}">
                   {#switch action.context.advisor.deactivated_recommendations.get(rec).total_risk}
-                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                   {/switch}
                 </td>
               </tr>

--- a/common-template/src/main/resources/templates/email/Advisor/deactivatedRecommendationInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Advisor/deactivatedRecommendationInstantEmailBody.html
@@ -38,10 +38,10 @@
             <td style="{body-section-table-td-style}">{it.payload.rule_description}</td>
             <td style="{body-section-table-td-style}">
                 {#switch it.payload.total_risk}
-                    {#case 1}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                    {#case 2}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                    {#case 3}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                    {#case 4}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {#case 1}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                    {#case 2}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                    {#case 3}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                    {#case 4}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                 {/switch}
             </td>
             <td style="{body-section-table-td-style}">{it.payload.affected_systems}</td>

--- a/common-template/src/main/resources/templates/email/Advisor/newRecommendationInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Advisor/newRecommendationInstantEmailBody.html
@@ -30,10 +30,10 @@
             </td>
             <td style="{body-section-table-td-style}">
                 {#switch it.payload.total_risk}
-                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                 {/switch}
             </td>
         </tr>

--- a/common-template/src/main/resources/templates/email/Advisor/resolvedRecommendationInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Advisor/resolvedRecommendationInstantEmailBody.html
@@ -30,10 +30,10 @@
             </td>
             <td style="{body-section-table-td-style}">
                 {#switch it.payload.total_risk}
-                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                 {/switch}
             </td>
         </tr>

--- a/common-template/src/main/resources/templates/email/AdvisorOpenshift/newRecommendationInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/AdvisorOpenshift/newRecommendationInstantEmailBody.html
@@ -30,13 +30,13 @@
             <td style="{body-section-table-td-style}">
                 {#switch it.payload.total_risk}
                 {#case '1'}
-                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low severity" width="55" border="0">
+                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low severity" width="55" border="0">
                 {#case '2'}
-                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate severity" width="85" border="0">
+                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate severity" width="85" border="0">
                 {#case '3'}
-                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important severity" width="86" border="0">
+                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important severity" width="86" border="0">
                 {#case '4'}
-                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical severity" width="70" border="0">
+                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical severity" width="70" border="0">
                 {/switch}
             </td>
             <td style="{body-section-table-td-style}">{it.payload.publish_date.toTimeAgo()}</td>

--- a/common-template/src/main/resources/templates/email/Errata/dailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Errata/dailyEmailBody.html
@@ -53,10 +53,10 @@
                     <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="{action.context.errata.base_url}{it.id}" target="_blank">{it.id}</a></td>
                     <td style="{body-section-table-td-style}">
                         {#switch it.severity.toLowerCase}
-                            {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                            {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                            {#case 'important'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                            {#case 'critical'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                            {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                            {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                            {#case 'important'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                            {#case 'critical'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                         {/switch}
                     </td>
                     <td style="{body-section-table-td-style}">{it.synopsis}</td>

--- a/common-template/src/main/resources/templates/email/Errata/securityEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Errata/securityEmailBody.html
@@ -30,10 +30,10 @@
                     <td style="{body-section-table-td-style}"><a style="{body-section-table-td-a-style}" href="{action.context.base_url}{it.payload.id}" target="_blank">{it.payload.id}</a></td>
                     <td style="{body-section-table-td-style}">
                         {#switch it.payload.severity.toLowerCase}
-                            {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                            {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                            {#case 'important'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                            {#case 'critical'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                            {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                            {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                            {#case 'important'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                            {#case 'critical'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                         {/switch}
                     </td>
                     <td style="{body-section-table-td-style}">{it.payload.synopsis}</td>

--- a/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
@@ -55,10 +55,10 @@
                     <td><a style="{body-section-table-td-a-style}" href="{cve.url}" target="_blank">{cve.cve}</a></td>
                     <td style="min-width: 85px">
                     {#switch cve.severity}
-                        {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                        {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                        {#case 'important'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                        {#case 'critical'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                        {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                        {#case 'moderate'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                        {#case 'important'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                        {#case 'critical'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                     {/switch}
                     </td>
                     </tr>

--- a/common-template/src/main/resources/templates/email/Secure/Advisor/dailyEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Secure/Advisor/dailyEmailBody.html
@@ -42,10 +42,10 @@
                 </td>
                 <td style="{body-section-table-td-style}">
                     {#switch action.context.advisor.new_recommendations.get(rec).total_risk}
-                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                     {/switch}
                 </td>
                 <td style="{body-section-table-td-style}">{action.context.advisor.new_recommendations.get(rec).systems}</td>
@@ -83,10 +83,10 @@
                 </td>
                 <td style="{body-section-table-td-style}">
                   {#switch action.context.advisor.resolved_recommendations.get(rec).total_risk}
-                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                   {/switch}
                 </td>
                 <td style="{body-section-table-td-style}">{action.context.advisor.resolved_recommendations.get(rec).systems}</td>
@@ -123,10 +123,10 @@
                 </td>
                 <td style="{body-section-table-td-style}">
                   {#switch action.context.advisor.deactivated_recommendations.get(rec).total_risk}
-                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v2.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
-                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v2.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
-                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v2.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
-                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v2.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
+                    {#case "1"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->
+                    {#case "2"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_moderate_v3.png" alt="Moderate" width="85" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderModerateTag}<!--<![endif]-->
+                    {#case "3"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_important_v3.png" alt="Important" width="86" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderImportantTag}<!--<![endif]-->
+                    {#case "4"}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_critical_v3.png" alt="Critical" width="70" border="0"><![endif]--><!--[if !mso]><!-->{renderCriticalTag}<!--<![endif]-->
                   {/switch}
                 </td>
               </tr>

--- a/common-template/src/test/java/email/TestAdvisorTemplate.java
+++ b/common-template/src/test/java/email/TestAdvisorTemplate.java
@@ -83,16 +83,16 @@ public class TestAdvisorTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains("/insights/advisor/recommendations/test|Active_rule_1"));
         assertTrue(result.contains("Active rule 1</a>"));
         assertTrue(result.contains("https://console.redhat.com/apps/frontend-assets/email-assets/img_incident.png"));
-        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_important_v2.png"));
+        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_important_v3.png"));
 
         assertTrue(result.contains("Resolved Recommendation"));
         assertTrue(result.contains("/insights/advisor/recommendations/test|Active_rule_2"));
         assertTrue(result.contains("Active rule 2</a>"));
-        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_low_v2.png"));
+        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_low_v3.png"));
         assertTrue(result.contains("Deactivated Recommendations"));
         assertTrue(result.contains("/insights/advisor/recommendations/test|Active_rule_3"));
         assertTrue(result.contains("Active rule 3</a>"));
-        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_critical_v2.png"));
+        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_critical_v3.png"));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
@@ -168,10 +168,10 @@ public class TestAdvisorTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains("Resolved Recommendation"));
         assertTrue(result.contains("/insights/advisor/recommendations/test|Active_rule_2"));
         assertTrue(result.contains("Active rule 2</a>"));
-        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_low_v2.png"));
+        assertTrue(result.contains("/apps/frontend-assets/email-assets/img_low_v3.png"));
         assertFalse(result.contains("New Recommendation"));
         assertFalse(result.contains("Deactivated Recommendation"));
-        assertFalse(result.contains("/apps/frontend-assets/email-assets/img_critical_v2.png"));
+        assertFalse(result.contains("/apps/frontend-assets/email-assets/img_critical_v3.png"));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 


### PR DESCRIPTION
## Jira work item

https://redhat.atlassian.net/browse/RHCLOUD-50375

## Description

> [!important]
> Merge after https://github.com/RedHatInsights/frontend-assets/pull/328

Update to v3 severity lozenges for email body templates, which are consistently filled and align with other appearances of PatternFly severity icons. Text may switch from white to black on some low-contrast icons.

<img width="257" height="358" alt="Screenshot From 2026-08-18 09-24-30" src="https://github.com/user-attachments/assets/22412d9d-1ae0-47c3-8995-21c03675716f" />

# Compatibility

Text and meaning of the icons has not changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated risk-severity badges in recommendation, errata, and CVE email notifications to use the latest visual assets.
  * Improved severity badge rendering for Outlook while preserving existing labels, dimensions, and non-Outlook formatting.

* **Tests**
  * Updated email template verification to reflect the latest severity badge assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->