### PR TITLE
RHCLOUD-50753: Remove CVE link from Lightwell email template

### DIFF
--- a/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lightwell/lightwellDefaultEmailBody.html
@@ -52,7 +52,7 @@
                 <table role="presentation">
                 {#for cve in release.related_cve}
                     <tr>
-                    <td><a style="{body-section-table-td-a-style}" href="{cve.url}" target="_blank">{cve.cve}</a></td>
+                    <td>{cve.cve}</td>
                     <td style="min-width: 85px">
                     {#switch cve.severity}
                         {#case 'low'}<!--[if mso]><img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_low_v3.png" alt="Low" width="55" border="0" style="vertical-align: -2px;"><![endif]--><!--[if !mso]><!-->{renderLowTag}<!--<![endif]-->


### PR DESCRIPTION
There is no where to route this link to currently, so it needs to be removed temporarily until this route is implemented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CVE identifiers in Lightwell email notifications are now displayed as plain text instead of clickable links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->