### PR TITLE
chore: dummy PR to verify GitHub App auth for PR perf test status

### DIFF
--- a/TEST_GITHUB_APP_AUTH.md
+++ b/TEST_GITHUB_APP_AUTH.md
@@ -1,0 +1,5 @@
+# Test PR — GitHub App auth verification
+
+Dummy PR to verify that Jenkins PR performance-test status/comments now
+post as the `hce-perfscale-pr-tester` GitHub App instead of a personal
+PAT. Safe to close/ignore — no functional code change.


### PR DESCRIPTION
Test PR to confirm Jenkins now posts commit status + PR comments via the `hce-perfscale-pr-tester` GitHub App (App ID 4820804) instead of a personal PAT.

No functional change — safe to close once verified. Will close this out myself after checking the results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented validation that performance-test statuses and pull request comments are posted through the GitHub App.
  - Recorded the required read/write pull request permission for publishing results-table comments.
  - Added retest notes covering corrected email notification configuration and successful performance-test validation.
  - Clarified that these updates document verification activities and do not introduce functional product changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->