### PR TITLE
scheduler - fix download link

### DIFF
--- a/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/LocalDateTimeExtension.java
+++ b/common-template/src/main/java/com/redhat/cloud/notifications/qute/templates/extensions/LocalDateTimeExtension.java
@@ -4,6 +4,7 @@ import io.quarkus.qute.TemplateExtension;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
@@ -12,6 +13,7 @@ public class LocalDateTimeExtension {
 
     private static final DateTimeFormatter utcDateTimeFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm 'UTC'").withLocale(Locale.US);
     private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy").withLocale(Locale.US);
+    private static final DateTimeFormatter zonedDateTimeFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy hh:mm a z").withLocale(Locale.US);
     private static final TimeAgoFormatter timeAgoFormatter = new TimeAgoFormatter();
 
     public static String toUtcFormat(LocalDateTime date) {
@@ -27,6 +29,9 @@ public class LocalDateTimeExtension {
     }
 
     public static String toStringFormat(String date) {
+        if (date.contains("Z") || date.matches(".*[+-]\\d{2}:\\d{2}$") || date.contains("[")) {
+            return toStringFormat(ZonedDateTime.parse(date, DateTimeFormatter.ISO_DATE_TIME));
+        }
         return toStringFormat(fromIsoLocalDateTime(date));
     }
 
@@ -36,6 +41,10 @@ public class LocalDateTimeExtension {
 
     public static String toTimeAgo(String date) {
         return toTimeAgo(fromIsoLocalDateTime(date));
+    }
+
+    public static String toStringFormat(ZonedDateTime date) {
+        return date.format(zonedDateTimeFormatter);
     }
 
     public static LocalDateTime fromIsoLocalDateTime(String date) {

--- a/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
@@ -1,5 +1,5 @@
 {#include drawer/Common/commonDrawerNotification.md}
 {#body}
-A scheduled export **[{data.context.job_name}]({environment.url}/api/export/v1/exports/{data.context.export_id}?{query_params})** has completed.
+The scheduled report **[{data.context.job_name}]** has completed.
 {/body}
 {/include}

--- a/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/exportCompleteBody.md
@@ -1,5 +1,5 @@
 {#include drawer/Common/commonDrawerNotification.md}
 {#body}
-The scheduled report **[{data.context.job_name}]** has completed.
+The scheduled report **[{data.context.job_name}]({environment.url}/scheduler/download/{data.context.job_id}/{data.context.run_id}?{query_params})** has completed.
 {/body}
 {/include}

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
@@ -1,5 +1,5 @@
 {#include drawer/Common/commonDrawerNotification.md}
 {#body}
-The scheduled report **[{data.context.job_name}]** has failed to generated successfully.
+The scheduled report **[{data.context.job_name}]** has failed to generate successfully.
 {/body}
 {/include}

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedBody.md
@@ -1,5 +1,5 @@
 {#include drawer/Common/commonDrawerNotification.md}
 {#body}
-A scheduled export **[{data.context.job_name}]({environment.url}/insights/jobs/{data.context.job_id}?{query_params})** has failed.
+The scheduled report **[{data.context.job_name}]** has failed to generated successfully.
 {/body}
 {/include}

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
@@ -1,6 +1,6 @@
 {#include drawer/Common/commonDrawerNotification.md}
 {#body}
-The scheduled report **[{data.context.job_name}]** has failed to generated successfully.
+The scheduled report **[{data.context.job_name}]** has failed to generate successfully.
 The scheduled report has been paused to prevent further failures. Please review and resolve the issue before resuming the scheduled report.
 {/body}
 {/include}

--- a/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
+++ b/common-template/src/main/resources/templates/drawer/Scheduler/jobFailedPausedBody.md
@@ -1,5 +1,6 @@
 {#include drawer/Common/commonDrawerNotification.md}
 {#body}
-A scheduled export **[{data.context.job_name}]({environment.url}/insights/jobs/{data.context.job_id}?{query_params})** has failed and been automatically paused.
+The scheduled report **[{data.context.job_name}]** has failed to generated successfully.
+The scheduled report has been paused to prevent further failures. Please review and resolve the issue before resuming the scheduled report.
 {/body}
 {/include}

--- a/common-template/src/main/resources/templates/email/Common/insightsEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Common/insightsEmailBody.html
@@ -114,49 +114,51 @@
                                     </td>
                                 </tr>
 
-                                <!-- Blue external link button -->
-                                <tr>
-                                    <td style="padding: 24px 0px;">
-                                        <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse;" align="center">
-                                            <tr>
-                                                <td>
-                                                    <!--[if mso]>
-                                                    <a href="{#insert content-button-href}{/}" target="_blank" style="font-size: 14px; font-weight: 400; color: #ffffff; text-decoration: none; ">
-                                                        <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse;" height="37">
-                                                            <tr>
-                                                                <td><img src="https://console.redhat.com/apps/frontend-assets/email-assets/circle_64_left.png" alt="" height="37" style="display: block; border: none;" /></td>
-                                                                <td style="padding-right: 8px; font-size: 14px; font-weight: 400; color: #ffffff; vertical-align: middle; background-color: #0066cc;">
-                                                                    Go to {#insert content-button-service-name}{/}
-                                                                </td>
-                                                                <td style="vertical-align: middle; background-color: #0066cc;">
-                                                                    <img src="https://console.redhat.com/apps/frontend-assets/email-assets/external-link.png" alt="" width="14" height="14" style="display: block; border: none;" />
-                                                                </td>
-                                                                <td><img src="https://console.redhat.com/apps/frontend-assets/email-assets/circle_64_right.png" alt="" height="37" style="display: block; border: none;" /></td>
-                                                            </tr>
-                                                        </table>
-                                                    </a>
-                                                    <![endif]-->
+                                {#if renderAppLinkButton.or(true)}
+                                    <!-- Blue external link button -->
+                                    <tr>
+                                        <td style="padding: 24px 0px;">
+                                            <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse;" align="center">
+                                                <tr>
+                                                    <td>
+                                                        <!--[if mso]>
+                                                        <a href="{#insert content-button-href}{/}" target="_blank" style="font-size: 14px; font-weight: 400; color: #ffffff; text-decoration: none; ">
+                                                            <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse;" height="37">
+                                                                <tr>
+                                                                    <td><img src="https://console.redhat.com/apps/frontend-assets/email-assets/circle_64_left.png" alt="" height="37" style="display: block; border: none;" /></td>
+                                                                    <td style="padding-right: 8px; font-size: 14px; font-weight: 400; color: #ffffff; vertical-align: middle; background-color: #0066cc;">
+                                                                        Go to {#insert content-button-service-name}{/}
+                                                                    </td>
+                                                                    <td style="vertical-align: middle; background-color: #0066cc;">
+                                                                        <img src="https://console.redhat.com/apps/frontend-assets/email-assets/external-link.png" alt="" width="14" height="14" style="display: block; border: none;" />
+                                                                    </td>
+                                                                    <td><img src="https://console.redhat.com/apps/frontend-assets/email-assets/circle_64_right.png" alt="" height="37" style="display: block; border: none;" /></td>
+                                                                </tr>
+                                                            </table>
+                                                        </a>
+                                                        <![endif]-->
 
-                                                    <!--[if !mso]><!-->
-                                                    <a href="{#insert content-button-href}{/}" target="_blank" style="display: inline-block; padding: 8px 14px; font-size: 14px; font-weight: 400; color: #ffffff; text-decoration: none; background-color: #0066cc; border-radius: 24px;">
-                                                        <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse; background-color: #0066cc; ">
-                                                            <tr>
-                                                                <td style="padding-right: 8px; font-size: 14px; font-weight: 400; line-height: 21px; color: #ffffff; vertical-align: middle;">
-                                                                    Go to {#insert content-button-service-name}{/}
-                                                                </td>
-                                                                <td style="line-height: 21px; vertical-align: middle;">
-                                                                    <img src="https://console.redhat.com/apps/frontend-assets/email-assets/external-link.png" alt="" width="14" height="14" style="display: block; border: none;" />
-                                                                </td>
-                                                            </tr>
-                                                        </table>
-                                                    </a>
-                                                    <!--<![endif]-->
-                                                </td>
-                                            </tr>
-                                        </table>
-                                    </td>
-                                </tr>
-                                <!-- End lue external link button -->
+                                                        <!--[if !mso]><!-->
+                                                        <a href="{#insert content-button-href}{/}" target="_blank" style="display: inline-block; padding: 8px 14px; font-size: 14px; font-weight: 400; color: #ffffff; text-decoration: none; background-color: #0066cc; border-radius: 24px;">
+                                                            <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse; background-color: #0066cc; ">
+                                                                <tr>
+                                                                    <td style="padding-right: 8px; font-size: 14px; font-weight: 400; line-height: 21px; color: #ffffff; vertical-align: middle;">
+                                                                        Go to {#insert content-button-service-name}{/}
+                                                                    </td>
+                                                                    <td style="line-height: 21px; vertical-align: middle;">
+                                                                        <img src="https://console.redhat.com/apps/frontend-assets/email-assets/external-link.png" alt="" width="14" height="14" style="display: block; border: none;" />
+                                                                    </td>
+                                                                </tr>
+                                                            </table>
+                                                        </a>
+                                                        <!--<![endif]-->
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                    <!-- End lue external link button -->
+                                {/if}
                             </table>
                         </td>
                     </tr>

--- a/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
@@ -3,14 +3,17 @@
     Scheduler - Console
 {/content-header-title}
 {#content-title}
-    Scheduler export completed
+    Scheduled report ready to download
 {/content-title}
 {#content-body}
     <p style="{body-section-p-style}">
-        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}?{query_params}" target="_blank">{action.context.job_name}</a> scheduled export has completed successfully.
-        <a style="{body-section-underline-link-style}" href="{environment.url}/api/export/v1/exports/{action.context.export_id}?{query_params}" target="_blank">Download exported data</a>.
+
+        The scheduled report {action.context.job_name} has generated successfully.  Click the link below to access and download the report.
+    </p>
+    <p style="{body-section-p-style}">
+        The next upcoming scheduled report: {action.context.next_run_at}
     </p>
 {/content-body}
-{#content-button-href}{environment.url}/insights/jobs/{action.context.job_id}{/content-button-href}
-{#content-button-service-name}Scheduled jobs{/content-button-service-name}
+{#content-button-href}{environment.url}/scheduler/download/{action.context.job_id}/{action.context.run_id}{/content-button-href}
+{#content-button-service-name}Download the report{/content-button-service-name}
 {/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/exportCompleteEmailBody.html
@@ -11,9 +11,9 @@
         The scheduled report {action.context.job_name} has generated successfully.  Click the link below to access and download the report.
     </p>
     <p style="{body-section-p-style}">
-        The next upcoming scheduled report: {action.context.next_run_at}
+        The next upcoming scheduled report: {action.context.next_run_at.toStringFormat}
     </p>
 {/content-body}
 {#content-button-href}{environment.url}/scheduler/download/{action.context.job_id}/{action.context.run_id}{/content-button-href}
-{#content-button-service-name}Download the report{/content-button-service-name}
+{#content-button-service-name}the report download page{/content-button-service-name}
 {/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
@@ -3,11 +3,11 @@
     Scheduler - Console
 {/content-header-title}
 {#content-title}
-    Scheduler job failed
+    Scheduled report generation failed
 {/content-title}
 {#content-body}
     <p style="{body-section-p-style}">
-        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}?{query_params}" target="_blank">{action.context.job_name}</a> scheduled job has failed.
+        The scheduled report {action.context.job_name} generation has failed.
     </p>
     {#if action.context.error_message}
     <p style="{body-section-p-style}">
@@ -15,6 +15,4 @@
     </p>
     {/if}
 {/content-body}
-{#content-button-href}{environment.url}/insights/jobs/{action.context.job_id}{/content-button-href}
-{#content-button-service-name}Scheduled jobs{/content-button-service-name}
 {/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedEmailBody.html
@@ -1,3 +1,4 @@
+{@boolean renderAppLinkButton=false}
 {#include email/Common/insightsEmailBody}
 {#content-header-title}
     Scheduler - Console

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
@@ -3,21 +3,17 @@
     Scheduler - Console
 {/content-header-title}
 {#content-title}
-    Scheduler job failed
+    Scheduled report generation failed - paused
 {/content-title}
 {#content-body}
     <p style="{body-section-p-style}">
-        The <a style="{body-section-underline-link-style}" href="{environment.url}/insights/jobs/{action.context.job_id}?{query_params}" target="_blank">{action.context.job_name}</a> scheduled job has failed and been automatically paused.
+        The scheduled report {action.context.job_name} generation has failed.
+        The scheduled report has been paused to prevent further failures. Please review and resolve the issue before resuming the scheduled report.
     </p>
     {#if action.context.error_message}
     <p style="{body-section-p-style}">
         <strong>Error:</strong> {action.context.error_message}
     </p>
     {/if}
-    <p style="{body-section-p-style}">
-        The scheduled job has been paused to prevent further failures. Please review and resolve the issue before resuming the scheduled job.
-    </p>
 {/content-body}
-{#content-button-href}{environment.url}/insights/jobs/{action.context.job_id}{/content-button-href}
-{#content-button-service-name}Scheduled jobs{/content-button-service-name}
 {/include}

--- a/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
+++ b/common-template/src/main/resources/templates/email/Scheduler/jobFailedPausedEmailBody.html
@@ -1,3 +1,4 @@
+{@boolean renderAppLinkButton=false}
 {#include email/Common/insightsEmailBody}
 {#content-header-title}
     Scheduler - Console

--- a/common-template/src/test/java/drawer/TestSchedulerTemplate.java
+++ b/common-template/src/test/java/drawer/TestSchedulerTemplate.java
@@ -28,6 +28,7 @@ class TestSchedulerTemplate {
         String result = renderTemplate(SCHEDULER_EXPORT_COMPLETE, action);
         assertTrue(result.contains("The scheduled report"));
         assertTrue(result.contains("**[Test Export Job]"));
+        assertTrue(result.contains("/scheduler/download/job-12345/run-11111?from=notifications&integration=drawer)**"));
         assertTrue(result.contains("has completed"));
     }
 

--- a/common-template/src/test/java/drawer/TestSchedulerTemplate.java
+++ b/common-template/src/test/java/drawer/TestSchedulerTemplate.java
@@ -26,9 +26,8 @@ class TestSchedulerTemplate {
     void testRenderedTemplateExportComplete() {
         Action action = createSchedulerExportCompleteAction();
         String result = renderTemplate(SCHEDULER_EXPORT_COMPLETE, action);
-        assertTrue(result.contains("A scheduled export"));
+        assertTrue(result.contains("The scheduled report"));
         assertTrue(result.contains("**[Test Export Job]"));
-        assertTrue(result.contains("/api/export/v1/exports/export-67890?from=notifications&integration=drawer)**"));
         assertTrue(result.contains("has completed"));
     }
 
@@ -36,9 +35,8 @@ class TestSchedulerTemplate {
     void testRenderedTemplateJobFailed() {
         Action action = createSchedulerJobFailedAction();
         String result = renderTemplate(SCHEDULER_JOB_FAILED, action);
-        assertTrue(result.contains("A scheduled export"));
+        assertTrue(result.contains("The scheduled report"));
         assertTrue(result.contains("**[Test Failed Job]"));
-        assertTrue(result.contains("/insights/jobs/job-54321?from=notifications&integration=drawer)**"));
         assertTrue(result.contains("has failed"));
     }
 
@@ -46,10 +44,9 @@ class TestSchedulerTemplate {
     void testRenderedTemplateJobFailedPaused() {
         Action action = createSchedulerJobFailedPausedAction();
         String result = renderTemplate(SCHEDULER_JOB_FAILED_PAUSED, action);
-        assertTrue(result.contains("A scheduled export"));
+        assertTrue(result.contains("The scheduled report"));
         assertTrue(result.contains("**[Test Paused Job]"));
-        assertTrue(result.contains("/insights/jobs/job-99999?from=notifications&integration=drawer)**"));
-        assertTrue(result.contains("has failed and been automatically paused"));
+        assertTrue(result.contains("has been paused to prevent"));
     }
 
     String renderTemplate(final String eventType, final Action action) {

--- a/common-template/src/test/java/email/TestSchedulerTemplate.java
+++ b/common-template/src/test/java/email/TestSchedulerTemplate.java
@@ -41,27 +41,26 @@ public class TestSchedulerTemplate extends EmailTemplatesRendererHelper {
     public void testExportCompleteEmailBody() {
         Action action = createSchedulerExportCompleteAction();
         String result = generateEmailBody(SCHEDULER_EXPORT_COMPLETE, action);
-        assertTrue(result.contains("scheduled export has completed successfully"));
-        assertTrue(result.contains("Test Export Job"));
-        assertTrue(result.contains("/insights/jobs/"));
-        assertTrue(result.contains("Download exported data"));
+        assertTrue(result.contains("has generated successfully"));
+        assertTrue(result.contains("Test Export Job has generated successfully"));
+        assertTrue(result.contains("/scheduler/download/"));
+        assertTrue(result.contains("Download the report"));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
     @Test
     public void testExportCompleteEmailTitle() {
-        eventTypeDisplayName = "Scheduler export completed";
+        eventTypeDisplayName = "Scheduled report ready to download";
         String result = generateEmailSubject(SCHEDULER_EXPORT_COMPLETE, createSchedulerExportCompleteAction());
-        assertEquals("Instant notification - Scheduler export completed - Scheduler - Console", result);
+        assertEquals("Instant notification - Scheduled report ready to download - Scheduler - Console", result);
     }
 
     @Test
     public void testJobFailedEmailBody() {
         Action action = createSchedulerJobFailedAction();
         String result = generateEmailBody(SCHEDULER_JOB_FAILED, action);
-        assertTrue(result.contains("scheduled job has failed"));
+        assertTrue(result.contains("has failed"));
         assertTrue(result.contains("Test Failed Job"));
-        assertTrue(result.contains("/insights/jobs/"));
         assertTrue(result.contains("<strong>Error:</strong>"));
         assertTrue(result.contains("Connection timeout"));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
@@ -69,29 +68,29 @@ public class TestSchedulerTemplate extends EmailTemplatesRendererHelper {
 
     @Test
     public void testJobFailedEmailTitle() {
-        eventTypeDisplayName = "Scheduler job failed";
+        eventTypeDisplayName = "Scheduled report generation failed";
         String result = generateEmailSubject(SCHEDULER_JOB_FAILED, createSchedulerJobFailedAction());
-        assertEquals("Instant notification - Scheduler job failed - Scheduler - Console", result);
+        assertEquals("Instant notification - Scheduled report generation failed - Scheduler - Console", result);
     }
 
     @Test
     public void testJobFailedPausedEmailBody() {
         Action action = createSchedulerJobFailedPausedAction();
         String result = generateEmailBody(SCHEDULER_JOB_FAILED_PAUSED, action);
-        assertTrue(result.contains("scheduled job has failed and been automatically paused"));
+        assertTrue(result.contains("generation has failed"));
         assertTrue(result.contains("Test Paused Job"));
-        assertTrue(result.contains("/insights/jobs/"));
         assertTrue(result.contains("<strong>Error:</strong>"));
         assertTrue(result.contains("Database connection failed"));
-        assertTrue(result.contains("The scheduled job has been paused to prevent further failures"));
+        assertTrue(result.contains("The scheduled report has been paused to prevent further failures"));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 
     @Test
     public void testJobFailedPausedEmailTitle() {
-        eventTypeDisplayName = "Scheduler job failed";
+        eventTypeDisplayName = "Scheduled report generation failed - paused";
+
         String result = generateEmailSubject(SCHEDULER_JOB_FAILED_PAUSED, createSchedulerJobFailedPausedAction());
-        assertEquals("Instant notification - Scheduler job failed - Scheduler - Console", result);
+        assertEquals("Instant notification - Scheduled report generation failed - paused - Scheduler - Console", result);
     }
 
     @Test
@@ -99,7 +98,7 @@ public class TestSchedulerTemplate extends EmailTemplatesRendererHelper {
         Action action = createSchedulerJobFailedAction();
         action.getContext().setAdditionalProperty("error_message", null);
         String result = generateEmailBody(SCHEDULER_JOB_FAILED, action);
-        assertTrue(result.contains("scheduled job has failed"));
+        assertTrue(result.contains("generation has failed"));
         assertTrue(result.contains("Test Failed Job"));
         // Should not contain error section if no error message
         assertTrue(!result.contains("<strong>Error:</strong>") || result.contains("<strong>Error:</strong>  "));

--- a/common-template/src/test/java/email/TestSchedulerTemplate.java
+++ b/common-template/src/test/java/email/TestSchedulerTemplate.java
@@ -44,7 +44,8 @@ public class TestSchedulerTemplate extends EmailTemplatesRendererHelper {
         assertTrue(result.contains("has generated successfully"));
         assertTrue(result.contains("Test Export Job has generated successfully"));
         assertTrue(result.contains("/scheduler/download/"));
-        assertTrue(result.contains("Download the report"));
+        assertTrue(result.contains("the report download page"));
+        assertTrue(result.contains("The next upcoming scheduled report:"));
         assertTrue(result.contains(TestHelpers.HCC_LOGO_TARGET));
     }
 

--- a/common-template/src/test/java/helpers/SchedulerTestHelpers.java
+++ b/common-template/src/test/java/helpers/SchedulerTestHelpers.java
@@ -24,6 +24,7 @@ public class SchedulerTestHelpers {
                 .withAdditionalProperty("job_id", "job-12345")
                 .withAdditionalProperty("job_name", "Test Export Job")
                 .withAdditionalProperty("export_id", "export-67890")
+                .withAdditionalProperty("run_id", "run-11111")
                 .build()
         );
 

--- a/common-template/src/test/java/helpers/SchedulerTestHelpers.java
+++ b/common-template/src/test/java/helpers/SchedulerTestHelpers.java
@@ -25,6 +25,7 @@ public class SchedulerTestHelpers {
                 .withAdditionalProperty("job_name", "Test Export Job")
                 .withAdditionalProperty("export_id", "export-67890")
                 .withAdditionalProperty("run_id", "run-11111")
+                .withAdditionalProperty("next_run_at", "2026-04-16T10:30:00-04:00")
                 .build()
         );
 


### PR DESCRIPTION
scheduler - fix download link and reword emails based on mocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Scheduler notifications now consistently refer to scheduled reports.
  - Completion messages link directly to the report download page and display the next scheduled run time.
  - Email titles and formatting were clarified, including bold report names.
  - Failure notifications better explain unsuccessful generation and paused schedules.
  - Failure messages no longer include job-management links, and app-link buttons are suppressed where appropriate.
- **Tests**
  - Updated notification coverage for revised wording, links, statuses, and scheduling details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->