### PR TITLE
[RHCLOUD-50970] Handle OCM severity with RH format on addition of legacy format

### DIFF
--- a/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
@@ -97,10 +97,16 @@ public class SeverityTransformer {
                 );
                 case "cluster-manager" -> events.stream().map(event -> {
                     try {
-                        return OcmServiceLogSeverity.valueOf(
-                            ((Map<String, Object>) event.getPayload().getAdditionalProperties().get("global_vars"))
-                                .get(SEVERITY).toString().toUpperCase()
-                        ).getSeverity();
+                        final String severityFromOcmPayload = ((Map<String, Object>) event.getPayload().getAdditionalProperties().get("global_vars"))
+                                .get(SEVERITY).toString().toUpperCase();
+                        try {
+                            // try to read severity using Red Hat standard format
+                            return Severity.valueOf(severityFromOcmPayload);
+                        } catch (Exception ex) {
+                            Log.debugf("Ocm is using old Severity format: '%s' for org :'%s'", severityFromOcmPayload, action.getOrgId());
+                            // try to read severity using OCM legacy format
+                            return OcmServiceLogSeverity.valueOf(severityFromOcmPayload).getSeverity();
+                        }
                     } catch (Exception ex) {
                         Log.errorf(ex, "Error extracting 'cluster-manager' severity from event '%s'", event);
                         return null;

--- a/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
+++ b/common/src/main/java/com/redhat/cloud/notifications/transformers/SeverityTransformer.java
@@ -103,7 +103,7 @@ public class SeverityTransformer {
                             // try to read severity using Red Hat standard format
                             return Severity.valueOf(severityFromOcmPayload);
                         } catch (Exception ex) {
-                            Log.debugf("Ocm is using old Severity format: '%s' for org :'%s'", severityFromOcmPayload, action.getOrgId());
+                            Log.debugf("Ocm is using old severity format: '%s' for org :'%s'", severityFromOcmPayload, action.getOrgId());
                             // try to read severity using OCM legacy format
                             return OcmServiceLogSeverity.valueOf(severityFromOcmPayload).getSeverity();
                         }

--- a/engine/src/test/java/com/redhat/cloud/notifications/transformers/SeverityTransformerTest.java
+++ b/engine/src/test/java/com/redhat/cloud/notifications/transformers/SeverityTransformerTest.java
@@ -141,6 +141,18 @@ class SeverityTransformerTest {
     }
 
     @Test
+    public void testOcmPayloadStandardRhSeverity() {
+        Optional<Map<String, Object>> severity = Optional.of(Map.of(SEVERITY, Severity.MODERATE));
+        Action action = OcmTestHelpers.createOcmAction("test-cluster-name", "Premium", "System rebooting",
+                "System reboot in progress", "test-title", severity);
+        Event event = new Event();
+        event.setEventWrapper(new EventWrapperAction(action));
+        event.setEventType(DEFAULT_EVENT_TYPE);
+
+        assertEquals(Severity.MODERATE, severityTransformer.getSeverity(event));
+    }
+
+    @Test
     public void testInventoryPayloadWithLegacySeverity() {
         Action action = InventoryTestHelpers.createInventoryAction("test-tenant", "rhel", "inventory", "validation-error");
         Event event = new Event();


### PR DESCRIPTION
OCM severity needs to be parsed using RH format first, it it fails OCM legacy format must be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved severity detection for cluster-manager notifications by supporting standard Red Hat severity values.
  * Preserved compatibility with legacy OCM severity formats through fallback handling.
* **Tests**
  * Added coverage for transforming a standard `MODERATE` severity value correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->