### PR TITLE
Align UserConfigResourceV2 permissions with V1

### DIFF
--- a/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/userconfig/UserConfigResourceV2.java
+++ b/backend/src/main/java/com/redhat/cloud/notifications/routers/handlers/userconfig/UserConfigResourceV2.java
@@ -1,7 +1,6 @@
 package com.redhat.cloud.notifications.routers.handlers.userconfig;
 
 import com.redhat.cloud.notifications.Severity;
-import com.redhat.cloud.notifications.auth.annotation.Authorization;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.repositories.ApplicationRepository;
 import com.redhat.cloud.notifications.db.repositories.BundleRepository;
@@ -55,10 +54,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.redhat.cloud.notifications.Constants.API_NOTIFICATIONS_V_2_0;
-import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_READ_NOTIFICATIONS;
-import static com.redhat.cloud.notifications.auth.ConsoleIdentityProvider.RBAC_WRITE_NOTIFICATIONS;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_EDIT;
-import static com.redhat.cloud.notifications.auth.kessel.permission.WorkspacePermission.NOTIFICATIONS_VIEW;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getOrgId;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.getUsername;
 import static com.redhat.cloud.notifications.routers.SecurityContextUtil.isServiceAccountAuthentication;
@@ -100,7 +95,6 @@ public class UserConfigResourceV2 {
     @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = BundleSubscriptionDTO.class)))
     @APIResponse(responseCode = "400", description = "A query parameter was specified without its required parent (e.g. 'application' without 'bundle')")
     @APIResponse(responseCode = "404", description = "The named bundle, application or event type doesn't exist")
-    @Authorization(legacyRBACRole = RBAC_READ_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_VIEW, resourceType = "notification_preference")
     public List<BundleSubscriptionDTO> getSubscriptions(
         @Context SecurityContext sec,
         @QueryParam("bundle") String bundleName,
@@ -257,7 +251,6 @@ public class UserConfigResourceV2 {
         description = "Partial update, not a full replace: any bundle, application, event type or channel omitted "
             + "from the request tree is left untouched rather than reset or unsubscribed."
     )
-    @Authorization(legacyRBACRole = RBAC_WRITE_NOTIFICATIONS, workspacePermissions = NOTIFICATIONS_EDIT, resourceType = "notification_preference")
     public void updateSubscriptions(
         @Context SecurityContext sec,
         @NotNull @NotEmpty @Valid @RequestBody(content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = BundleSubscriptionUpdateDTO.class)))

--- a/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/userconfig/UserConfigResourceV2Test.java
+++ b/backend/src/test/java/com/redhat/cloud/notifications/routers/handlers/userconfig/UserConfigResourceV2Test.java
@@ -5,9 +5,6 @@ import com.redhat.cloud.notifications.Severity;
 import com.redhat.cloud.notifications.TestConstants;
 import com.redhat.cloud.notifications.TestHelpers;
 import com.redhat.cloud.notifications.TestLifecycleManager;
-import com.redhat.cloud.notifications.auth.kessel.KesselCheckClient;
-import com.redhat.cloud.notifications.auth.kessel.KesselTestHelper;
-import com.redhat.cloud.notifications.auth.rbac.workspace.WorkspaceUtils;
 import com.redhat.cloud.notifications.config.BackendConfig;
 import com.redhat.cloud.notifications.db.DbIsolatedTest;
 import com.redhat.cloud.notifications.db.ResourceHelpers;
@@ -43,17 +40,13 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.FULL_ACCESS;
-import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.NO_ACCESS;
-import static com.redhat.cloud.notifications.MockServerConfig.RbacAccess.READ_ACCESS;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ACCOUNT_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_ORG_ID;
 import static com.redhat.cloud.notifications.TestConstants.DEFAULT_USER;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.project_kessel.api.inventory.v1beta2.Allowed.ALLOWED_FALSE;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
@@ -73,15 +66,6 @@ public class UserConfigResourceV2Test extends DbIsolatedTest {
     @InjectMock
     BackendConfig backendConfig;
 
-    @InjectMock
-    KesselCheckClient kesselCheckClient;
-
-    @InjectMock
-    WorkspaceUtils workspaceUtils;
-
-    @Inject
-    KesselTestHelper kesselTestHelper;
-
     Header identityHeader;
 
     @BeforeEach
@@ -90,13 +74,6 @@ public class UserConfigResourceV2Test extends DbIsolatedTest {
         String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, DEFAULT_USER);
         identityHeader = TestHelpers.createRHIdentityHeader(identityHeaderValue);
         MockServerConfig.addMockRbacAccess(identityHeaderValue, FULL_ACCESS);
-        // Since BackendConfig is mocked, isRBACEnabled() defaults to false, which makes
-        // ConsoleIdentityProvider build an all-privileges principal regardless of the RBAC mock
-        // responses below. Enable it so the NO_ACCESS/READ_ACCESS tests actually exercise RBAC.
-        when(backendConfig.isRBACEnabled()).thenReturn(true);
-        when(workspaceUtils.getDefaultWorkspaceId(DEFAULT_ORG_ID)).thenReturn(KesselTestHelper.RBAC_DEFAULT_WORKSPACE_ID);
-        when(kesselCheckClient.check(any())).thenReturn(kesselTestHelper.buildCheckResponse(ALLOWED_FALSE));
-        when(kesselCheckClient.checkForUpdate(any())).thenReturn(kesselTestHelper.buildCheckForUpdateResponse(ALLOWED_FALSE));
         // Bypass the legacy per-event-type template existence check in SubscriptionRepository.updateSubscription:
         // this test suite is about the subscription tree shape, not about template wiring.
         when(backendConfig.isUseCommonTemplateModuleForUserPrefApisToggle()).thenReturn(true);
@@ -430,24 +407,6 @@ public class UserConfigResourceV2Test extends DbIsolatedTest {
             .when().put(SUBSCRIPTIONS_PATH)
             .then()
             .statusCode(HttpStatus.SC_FORBIDDEN);
-    }
-
-    @Test
-    void testInsufficientPrivileges() {
-        Header noAccessIdentityHeader = initRbacMock(DEFAULT_USER + "-no-access", NO_ACCESS);
-        Header readAccessIdentityHeader = initRbacMock(DEFAULT_USER + "-read-access", READ_ACCESS);
-
-        given().header(noAccessIdentityHeader).when().get(SUBSCRIPTIONS_PATH).then().statusCode(HttpStatus.SC_FORBIDDEN);
-        given().header(noAccessIdentityHeader).when().put(SUBSCRIPTIONS_PATH).then().statusCode(HttpStatus.SC_FORBIDDEN);
-
-        given().header(readAccessIdentityHeader).when().get(SUBSCRIPTIONS_PATH).then().statusCode(HttpStatus.SC_OK);
-        given().header(readAccessIdentityHeader).when().put(SUBSCRIPTIONS_PATH).then().statusCode(HttpStatus.SC_FORBIDDEN);
-    }
-
-    private Header initRbacMock(String username, MockServerConfig.RbacAccess access) {
-        String identityHeaderValue = TestHelpers.encodeRHIdentityInfo(DEFAULT_ACCOUNT_ID, DEFAULT_ORG_ID, username);
-        MockServerConfig.addMockRbacAccess(identityHeaderValue, access);
-        return TestHelpers.createRHIdentityHeader(identityHeaderValue);
     }
 
     private BundleSubscriptionUpdateDTO buildSingleLeafUpdate(String bundle, String application, String eventType, SubscriptionTypeDTO channel, List<SeverityDTO> severities) {


### PR DESCRIPTION
## Summary
- `UserConfigResourceV2`'s `/subscriptions` GET/PUT endpoints required `NOTIFICATIONS_VIEW`/`NOTIFICATIONS_EDIT` RBAC/Kessel permissions via `@Authorization`, while the V1 `UserConfigResource` equivalents only require authentication (and reject service accounts).
- Removed the `@Authorization` annotations (and now-unused imports) from V2 so both versions share the same access model: any authenticated, non-service-account user can manage their own notification preferences.
- Updated `UserConfigResourceV2Test` to drop the now-obsolete `testInsufficientPrivileges` test and the Kessel/RBAC mocking scaffolding that only existed to exercise it.

## Test plan
- [x] `./mvnw validate -pl :notifications-backend -am` — 0 checkstyle violations
- [x] `./mvnw clean verify -pl :notifications-backend -am -Dtest=UserConfigResourceV2Test,UserConfigResourceTest` — 25/25 tests pass, including `testServiceAccountForbidden` which still returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified authorization handling for V2 user subscription configuration endpoints.
  - Removed legacy permission checks and related test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->