### PR TITLE
(feat) [RHCLOUD-50831] Add ApplicationId as predicate of include-severity-to-filter-recipients Unleash flag

### DIFF
--- a/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/config/EngineConfig.java
@@ -201,7 +201,7 @@ public class EngineConfig {
         config.put(NOTIFICATIONS_INGRESSREPLAY_END_TIME, replayEndTime);
         config.put(toggleKafkaOutgoingHighVolumeTopic, isOutgoingKafkaHighVolumeTopicEnabled());
         config.put(asyncEventProcessingToggle, isAsyncEventProcessing());
-        config.put(toggleIncludeSeverityToFilterRecipients, isIncludeSeverityToFilterRecipientsEnabled(""));
+        config.put(toggleIncludeSeverityToFilterRecipients, isIncludeSeverityToFilterRecipientsEnabled("", null));
         config.put(toggleSkipProcessingMessagesOnReplayService, isSkipMessageProcessing());
         config.put(valkeyEventDeduplicatorToggle, isValkeyEventDeduplicatorEnabled());
         config.put(IN_MEMORY_DB_ENABLED, isInMemoryDbEnabled());
@@ -318,8 +318,16 @@ public class EngineConfig {
         return this.unleash.isEnabled(this.toggleKafkaOutgoingHighVolumeTopic, false);
     }
 
-    public boolean isIncludeSeverityToFilterRecipientsEnabled(String orgId) {
-        return unleash.isEnabled(toggleIncludeSeverityToFilterRecipients, UnleashContextBuilder.buildUnleashContextWithOrgId(orgId), false);
+    public boolean isIncludeSeverityToFilterRecipientsEnabled(String orgId, UUID applicationId) {
+        final UnleashContext.Builder builder = UnleashContext.builder();
+        if (orgId != null) {
+            builder.addProperty("orgId", orgId);
+        }
+        if (applicationId != null) {
+            builder.addProperty("applicationId", applicationId.toString());
+        }
+
+        return unleash.isEnabled(toggleIncludeSeverityToFilterRecipients, builder.build(), false);
     }
 
     public boolean isSkipMessageProcessing() {

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/drawer/DrawerProcessor.java
@@ -106,7 +106,7 @@ public class DrawerProcessor extends SystemEndpointTypeProcessor {
         DrawerEntryPayload drawerEntryPayload = buildJsonPayloadFromEvent(event);
 
         Optional<Severity> eventSeverity = Optional.empty();
-        if (engineConfig.isIncludeSeverityToFilterRecipientsEnabled(event.getOrgId())) {
+        if (engineConfig.isIncludeSeverityToFilterRecipientsEnabled(event.getOrgId(), event.getApplicationId())) {
             eventSeverity = Optional.ofNullable(event.getSeverity());
         }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailAggregator.java
@@ -80,7 +80,7 @@ public class EmailAggregator {
                 .getUnsubscribersByEventType(aggregationKey.getOrgId(), appId, subscriptionType);
 
         Optional<Map<String, Set<SubscribedEventTypeSeverities>>> subscribersWithSeverities = Optional.empty();
-        if (engineConfig.isIncludeSeverityToFilterRecipientsEnabled(aggregationKey.getOrgId())) {
+        if (engineConfig.isIncludeSeverityToFilterRecipientsEnabled(aggregationKey.getOrgId(), appId)) {
             subscribersWithSeverities = Optional.of(subscriptionRepository.getSubscriptionsByEventTypeWithSeverities(aggregationKey.getOrgId(), appId, subscriptionType));
         }
 

--- a/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
+++ b/engine/src/main/java/com/redhat/cloud/notifications/processors/email/EmailProcessor.java
@@ -92,7 +92,7 @@ public class EmailProcessor extends SystemEndpointTypeProcessor {
         Set<String> unsubscribers;
 
         Optional<Severity> eventSeverity = Optional.empty();
-        if (engineConfig.isIncludeSeverityToFilterRecipientsEnabled(event.getOrgId())) {
+        if (engineConfig.isIncludeSeverityToFilterRecipientsEnabled(event.getOrgId(), event.getApplicationId())) {
             eventSeverity = Optional.ofNullable(event.getSeverity());
         }
 

--- a/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/SubscriptionRepositoryTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/db/repositories/SubscriptionRepositoryTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +77,7 @@ public class SubscriptionRepositoryTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testEmailSubscribersUserIdWithoutSeverity(boolean useSeverity) {
-        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString())).thenReturn(useSeverity);
+        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString(), any())).thenReturn(useSeverity);
 
         Bundle bundle = resourceHelpers.createBundle(BUNDLE_NAME);
         Application application = resourceHelpers.createApp(bundle.getId(), APP_NAME);

--- a/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/processors/email/EmailAggregatorTest.java
@@ -160,14 +160,14 @@ class EmailAggregatorTest {
     @Test
     void shouldTestOneRecipientSubscribedSeverityEnabled() {
         // enable filter on severity without any user severity subscription config
-        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString())).thenReturn(true);
+        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString(), any())).thenReturn(true);
         // nothing should change
         shouldTestOneRecipientSubscribed();
     }
 
     @Test
     void shouldTestOneRecipientSubscribedToModerateSeverity() {
-        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString())).thenReturn(true);
+        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString(), any())).thenReturn(true);
         initDataForSubscriptionTests();
 
         // enable filter on "MODERATE" severity
@@ -189,7 +189,7 @@ class EmailAggregatorTest {
 
     @Test
     void shouldTestOneRecipientUnsubscribedFromAllSeverities() {
-        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString())).thenReturn(true);
+        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString(), any())).thenReturn(true);
         initDataForSubscriptionTests();
 
         // User unsubscribe from all severities (don't make real sens, but just to check)
@@ -214,7 +214,7 @@ class EmailAggregatorTest {
         verify(recipientsResolverService, times(4)).getRecipients(any(RecipientsQuery.class));
 
         // disable the severity filtering
-        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString())).thenReturn(false);
+        when(engineConfig.isIncludeSeverityToFilterRecipientsEnabled(anyString(), any())).thenReturn(false);
 
         result = aggregate();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Severity-based recipient filtering now supports application-specific configuration in addition to organization-level settings.
  * Email and drawer notifications apply filtering based on both organization and application context.

* **Tests**
  * Updated coverage for enabled and disabled severity-filtering scenarios using application-specific configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->