### PR TITLE
RHCLOUD-50496 - prometheus scraping

### DIFF
--- a/.rhcicd/clowdapp-aggregator.yaml
+++ b/.rhcicd/clowdapp-aggregator.yaml
@@ -66,6 +66,10 @@ objects:
           value: ${CLUSTER_ID}
         - name: PROMETHEUS_PUSHGATEWAY_URL
           value: ${PROMETHEUS_PUSHGATEWAY}
+        - name: NOTIFICATIONS_AGGREGATOR_METRICS_SCRAPE_MODE_ENABLED
+          value: ${METRICS_SCRAPE_MODE_ENABLED}
+        - name: NOTIFICATIONS_AGGREGATOR_METRICS_SCRAPE_KEEP_ALIVE_SECONDS
+          value: ${METRICS_SCRAPE_KEEP_ALIVE_SECONDS}
 parameters:
 - name: CLOUDWATCH_ENABLED
   description: Enable Cloudwatch (or not)
@@ -98,6 +102,12 @@ parameters:
 - name: MEMORY_REQUEST
   description: Memory request
   value: 250Mi
+- name: METRICS_SCRAPE_MODE_ENABLED
+  description: "Metrics scrape mode: false (default, crc - push to Pushgateway) or true (interim HCC fix, RHCLOUD-50496)"
+  value: "false"
+- name: METRICS_SCRAPE_KEEP_ALIVE_SECONDS
+  description: How long the job stays alive after completion in "scrape" mode, to allow Prometheus to scrape /metrics
+  value: "150"
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
   value: INFO

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -92,6 +92,12 @@
             <version>${pushgateway.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>${pushgateway.version}</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.redhat.cloud.notifications</groupId>

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -1,7 +1,5 @@
 package com.redhat.cloud.notifications;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.config.AggregatorConfig;
 import com.redhat.cloud.notifications.db.AggregationOrgConfigRepository;
 import com.redhat.cloud.notifications.db.EmailAggregationRepository;
@@ -27,7 +25,6 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
-import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -153,35 +150,20 @@ public class DailyEmailAggregationJob {
      * removed once Pushgateway is available on HCC.
      */
     private void exposeMetricsForScraping(CollectorRegistry registry) {
+        Optional<Integer> metricsPort = aggregatorConfig.getMetricsPort();
+        if (metricsPort.isEmpty()) {
+            return;
+        }
+
         try {
-            // Read cdappconfig.json directly instead of @ConfigProperty: clowder-quarkus-config-source
-            // has no property handler for metricsPort/metricsPath, so they're not injectable.
-            String cdAppConfigPath = System.getenv("ACG_CONFIG");
-            if (cdAppConfigPath == null || cdAppConfigPath.isBlank()) {
-                Log.warn("ACG_CONFIG is not set, cannot determine the metrics port for scrape mode.");
-                return;
-            }
-
-            JsonNode cdAppConfig = new ObjectMapper().readTree(new File(cdAppConfigPath));
-            JsonNode metricsPortNode = cdAppConfig.get("metricsPort");
-            if (metricsPortNode == null || !metricsPortNode.isIntegralNumber()) {
-                Log.warnf("cdappconfig.json has no valid metricsPort field (value: %s), cannot expose metrics for scraping.", metricsPortNode);
-                return;
-            }
-            int metricsPort = metricsPortNode.asInt();
-            if (metricsPort < 1 || metricsPort > 65535) {
-                Log.warnf("cdappconfig.json metricsPort %d is out of the valid port range, cannot expose metrics for scraping.", metricsPort);
-                return;
-            }
-
             int keepAliveSeconds = aggregatorConfig.getMetricsScrapeKeepAliveSeconds();
             HTTPServer server = new HTTPServer.Builder()
-                    .withPort(metricsPort)
+                    .withPort(metricsPort.get())
                     .withRegistry(registry)
                     .withDaemonThreads(true)
                     .build();
             try {
-                Log.infof("Exposing metrics for scraping on port %d for %d seconds", metricsPort, keepAliveSeconds);
+                Log.infof("Exposing metrics for scraping on port %d for %d seconds", metricsPort.get(), keepAliveSeconds);
                 Thread.sleep(keepAliveSeconds * 1000L);
             } finally {
                 server.close();

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.config.AggregatorConfig;
 import com.redhat.cloud.notifications.db.AggregationOrgConfigRepository;
 import com.redhat.cloud.notifications.db.EmailAggregationRepository;
@@ -12,6 +14,7 @@ import com.redhat.cloud.notifications.ingress.Payload;
 import com.redhat.cloud.notifications.models.AggregationCommand;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
+import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.exporter.PushGateway;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.LaunchMode;
@@ -24,6 +27,7 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -124,13 +128,65 @@ public class DailyEmailAggregationJob {
         } finally {
             durationTimer.setDuration();
             if (!LaunchMode.current().isDevOrTest()) {
-                PushGateway pg = new PushGateway(prometheusPushGatewayUrl);
-                try {
-                    pg.pushAdd(registry, "aggregator_job");
-                } catch (IOException e) {
-                    Log.warn("Could not push metrics to Prometheus Pushgateway.", e);
+                if (aggregatorConfig.isScrapeExportMode()) {
+                    exposeMetricsForScraping(registry);
+                } else {
+                    pushMetricsToGateway(registry);
                 }
             }
+        }
+    }
+
+    private void pushMetricsToGateway(CollectorRegistry registry) {
+        PushGateway pg = new PushGateway(prometheusPushGatewayUrl);
+        try {
+            pg.pushAdd(registry, "aggregator_job");
+        } catch (IOException e) {
+            Log.warn("Could not push metrics to Prometheus Pushgateway.", e);
+        }
+    }
+
+    /**
+     * Interim fix for RHCLOUD-50496: Pushgateway isn't deployed on HCC clusters yet
+     * (RHCLOUD-48965), so instead of pushing, expose the registry on an embedded HTTP
+     * server for long enough to be scraped, then let the job exit normally. To be
+     * removed once Pushgateway is available on HCC.
+     */
+    private void exposeMetricsForScraping(CollectorRegistry registry) {
+        try {
+            // Read cdappconfig.json directly instead of @ConfigProperty: clowder-quarkus-config-source
+            // has no property handler for metricsPort/metricsPath, so they're not injectable.
+            String cdAppConfigPath = System.getenv("ACG_CONFIG");
+            if (cdAppConfigPath == null || cdAppConfigPath.isBlank()) {
+                Log.warn("ACG_CONFIG is not set, cannot determine the metrics port for scrape mode.");
+                return;
+            }
+
+            JsonNode cdAppConfig = new ObjectMapper().readTree(new File(cdAppConfigPath));
+            JsonNode metricsPortNode = cdAppConfig.get("metricsPort");
+            if (metricsPortNode == null) {
+                Log.warn("cdappconfig.json has no metricsPort field, cannot expose metrics for scraping.");
+                return;
+            }
+            int metricsPort = metricsPortNode.asInt();
+
+            int keepAliveSeconds = aggregatorConfig.getMetricsScrapeKeepAliveSeconds();
+            HTTPServer server = new HTTPServer.Builder()
+                    .withPort(metricsPort)
+                    .withRegistry(registry)
+                    .withDaemonThreads(true)
+                    .build();
+            try {
+                Log.infof("Exposing metrics for scraping on port %d for %d seconds", metricsPort, keepAliveSeconds);
+                Thread.sleep(keepAliveSeconds * 1000L);
+            } finally {
+                server.close();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Log.warn("Interrupted while exposing metrics for scraping.", e);
+        } catch (Exception e) {
+            Log.warn("Could not expose metrics for scraping.", e);
         }
     }
 

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/DailyEmailAggregationJob.java
@@ -164,11 +164,15 @@ public class DailyEmailAggregationJob {
 
             JsonNode cdAppConfig = new ObjectMapper().readTree(new File(cdAppConfigPath));
             JsonNode metricsPortNode = cdAppConfig.get("metricsPort");
-            if (metricsPortNode == null) {
-                Log.warn("cdappconfig.json has no metricsPort field, cannot expose metrics for scraping.");
+            if (metricsPortNode == null || !metricsPortNode.isIntegralNumber()) {
+                Log.warnf("cdappconfig.json has no valid metricsPort field (value: %s), cannot expose metrics for scraping.", metricsPortNode);
                 return;
             }
             int metricsPort = metricsPortNode.asInt();
+            if (metricsPort < 1 || metricsPort > 65535) {
+                Log.warnf("cdappconfig.json metricsPort %d is out of the valid port range, cannot expose metrics for scraping.", metricsPort);
+                return;
+            }
 
             int keepAliveSeconds = aggregatorConfig.getMetricsScrapeKeepAliveSeconds();
             HTTPServer server = new HTTPServer.Builder()

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
@@ -25,6 +25,7 @@ public class AggregatorConfig {
     private static final String CLUSTER_ID = "notifications.aggregator.cluster-id";
     private static final String METRICS_SCRAPE_MODE_ENABLED = "notifications.aggregator.metrics.scrape-mode-enabled";
     private static final String METRICS_SCRAPE_KEEP_ALIVE_SECONDS = "notifications.aggregator.metrics.scrape-keep-alive-seconds";
+    private static final int DEFAULT_METRICS_SCRAPE_KEEP_ALIVE_SECONDS = 150;
 
     /*
      * Unleash configuration
@@ -37,7 +38,7 @@ public class AggregatorConfig {
     @ConfigProperty(name = METRICS_SCRAPE_MODE_ENABLED, defaultValue = "false")
     boolean metricsScrapeModeEnabled;
 
-    @ConfigProperty(name = METRICS_SCRAPE_KEEP_ALIVE_SECONDS, defaultValue = "150")
+    @ConfigProperty(name = METRICS_SCRAPE_KEEP_ALIVE_SECONDS, defaultValue = DEFAULT_METRICS_SCRAPE_KEEP_ALIVE_SECONDS + "")
     int metricsScrapeKeepAliveSeconds;
 
     @Inject
@@ -61,6 +62,11 @@ public class AggregatorConfig {
     }
 
     public int getMetricsScrapeKeepAliveSeconds() {
+        if (metricsScrapeKeepAliveSeconds < 1) {
+            Log.warnf("%s must be a positive number of seconds, got %d. Falling back to %d.",
+                    METRICS_SCRAPE_KEEP_ALIVE_SECONDS, metricsScrapeKeepAliveSeconds, DEFAULT_METRICS_SCRAPE_KEEP_ALIVE_SECONDS);
+            return DEFAULT_METRICS_SCRAPE_KEEP_ALIVE_SECONDS;
+        }
         return metricsScrapeKeepAliveSeconds;
     }
 

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
@@ -1,5 +1,7 @@
 package com.redhat.cloud.notifications.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.notifications.unleash.ToggleRegistry;
 import io.getunleash.Unleash;
 import io.getunleash.variant.Payload;
@@ -12,6 +14,7 @@ import jakarta.enterprise.event.Startup;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.io.File;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -68,6 +71,40 @@ public class AggregatorConfig {
             return DEFAULT_METRICS_SCRAPE_KEEP_ALIVE_SECONDS;
         }
         return metricsScrapeKeepAliveSeconds;
+    }
+
+    /**
+     * POC for RHCLOUD-50496: clowder-quarkus-config-source has no property handler for
+     * cdappconfig.json's metricsPort, so it can't be injected via {@code @ConfigProperty}.
+     * Reads it directly instead. Once metricsPort is exposed as a proper config property,
+     * this should be replaced by one.
+     */
+    public Optional<Integer> getMetricsPort() {
+        String cdAppConfigPath = System.getenv("ACG_CONFIG");
+        if (cdAppConfigPath == null || cdAppConfigPath.isBlank()) {
+            Log.warn("ACG_CONFIG is not set, cannot determine the metrics port for scrape mode.");
+            return Optional.empty();
+        }
+
+        try {
+            JsonNode cdAppConfig = new ObjectMapper().readTree(new File(cdAppConfigPath));
+            JsonNode metricsPortNode = cdAppConfig.get("metricsPort");
+            if (metricsPortNode == null || !metricsPortNode.isIntegralNumber()) {
+                Log.warnf("cdappconfig.json has no valid metricsPort field (value: %s), cannot expose metrics for scraping.", metricsPortNode);
+                return Optional.empty();
+            }
+
+            int metricsPort = metricsPortNode.asInt();
+            if (metricsPort < 1 || metricsPort > 65535) {
+                Log.warnf("cdappconfig.json metricsPort %d is out of the valid port range, cannot expose metrics for scraping.", metricsPort);
+                return Optional.empty();
+            }
+
+            return Optional.of(metricsPort);
+        } catch (Exception e) {
+            Log.warn("Could not read metricsPort from cdappconfig.json.", e);
+            return Optional.empty();
+        }
     }
 
     /**

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
@@ -89,7 +89,10 @@ public class AggregatorConfig {
         try {
             JsonNode cdAppConfig = new ObjectMapper().readTree(new File(cdAppConfigPath));
             JsonNode metricsPortNode = cdAppConfig.get("metricsPort");
-            if (metricsPortNode == null || !metricsPortNode.isIntegralNumber()) {
+            // isIntegralNumber() alone is not enough: it's also true for integral values that don't
+            // fit in an int (e.g. a corrupted LongNode), and asInt() silently narrows those instead
+            // of rejecting them. canConvertToInt() is the guard that actually catches that case.
+            if (metricsPortNode == null || !metricsPortNode.isIntegralNumber() || !metricsPortNode.canConvertToInt()) {
                 Log.warnf("cdappconfig.json has no valid metricsPort field (value: %s), cannot expose metrics for scraping.", metricsPortNode);
                 return Optional.empty();
             }

--- a/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
+++ b/aggregator/src/main/java/com/redhat/cloud/notifications/config/AggregatorConfig.java
@@ -23,6 +23,8 @@ public class AggregatorConfig {
      * Env vars configuration
      */
     private static final String CLUSTER_ID = "notifications.aggregator.cluster-id";
+    private static final String METRICS_SCRAPE_MODE_ENABLED = "notifications.aggregator.metrics.scrape-mode-enabled";
+    private static final String METRICS_SCRAPE_KEEP_ALIVE_SECONDS = "notifications.aggregator.metrics.scrape-keep-alive-seconds";
 
     /*
      * Unleash configuration
@@ -31,6 +33,12 @@ public class AggregatorConfig {
 
     @ConfigProperty(name = CLUSTER_ID)
     Optional<String> clusterId;
+
+    @ConfigProperty(name = METRICS_SCRAPE_MODE_ENABLED, defaultValue = "false")
+    boolean metricsScrapeModeEnabled;
+
+    @ConfigProperty(name = METRICS_SCRAPE_KEEP_ALIVE_SECONDS, defaultValue = "150")
+    int metricsScrapeKeepAliveSeconds;
 
     @Inject
     Unleash unleash;
@@ -46,6 +54,14 @@ public class AggregatorConfig {
 
     public Optional<String> getClusterId() {
         return clusterId.map(String::trim).filter(value -> !value.isEmpty());
+    }
+
+    public boolean isScrapeExportMode() {
+        return metricsScrapeModeEnabled;
+    }
+
+    public int getMetricsScrapeKeepAliveSeconds() {
+        return metricsScrapeKeepAliveSeconds;
     }
 
     /**
@@ -86,6 +102,8 @@ public class AggregatorConfig {
     void logConfigAtStartup(@Observes Startup event) {
         Map<String, Object> config = new TreeMap<>();
         config.put(CLUSTER_ID, getClusterId().orElse("not-configured"));
+        config.put(METRICS_SCRAPE_MODE_ENABLED, metricsScrapeModeEnabled);
+        config.put(METRICS_SCRAPE_KEEP_ALIVE_SECONDS, metricsScrapeKeepAliveSeconds);
         if (activeClusterToggle != null) {
             config.put(activeClusterToggle, getActiveCluster().orElse("unable-to-determine"));
         }

--- a/aggregator/src/main/resources/application.properties
+++ b/aggregator/src/main/resources/application.properties
@@ -46,5 +46,11 @@ quarkus.unleash.url=http://localhost:4242
 # Must be set in deployment for cluster coordination to work
 # notifications.aggregator.cluster-id=
 
+# Metrics scrape mode: false (default, crc - push to Pushgateway) or true (interim, hcc - see RHCLOUD-50496)
+# notifications.aggregator.metrics.scrape-mode-enabled=false
+
+# How long the job stays alive after completion in "scrape" mode, to allow Prometheus to scrape /metrics
+# notifications.aggregator.metrics.scrape-keep-alive-seconds=150
+
 # Uncomment to log Hibernate SQL statements
 #quarkus.hibernate-orm.log.sql=true


### PR DESCRIPTION
implement functionality for Prometheus scraping, keep old push functionality and add switch by flag

Assisted-by: Claude Sonnet 5 (via Claude Code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Prometheus metrics scrape mode for the aggregator job.
  * Metrics can now be served through an HTTP endpoint on a configurable port and for a configurable duration.
  * Retained Pushgateway publishing as the default metrics behavior.
  * Added configuration options for enabling scrape mode and setting its keep-alive period.
  * Added deployment template support for passing scrape-mode settings to the job.
  * Added validation and safe defaults for scrape configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->