### PR TITLE
[RHINENG-30043] Fix lifecycle description

### DIFF
--- a/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Lifecycle/retiringLifecycleInstantEmailBody.html
@@ -32,9 +32,9 @@ Red Hat Enterprise Linux - Life Cycle Monthly Report - {action.context.lifecycle
                 <img src="https://console.redhat.com/apps/frontend-assets/email-assets/img_info_purple.png" title="Info" alt="Info" border="0" width="16" style="vertical-align: -2px;"/>
             </td>
             <td style="padding: 10px 10px 10px 8px;">
-                <p style="margin-top: 0; font-size: 14px; font-weight: 700; color: #151515;">Systems on RHEL 6 and below are not shown in this report</p>
+                <p style="margin-top: 0; font-size: 14px; font-weight: 700; color: #151515;">Systems on RHEL 6 and earlier are not shown in this report</p>
                 <p style="margin-bottom: 0; font-size: 14px; font-weight: 400; color: #151515;">
-                    Only RHEL 7 and above and Application Streams are displayed.
+                    Only systems on RHEL 7 and later, and Application Streams, are displayed
                 </p>
             </td>
         </tr>

--- a/common-template/src/test/java/email/TestLifecycleTemplate.java
+++ b/common-template/src/test/java/email/TestLifecycleTemplate.java
@@ -90,9 +90,9 @@ public class TestLifecycleTemplate extends EmailTemplatesRendererHelper {
     @Test
     public void testRetiringLifecycleEmailBodyContainsRhelVersionInfoBox() {
         String result = generateEmailBody(RETIRING_LIFECYCLE_REPORT, createLifecycleAction());
-        assertTrue(result.contains("Systems on RHEL 6 and below are not shown in this report"),
+        assertTrue(result.contains("Systems on RHEL 6 and earlier are not shown in this report"),
             "Body should contain the RHEL 6 info box headline");
-        assertTrue(result.contains("Only RHEL 7 and above and Application Streams are displayed."),
+        assertTrue(result.contains("Only systems on RHEL 7 and later, and Application Streams, are displayed"),
             "Body should contain the RHEL 6 info box body text");
         assertTrue(result.contains("img_info_purple.png"),
             "Info box should use the purple info icon");


### PR DESCRIPTION
Fix lifecycle notification description which I forgot to commit.

Payload for test:
```
{"version": "v1.0.0", "id": "900f1b65-36ff-50d5-826c-ea062cb3f37d", "bundle": "rhel", "application": "life-cycle", "event_type": "retiring-lifecycle-monthly-report", "timestamp": "2026-08-25T09:34:53Z", "org_id": "1234", "context": {"lifecycle": {"report_date": "August 2026"}}, "events": [{"metadata": {}, "payload": {"rhel_retired": {"rhel_versions_count": 17, "systems_count": 68}, "rhel_near_retirement": {"rhel_versions_count": 0, "systems_count": 0}, "appstream_retired": {"rhel9": {"count": 5, "systems_count": 15}, "rhel8": {"count": 2, "systems_count": 8}, "rhel10": {"count": 0, "systems_count": 0}}, "appstream_near_retirement": {"rhel9": {"count": 1, "systems_count": 3}, "rhel8": {"count": 1, "systems_count": 1}, "rhel10": {"count": 0, "systems_count": 0}}}}], "recipients": []}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated lifecycle email notices to clarify that RHEL 6 and earlier systems are excluded.
  * Clarified that only RHEL 7 and later, along with Application Streams, are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->