### PR TITLE
[RHINENG-30043] Add message to Lifecycle template

### DIFF
--- a/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
@@ -35,7 +35,6 @@ Red Hat Enterprise Linux - Life Cycle Monthly Report - {action.context.lifecycle
                 <p style="margin-top: 0; font-size: 14px; font-weight: 700; color: #151515;">Systems on RHEL 6 and below are not shown in this report</p>
                 <p style="margin-bottom: 0; font-size: 14px; font-weight: 400; color: #151515;">
                     Only RHEL 7 and above and Application Streams are displayed.
-                    <a style="{body-section-underline-link-style}" href="https://access.redhat.com/support/policy/updates/errata" target="_blank">Learn more about the RHEL life cycle.</a>
                 </p>
             </td>
         </tr>

--- a/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
@@ -25,6 +25,23 @@ Red Hat Enterprise Linux - Life Cycle Monthly Report - {action.context.lifecycle
     rhel8SystemsCount = action.events[0].payload.appstream_retired.orEmpty.rhel8.orEmpty.systems_count.or(0)
 }
 <table style="width: 100%; border: 0">
+<tr><td>
+    <table cellspacing="0" cellpadding="0" border="0" width="100%" style="border-radius: 16px; border-color: #5e40be; border-width: 2px; border-style: solid; overflow: hidden; background-color: #ffffff;">
+        <tr>
+            <td style="padding: 10px 0 10px 10px; vertical-align: top;">
+                <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_info_purple.png" title="Info" alt="Info" border="0" width="16" style="vertical-align: -2px;"/>
+            </td>
+            <td style="padding: 10px 10px 10px 8px;">
+                <p style="margin-top: 0; font-size: 14px; font-weight: 700; color: #151515;">Systems on RHEL 6 and below are not shown in this report</p>
+                <p style="margin-bottom: 0; font-size: 14px; font-weight: 400; color: #151515;">
+                    Only RHEL 7 and above and Application Streams are displayed.
+                    <a style="{body-section-underline-link-style}" href="https://access.redhat.com/support/policy/updates/errata" target="_blank">Learn more about the RHEL life cycle.</a>
+                </p>
+            </td>
+        </tr>
+    </table>
+</td></tr>
+<tr><td style="line-height: 24px">&#xA0;</td></tr>
 {#if rhelData.rhel_versions_count.or(-1) >= 0 || rhel10Data.count.or(-1) >= 0 || rhel9Data.count.or(-1) >= 0 || rhel8Data.count.or(-1) >= 0}
 {! RHEL life cycle section !}
 {#if rhelData.rhel_versions_count.or(-1) >= 0}

--- a/common-template/src/test/java/email/TestLifecycleTemplate.java
+++ b/common-template/src/test/java/email/TestLifecycleTemplate.java
@@ -94,10 +94,6 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
             "Body should contain the RHEL 6 info box headline");
         assertTrue(result.contains("Only RHEL 7 and above and Application Streams are displayed."),
             "Body should contain the RHEL 6 info box body text");
-        assertTrue(result.contains("Learn more about the RHEL life cycle."),
-            "Body should contain the RHEL life cycle learn-more link text");
-        assertTrue(result.contains("href=\"https://access.redhat.com/support/policy/updates/errata\""),
-            "Learn-more link should point to the RHEL life cycle documentation");
         assertTrue(result.contains("img_info_purple.png"),
             "Info box should use the purple info icon");
     }

--- a/common-template/src/test/java/email/TestLifecycleTemplate.java
+++ b/common-template/src/test/java/email/TestLifecycleTemplate.java
@@ -88,6 +88,21 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
     }
 
     @Test
+    public void testRetiringLifecycleEmailBodyContainsRhelVersionInfoBox() {
+        String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
+        assertTrue(result.contains("Systems on RHEL 6 and below are not shown in this report"),
+            "Body should contain the RHEL 6 info box headline");
+        assertTrue(result.contains("Only RHEL 7 and above and Application Streams are displayed."),
+            "Body should contain the RHEL 6 info box body text");
+        assertTrue(result.contains("Learn more about the RHEL life cycle."),
+            "Body should contain the RHEL life cycle learn-more link text");
+        assertTrue(result.contains("href=\"https://access.redhat.com/support/policy/updates/errata\""),
+            "Learn-more link should point to the RHEL life cycle documentation");
+        assertTrue(result.contains("img_info_purple.png"),
+            "Info box should use the purple info icon");
+    }
+
+    @Test
     public void testRetiringLifecycleEmailBodyContainsReportDate() {
         String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
         assertTrue(result.contains("15th Dec 2025"), "Body should contain the report date");


### PR DESCRIPTION
Add message to Planning Lifecycle email template about considering RHEL 7+ systems in the report.

Before:
<img width="651" height="1149" alt="image" src="https://github.com/user-attachments/assets/22275df5-9f2f-436f-b10c-da0175a77722" />

After:
<img width="649" height="1259" alt="Screenshot From 2026-08-26 08-20-37" src="https://github.com/user-attachments/assets/27c578ec-a233-467b-bf4e-65b886e7e31a" />


Payload for testing with rendering tool:
```
{"version": "v1.0.0", "id": "900f1b65-36ff-50d5-826c-ea062cb3f37d", "bundle": "rhel", "application": "life-cycle", "event_type": "retiring-lifecycle-monthly-report", "timestamp": "2026-08-25T09:34:53Z", "org_id": "1234", "context": {"lifecycle": {"report_date": "August 2026"}}, "events": [{"metadata": {}, "payload": {"rhel_retired": {"rhel_versions_count": 17, "systems_count": 68}, "rhel_near_retirement": {"rhel_versions_count": 0, "systems_count": 0}, "appstream_retired": {"rhel9": {"count": 5, "systems_count": 15}, "rhel8": {"count": 2, "systems_count": 8}, "rhel10": {"count": 0, "systems_count": 0}}, "appstream_near_retirement": {"rhel9": {"count": 1, "systems_count": 3}, "rhel8": {"count": 1, "systems_count": 1}, "rhel10": {"count": 0, "systems_count": 0}}}}], "recipients": []}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Information**
  - Lifecycle emails now include an informational callout about supported RHEL versions.
  - Clarifies that systems running RHEL 6 and earlier are excluded from lifecycle views.
  - Explains that only RHEL 7 and later systems, along with Application Streams, are displayed.
  - Includes a visual information indicator to make this guidance easier to notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->