### PR TITLE
Fix CI: run Mintmaker lockfile self-heal on pull_request events too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         # Needed before "Regenerate yarn.lock for Mintmaker branches" (so that
         # commit is signed too), not just before "Create PR for admin-console
         # updates" further down.
-        if: github.event_name == 'push' && ((steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.yarn-files-changed.outputs.any_changed == 'true' && startsWith(github.ref_name, 'konflux/mintmaker/')))
+        if: (github.event_name == 'push' && steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.yarn-files-changed.outputs.any_changed == 'true' && ((github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')) || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'konflux/mintmaker/') && github.event.pull_request.head.repo.fork == false)))
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -105,7 +105,7 @@ jobs:
           fi
       - name: Set up Node for Mintmaker lockfile refresh
         # Keep this version in sync with <nodeVersion> in admin-console/pom.xml.
-        if: steps.yarn-files-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        if: steps.yarn-files-changed.outputs.any_changed == 'true' && ((github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')) || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'konflux/mintmaker/') && github.event.pull_request.head.repo.fork == false))
         uses: actions/setup-node@v7
         with:
           node-version: 22.23.2
@@ -118,12 +118,23 @@ jobs:
         # check below makes this a no-op when nothing actually changes.
         # Relies on the git identity and signing key set up by "Configure GPG
         # signing" so the pushed commit shows as Verified.
-        if: steps.yarn-files-changed.outputs.any_changed == 'true' && github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')
+        #
+        # Also runs on pull_request (restricted to non-fork Mintmaker branches)
+        # as a fallback for when the branch's own copy of this workflow
+        # predates this step and never ran it on push: the base branch's
+        # (master's) workflow is what actually executes for pull_request
+        # events, so it still catches the mismatch even if the branch is
+        # stale. Explicit checkout of the head branch below is required
+        # because pull_request builds a detached merge commit, not the
+        # branch tip.
+        if: steps.yarn-files-changed.outputs.any_changed == 'true' && ((github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')) || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'konflux/mintmaker/') && github.event.pull_request.head.repo.fork == false))
         working-directory: admin-console/src/main/webapp
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
-          BRANCH_REF: ${{ github.ref_name }}
+          BRANCH_REF: ${{ github.head_ref || github.ref_name }}
         run: |
+          git fetch origin "${BRANCH_REF}"
+          git checkout -B "${BRANCH_REF}" FETCH_HEAD
           corepack enable
           yarn install
           if git diff --quiet -- yarn.lock; then
@@ -142,7 +153,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/push-admin-console.sh
       - name: Cleanup GPG key
-        if: always() && github.event_name == 'push' && ((steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.yarn-files-changed.outputs.any_changed == 'true' && startsWith(github.ref_name, 'konflux/mintmaker/')))
+        if: always() && ((github.event_name == 'push' && steps.admin-console-changed.outputs.any_changed == 'true' && github.ref == 'refs/heads/master') || (steps.yarn-files-changed.outputs.any_changed == 'true' && ((github.event_name == 'push' && startsWith(github.ref_name, 'konflux/mintmaker/')) || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'konflux/mintmaker/') && github.event.pull_request.head.repo.fork == false))))
         run: |
           if [ -n "${GPG_KEY_FINGERPRINT}" ]; then
             gpg --batch --yes --delete-secret-and-public-key "${GPG_KEY_FINGERPRINT}" || true


### PR DESCRIPTION
## Summary
- PR #4792 (a Mintmaker "Update react monorepo" dependency-bump PR) fails the `Build` check because `package.json` was bumped without a matching `yarn.lock` update, and Yarn's hardened mode refuses to auto-modify the lockfile on public PR builds (`The lockfile would have been modified by this install, which is explicitly forbidden.`).
- The workflow already has a self-heal mechanism for this ("Regenerate yarn.lock for Mintmaker branches"), but it only runs on `push` events. Investigation showed why that wasn't enough for #4792:
  - The `pull_request` run executes the **base branch's** (master's) copy of `build.yml`, which has the fix but gates it to `push` only, so it's skipped.
  - The `push` run on the Mintmaker branch executes **that branch's own** copy of `build.yml`, which was cut before this step existed, so the step isn't even present.
  - Net result: neither event path applies the fix for a Mintmaker branch created before the self-heal step was added.
- This PR extends the "Configure GPG signing", "Set up Node for Mintmaker lockfile refresh", "Regenerate yarn.lock for Mintmaker branches", and "Cleanup GPG key" steps to also run on `pull_request`, scoped to `konflux/mintmaker/*` branches where `github.event.pull_request.head.repo.fork == false` — so real external contributor (fork) PRs are unaffected and Yarn's hardened mode stays enabled for them.
- Since `pull_request` builds check out a detached synthetic merge commit rather than the branch tip, the regen step now explicitly `git fetch`/`checkout -B`s the actual head branch before running `yarn install` and pushing the fix commit, instead of assuming `HEAD` is already the branch to push to.

## Test plan
- [ ] Re-run the `Build` check on PR #4792 (or open a fresh Mintmaker PR) and confirm the "Regenerate yarn.lock for Mintmaker branches" step now executes on the `pull_request` event and pushes a corrected `yarn.lock`.
- [ ] Confirm the pushed lockfile-fix commit is GPG-signed and shows as Verified.
- [ ] Confirm a genuine external fork PR still runs with hardened mode enabled (step stays skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated dependency lockfile updates for supported pull requests.
  * Ensured lockfile refreshes use the correct pull-request branch.
  * Expanded GPG cleanup coverage for pull-request workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->